### PR TITLE
Fix undefined behavior in JDLIB::hash_set_thread::get_key

### DIFF
--- a/src/jdlib/hash_set.cpp
+++ b/src/jdlib/hash_set.cpp
@@ -5,11 +5,6 @@
 
 #include "hash_set.h"
 
-#include "dbtree/interface.h"
-
-#include <cstdlib>
-
-
 using namespace JDLIB;
 
 
@@ -79,9 +74,7 @@ hash_set_thread::hash_set_thread()
 
 int hash_set_thread::get_key( const std::string& url )
 {
-
-    const int lng = DBTREE::url_datbase( url ).length();
-    const int key = atoi(  url.substr( lng < (int) url.length() ? lng : 0  ).c_str() ) % size();
+    const int key = std::hash<std::string>()(url) % size();
 
 #ifdef _DEBUG
     std::cout << "hash_set_thread::get_key url = " << url << " key = " << key << std::endl;


### PR DESCRIPTION
`JDLIB::hash_set_thread::get_key` が不正な値を返さないように修正します。

`JDLIB::hash_set_thread::get_key`はハッシュ値としてスレッドの番号(datの番号)を利用していますが
その際に呼び出している`atoi` はintの範囲を超えると未定義動作を起こします。
(すでにスレッドが落ちてしまっていますが[http://leia.5ch.net/test/read.cgi/poverty/2321433869/](http://leia.5ch.net/test/read.cgi/poverty/2321433869/)などを開くとクラッシュしました)
 
C++11には無例外動作が保証されている`std::hash`というハッシュ関数が標準で用意されているのでそちらを使うようにしました。

バグの確認環境:
```
[バージョン] 2.8.9-20190109(git:df8e0c1d20:M)
[ディストリ ] Ubuntu 18.10 (x86_64)
[パッケージ] バイナリ/ソース( <配布元> )
[ DE／WM ] GNOME
[　gtkmm 　] 2.24.5
[　glibmm 　] 2.56.0
[オプション ] 
[ そ の 他 ] 
```