### PR TITLE
Fix JBBS board URL for setting board info

### DIFF
--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -559,7 +559,7 @@ int Root::get_board_type( const std::string& url, std::string& root, std::string
     else if( is_JBBS( url ) ){
 
         if( regex.exec( "(https?://[^/]*)/(.*)/(index2?\\.html?)?$" , url, offset, icase, newline, usemigemo, wchar ) ){
-            root = "http://jbbs.shitaraba.net";
+            root = regex.str( 1 );
             path_board = "/" + regex.str( 2 );
 
             type = TYPE_BOARD_JBBS;


### PR DESCRIPTION
JBBS型(したらば掲示板)の板を一覧に追加するときに`http://jbbs.shitaraba.net`ではなく板URLの解析結果を使うように修正する。以前の方法ではhttpsではじまるURLを正常に設定できない問題があった。

#### 互換性に関する注意
JBBS型の板のうち`https?://jbbs.shitaraba.net`からはじまらないものは修正によって登録URLが換わる。そのため修正前から登録してある板を削除すると再登録したときにURLが換わり板情報が引き継がれないことがある。