### PR TITLE
Fix enabling digitlink in NodeTreeBase::parse_name

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1704,7 +1704,8 @@ void NodeTreeBase::parse_name( NODE* header, const char* str, const int lng, con
 
             // </b>の前までパース
             if( i != pos ){
-                digitlink = true;
+                // デフォルト名無しと同じときはアンカーを作らない
+                digitlink = ( strncmp( m_default_noname.data(), str + pos, i - pos ) != 0 );
                 parse_html( str + pos, i - pos, color_name, digitlink, bold, ahref );
             }
             if( i >= lng ) break;


### PR DESCRIPTION
JD(im) には，名前欄に数字が含まれる場合に，その数字をアンカー扱いにする機能がありますが，名前欄がデフォルト名無し(板の SETTING.TXT の BBS_NONAME_NAME で設定されている名前)に一致している場合はその機能は無効になります。
しかしながら，その判定は県名表示なども含む完全一致で行われているため，デフォルト名無しに加えて県名表示やワッチョイなどが有効になっている板(やスレッド)では，機能が有効のままになってしまいます(例: [地下アイドル(AKB48)](http://rosie.5ch.net/akb/)板など)。
そこでこの変更では，名前欄の解析を行う際にも，デフォルト名無しに一致しているかチェックすることにより，機能を無効に出来るようにしました。

確認環境:
```
[バージョン] 0.1.0-20190123(git:f6390b7f97)
[ディストリ ] Debian GNU/Linux buster/sid (x86_64)
[パッケージ] バイナリ/ソース( <配布元> )
[ DE／WM ] 
[　gtkmm 　] 2.24.5
[　glibmm 　] 2.58.0
[ そ の 他 ] LANG = en_US.utf8
```