### PR TITLE
Debianでの開発環境について更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ dnf install gtkmm30-devel gnutls-devel libgcrypt-devel libSM-devel libtool autom
 
 #### Debian
 ```sh
-sudo apt-get install libc6-dev make gcc g++ （開発環境の導入）
+sudo apt install libc6-dev make gcc g++ （開発環境の導入）
 sudo vi /etc/apt/sources.list (エディタは何でも良い。deb-src行でstretch-backports以降を有効にする）
 sudo apt update
-sudo apt-get build-dep jdim
+sudo apt build-dep jdim
 ```
 
 #### Ubuntu 18.04

--- a/README.md
+++ b/README.md
@@ -59,15 +59,12 @@ dnf install gtkmm24-devel gnutls-devel libgcrypt-devel libSM-devel libtool autom
 dnf install gtkmm30-devel gnutls-devel libgcrypt-devel libSM-devel libtool automake autoconf-archive git
 ```
 
-#### Debian系
+#### Debian
 ```sh
-sudo apt-get build-dep jd
-```
-
-開発環境が入っていない場合は、
-
-```sh
-sudo apt-get install build-essential automake autoconf-archive git
+sudo apt-get install libc6-dev make gcc g++ （開発環境の導入）
+sudo vi /etc/apt/sources.list (エディタは何でも良い。deb-src行でstretch-backports以降を有効にする）
+sudo apt update
+sudo apt-get build-dep jdim
 ```
 
 #### Ubuntu 18.04

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ dnf install gtkmm30-devel gnutls-devel libgcrypt-devel libSM-devel libtool autom
 #### Debian
 ```sh
 sudo apt install libc6-dev make gcc g++ （開発環境の導入）
-sudo vi /etc/apt/sources.list (エディタは何でも良い。deb-src行でstretch-backports以降を有効にする）
+sudo vi /etc/apt/sources.list (エディタは何でも良い。deb-src行でstretch-backportsあるいはbuster以降を有効にする）
 sudo apt update
 sudo apt build-dep jdim
 ```

--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ dnf install gtkmm24-devel gnutls-devel libgcrypt-devel libSM-devel libtool autom
 dnf install gtkmm30-devel gnutls-devel libgcrypt-devel libSM-devel libtool automake autoconf-archive git
 ```
 
-#### Debian
+#### Debian (stretch-backportsあるいはbuster以降)
 ```sh
-sudo apt install libc6-dev make gcc g++ （開発環境の導入）
-sudo vi /etc/apt/sources.list (エディタは何でも良い。deb-src行でstretch-backportsあるいはbuster以降を有効にする）
+sudo apt install libc6-dev make gcc g++ git
+sudo vi /etc/apt/sources.list
+# ↑エディタは何でも良い。deb-src行でstretch-backportsあるいはbuster以降を有効にする
 sudo apt update
 sudo apt build-dep jdim
 ```


### PR DESCRIPTION
jdパッケージの削除とjdimパッケージの導入に伴ってbuild-depの指定が変更。
その前の準備についても整理した