### PR TITLE
Add progname info

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -27,6 +27,7 @@
 #include <windows.h>
 #endif
 
+std::string ENVIRONMENT::get_progname() { return "JDim"; }
 std::string ENVIRONMENT::get_jdcomments(){ return std::string( JDCOMMENT ); }
 std::string ENVIRONMENT::get_jdcopyright(){ return std::string( JDCOPYRIGHT ); }
 std::string ENVIRONMENT::get_jdbbs(){ return std::string( JDBBS ); }
@@ -602,6 +603,8 @@ std::string ENVIRONMENT::get_jdinfo()
 {
     std::stringstream jd_info;
 
+    const std::string progname = get_progname();
+
     // バージョンを取得(jdversion.h)
     const std::string version = get_jdversion();
 
@@ -620,7 +623,7 @@ std::string ENVIRONMENT::get_jdinfo()
     else if( lang != "ja_JP.utf8" && lang != "ja_JP.UTF-8" ) other.append( "LANG = " + lang );
 
     jd_info <<
-    "[バージョン] " << version << "\n" <<
+    "[バージョン] " << progname << " " << version << "\n" <<
 //#ifdef SVN_REPOSITORY
 //    "[リポジトリ ] " << SVN_REPOSITORY << "\n" <<
 //#endif

--- a/src/environment.h
+++ b/src/environment.h
@@ -25,6 +25,7 @@ namespace ENVIRONMENT
 		CONFIGURE_FULL
     };
 
+    std::string get_progname();
     std::string get_jdcomments();
     std::string get_jdcopyright();
 	std::string get_jdbbs();

--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -15,7 +15,7 @@
 #include "control/controlid.h"
 
 #include "command.h"
-#include "jdversion.h"
+#include "environment.h"
 
 using namespace CORE;
 
@@ -53,7 +53,7 @@ LinkFilterDiag::LinkFilterDiag( Gtk::Window* parent, const std::string& url, con
 
 void LinkFilterDiag::slot_show_manual()
 {
-    CORE::core_set_command( "open_url_browser", JDHELPCMD );
+    CORE::core_set_command( "open_url_browser", ENVIRONMENT::get_jdhelpcmd() );
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -431,7 +431,7 @@ int main( int argc, char **argv )
                 break;
 
             case 'V': // バージョンと完全なconfigureオプションを表示
-                std::cout << "JDim " << ENVIRONMENT::get_jdversion() << "\n" <<
+                std::cout << ENVIRONMENT::get_progname() << " " << ENVIRONMENT::get_jdversion() << "\n" <<
                 ENVIRONMENT::get_jdcopyright() << "\n"
                 "configure: " << ENVIRONMENT::get_configure_args( ENVIRONMENT::CONFIGURE_FULL ) << std::endl;
                 exit( 0 );

--- a/src/usrcmdpref.cpp
+++ b/src/usrcmdpref.cpp
@@ -6,10 +6,11 @@
 
 #include "usrcmdpref.h"
 #include "usrcmdmanager.h"
+
 #include "command.h"
-#include "type.h"
-#include "jdversion.h"
 #include "dndmanager.h"
+#include "environment.h"
+#include "type.h"
 
 #include "control/controlid.h"
 #include "control/controlutil.h"
@@ -58,7 +59,7 @@ UsrCmdDiag::UsrCmdDiag( Gtk::Window* parent, const Glib::ustring& name, const Gl
 
 void UsrCmdDiag::slot_show_manual()
 {
-    CORE::core_set_command( "open_url_browser", JDHELPCMD );
+    CORE::core_set_command( "open_url_browser", ENVIRONMENT::get_jdhelpcmd() );
 }
 
 ///////////////////////////////////////////


### PR DESCRIPTION
* 動作環境をクリップボードへコピーするときバージョン情報にプログラム名(JDim)を追加します。

  Example(抜粋):
  `[バージョン] JDim 0.1.0-20190122(git:95e5f2d5c8)`

* gitリビジョンの変化によって再コンパイルが発生するファイルを減らします。
