### PR TITLE
Fix return types

### DIFF
--- a/src/aamanager.cpp
+++ b/src/aamanager.cpp
@@ -227,13 +227,13 @@ void AAManager::save_history()
 
 
 // ラベル、AA取得
-const std::string AAManager::get_label( const int id )
+std::string AAManager::get_label( const int id )
 {
     if( id >= (int) m_vec_label.size() ) return std::string();
     return m_vec_label[ id ];
 }
 
-const std::string AAManager::get_aa( const int id )
+std::string AAManager::get_aa( const int id )
 {
     if( id >= (int) m_vec_aa.size() ) return std::string();
     return m_vec_aa[ id ]; 
@@ -243,7 +243,7 @@ const std::string AAManager::get_aa( const int id )
 //
 // ショートカットキー取得
 //
-const std::string AAManager::id2shortcut( const int id )
+std::string AAManager::id2shortcut( const int id )
 {
     if( id >= (int) m_map_shortcut.size() ) return std::string();
 

--- a/src/aamanager.h
+++ b/src/aamanager.h
@@ -29,11 +29,11 @@ namespace CORE
         int get_size(){ return m_vec_label.size(); }
         int get_historysize(){ return m_history.size(); }
 
-        const std::string get_label( const int id );
-        const std::string get_aa( const int id );
+        std::string get_label( const int id );
+        std::string get_aa( const int id );
 
         // ショートカットキー取得
-        const std::string id2shortcut( const int id );
+        std::string id2shortcut( const int id );
 
         // ショートカットからid取得
         int shortcut2id( const char key );

--- a/src/article/articleadmin.cpp
+++ b/src/article/articleadmin.cpp
@@ -362,7 +362,7 @@ COMMAND_ARGS ArticleAdmin::url_to_openarg( const std::string& url, const bool ta
 }
 
 
-const std::string ArticleAdmin::command_to_url( const COMMAND_ARGS& command )
+std::string ArticleAdmin::command_to_url( const COMMAND_ARGS& command )
 {
     std::string url;
 

--- a/src/article/articleadmin.h
+++ b/src/article/articleadmin.h
@@ -52,7 +52,7 @@ namespace ARTICLE
 
         void restore( const bool only_locked ) override;
         COMMAND_ARGS url_to_openarg( const std::string& url, const bool tab, const bool lock ) override;
-        const std::string command_to_url( const COMMAND_ARGS& command ) override;
+        std::string command_to_url( const COMMAND_ARGS& command ) override;
 
         void switch_admin() override;
 

--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -120,7 +120,7 @@ SKELETON::Admin* ArticleViewBase::get_admin()
 //
 // メインウィンドウのURLバーなどの表示用にも使う
 //
-const std::string ArticleViewBase::url_for_copy()
+std::string ArticleViewBase::url_for_copy()
 {
     return DBTREE::url_readcgi( m_url_article, 0, 0 );
 }
@@ -470,7 +470,7 @@ void ArticleViewBase::setup_action()
 //
 // 通常の右クリックメニューの作成
 //
-const std::string ArticleViewBase::create_context_menu()
+std::string ArticleViewBase::create_context_menu()
 {
     std::list< int > list_menu;
 
@@ -1600,7 +1600,7 @@ void ArticleViewBase::slot_setup_abone_all()
 //
 // 荒らし報告用のURLリストをHTML形式で取得
 //
-const std::string ArticleViewBase::get_html_url4report( const std::list< int >& list_resnum )
+std::string ArticleViewBase::get_html_url4report( const std::list< int >& list_resnum )
 {
     std::string html;
 

--- a/src/article/articleviewbase.h
+++ b/src/article/articleviewbase.h
@@ -102,7 +102,7 @@ namespace ARTICLE
 
         void save_session() override {}
 
-        const std::string url_for_copy() override; // コピーやURLバー表示用のURL
+        std::string url_for_copy() override; // コピーやURLバー表示用のURL
         int width_client() override;
         int height_client() override;
         int get_icon( const std::string& iconname ) override;
@@ -246,7 +246,7 @@ namespace ARTICLE
         void setup_action();
 
         // 通常の右クリックメニューの作成
-        const std::string create_context_menu();
+        std::string create_context_menu();
         const char* get_menu_item( const int item );
 
         virtual void exec_reload();
@@ -255,7 +255,7 @@ namespace ARTICLE
         void exec_delete();
 
         // 荒らし報告用のURLリストをHTML形式で取得
-        const std::string get_html_url4report( const std::list< int >& list_resnum );
+        std::string get_html_url4report( const std::list< int >& list_resnum );
         
         // drawarea の signal を受け取る slots
         virtual bool slot_button_press( std::string url, int res_number, GdkEventButton* event );

--- a/src/article/articleviewsearch.cpp
+++ b/src/article/articleviewsearch.cpp
@@ -117,7 +117,7 @@ void ArticleViewSearch::set_toolbar_from_url()
 // queryが変化したときにurlを更新しないと再起動したときのrestoreで
 // 古いqueryのままになる
 //
-const std::string ArticleViewSearch::get_new_url()
+std::string ArticleViewSearch::get_new_url()
 {
     std::string url_tmp = m_url_board;
 
@@ -186,7 +186,7 @@ void ArticleViewSearch::regex_escape()
 //
 // メインウィンドウのURLバーなどの表示用にも使う
 //
-const std::string ArticleViewSearch::url_for_copy()
+std::string ArticleViewSearch::url_for_copy()
 {
     if( m_searchmode == CORE::SEARCHMODE_TITLE ) return m_url_title;
 

--- a/src/article/articleviewsearch.h
+++ b/src/article/articleviewsearch.h
@@ -35,7 +35,7 @@ namespace ARTICLE
 
         // SKELETON::View の関数のオーバロード
 
-        const std::string url_for_copy() override; // コピーやURLバー表示用のURL
+        std::string url_for_copy() override; // コピーやURLバー表示用のURL
         bool set_command( const std::string& command,
                           const std::string& arg1 = {},
                           const std::string& arg2 = {} ) override;
@@ -65,7 +65,7 @@ namespace ARTICLE
         void set_toolbar_from_url();
 
         // queryなどを変更した時の新しいURL
-        const std::string get_new_url();
+        std::string get_new_url();
 
         // ラベルやタブを更新
         void update_label();

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -592,7 +592,7 @@ int DrawAreaBase::get_current_res_num()
 
 
 // 範囲選択中の文字列
-const std::string DrawAreaBase::str_selection()
+std::string DrawAreaBase::str_selection()
 {
     if( ! m_selection.select ) return std::string();
 

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -280,7 +280,7 @@ namespace ARTICLE
         void select_all(); 
 
         // 範囲選択中の文字列
-        const std::string str_selection(); 
+        std::string str_selection();
         const std::string& str_pre_selection() const { return m_selection.str_pre; }  // 一つ前の選択文字列
 
         // 範囲選択を開始したレス番号

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -251,8 +251,8 @@ namespace ARTICLE
         ~DrawAreaBase();
 
         const std::string& get_url() const { return m_url; }
-        const int& width_client() const { return m_width_client; }
-        const int& height_client() const { return m_height_client; }
+        int width_client() const { return m_width_client; }
+        int height_client() const { return m_height_client; }
 
         void clock_in();
         void clock_in_smooth_scroll();

--- a/src/bbslist/addetcdialog.h
+++ b/src/bbslist/addetcdialog.h
@@ -25,10 +25,10 @@ namespace BBSLIST
 
         AddEtcDialog( const bool move, const std::string& url, const std::string& _name, const std::string& _id, const std::string& _passwd );
 
-        const std::string get_name(){ return m_entry_name.get_text(); }
-        const std::string get_url(){ return m_entry_url.get_text(); }
-        const std::string get_id(){ return m_entry_id.get_text(); }
-        const std::string get_passwd(){ return m_entry_pw.get_text(); }
+        std::string get_name() const { return m_entry_name.get_text(); }
+        std::string get_url() const { return m_entry_url.get_text(); }
+        std::string get_id() const { return m_entry_id.get_text(); }
+        std::string get_passwd() const { return m_entry_pw.get_text(); }
     };   
 
 }

--- a/src/bbslist/bbslistadmin.cpp
+++ b/src/bbslist/bbslistadmin.cpp
@@ -275,7 +275,7 @@ void BBSListAdmin::get_threads( const std::string& url, const int dirid, std::ve
 
 
 // サイドバーの指定したidのディレクトリの名前を取得
-const std::string BBSListAdmin::get_dirname( const std::string& url, const int dirid )
+std::string BBSListAdmin::get_dirname( const std::string& url, const int dirid )
 {
     BBSListViewBase* view = dynamic_cast< BBSListViewBase* >( get_view( url ) );
     if( view ) return view->get_dirname( dirid );

--- a/src/bbslist/bbslistadmin.h
+++ b/src/bbslist/bbslistadmin.h
@@ -41,7 +41,7 @@ namespace BBSLIST
         void get_threads( const std::string& url, const int dirid, std::vector< std::string >& list_url );
 
         // サイドバーの指定したidのディレクトリの名前を取得
-        const std::string get_dirname( const std::string& url, const int dirid );
+        std::string get_dirname( const std::string& url, const int dirid );
 
       protected:
 

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -2060,7 +2060,7 @@ void BBSListViewBase::slot_sort( const int mode )
 //
 // path -> url 変換
 //
-const Glib::ustring BBSListViewBase::path2rawurl( const Gtk::TreePath& path )
+Glib::ustring BBSListViewBase::path2rawurl( const Gtk::TreePath& path )
 {
     Gtk::TreeModel::Row row = m_treeview.get_row( path );
     if( !row ) return Glib::ustring();
@@ -2070,7 +2070,7 @@ const Glib::ustring BBSListViewBase::path2rawurl( const Gtk::TreePath& path )
 
 
 // 移転をチェックするバージョン
-const Glib::ustring BBSListViewBase::path2url( const Gtk::TreePath& path )
+Glib::ustring BBSListViewBase::path2url( const Gtk::TreePath& path )
 {
     Gtk::TreeModel::Row row = m_treeview.get_row( path );
     if( !row ) return Glib::ustring();
@@ -2104,7 +2104,7 @@ const Glib::ustring BBSListViewBase::path2url( const Gtk::TreePath& path )
 // 板の場合は boardbase
 // スレの場合は dat 型のアドレスを返す
 //
-const Glib::ustring BBSListViewBase::row2url( const Gtk::TreeModel::Row& row )
+Glib::ustring BBSListViewBase::row2url( const Gtk::TreeModel::Row& row )
 {
     if( ! row ) return Glib::ustring();
 
@@ -2135,7 +2135,7 @@ const Glib::ustring BBSListViewBase::row2url( const Gtk::TreeModel::Row& row )
 //
 // path -> name 変換
 //
-const Glib::ustring BBSListViewBase::path2name( const Gtk::TreePath& path )
+Glib::ustring BBSListViewBase::path2name( const Gtk::TreePath& path )
 {
     Gtk::TreeModel::Row row = m_treeview.get_row( path );
     if( !row ) return Glib::ustring();
@@ -2168,7 +2168,7 @@ int BBSListViewBase::row2type( const Gtk::TreeModel::Row& row )
 //
 // row -> name 変換
 //
-const Glib::ustring BBSListViewBase::row2name( const Gtk::TreeModel::Row& row )
+Glib::ustring BBSListViewBase::row2name( const Gtk::TreeModel::Row& row )
 {
     if( !row ) return Glib::ustring();
     return row[ m_columns.m_name ];
@@ -3033,7 +3033,7 @@ void BBSListViewBase::get_threads( const size_t dirid, std::vector< std::string 
 
 
 // 指定したidのディレクトリの名前を取得
-const std::string BBSListViewBase::get_dirname( const int dirid )
+std::string BBSListViewBase::get_dirname( const int dirid )
 {
     if( ! dirid ) return get_label();
 

--- a/src/bbslist/bbslistviewbase.h
+++ b/src/bbslist/bbslistviewbase.h
@@ -141,22 +141,22 @@ namespace BBSLIST
         int row2type( const Gtk::TreeModel::Row& row );
 
         // row -> name 変換
-        const Glib::ustring row2name( const Gtk::TreeModel::Row& row );
+        Glib::ustring row2name( const Gtk::TreeModel::Row& row );
 
         // row -> url 変換
         // 板の場合は boardbase
         // スレの場合は dat 型のアドレスを返す
-        const Glib::ustring row2url( const Gtk::TreeModel::Row& row );
+        Glib::ustring row2url( const Gtk::TreeModel::Row& row );
 
         // row -> dirid 変換
         size_t row2dirid( const Gtk::TreeModel::Row& row );
 
         // path からその行の名前を取得
-        const Glib::ustring path2name( const Gtk::TreePath& path );
+        Glib::ustring path2name( const Gtk::TreePath& path );
 
         // path からその行のURLを取得
-        const Glib::ustring path2rawurl( const Gtk::TreePath& path );
-        const Glib::ustring path2url( const Gtk::TreePath& path ); // 移転をチェックするバージョン
+        Glib::ustring path2rawurl( const Gtk::TreePath& path );
+        Glib::ustring path2url( const Gtk::TreePath& path ); // 移転をチェックするバージョン
 
         // url で指定した項目を削除
         void remove_item( const std::string& url );
@@ -193,7 +193,7 @@ namespace BBSLIST
         // 親ウィンドウをセット
         void set_parent_win( Gtk::Window* parent_win ) override;
 
-        const std::string url_for_copy() override { return {}; }
+        std::string url_for_copy() override { return {}; }
 
         bool set_command( const std::string& command,
                           const std::string& arg1 = {},
@@ -241,7 +241,7 @@ namespace BBSLIST
         void get_threads( const size_t dirid, std::vector< std::string >& list_url );
 
         // 指定したidのディレクトリの名前を取得
-        const std::string get_dirname( const int dirid );
+        std::string get_dirname( const int dirid );
 
         // selectdialogで使う
         Gtk::TreePath get_current_path() { return m_treeview.get_current_path(); }

--- a/src/bbslist/bbslistviewbase.h
+++ b/src/bbslist/bbslistviewbase.h
@@ -103,7 +103,7 @@ namespace BBSLIST
 
         Glib::RefPtr< Gtk::TreeStore >& get_treestore() { return m_treestore; }
         SKELETON::EditTreeView& get_treeview() { return  m_treeview; }
-        const bool& get_ready_tree() const{ return m_ready_tree; }
+        bool get_ready_tree() const { return m_ready_tree; }
         void set_open_only_onedir( const bool set ){ m_open_only_onedir = set; }
 
         void activate_act_before_popupmenu( const std::string& url ) override;

--- a/src/bbslist/selectdialog.cpp
+++ b/src/bbslist/selectdialog.cpp
@@ -113,12 +113,12 @@ void SelectListDialog::slot_ok_clicked()
 }
 
 
-const std::string SelectListDialog::get_name()
+std::string SelectListDialog::get_name()
 {
     return m_label_name.get_text();
 }
 
-const std::string SelectListDialog::get_path()
+std::string SelectListDialog::get_path()
 {
     std::string path;
     if( m_selectview ) path = m_selectview->get_current_path().to_string();

--- a/src/bbslist/selectdialog.h
+++ b/src/bbslist/selectdialog.h
@@ -36,8 +36,8 @@ namespace BBSLIST
         SelectListDialog( Gtk::Window* parent, const std::string& url, Glib::RefPtr< Gtk::TreeStore >& treestore );
         ~SelectListDialog();
 
-        const std::string get_name();
-        const std::string get_path();
+        std::string get_name();
+        std::string get_path();
 
       protected:
 

--- a/src/board/boardadmin.cpp
+++ b/src/board/boardadmin.cpp
@@ -210,7 +210,7 @@ COMMAND_ARGS BoardAdmin::url_to_openarg( const std::string& url, const bool tab,
 }
 
 
-const std::string BoardAdmin::command_to_url( const COMMAND_ARGS& command )
+std::string BoardAdmin::command_to_url( const COMMAND_ARGS& command )
 {
     if( command.arg4 == "NEXT" ) return command.url + NEXT_SIGN + ARTICLE_SIGN + command.arg5;
 

--- a/src/board/boardadmin.h
+++ b/src/board/boardadmin.h
@@ -44,7 +44,7 @@ namespace BOARD
 
         void restore( const bool only_locked ) override;
         COMMAND_ARGS url_to_openarg( const std::string& url, const bool tab, const bool lock ) override;
-        const std::string command_to_url( const COMMAND_ARGS& command ) override;
+        std::string command_to_url( const COMMAND_ARGS& command ) override;
 
         void switch_admin() override;
 

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -1817,7 +1817,7 @@ void BoardViewBase::update_item_all()
 //
 // 行を作って内容をセット
 //
-const Gtk::TreeModel::Row BoardViewBase::prepend_row( DBTREE::ArticleBase* art, const int id )
+Gtk::TreeModel::Row BoardViewBase::prepend_row( DBTREE::ArticleBase* art, const int id )
 {
     Gtk::TreeModel::Row row = *( m_liststore->prepend() ); // append より prepend の方が速いらしい
 

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -240,7 +240,7 @@ int BoardViewBase::get_icon( const std::string& iconname )
 //
 // コピー用URL(メインウィンドウのURLバーなどに表示する)
 //
-const std::string BoardViewBase::url_for_copy()
+std::string BoardViewBase::url_for_copy()
 {
     return DBTREE::url_boardbase( get_url_board() );
 }
@@ -360,7 +360,7 @@ void BoardViewBase::setup_action()
 //
 // 通常の右クリックメニューの作成
 //
-const std::string BoardViewBase::create_context_menu()
+std::string BoardViewBase::create_context_menu()
 {
     std::list< int > list_menu;
 
@@ -2531,7 +2531,7 @@ void BoardViewBase::open_selected_rows( const bool reget )
 //
 // path -> スレッドの(dat型)URL変換
 //
-const std::string BoardViewBase::path2daturl( const Gtk::TreePath& path )
+std::string BoardViewBase::path2daturl( const Gtk::TreePath& path )
 {
     Gtk::TreeModel::Row row = m_treeview.get_row( path );
     if( !row ) return std::string();
@@ -2544,7 +2544,7 @@ const std::string BoardViewBase::path2daturl( const Gtk::TreePath& path )
 //
 // path -> 板URL変換
 //
-const std::string BoardViewBase::path2url_board( const Gtk::TreePath& path )
+std::string BoardViewBase::path2url_board( const Gtk::TreePath& path )
 {
     if( ! get_url_board().empty() ) return get_url_board();
     if( path.empty() ) return std::string();
@@ -2965,7 +2965,7 @@ void BoardViewBase::slot_abone_thread()
 // path と column からそのセルの内容を取得
 //
 template < typename ColumnType >
-const std::string BoardViewBase::get_name_of_cell( Gtk::TreePath& path, const Gtk::TreeModelColumn< ColumnType >& column )
+std::string BoardViewBase::get_name_of_cell( Gtk::TreePath& path, const Gtk::TreeModelColumn< ColumnType >& column )
 {
     Gtk::TreeModel::Row row = m_treeview.get_row( path );
     if( !row ) return std::string();

--- a/src/board/boardviewbase.h
+++ b/src/board/boardviewbase.h
@@ -104,7 +104,7 @@ namespace BOARD
         ~BoardViewBase();
 
         const std::string& get_url_board() const { return m_url_board; }
-        const std::string url_for_copy() override;
+        std::string url_for_copy() override;
 
         // 行数
         int get_row_size();
@@ -214,12 +214,12 @@ namespace BOARD
         void setup_action();
 
         // 通常の右クリックメニューの作成
-        const std::string create_context_menu();
+        std::string create_context_menu();
         const char* get_menu_item( const int item );
 
         // 次スレ移行処理に使用する前スレのアドレス
         // BOARD::BoardViewNext と BoardViewBase::open_row()を参照せよ
-        virtual const std::string get_url_pre_article(){ return std::string(); }
+        virtual std::string get_url_pre_article(){ return std::string(); }
 
         void update_columns();
 
@@ -278,17 +278,17 @@ namespace BOARD
 
         bool open_row( Gtk::TreePath& path, const bool tab, const bool reget );
         void open_selected_rows( const bool reget );
-        const std::string path2daturl( const Gtk::TreePath& path );
-        const std::string path2url_board( const Gtk::TreePath& path );
+        std::string path2daturl( const Gtk::TreePath& path );
+        std::string path2url_board( const Gtk::TreePath& path );
 
         // 検索
         bool drawout( const bool force_reset );
 
         void update_row_common( const Gtk::TreeModel::Row& row );
-        const std::string get_subject_from_path( Gtk::TreePath& path );
+        std::string get_subject_from_path( Gtk::TreePath& path ); // XXX: 実装がない
 
         template < typename ColumnType >
-        const std::string get_name_of_cell( Gtk::TreePath& path, const Gtk::TreeModelColumn< ColumnType >& column );
+        std::string get_name_of_cell( Gtk::TreePath& path, const Gtk::TreeModelColumn< ColumnType >& column );
 
         void set_article_to_buffer();
         void set_board_to_buffer();

--- a/src/board/boardviewbase.h
+++ b/src/board/boardviewbase.h
@@ -201,7 +201,7 @@ namespace BOARD
         void set_load_subject_txt( const bool load ){ m_load_subject_txt = load; }
 
         // 行を作って内容をセット
-        const Gtk::TreeModel::Row prepend_row( DBTREE::ArticleBase* art, const int id );
+        Gtk::TreeModel::Row prepend_row( DBTREE::ArticleBase* art, const int id );
 
         // デフォルトのソート状態
         virtual int get_default_sort_column();

--- a/src/board/boardviewnext.h
+++ b/src/board/boardviewnext.h
@@ -49,7 +49,7 @@ namespace BOARD
 
         // 次スレ移行処理に使用する前スレのアドレス
         // 次スレ移行処理に使用する。BoardViewBase::open_row()を参照せよ
-        const std::string get_url_pre_article() override { return m_url_pre_article; }
+        std::string get_url_pre_article() override { return m_url_pre_article; }
 
         void slot_abone_thread() override;
 

--- a/src/browsers.cpp
+++ b/src/browsers.cpp
@@ -35,13 +35,13 @@ namespace CORE
 #endif
     };
 
-    const std::string get_browser_label( const int num ){
+    std::string get_browser_label( const int num ){
 
         if( num >= BROWSER_NUM ) return std::string();
         return browsers[ num ][ 0 ];
     }
 
-    const std::string get_browser_name( const int num ){
+    std::string get_browser_name( const int num ){
 
         if( num >= BROWSER_NUM ) return std::string();
         std::string name = browsers[ num ][ 1 ];

--- a/src/browsers.h
+++ b/src/browsers.h
@@ -9,9 +9,9 @@
 
 namespace CORE
 {
-    const std::string get_browser_label( const int num );
+    std::string get_browser_label( const int num );
 
-    const std::string get_browser_name( const int num );
+    std::string get_browser_name( const int num );
 
     int get_browser_number();
 }

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -507,7 +507,7 @@ std::string CACHE::path_aahistory()
 //
 // テーマのルートパス
 //
-const std::string CACHE::path_theme_root()
+std::string CACHE::path_theme_root()
 {
     return CACHE::path_root() + "theme/";
 }
@@ -515,7 +515,7 @@ const std::string CACHE::path_theme_root()
 //
 // アイコンテーマのルートパス
 //
-const std::string CACHE::path_theme_icon_root()
+std::string CACHE::path_theme_icon_root()
 {
     return CACHE::path_theme_root() + "icons/";
 }
@@ -1204,7 +1204,7 @@ guint64 CACHE::get_dirsize( const std::string& dir )
 
 // 相対パスから絶対パスを取得してファイルが存在すれば絶対パスを返す
 // ファイルが存在しない場合は std::string() を返す
-const std::string CACHE::get_realpath( const std::string& path )
+std::string CACHE::get_realpath( const std::string& path )
 {
     std::string path_real;
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -141,10 +141,10 @@ namespace CACHE
     std::string path_aahistory();  // AAの使用履歴ファイル
 
     // テーマのルートパス
-    const std::string path_theme_root();
+    std::string path_theme_root();
 
     // アイコンテーマのルートパス
-    const std::string path_theme_icon_root();
+    std::string path_theme_icon_root();
 
     // css
     std::string path_css();
@@ -236,7 +236,7 @@ namespace CACHE
 
     // 相対パスから絶対パスを取得してファイルが存在すれば絶対パスを返す
     // ファイルが存在しない場合は std::string() を返す
-    const std::string get_realpath( const std::string& path );
+    std::string get_realpath( const std::string& path );
 }
 
 #endif

--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -363,7 +363,7 @@ void AboutConfig::set_value( Gtk::TreeModel::Row& row, const std::string& value 
 }
 
 
-void AboutConfig::set_value( Gtk::TreeModel::Row& row, const int& value )
+void AboutConfig::set_value( Gtk::TreeModel::Row& row, const int value )
 {
     row[ m_columns.m_col_value ] = MISC::itostr( value );
 
@@ -373,7 +373,7 @@ void AboutConfig::set_value( Gtk::TreeModel::Row& row, const int& value )
 }
 
 
-void AboutConfig::set_value( Gtk::TreeModel::Row& row, const bool& value )
+void AboutConfig::set_value( Gtk::TreeModel::Row& row, const bool value )
 {
     if( value ) row[ m_columns.m_col_value ] = "はい";
     else row[ m_columns.m_col_value ] = "いいえ";

--- a/src/config/aboutconfig.h
+++ b/src/config/aboutconfig.h
@@ -78,8 +78,8 @@ namespace CONFIG
         void append_row( const std::string& comment );
 
         void set_value( Gtk::TreeModel::Row& row, const std::string& value );
-        void set_value( Gtk::TreeModel::Row& row, const int& value );
-        void set_value( Gtk::TreeModel::Row& row, const bool& value );
+        void set_value( Gtk::TreeModel::Row& row, const int value );
+        void set_value( Gtk::TreeModel::Row& row, const bool value );
 
         void slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::TreeViewColumn* column );
     };

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -137,11 +137,11 @@ void CONFIG::reset_fonts(){ get_confitem()->reset_fonts(); }
 bool CONFIG::get_aafont_enabled(){ return get_confitem()->aafont_enabled; }
 
 
-const std::string CONFIG::get_ref_prefix(){ return get_confitem()->ref_prefix + get_confitem()->ref_prefix_space_str; }
+std::string CONFIG::get_ref_prefix(){ return get_confitem()->ref_prefix + get_confitem()->ref_prefix_space_str; }
 int CONFIG::ref_prefix_space(){ return get_confitem()->ref_prefix_space; }
 
 // レスにアスキーアートがあると判定する正規表現
-const std::string CONFIG::get_regex_res_aa(){
+std::string CONFIG::get_regex_res_aa(){
     std::string str = get_confitem()->regex_res_aa;
     int size = str.size();
 
@@ -329,10 +329,10 @@ bool CONFIG::get_open_one_category(){ return get_confitem()->open_one_category; 
 bool CONFIG::get_open_one_favorite(){ return get_confitem()->open_one_favorite; }
 
 // デフォルトの書き込み名
-const std::string CONFIG::get_write_name(){ return get_confitem()->write_name; }
+std::string CONFIG::get_write_name(){ return get_confitem()->write_name; }
 
 // デフォルトのメールアドレス
-const std::string CONFIG::get_write_mail(){ return get_confitem()->write_mail; }
+std::string CONFIG::get_write_mail(){ return get_confitem()->write_mail; }
 
 bool CONFIG::get_always_write_ok() { return get_confitem()->always_write_ok; }
 void CONFIG::set_always_write_ok( const bool write_ok ){ get_confitem()->always_write_ok = write_ok; }

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -88,13 +88,13 @@ namespace CONFIG
     bool get_aafont_enabled();
 
     // レスを参照するときに前に付ける文字
-    const std::string get_ref_prefix();
+    std::string get_ref_prefix();
 
     // 参照文字( ref_prefix ) の後のスペースの数
     int ref_prefix_space();
 
     // レスにアスキーアートがあると判定する正規表現
-    const std::string get_regex_res_aa();
+    std::string get_regex_res_aa();
     void set_regex_res_aa( const std::string& regex );
 
     // JD ホームページのアドレス
@@ -339,10 +339,10 @@ namespace CONFIG
     bool get_open_one_favorite();
 
     // デフォルトの書き込み名
-    const std::string get_write_name();
+    std::string get_write_name();
 
     // デフォルトのメールアドレス
-    const std::string get_write_mail();
+    std::string get_write_mail();
 
     // 書き込み時に書き込み確認ダイアログを出すかどうか
     bool get_always_write_ok();

--- a/src/control/buttonpref.cpp
+++ b/src/control/buttonpref.cpp
@@ -42,11 +42,10 @@ std::string ButtonDiag::get_default_motions( const int id )
 }
 
 
-const std::vector< int > ButtonDiag::check_conflict( const int mode, const std::string& str_motion )
+std::vector< int > ButtonDiag::check_conflict( const int mode, const std::string& str_motion )
 {
     // 衝突判定をしない
-    std::vector< int > vec_ids;
-    return vec_ids;
+    return {};
 }
 
 

--- a/src/control/buttonpref.cpp
+++ b/src/control/buttonpref.cpp
@@ -36,7 +36,7 @@ InputDiag* ButtonDiag::create_inputdiag()
 }
 
 
-const std::string ButtonDiag::get_default_motions( const int id )
+std::string ButtonDiag::get_default_motions( const int id )
 {
     return CONTROL::get_default_buttonmotions( id );
 }
@@ -127,13 +127,13 @@ MouseKeyDiag* ButtonPref::create_setting_diag( const int id, const std::string& 
 }
 
 
-const std::string ButtonPref::get_str_motions( const int id )
+std::string ButtonPref::get_str_motions( const int id )
 {
     return CONTROL::get_str_buttonmotions( id );
 }
 
 
-const std::string ButtonPref::get_default_motions( const int id )
+std::string ButtonPref::get_default_motions( const int id )
 {
     return CONTROL::get_default_buttonmotions( id );
 }

--- a/src/control/buttonpref.h
+++ b/src/control/buttonpref.h
@@ -41,7 +41,7 @@ namespace CONTROL
 
         InputDiag* create_inputdiag() override;
         std::string get_default_motions( const int id ) override;
-        const std::vector< int > check_conflict( const int mode, const std::string& str_motion ) override;
+        std::vector< int > check_conflict( const int mode, const std::string& str_motion ) override;
     };
 
 

--- a/src/control/buttonpref.h
+++ b/src/control/buttonpref.h
@@ -40,7 +40,7 @@ namespace CONTROL
       protected:
 
         InputDiag* create_inputdiag() override;
-        const std::string get_default_motions( const int id ) override;
+        std::string get_default_motions( const int id ) override;
         const std::vector< int > check_conflict( const int mode, const std::string& str_motion ) override;
     };
 
@@ -60,8 +60,8 @@ namespace CONTROL
       protected:
 
         MouseKeyDiag* create_setting_diag( const int id, const std::string& str_motions ) override;
-        const std::string get_str_motions( const int id ) override;
-        const std::string get_default_motions( const int id ) override;
+        std::string get_str_motions( const int id ) override;
+        std::string get_default_motions( const int id ) override;
         void set_motions( const int id, const std::string& str_motions ) override;
         bool remove_motions( const int id ) override;
 

--- a/src/control/controlutil.cpp
+++ b/src/control/controlutil.cpp
@@ -768,7 +768,7 @@ bool CONTROL::remove_keymotions( const int id )
 
 
 // キーボード操作が重複していないか
-const std::vector< int > CONTROL::check_key_conflict( const int mode, const std::string& str_motion )
+std::vector< int > CONTROL::check_key_conflict( const int mode, const std::string& str_motion )
 {
     return CONTROL::get_keyconfig()->check_conflict( mode, str_motion );
 }
@@ -877,7 +877,7 @@ bool CONTROL::remove_mousemotions( const int id )
 
 
 // マウスジェスチャが重複していないか
-const std::vector< int > CONTROL::check_mouse_conflict( const int mode, const std::string& str_motion )
+std::vector< int > CONTROL::check_mouse_conflict( const int mode, const std::string& str_motion )
 {
     const std::string motion = convert_mouse_motions_reverse( str_motion );
     return CONTROL::get_mouseconfig()->check_conflict( mode, motion );
@@ -930,7 +930,7 @@ bool CONTROL::remove_buttonmotions( const int id )
 
 
     // ボタンが重複していないか
-const std::vector< int > CONTROL::check_button_conflict( const int mode, const std::string& str_motion )
+std::vector< int > CONTROL::check_button_conflict( const int mode, const std::string& str_motion )
 {
     return CONTROL::get_buttonconfig()->check_conflict( mode, str_motion );
 }

--- a/src/control/controlutil.cpp
+++ b/src/control/controlutil.cpp
@@ -249,7 +249,7 @@ int CONTROL::get_mode( const int id )
 
 // 操作モードIDからモード名取得
 // 例えば mode == CONTROL::MODE_COMMON の時は "共通" を返す
-const std::string CONTROL::get_mode_label( const int mode )
+std::string CONTROL::get_mode_label( const int mode )
 {
     if( mode < CONTROL::MODE_START || mode > MODE_END ) return std::string();
 
@@ -289,7 +289,7 @@ guint CONTROL::get_keysym( const std::string& keyname )
 
 // keysymからキー名を取得
 // 例えば keysym == GDK_space の時は "Space"  を返す
-const std::string CONTROL::get_keyname( const guint keysym )
+std::string CONTROL::get_keyname( const guint keysym )
 {
 #ifdef _DEBUG
     std::cout << "CONTROL::get_keyname sym = " << keysym;
@@ -336,7 +336,7 @@ int CONTROL::get_id( const std::string& name )
 
 // IDから操作名取得
 // 例えば id == CONTROL::Up の時は "Up" を返す
-const std::string CONTROL::get_name( const int id )
+std::string CONTROL::get_name( const int id )
 {
     if( id < CONTROL::COMMONMOTION || id >=  CONTROL::CONTROL_END ) return std::string();
 
@@ -346,7 +346,7 @@ const std::string CONTROL::get_name( const int id )
 
 // IDからラベル取得
 // 例えば id == CONTROL::Up の時は "上移動" を返す
-const std::string CONTROL::get_label( const int id )
+std::string CONTROL::get_label( const int id )
 {
     if( id < CONTROL::COMMONMOTION || id >=  CONTROL::CONTROL_END ) return std::string();
 
@@ -356,7 +356,7 @@ const std::string CONTROL::get_label( const int id )
 
 // IDからショートカットを付けたラベルを取得
 // 例えば id == CONTROL::Save の時は "名前を付けて保存(_S)..." を返す
-const std::string CONTROL::get_label_with_mnemonic( const int id )
+std::string CONTROL::get_label_with_mnemonic( const int id )
 {
     unsigned int pos;
 
@@ -540,7 +540,7 @@ const std::string CONTROL::get_label_with_mnemonic( const int id )
 
 
 // IDからキーボードとマウスジェスチャの両方を取得
-const std::string CONTROL::get_str_motions( const int id )
+std::string CONTROL::get_str_motions( const int id )
 {
     int ctl = id;
 
@@ -570,7 +570,7 @@ const std::string CONTROL::get_str_motions( const int id )
 
 
 // IDからラベルと操作の両方を取得
-const std::string CONTROL::get_label_motions( const int id )
+std::string CONTROL::get_label_motions( const int id )
 {
     std::string motion = CONTROL::get_str_motions( id );
     return CONTROL::get_label( id ) + ( motion.empty() ? "" :  "  " ) + motion;
@@ -740,14 +740,14 @@ void CONTROL::restore_keyconfig()
 
 
 // IDからキーボード操作を取得
-const std::string CONTROL::get_str_keymotions( const int id )
+std::string CONTROL::get_str_keymotions( const int id )
 {
     return CONTROL::get_keyconfig()->get_str_motions( id );
 }
 
 
 // IDからデフォルトキーボード操作を取得
-const std::string CONTROL::get_default_keymotions( const int id )
+std::string CONTROL::get_default_keymotions( const int id )
 {
     return CONTROL::get_keyconfig()->get_default_motions( id );
 }
@@ -848,14 +848,14 @@ void CONTROL::restore_mouseconfig()
 
 
 // IDからマウスジェスチャを取得
-const std::string CONTROL::get_str_mousemotions( const int id )
+std::string CONTROL::get_str_mousemotions( const int id )
 {
     return convert_mouse_motions( CONTROL::get_mouseconfig()->get_str_motions( id ) );
 }
 
 
 // IDからデフォルトマウスジェスチャを取得
-const std::string CONTROL::get_default_mousemotions( const int id )
+std::string CONTROL::get_default_mousemotions( const int id )
 {
     return convert_mouse_motions( CONTROL::get_mouseconfig()->get_default_motions( id ) );
 }
@@ -903,14 +903,14 @@ void CONTROL::restore_buttonconfig()
 
 
 // IDからボタン設定を取得
-const std::string CONTROL::get_str_buttonmotions( const int id )
+std::string CONTROL::get_str_buttonmotions( const int id )
 {
     return CONTROL::get_buttonconfig()->get_str_motions( id );
 }
 
 
 // IDからデフォルトボタン設定を取得
-const std::string CONTROL::get_default_buttonmotions( const int id )
+std::string CONTROL::get_default_buttonmotions( const int id )
 {
     return CONTROL::get_buttonconfig()->get_default_motions( id );
 }

--- a/src/control/controlutil.h
+++ b/src/control/controlutil.h
@@ -92,7 +92,7 @@ namespace CONTROL
     bool remove_keymotions( const int id );
 
     // キーボード操作が重複していないか
-    const std::vector< int > check_key_conflict( const int mode, const std::string& str_motion );
+    std::vector< int > check_key_conflict( const int mode, const std::string& str_motion );
 
     // editviewの操作をemacs風にする
     bool is_emacs_mode();
@@ -126,7 +126,7 @@ namespace CONTROL
     bool remove_mousemotions( const int id );
 
     // マウスジェスチャが重複していないか
-    const std::vector< int > check_mouse_conflict( const int mode, const std::string& str_motion );
+    std::vector< int > check_mouse_conflict( const int mode, const std::string& str_motion );
 
 
     ///////////////////////
@@ -149,7 +149,7 @@ namespace CONTROL
     bool remove_buttonmotions( const int id );
 
     // ボタンが重複していないか
-    const std::vector< int > check_button_conflict( const int mode, const std::string& str_motion );
+    std::vector< int > check_button_conflict( const int mode, const std::string& str_motion );
 
 
     ///////////////////////

--- a/src/control/controlutil.h
+++ b/src/control/controlutil.h
@@ -36,7 +36,7 @@ namespace CONTROL
 
     // 操作モードIDからモード名取得
     // 例えば mode == CONTROL::MODE_COMMON の時は "共通" を返す
-    const std::string get_mode_label( const int mode );
+    std::string get_mode_label( const int mode );
 
     // キー名からkeysymを取得
     // 例えば keyname == "Space" の時は GDK_space を返す
@@ -44,7 +44,7 @@ namespace CONTROL
 
     // keysymからキー名を取得
     // 例えば keysym == GDK_space の時は "Space"  を返す
-    const std::string get_keyname( const guint keysym );
+    std::string get_keyname( const guint keysym );
 
     // 操作名からID取得
     // 例えば name == "Up" の時は CONTROL::Up を返す
@@ -52,21 +52,21 @@ namespace CONTROL
 
     // IDから操作名取得
     // 例えば id == CONTROL::Up の時は "Up" を返す
-    const std::string get_name( const int id );
+    std::string get_name( const int id );
 
     // IDからラベル取得
     // 例えば id == CONTROL::Up の時は "上移動" を返す
-    const std::string get_label( const int id );
+    std::string get_label( const int id );
 
     // IDからショートカットを付けたラベルを取得
     // 例えば id == CONTROL::Save の時は "名前を付けて保存(_S)..." を返す
-    const std::string get_label_with_mnemonic( const int id );
+    std::string get_label_with_mnemonic( const int id );
 
     // IDからキーボードとマウスジェスチャの両方を取得
-    const std::string get_str_motions( const int id );
+    std::string get_str_motions( const int id );
 
     // IDからラベルと操作の両方を取得
-    const std::string get_label_motions( const int id );
+    std::string get_label_motions( const int id );
 
     // 共通操作
     bool operate_common( const int control, const std::string& url, SKELETON::Admin* admin );
@@ -80,10 +80,10 @@ namespace CONTROL
     void restore_keyconfig();
 
     // IDからキーボード操作を取得
-    const std::string get_str_keymotions( const int id );
+    std::string get_str_keymotions( const int id );
 
     // IDからデフォルトキーボード操作を取得
-    const std::string get_default_keymotions( const int id );
+    std::string get_default_keymotions( const int id );
 
     // スペースで区切られた複数のキーボード操作をデータベースに登録
     void set_keymotions( const int id, const std::string& str_motions );
@@ -114,10 +114,10 @@ namespace CONTROL
     void restore_mouseconfig();
 
     // IDからマウスジェスチャを取得
-    const std::string get_str_mousemotions( const int id );
+    std::string get_str_mousemotions( const int id );
 
     // IDからデフォルトマウスジェスチャを取得
-    const std::string get_default_mousemotions( const int id );
+    std::string get_default_mousemotions( const int id );
 
     // スペースで区切られた複数のマウスジェスチャをデータベースに登録
     void set_mousemotions( const int id, const std::string& str_motions );
@@ -137,10 +137,10 @@ namespace CONTROL
     void restore_buttonconfig();
 
     // IDからボタン設定を取得
-    const std::string get_str_buttonmotions( const int id );
+    std::string get_str_buttonmotions( const int id );
 
     // IDからデフォルトボタン設定を取得
-    const std::string get_default_buttonmotions( const int id );
+    std::string get_default_buttonmotions( const int id );
 
     // スペースで区切られた複数のボタン設定をデータベースに登録
     void set_buttonmotions( const int id, const std::string& str_motions );

--- a/src/control/keypref.cpp
+++ b/src/control/keypref.cpp
@@ -42,7 +42,7 @@ InputDiag* KeyDiag::create_inputdiag()
 }
 
 
-const std::string KeyDiag::get_default_motions( const int id )
+std::string KeyDiag::get_default_motions( const int id )
 {
     return CONTROL::get_default_keymotions( id );
 }
@@ -237,13 +237,13 @@ MouseKeyDiag* KeyPref::create_setting_diag( const int id, const std::string& str
 }
 
 
-const std::string KeyPref::get_str_motions( const int id )
+std::string KeyPref::get_str_motions( const int id )
 {
     return CONTROL::get_str_keymotions( id );
 }
 
 
-const std::string KeyPref::get_default_motions( const int id )
+std::string KeyPref::get_default_motions( const int id )
 {
     return CONTROL::get_default_keymotions( id );
 }

--- a/src/control/keypref.cpp
+++ b/src/control/keypref.cpp
@@ -48,7 +48,7 @@ std::string KeyDiag::get_default_motions( const int id )
 }
 
 
-const std::vector< int > KeyDiag::check_conflict( const int mode, const std::string& str_motion )
+std::vector< int > KeyDiag::check_conflict( const int mode, const std::string& str_motion )
 {
     return CONTROL::check_key_conflict( mode, str_motion );
 }

--- a/src/control/keypref.h
+++ b/src/control/keypref.h
@@ -38,7 +38,7 @@ namespace CONTROL
       protected:
 
         InputDiag* create_inputdiag() override;
-        const std::string get_default_motions( const int id ) override;
+        std::string get_default_motions( const int id ) override;
         const std::vector< int > check_conflict( const int mode, const std::string& str_motion ) override;
     };
 
@@ -57,8 +57,8 @@ namespace CONTROL
       protected:
 
         MouseKeyDiag* create_setting_diag( const int id, const std::string& str_motions ) override;
-        const std::string get_str_motions( const int id ) override;
-        const std::string get_default_motions( const int id ) override;
+        std::string get_str_motions( const int id ) override;
+        std::string get_default_motions( const int id ) override;
         void set_motions( const int id, const std::string& str_motions ) override;
         bool remove_motions( const int id ) override;
 

--- a/src/control/keypref.h
+++ b/src/control/keypref.h
@@ -39,7 +39,7 @@ namespace CONTROL
 
         InputDiag* create_inputdiag() override;
         std::string get_default_motions( const int id ) override;
-        const std::vector< int > check_conflict( const int mode, const std::string& str_motion ) override;
+        std::vector< int > check_conflict( const int mode, const std::string& str_motion ) override;
     };
 
 

--- a/src/control/mouseconfig.cpp
+++ b/src/control/mouseconfig.cpp
@@ -105,7 +105,7 @@ void MouseConfig::set_one_motion_impl( const int id, const int mode, const std::
 
 
 // 操作文字列取得
-const std::string MouseConfig::get_str_motions( const int id_ )
+std::string MouseConfig::get_str_motions( const int id_ )
 {
     int id = id_;
 
@@ -117,7 +117,7 @@ const std::string MouseConfig::get_str_motions( const int id_ )
 
 
 // IDからデフォルトの操作文字列取得
-const std::string MouseConfig::get_default_motions( const int id_ )
+std::string MouseConfig::get_default_motions( const int id_ )
 {
     int id = id_;
     if( id == CONTROL::CancelMosaic ) id = CONTROL::CancelMosaicButton;

--- a/src/control/mouseconfig.h
+++ b/src/control/mouseconfig.h
@@ -21,10 +21,10 @@ namespace CONTROL
         void load_conf() override;
 
         // 操作文字列取得
-        const std::string get_str_motions( const int id ) override;
+        std::string get_str_motions( const int id ) override;
 
         // IDからデフォルトの操作文字列取得
-        const std::string get_default_motions( const int id ) override;
+        std::string get_default_motions( const int id ) override;
 
       private:
 

--- a/src/control/mousekeyconf.cpp
+++ b/src/control/mousekeyconf.cpp
@@ -140,7 +140,7 @@ const std::vector< int >  MouseKeyConf::check_conflict( const int mode, const st
 
 
 // IDから操作文字列取得
-const std::string MouseKeyConf::get_str_motions( const int id )
+std::string MouseKeyConf::get_str_motions( const int id )
 {
     std::string motions;
 
@@ -158,7 +158,7 @@ const std::string MouseKeyConf::get_str_motions( const int id )
 
 
 // IDからデフォルトの操作文字列取得
-const std::string MouseKeyConf::get_default_motions( const int id )
+std::string MouseKeyConf::get_default_motions( const int id )
 {
     std::map< int, std::string >::iterator it = m_map_default_motions.find( id );
     if( it != m_map_default_motions.end() ) return ( *it ).second;

--- a/src/control/mousekeyconf.cpp
+++ b/src/control/mousekeyconf.cpp
@@ -124,7 +124,7 @@ bool MouseKeyConf::alloted( const int id,
 
 
 // 同じモード内でモーションが重複していないかチェック
-const std::vector< int >  MouseKeyConf::check_conflict( const int mode, const std::string& str_motion )
+std::vector< int > MouseKeyConf::check_conflict( const int mode, const std::string& str_motion )
 {
     std::vector< int > vec_ids;
 

--- a/src/control/mousekeyconf.h
+++ b/src/control/mousekeyconf.h
@@ -57,7 +57,7 @@ namespace CONTROL
 
         // 同じモード内でモーションが重複していないかチェック
         // 戻り値 : コントロールID
-        const std::vector< int > check_conflict( const int mode, const std::string& str_motion );
+        std::vector< int > check_conflict( const int mode, const std::string& str_motion );
 
         // スペースで区切られた複数の操作をデータベースに登録
         void set_motions( const int id, const std::string& str_motions );

--- a/src/control/mousekeyconf.h
+++ b/src/control/mousekeyconf.h
@@ -50,10 +50,10 @@ namespace CONTROL
                       const bool dblclick, const bool trpclick );
 
         // IDから操作文字列取得
-        virtual const std::string get_str_motions( const int id );
+        virtual std::string get_str_motions( const int id );
 
         // IDからデフォルトの操作文字列取得
-        virtual const std::string get_default_motions( const int id );
+        virtual std::string get_default_motions( const int id );
 
         // 同じモード内でモーションが重複していないかチェック
         // 戻り値 : コントロールID

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -205,7 +205,7 @@ bool InputDiag::on_motion_notify_event( GdkEventMotion* event )
 }
 
 
-const std::string InputDiag::get_key_label()
+std::string InputDiag::get_key_label()
 {
     std::string label;
 
@@ -225,7 +225,7 @@ const std::string InputDiag::get_key_label()
 
 
 
-const std::string InputDiag::get_mouse_label()
+std::string InputDiag::get_mouse_label()
 {
     std::string label;
 
@@ -244,7 +244,7 @@ const std::string InputDiag::get_mouse_label()
 }
 
 
-const std::string InputDiag::get_button_label()
+std::string InputDiag::get_button_label()
 {
     std::string label;
 
@@ -335,7 +335,7 @@ Gtk::TreeModel::Row MouseKeyDiag::append_row( const std::string& motion )
 }
 
 
-const std::string MouseKeyDiag::get_str_motions()
+std::string MouseKeyDiag::get_str_motions()
 {
     std::string str_motions;
 
@@ -357,7 +357,7 @@ const std::string MouseKeyDiag::get_str_motions()
 //
 // 入力ダイアログを表示
 //
-const std::string MouseKeyDiag::show_inputdiag( bool is_append )
+std::string MouseKeyDiag::show_inputdiag( bool is_append )
 {
     std::string str_motion;
 

--- a/src/control/mousekeypref.h
+++ b/src/control/mousekeypref.h
@@ -118,7 +118,7 @@ namespace CONTROL
 
         virtual InputDiag* create_inputdiag() = 0;
         virtual std::string get_default_motions( const int id ) = 0;
-        virtual const std::vector< int > check_conflict( const int mode, const std::string& str_motion ) = 0;
+        virtual std::vector< int > check_conflict( const int mode, const std::string& str_motion ) = 0;
 
       private:
 

--- a/src/control/mousekeypref.h
+++ b/src/control/mousekeypref.h
@@ -48,9 +48,9 @@ namespace CONTROL
 
         int get_id() const { return m_id; }
 
-        const std::string get_key_label();
-        const std::string get_mouse_label();
-        const std::string get_button_label();
+        std::string get_key_label();
+        std::string get_mouse_label();
+        std::string get_button_label();
 
       private:
 
@@ -105,7 +105,7 @@ namespace CONTROL
         MouseKeyDiag( Gtk::Window* parent, const std::string& url,
                       const int id, const std::string& target, const std::string& str_motions );
 
-        const std::string get_str_motions();
+        std::string get_str_motions();
 
       protected:
 
@@ -117,7 +117,7 @@ namespace CONTROL
         void set_single( bool single ){ m_single = single; }
 
         virtual InputDiag* create_inputdiag() = 0;
-        virtual const std::string get_default_motions( const int id ) = 0;
+        virtual std::string get_default_motions( const int id ) = 0;
         virtual const std::vector< int > check_conflict( const int mode, const std::string& str_motion ) = 0;
 
       private:
@@ -125,7 +125,7 @@ namespace CONTROL
         Gtk::TreeModel::Row append_row( const std::string& motion );
 
         // 入力ダイアログを表示
-        const std::string show_inputdiag( bool is_append );
+        std::string show_inputdiag( bool is_append );
 
         // 行をダブルクリック
         void slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::TreeViewColumn* column );
@@ -191,8 +191,8 @@ namespace CONTROL
         void append_comment_row( const std::string& comment );
 
         virtual MouseKeyDiag* create_setting_diag( const int id, const std::string& str_motions ) = 0;
-        virtual const std::string get_str_motions( const int id ) = 0;
-        virtual const std::string get_default_motions( const int id ) = 0;
+        virtual std::string get_str_motions( const int id ) = 0;
+        virtual std::string get_default_motions( const int id ) = 0;
         virtual void set_motions( const int id, const std::string& str_motions ) = 0;
         virtual bool remove_motions( const int id ) = 0;
 

--- a/src/control/mousepref.cpp
+++ b/src/control/mousepref.cpp
@@ -42,7 +42,7 @@ std::string MouseDiag::get_default_motions( const int id )
 }
 
 
-const std::vector< int > MouseDiag::check_conflict( const int mode, const std::string& str_motion )
+std::vector< int > MouseDiag::check_conflict( const int mode, const std::string& str_motion )
 {
     return CONTROL::check_mouse_conflict( mode, str_motion );
 }

--- a/src/control/mousepref.cpp
+++ b/src/control/mousepref.cpp
@@ -36,7 +36,7 @@ InputDiag* MouseDiag::create_inputdiag()
 }
 
 
-const std::string MouseDiag::get_default_motions( const int id )
+std::string MouseDiag::get_default_motions( const int id )
 {
     return CONTROL::get_default_mousemotions( id );
 }
@@ -118,13 +118,13 @@ MouseKeyDiag* MousePref::create_setting_diag( const int id, const std::string& s
 }
 
 
-const std::string MousePref::get_str_motions( const int id )
+std::string MousePref::get_str_motions( const int id )
 {
     return CONTROL::get_str_mousemotions( id );
 }
 
 
-const std::string MousePref::get_default_motions( const int id )
+std::string MousePref::get_default_motions( const int id )
 {
     return CONTROL::get_default_mousemotions( id );
 }

--- a/src/control/mousepref.h
+++ b/src/control/mousepref.h
@@ -39,7 +39,7 @@ namespace CONTROL
       protected:
 
         InputDiag* create_inputdiag() override;
-        const std::string get_default_motions( const int id ) override;
+        std::string get_default_motions( const int id ) override;
         const std::vector< int > check_conflict( const int mode, const std::string& str_motion ) override;
     };
 
@@ -59,8 +59,8 @@ namespace CONTROL
       protected:
 
         MouseKeyDiag* create_setting_diag( const int id, const std::string& str_motions ) override;
-        const std::string get_str_motions( const int id ) override;
-        const std::string get_default_motions( const int id ) override;
+        std::string get_str_motions( const int id ) override;
+        std::string get_default_motions( const int id ) override;
         void set_motions( const int id, const std::string& str_motions ) override;
         bool remove_motions( const int id ) override;
 

--- a/src/control/mousepref.h
+++ b/src/control/mousepref.h
@@ -40,7 +40,7 @@ namespace CONTROL
 
         InputDiag* create_inputdiag() override;
         std::string get_default_motions( const int id ) override;
-        const std::vector< int > check_conflict( const int mode, const std::string& str_motion ) override;
+        std::vector< int > check_conflict( const int mode, const std::string& str_motion ) override;
     };
 
 

--- a/src/dbimg/img.cpp
+++ b/src/dbimg/img.cpp
@@ -239,7 +239,7 @@ void Img::set_abone( bool abone )
 }
 
 
-const std::string Img::get_cache_path()
+std::string Img::get_cache_path()
 {
     if( m_protect ) return CACHE::path_img_protect( m_url );
 

--- a/src/dbimg/img.h
+++ b/src/dbimg/img.h
@@ -62,7 +62,7 @@ namespace DBIMG
         void clear();
 
         const std::string& url() const { return m_url; }
-        const std::string get_cache_path();
+        std::string get_cache_path();
 
         bool is_wait() const { return m_wait; }
 

--- a/src/dbimg/imginterface.cpp
+++ b/src/dbimg/imginterface.cpp
@@ -81,7 +81,7 @@ DBIMG::Img* DBIMG::get_img( const std::string& url )
 }
 
 
-const std::string DBIMG::get_cache_path( const std::string& url )
+std::string DBIMG::get_cache_path( const std::string& url )
 {
     DBIMG::Img* img = DBIMG::get_img( url );
     if( img ) return img->get_cache_path();
@@ -201,7 +201,7 @@ int DBIMG::get_code( const std::string& url )
 }
 
 
-const std::string DBIMG::get_str_code( const std::string& url )
+std::string DBIMG::get_str_code( const std::string& url )
 {
     DBIMG::Img* img = DBIMG::get_img( url );
     if( img ) return img->get_str_code();
@@ -261,7 +261,7 @@ void DBIMG::set_size( const std::string& url, int size )
 }
 
 
-const std::string DBIMG::get_refurl( const std::string& url )
+std::string DBIMG::get_refurl( const std::string& url )
 {
     DBIMG::Img* img = DBIMG::get_img( url );
     if( img ) return img->get_refurl();

--- a/src/dbimg/imginterface.h
+++ b/src/dbimg/imginterface.h
@@ -62,7 +62,7 @@ namespace DBIMG
     int get_type_real( const std::string& url );
 
     DBIMG::Img* get_img( const std::string& url );
-    const std::string get_cache_path( const std::string& url );
+    std::string get_cache_path( const std::string& url );
 
     // ロード開始
     // refurl : 参照元のスレのアドレス
@@ -86,7 +86,7 @@ namespace DBIMG
     bool is_loading( const std::string& url );
     bool is_wait( const std::string& url );
     int get_code( const std::string& url );
-    const std::string get_str_code( const std::string& url );
+    std::string get_str_code( const std::string& url );
     bool get_mosaic( const std::string& url );
     void set_mosaic( const std::string& url, bool mosaic );
     void show_large_img( const std::string& url );
@@ -94,7 +94,7 @@ namespace DBIMG
     void set_zoom_to_fit( const std::string& url, bool fit );
     int get_size( const std::string& url );
     void set_size( const std::string& url, int size );
-    const std::string get_refurl( const std::string& url );
+    std::string get_refurl( const std::string& url );
 
     size_t byte( const std::string& url );
     size_t get_filesize( const std::string& url );

--- a/src/dbtree/article2ch.cpp
+++ b/src/dbtree/article2ch.cpp
@@ -31,7 +31,7 @@ Article2ch::~Article2ch() noexcept
 
 
 // 書き込みメッセージ変換
-const std::string Article2ch::create_write_message( const std::string& name, const std::string& mail, const std::string& msg )
+std::string Article2ch::create_write_message( const std::string& name, const std::string& mail, const std::string& msg )
 {
     if( msg.empty() ) return std::string();
 
@@ -82,7 +82,7 @@ const std::string Article2ch::create_write_message( const std::string& name, con
 // (例) "http://www.hoge2ch.net/test/bbs.cgi"
 //
 //
-const std::string Article2ch::url_bbscgi()
+std::string Article2ch::url_bbscgi()
 {
     if( CORE::get_loginp2()->login_now() ) return CONFIG::get_url_loginp2() + "post.php";
 
@@ -96,7 +96,7 @@ const std::string Article2ch::url_bbscgi()
 //
 // (例) "http://www.hoge2ch.net/test/subbbs.cgi"
 //
-const std::string Article2ch::url_subbbscgi()
+std::string Article2ch::url_subbbscgi()
 {
     if( CORE::get_loginp2()->login_now() ) return CONFIG::get_url_loginp2() + "post.php";
 

--- a/src/dbtree/article2ch.h
+++ b/src/dbtree/article2ch.h
@@ -19,14 +19,14 @@ namespace DBTREE
         ~Article2ch() noexcept;
 
         // 書き込みメッセージ変換
-        const std::string create_write_message( const std::string& name, const std::string& mail,
-                                                const std::string& msg ) override;
+        std::string create_write_message( const std::string& name, const std::string& mail,
+                                          const std::string& msg ) override;
 
         // bbscgi のURL
-        const std::string url_bbscgi() override;
+        std::string url_bbscgi() override;
         
         // subbbscgi のURL
-        const std::string url_subbbscgi() override;
+        std::string url_subbbscgi() override;
 
       protected:
 

--- a/src/dbtree/article2chcompati.cpp
+++ b/src/dbtree/article2chcompati.cpp
@@ -41,7 +41,7 @@ Article2chCompati::~Article2chCompati() noexcept
 
 
 // 書き込みメッセージ変換
-const std::string Article2chCompati::create_write_message( const std::string& name, const std::string& mail, const std::string& msg )
+std::string Article2chCompati::create_write_message( const std::string& name, const std::string& mail, const std::string& msg )
 {
     if( msg.empty() ) return std::string();
 
@@ -73,7 +73,7 @@ const std::string Article2chCompati::create_write_message( const std::string& na
 // (例) "http://www.hoge2ch.net/test/bbs.cgi"
 //
 //
-const std::string Article2chCompati::url_bbscgi()
+std::string Article2chCompati::url_bbscgi()
 {
     std::string cgibase = DBTREE::url_bbscgibase( get_url() );
     return cgibase.substr( 0, cgibase.length() -1 ); // 最後の '/' を除く
@@ -86,7 +86,7 @@ const std::string Article2chCompati::url_bbscgi()
 //
 // (例) "http://www.hoge2ch.net/test/subbbs.cgi"
 //
-const std::string Article2chCompati::url_subbbscgi()
+std::string Article2chCompati::url_subbbscgi()
 {
     std::string cgibase = DBTREE::url_subbbscgibase( get_url() );
     return cgibase.substr( 0, cgibase.length() -1 ); // 最後の '/' を除く

--- a/src/dbtree/article2chcompati.h
+++ b/src/dbtree/article2chcompati.h
@@ -19,14 +19,14 @@ namespace DBTREE
         ~Article2chCompati() noexcept;
 
         // 書き込みメッセージ変換
-        const std::string create_write_message( const std::string& name, const std::string& mail,
-                                                const std::string& msg ) override;
+        std::string create_write_message( const std::string& name, const std::string& mail,
+                                          const std::string& msg ) override;
 
         // bbscgi のURL
-        const std::string url_bbscgi() override;
+        std::string url_bbscgi() override;
         
         // subbbscgi のURL
-        const std::string url_subbbscgi() override;
+        std::string url_subbbscgi() override;
 
       private:
         

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -137,7 +137,7 @@ bool ArticleBase::equal( const std::string& datbase, const std::string& id )
 //
 // 移転する前のオリジナルのURL
 //
-const std::string ArticleBase::get_org_url()
+std::string ArticleBase::get_org_url()
 {
     std::string newhost = MISC::get_hostname( m_url );
     return m_org_host + m_url.substr( newhost.length() );
@@ -185,7 +185,7 @@ NODE* ArticleBase::res_header( int number )
 //
 // number番の名前
 //
-const std::string ArticleBase::get_name( int number )
+std::string ArticleBase::get_name( int number )
 {
     return get_nodetree()->get_name( number );
 }
@@ -213,7 +213,7 @@ std::list< int > ArticleBase::get_res_name( const std::string& name )
 // number番のレスの時刻を文字列で取得
 // 内部で regex　を使っているので遅い
 //
-const std::string ArticleBase::get_time_str( int number )
+std::string ArticleBase::get_time_str( int number )
 {
     return get_nodetree()->get_time_str( number );
 }
@@ -222,7 +222,7 @@ const std::string ArticleBase::get_time_str( int number )
 //
 // number番の発言者ID
 //
-const std::string ArticleBase::get_id_name( int number )
+std::string ArticleBase::get_id_name( int number )
 {
     return get_nodetree()->get_id_name( number );
 }
@@ -334,7 +334,7 @@ const std::list< int > ArticleBase::get_res_query( const std::string& query, con
 // number番のレスの文字列を返す
 // ref == true なら先頭に ">" を付ける        
 //
-const std::string ArticleBase::get_res_str( int number, bool ref )
+std::string ArticleBase::get_res_str( int number, bool ref )
 {
     return get_nodetree()->get_res_str( number, ref );
 }
@@ -343,7 +343,7 @@ const std::string ArticleBase::get_res_str( int number, bool ref )
 //
 // number　番のレスの生文字列を返す
 //
-const std::string ArticleBase::get_raw_res_str( int number )
+std::string ArticleBase::get_raw_res_str( int number )
 {
     return get_nodetree()->get_raw_res_str( number );
 }
@@ -424,7 +424,7 @@ void ArticleBase::set_org_host( const std::string& host )
 //
 // access_time を 文字列に変換して返す
 //
-const std::string ArticleBase::get_access_time_str()
+std::string ArticleBase::get_access_time_str()
 {
     return MISC::timevaltostr( m_access_time );
 }

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -322,7 +322,7 @@ std::list< int > ArticleBase::get_res_with_url()
 //
 // mode_or == true なら OR抽出
 //
-const std::list< int > ArticleBase::get_res_query( const std::string& query, const bool mode_or )
+std::list< int > ArticleBase::get_res_query( const std::string& query, const bool mode_or )
 {
     if( empty() ){ std::list< int > tmp; return tmp; }
 

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -132,7 +132,7 @@ namespace DBTREE
         void update_datbase( const std::string& datbase );
 
         // 移転する前のオリジナルのURL
-        const std::string get_org_url();
+        std::string get_org_url();
 
         // 移転する前のオリジナルのホスト名
         const std::string& get_org_host() const { return m_org_host; }
@@ -159,7 +159,7 @@ namespace DBTREE
         NODE* res_header( int number );
 
         // number番のレスの発言者の名前
-        const std::string get_name( int number );
+        std::string get_name( int number );
 
         // number番の名前の重複数( = 発言数 )
         int get_num_name( int number );
@@ -169,10 +169,10 @@ namespace DBTREE
 
         // number番のレスの時刻を文字列で取得
         // 内部で regex　を使っているので遅い
-        const std::string get_time_str( int number );
+        std::string get_time_str( int number );
 
         // number番のレスの発言者ID( スレIDではなくて名前の横のID )
-        const std::string get_id_name( int number );
+        std::string get_id_name( int number );
 
         // 指定した発言者ID の重複数( = 発言数 )
         // (注) 下の get_num_id_name( int number )と違って検索するので遅い
@@ -210,10 +210,10 @@ namespace DBTREE
 
         // number番のレスの文字列を返す
         // ref == true なら先頭に ">" を付ける
-        const std::string get_res_str( int number, bool ref = false );
+        std::string get_res_str( int number, bool ref = false );
 
         // number　番のレスの生文字列を返す
-        const std::string get_raw_res_str( int number );
+        std::string get_raw_res_str( int number );
 
         // 書き込み時の名前とメアド
         const std::string& get_write_name() const { return m_write_name; }
@@ -227,17 +227,17 @@ namespace DBTREE
         void set_write_fixmail( bool set ){ m_save_info = true; m_write_fixmail = set; }
 
         // 書き込みメッセージ作成
-        virtual const std::string create_write_message( const std::string& name, const std::string& mail, const std::string& msg )
-        { return std::string(); }
+        virtual std::string create_write_message( const std::string& name, const std::string& mail,
+                                                  const std::string& msg ) { return {}; }
 
         // bbscgi のURL
-        virtual const std::string url_bbscgi() { return std::string(); }
+        virtual std::string url_bbscgi() { return std::string(); }
 
         // subbbscgi のURL
-        virtual const std::string url_subbbscgi() { return std::string(); }
+        virtual std::string url_subbbscgi() { return std::string(); }
 
         // 最終アクセス時間
-        const std::string get_access_time_str();
+        std::string get_access_time_str();
         const time_t& get_access_time() const { return m_access_time.tv_sec; } // 秒
         const std::string& get_access_date(); // string型
         void reset_access_date(){ m_access_date = std::string(); }

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -206,7 +206,7 @@ namespace DBTREE
 
         // query を含むレス番号をリストにして取得
         // mode_or == true なら OR抽出
-        const std::list< int > get_res_query( const std::string& query, const bool mode_or );
+        std::list< int > get_res_query( const std::string& query, const bool mode_or );
 
         // number番のレスの文字列を返す
         // ref == true なら先頭に ">" を付ける

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -238,12 +238,12 @@ namespace DBTREE
 
         // 最終アクセス時間
         std::string get_access_time_str();
-        const time_t& get_access_time() const { return m_access_time.tv_sec; } // 秒
+        time_t get_access_time() const { return m_access_time.tv_sec; } // 秒
         const std::string& get_access_date(); // string型
         void reset_access_date(){ m_access_date = std::string(); }
 
         // 最終書き込み時間
-        const time_t& get_write_time() const { return m_write_time.tv_sec; } // 秒
+        time_t get_write_time() const { return m_write_time.tv_sec; } // 秒
         const std::string& get_write_date(); // string型
         void reset_write_date(){ m_write_time_date = std::string(); }
 
@@ -263,7 +263,7 @@ namespace DBTREE
         void clear_post_history();
 
         // スレ立て時刻
-        const time_t& get_since_time() const { return m_since_time; };
+        time_t get_since_time() const { return m_since_time; };
         const std::string& get_since_date();
         void reset_since_date(){ m_since_date = std::string(); }
 

--- a/src/dbtree/articlehash.cpp
+++ b/src/dbtree/articlehash.cpp
@@ -82,7 +82,7 @@ ArticleBase* ArticleHash::find( const std::string& datbase, const std::string& i
 }
 
 
-const ArticleHashIterator ArticleHash::begin()
+ArticleHashIterator ArticleHash::begin()
 {
     m_it_hash = m_min_hash;
     m_it_pos = 0;

--- a/src/dbtree/articlehash.h
+++ b/src/dbtree/articlehash.h
@@ -41,7 +41,7 @@ namespace DBTREE
 
         ArticleBase* find( const std::string& datbase, const std::string& id );
 
-        const ArticleHashIterator begin();
+        ArticleHashIterator begin();
         size_t end() const { return size(); }
 
       private:

--- a/src/dbtree/articlejbbs.cpp
+++ b/src/dbtree/articlejbbs.cpp
@@ -31,7 +31,7 @@ ArticleJBBS::~ArticleJBBS()
 {}
 
 
-const std::string ArticleJBBS::create_write_message( const std::string& name, const std::string& mail, const std::string& msg )
+std::string ArticleJBBS::create_write_message( const std::string& name, const std::string& mail, const std::string& msg )
 {
     if( msg.empty() ) return std::string();
 
@@ -70,7 +70,7 @@ const std::string ArticleJBBS::create_write_message( const std::string& name, co
 // (例) "http://jbbs.shitaraba.net/bbs/write.cgi/computer/123/1234567/"
 //
 //
-const std::string ArticleJBBS::url_bbscgi()
+std::string ArticleJBBS::url_bbscgi()
 {
     return DBTREE::url_bbscgibase( get_url() ) + DBTREE::board_id( get_url() ) + "/" + get_key() + "/";
 }
@@ -81,7 +81,7 @@ const std::string ArticleJBBS::url_bbscgi()
 //
 // (例) "http://jbbs.shitaraba.net/bbs/write.cgi/computer/123/1234567/"
 //
-const std::string ArticleJBBS::url_subbbscgi()
+std::string ArticleJBBS::url_subbbscgi()
 {
     return DBTREE::url_subbbscgibase( get_url() ) + DBTREE::board_id( get_url() ) + "/" + get_key() + "/";
 }

--- a/src/dbtree/articlejbbs.h
+++ b/src/dbtree/articlejbbs.h
@@ -21,14 +21,14 @@ namespace DBTREE
         ~ArticleJBBS();
 
         // 書き込みメッセージ変換
-        const std::string create_write_message( const std::string& name, const std::string& mail,
-                                                const std::string& msg ) override;
+        std::string create_write_message( const std::string& name, const std::string& mail,
+                                          const std::string& msg ) override;
 
         // bbscgi のURL
-        const std::string url_bbscgi() override;
+        std::string url_bbscgi() override;
         
         // subbbscgi のURL
-        const std::string url_subbbscgi() override;
+        std::string url_subbbscgi() override;
 
       private:
         

--- a/src/dbtree/articlemachi.cpp
+++ b/src/dbtree/articlemachi.cpp
@@ -34,7 +34,7 @@ ArticleMachi::~ArticleMachi() noexcept
 {}
 
 
-const std::string ArticleMachi::create_write_message( const std::string& name, const std::string& mail, const std::string& msg )
+std::string ArticleMachi::create_write_message( const std::string& name, const std::string& mail, const std::string& msg )
 {
     if( msg.empty() ) return std::string();
 
@@ -66,7 +66,7 @@ const std::string ArticleMachi::create_write_message( const std::string& name, c
 // (例) "http://www.machi.to/bbs/write.cgi"
 //
 //
-const std::string ArticleMachi::url_bbscgi()
+std::string ArticleMachi::url_bbscgi()
 {
     std::string cgibase = DBTREE::url_bbscgibase( get_url() );
     return cgibase.substr( 0, cgibase.length() -1 ); // 最後の '/' を除く
@@ -78,7 +78,7 @@ const std::string ArticleMachi::url_bbscgi()
 //
 // (例) "http://www.machi.to/bbs/write.cgi"
 //
-const std::string ArticleMachi::url_subbbscgi()
+std::string ArticleMachi::url_subbbscgi()
 {
     std::string cgibase = DBTREE::url_subbbscgibase( get_url() );
     return cgibase.substr( 0, cgibase.length() -1 ); // 最後の '/' を除く

--- a/src/dbtree/articlemachi.h
+++ b/src/dbtree/articlemachi.h
@@ -21,14 +21,14 @@ namespace DBTREE
         ~ArticleMachi() noexcept;
 
         // 書き込みメッセージ変換
-        const std::string create_write_message( const std::string& name, const std::string& mail,
-                                                const std::string& msg ) override;
+        std::string create_write_message( const std::string& name, const std::string& mail,
+                                          const std::string& msg ) override;
 
         // bbscgi のURL
-        const std::string url_bbscgi() override;
+        std::string url_bbscgi() override;
         
         // subbbscgi のURL
-        const std::string url_subbbscgi() override;
+        std::string url_subbbscgi() override;
 
       private:
         

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -52,7 +52,7 @@ const std::string& Board2ch::get_agent_w()
 
 
 // 読み込み用プロキシ
-const std::string Board2ch::get_proxy_host()
+std::string Board2ch::get_proxy_host()
 {
     const int mode = get_mode_local_proxy();
 
@@ -75,7 +75,7 @@ int Board2ch::get_proxy_port()
     return 0;
 }
 
-const std::string Board2ch::get_proxy_basicauth()
+std::string Board2ch::get_proxy_basicauth()
 {
     const int mode = get_mode_local_proxy();
 
@@ -87,7 +87,7 @@ const std::string Board2ch::get_proxy_basicauth()
 
 
 // 書き込み用プロキシ
-const std::string Board2ch::get_proxy_host_w()
+std::string Board2ch::get_proxy_host_w()
 {
     if( CORE::get_loginp2()->login_now() ){
 
@@ -118,7 +118,7 @@ int Board2ch::get_proxy_port_w()
 }
 
 
-const std::string Board2ch::get_proxy_basicauth_w()
+std::string Board2ch::get_proxy_basicauth_w()
 {
     if( CORE::get_loginp2()->login_now() ) return CONFIG::get_proxy_basicauth_for_data();
 
@@ -132,7 +132,7 @@ const std::string Board2ch::get_proxy_basicauth_w()
 
 
 //書き込み用クッキー作成
-const std::string Board2ch::cookie_for_write()
+std::string Board2ch::cookie_for_write()
 {
 #ifdef _DEBUG
     std::cout << "Board2ch::cookie_for_write\n";
@@ -161,7 +161,7 @@ const std::string Board2ch::cookie_for_write()
 }
 
 
-const std::string Board2ch::get_write_referer()
+std::string Board2ch::get_write_referer()
 {
     // p2ログインの場合はとりあえず空文字
     if( CORE::get_loginp2()->login_now() ) return std::string();
@@ -171,8 +171,8 @@ const std::string Board2ch::get_write_referer()
 
 
 // 新スレ作成時の書き込みメッセージ作成
-const std::string Board2ch::create_newarticle_message( const std::string& subject,
-                                                       const std::string& name, const std::string& mail, const std::string& msg )
+std::string Board2ch::create_newarticle_message( const std::string& subject, const std::string& name,
+                                                 const std::string& mail, const std::string& msg )
 {
     if( subject.empty() ) return std::string();
     if( msg.empty() ) return std::string();
@@ -225,7 +225,7 @@ const std::string Board2ch::create_newarticle_message( const std::string& subjec
 // (例) "http://www.hoge2ch.net/test/bbs.cgi"
 //
 //
-const std::string Board2ch::url_bbscgi_new()
+std::string Board2ch::url_bbscgi_new()
 {
     if( CORE::get_loginp2()->login_now() ) return CONFIG::get_url_loginp2() + "post.php";
 
@@ -238,7 +238,7 @@ const std::string Board2ch::url_bbscgi_new()
 //
 // (例) "http://www.hoge2ch.net/test/subbbs.cgi"
 //
-const std::string Board2ch::url_subbbscgi_new()
+std::string Board2ch::url_subbbscgi_new()
 {
     if( CORE::get_loginp2()->login_now() ) return CONFIG::get_url_loginp2() + "post.php";
 
@@ -271,7 +271,7 @@ ArticleBase* Board2ch::append_article( const std::string& datbase, const std::st
 
 
 // 2chのクッキー:HAP
-const std::string Board2ch::get_hap()
+std::string Board2ch::get_hap()
 {
     if( ! CONFIG::get_use_cookie_hap() ) return std::string();
 

--- a/src/dbtree/board2ch.h
+++ b/src/dbtree/board2ch.h
@@ -29,30 +29,30 @@ namespace DBTREE
         const std::string& get_agent_w() override; // 書き込み用
 
         // 読み込み用プロキシ
-        const std::string get_proxy_host() override;
+        std::string get_proxy_host() override;
         int get_proxy_port() override;
-        const std::string get_proxy_basicauth() override;
+        std::string get_proxy_basicauth() override;
 
         // 書き込み用プロキシ
-        const std::string get_proxy_host_w() override;
+        std::string get_proxy_host_w() override;
         int get_proxy_port_w() override;
-        const std::string get_proxy_basicauth_w() override;
+        std::string get_proxy_basicauth_w() override;
 
         // 書き込み用クッキー
-        const std::string cookie_for_write() override;
+        std::string cookie_for_write() override;
 
         // 書き込み時のリファラ
-        const std::string get_write_referer() override;
+        std::string get_write_referer() override;
 
         // 新スレ作成用のメッセージ変換
-        const std::string create_newarticle_message( const std::string& subject, const std::string& name,
-                                                     const std::string& mail, const std::string& msg ) override;
+        std::string create_newarticle_message( const std::string& subject, const std::string& name,
+                                               const std::string& mail, const std::string& msg ) override;
 
         // 新スレ作成用のbbscgi のURL
-        const std::string url_bbscgi_new() override;
+        std::string url_bbscgi_new() override;
         
         // 新スレ作成用のsubbbscgi のURL
-        const std::string url_subbbscgi_new() override;
+        std::string url_subbbscgi_new() override;
 
         // datの最大サイズ(Kバイト)
         int get_max_dat_lng() const override { return DEFAULT_MAX_DAT_LNG; }
@@ -60,7 +60,7 @@ namespace DBTREE
       protected:
 
         // クッキー:HAP
-        const std::string get_hap() override;
+        std::string get_hap() override;
         void set_hap( const std::string& hap ) override;
 
         // クッキー:HAPの更新 (クッキーをセットした時に実行)

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -88,7 +88,7 @@ bool Board2chCompati::is_valid( const std::string& filename )
 
 
 //書き込み用クッキー作成
-const std::string Board2chCompati::cookie_for_write()
+std::string Board2chCompati::cookie_for_write()
 {
     const std::list< std::string > list_cookies = BoardBase::list_cookies_for_write();
     if( list_cookies.empty() ) return std::string();
@@ -252,7 +252,7 @@ void Board2chCompati::analyze_keyword_for_write( const std::string& html )
 
 
 // 新スレ作成時の書き込みメッセージ作成
-const std::string Board2chCompati::create_newarticle_message( const std::string& subject,
+std::string Board2chCompati::create_newarticle_message( const std::string& subject,
                                                        const std::string& name, const std::string& mail, const std::string& msg )
 {
     if( subject.empty() ) return std::string();
@@ -283,7 +283,7 @@ const std::string Board2chCompati::create_newarticle_message( const std::string&
 // (例) "http://www.hoge2ch.net/test/bbs.cgi"
 //
 //
-const std::string Board2chCompati::url_bbscgi_new()
+std::string Board2chCompati::url_bbscgi_new()
 {
     std::string cgibase = url_bbscgibase();
     return cgibase.substr( 0, cgibase.length() -1 ); // 最後の '/' を除く
@@ -295,7 +295,7 @@ const std::string Board2chCompati::url_bbscgi_new()
 //
 // (例) "http://www.hoge2ch.net/test/subbbs.cgi"
 //
-const std::string Board2chCompati::url_subbbscgi_new()
+std::string Board2chCompati::url_subbbscgi_new()
 {
     std::string cgibase = url_subbbscgibase();
     return cgibase.substr( 0, cgibase.length() -1 ); // 最後の '/' を除く
@@ -481,7 +481,7 @@ void Board2chCompati::regist_article( const bool is_online )
 }
 
 
-const std::string Board2chCompati::localrule()
+std::string Board2chCompati::localrule()
 {
     if( m_ruleloader ){
         if( m_ruleloader->is_loading() ) return "ロード中です";
@@ -496,7 +496,7 @@ const std::string Board2chCompati::localrule()
 }
 
 
-const std::string Board2chCompati::settingtxt()
+std::string Board2chCompati::settingtxt()
 {
     if( m_settingloader ){
         if( m_settingloader->is_loading() ) return "ロード中です";
@@ -511,7 +511,7 @@ const std::string Board2chCompati::settingtxt()
 }
 
 
-const std::string Board2chCompati::default_noname()
+std::string Board2chCompati::default_noname()
 {
     if( m_settingloader
         && m_settingloader->get_code() == HTTP_OK ) return m_settingloader->default_noname();
@@ -538,7 +538,7 @@ int Board2chCompati::message_count()
 }    
 
 
-const std::string Board2chCompati::get_unicode()
+std::string Board2chCompati::get_unicode()
 {
     if( m_settingloader
         && m_settingloader->get_code() == HTTP_OK ) return m_settingloader->get_unicode();

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -25,31 +25,31 @@ namespace DBTREE
         ~Board2chCompati();
 
         // 書き込み用クッキー
-        const std::string cookie_for_write() override;
+        std::string cookie_for_write() override;
 
         // 書き込み時に必要なキーワード( hana=mogera や suka=pontan など )を
         // 確認画面のhtmlから解析する      
         void analyze_keyword_for_write( const std::string& html ) override;
 
         // 新スレ作成用のメッセージ変換
-        const std::string create_newarticle_message( const std::string& subject, const std::string& name,
-                                                     const std::string& mail, const std::string& msg ) override;
+        std::string create_newarticle_message( const std::string& subject, const std::string& name,
+                                               const std::string& mail, const std::string& msg ) override;
 
         // 新スレ作成用のbbscgi のURL
-        const std::string url_bbscgi_new() override;
+        std::string url_bbscgi_new() override;
         
         // 新スレ作成用のsubbbscgi のURL
-        const std::string url_subbbscgi_new() override;
+        std::string url_subbbscgi_new() override;
 
         // ローカルルール
-        const std::string localrule() override;
+        std::string localrule() override;
 
         // SETTING.TXT 
-        const std::string settingtxt() override;
-        const std::string default_noname() override;
+        std::string settingtxt() override;
+        std::string default_noname() override;
         int line_number() override;
         int message_count() override;
-        const std::string get_unicode() override;
+        std::string get_unicode() override;
 
       private:
 

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1847,7 +1847,7 @@ void BoardBase::search_cache( std::vector< DBTREE::ArticleBase* >& list_article,
                               const std::string& query,
                               const bool mode_or, // 今のところ無視
                               const bool bm,
-                              const bool& stop // 呼出元のスレッドで true にセットすると検索を停止する
+                              const bool stop // 呼出元のスレッドで true にセットすると検索を停止する
     )
 {
 #ifdef _DEBUG

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -2341,7 +2341,7 @@ void BoardBase::show_updateicon( const bool update )
 
 // 板の更新チェック時に、更新チェックを行うスレのアドレスのリスト
 // キャッシュが存在し、かつdat落ちしていないで新着数が0のスレを速度の順でソートして返す
-const std::list< std::string > BoardBase::get_check_update_articles()
+std::list< std::string > BoardBase::get_check_update_articles()
 {
     std::list< std::string > list_url;
 

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -165,7 +165,7 @@ const std::string& BoardBase::get_agent_w()
 
 
 // 読み込み用プロキシ
-const std::string BoardBase::get_proxy_host()
+std::string BoardBase::get_proxy_host()
 {
     const int mode = get_mode_local_proxy();
 
@@ -188,7 +188,7 @@ int BoardBase::get_proxy_port()
     return 0;
 }
 
-const std::string BoardBase::get_proxy_basicauth()
+std::string BoardBase::get_proxy_basicauth()
 {
     const int mode = get_mode_local_proxy();
 
@@ -200,7 +200,7 @@ const std::string BoardBase::get_proxy_basicauth()
 
 
 // 書き込み用プロキシ
-const std::string BoardBase::get_proxy_host_w()
+std::string BoardBase::get_proxy_host_w()
 {
     const int mode = get_mode_local_proxy_w();
 
@@ -224,7 +224,7 @@ int BoardBase::get_proxy_port_w()
 }
 
 
-const std::string BoardBase::get_proxy_basicauth_w()
+std::string BoardBase::get_proxy_basicauth_w()
 {
     const int mode = get_mode_local_proxy_w();
 
@@ -236,20 +236,20 @@ const std::string BoardBase::get_proxy_basicauth_w()
 
 
 // ローカルルール
-const std::string BoardBase::localrule()
+std::string BoardBase::localrule()
 {
     return "利用できません";
 }
 
 
 // setting.txt
-const std::string BoardBase::settingtxt()
+std::string BoardBase::settingtxt()
 {
     return "利用できません";
 }
 
 // デフォルトの名無し名
-const std::string BoardBase::default_noname()
+std::string BoardBase::default_noname()
 {
     return "???";
 }
@@ -270,14 +270,14 @@ int BoardBase::message_count()
 
 
 // 特殊文字書き込み可能か( pass なら可能、 change なら不可 )
-const std::string BoardBase::get_unicode()
+std::string BoardBase::get_unicode()
 {
-    return "";
+    return {};
 }
 
 
 //書き込み用クッキー
-const std::string BoardBase::cookie_for_write()
+std::string BoardBase::cookie_for_write()
 {
     if( m_list_cookies_for_write.empty() ) return std::string();
 
@@ -570,7 +570,7 @@ void BoardBase::update_url( const std::string& root, const std::string& path_boa
 //
 // 戻り値 : "http://www.hoge2ch.net/hogeboard/dat/12345.dat",  num_from = 12, num_to = 15, num_str = "12-15"
 //
-const std::string BoardBase::url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str )
+std::string BoardBase::url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str )
 {
     if( empty() ) return std::string();
 
@@ -719,7 +719,7 @@ const std::string BoardBase::url_dat( const std::string& url, int& num_from, int
 //
 // 戻り値 : "http://www.hoge2ch.net/test/read.cgi/hogeboard/12345/12-15"
 //
-const std::string BoardBase::url_readcgi( const std::string& url, int num_from, int num_to )
+std::string BoardBase::url_readcgi( const std::string& url, int num_from, int num_to )
 {
     if( empty() ) return std::string();
 
@@ -757,7 +757,7 @@ const std::string BoardBase::url_readcgi( const std::string& url, int num_from, 
 //
 // (例) "http://www.hoge2ch.net/hogeboard/subject.txt"
 //
-const std::string BoardBase::url_subject()
+std::string BoardBase::url_subject()
 {
     if( empty() ) return std::string();
 
@@ -771,7 +771,7 @@ const std::string BoardBase::url_subject()
 //
 // (例) "http://www.hoge2ch.net/"  (最後に '/' がつく)
 //
-const std::string BoardBase::url_root()
+std::string BoardBase::url_root()
 {
     if( empty() ) return std::string();
 
@@ -784,7 +784,7 @@ const std::string BoardBase::url_root()
 //
 // (例) "http://www.hoge2ch.net/hogeboard/"  (最後に '/' がつく)
 //
-const std::string BoardBase::url_boardbase()
+std::string BoardBase::url_boardbase()
 {
     if( empty() ) return std::string();
 
@@ -797,7 +797,7 @@ const std::string BoardBase::url_boardbase()
 //
 // (例) "http://www.hoge2ch.net/hogeboard/dat/" (最後に '/' がつく)
 //
-const std::string BoardBase::url_datbase()
+std::string BoardBase::url_datbase()
 {
     if( empty() ) return std::string();
 
@@ -810,7 +810,7 @@ const std::string BoardBase::url_datbase()
 //
 // (例) "/hogeboard/dat/"  (最初と最後に '/' がつく)
 //
-const std::string BoardBase::url_datpath()
+std::string BoardBase::url_datpath()
 {
     if( empty() ) return std::string();
 
@@ -824,7 +824,7 @@ const std::string BoardBase::url_datpath()
 //
 // (例) "http://www.hoge2ch.net/test/read.cgi/hogeboard/"  (最後に '/' がつく)
 //
-const std::string BoardBase::url_readcgibase()
+std::string BoardBase::url_readcgibase()
 {
     if( empty() ) return std::string();
 
@@ -837,7 +837,7 @@ const std::string BoardBase::url_readcgibase()
 //
 // (例) "/test/read.cgi/hogeboard/"   (最初と最後に '/' がつく)
 //
-const std::string BoardBase::url_readcgipath()
+std::string BoardBase::url_readcgipath()
 {
     if( empty() ) return std::string();
 
@@ -851,7 +851,7 @@ const std::string BoardBase::url_readcgipath()
 // (例) "http://www.hoge2ch.net/test/bbs.cgi/" ( 最後に '/' がつく )
 //
 //
-const std::string BoardBase::url_bbscgibase()
+std::string BoardBase::url_bbscgibase()
 {
     if( empty() ) return std::string();
 
@@ -864,7 +864,7 @@ const std::string BoardBase::url_bbscgibase()
 //
 // (例) "http://www.hoge2ch.net/test/subbbs.cgi/"  ( 最後に '/' がつく )
 //
-const std::string BoardBase::url_subbbscgibase()
+std::string BoardBase::url_subbbscgibase()
 {
     if( empty() ) return std::string();
 
@@ -1930,7 +1930,7 @@ void BoardBase::search_cache( std::vector< DBTREE::ArticleBase* >& list_article,
 
 // datファイルのインポート
 // 成功したらdat型のurlを返す
-const std::string BoardBase::import_dat( const std::string& filename )
+std::string BoardBase::import_dat( const std::string& filename )
 {
     if( empty() ) return std::string();
     if( CACHE::file_exists( filename ) != CACHE::EXIST_FILE ){

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -554,7 +554,7 @@ namespace DBTREE
 
         // 板の更新チェック時に、更新チェックを行うスレのアドレスのリスト
         // キャッシュが存在し、かつdat落ちしていないで新着数が0のスレを速度の順でソートして返す
-        const std::list< std::string > get_check_update_articles();
+        std::list< std::string > get_check_update_articles();
 
       private:
 

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -496,7 +496,7 @@ namespace DBTREE
 
         // 最終書き込み時間
         void update_writetime();
-        const time_t& get_write_time() const { return m_write_time.tv_sec; } // 秒
+        time_t get_write_time() const { return m_write_time.tv_sec; } // 秒
         time_t get_write_pass(); // 経過時間(秒)
         time_t get_samba_sec() const { return m_samba_sec; } // samba(秒)
         void set_samba_sec( time_t sec ){ m_samba_sec = sec; }
@@ -541,7 +541,7 @@ namespace DBTREE
                                    const std::string& query,
                                    const bool mode_or, // 今のところ無視
                                    const bool bm,
-                                   const bool& stop // 呼出元のスレッドで true にセットすると検索を停止する
+                                   const bool stop // 呼出元のスレッドで true にセットすると検索を停止する
             );
 
         // datファイルのインポート

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -237,7 +237,7 @@ namespace DBTREE
         void send_update_board();
 
         // クッキー:HAP
-        virtual const std::string get_hap(){ return std::string(); }
+        virtual std::string get_hap(){ return std::string(); }
         virtual void set_hap( const std::string& hap ){}
 
         // クッキー:HAPの更新 (クッキーをセットした時に実行)
@@ -302,23 +302,23 @@ namespace DBTREE
         virtual const std::string& get_agent_w(); // 書き込み用
 
         // ダウンロード時のプロキシ
-        virtual const std::string get_proxy_host();
+        virtual std::string get_proxy_host();
         virtual int get_proxy_port();
-        virtual const std::string get_proxy_basicauth();
+        virtual std::string get_proxy_basicauth();
 
         // 書き込み時のプロキシ
-        virtual const std::string get_proxy_host_w();
+        virtual std::string get_proxy_host_w();
         virtual int get_proxy_port_w();
-        virtual const std::string get_proxy_basicauth_w();
+        virtual std::string get_proxy_basicauth_w();
 
         // ローカルルール
-        virtual const std::string localrule();
+        virtual std::string localrule();
 
         // SETTING.TXT
-        virtual const std::string settingtxt();
+        virtual std::string settingtxt();
 
         // 書き込みの時のデフォルト名
-        virtual const std::string default_noname();
+        virtual std::string default_noname();
 
         // 最大改行数/2
         virtual int line_number();
@@ -327,10 +327,10 @@ namespace DBTREE
         virtual int message_count();
 
         // 特殊文字書き込み可能か( pass なら可能、 change なら不可 )
-        virtual const std::string get_unicode();
+        virtual std::string get_unicode();
 
         // 書き込み用クッキー
-        virtual const std::string cookie_for_write();
+        virtual std::string cookie_for_write();
         const std::list< std::string >& list_cookies_for_write() { return m_list_cookies_for_write; }
         void set_list_cookies_for_write( const std::list< std::string >& list_cookies );
         void reset_list_cookies_for_write(){ m_list_cookies_for_write.clear(); }
@@ -345,7 +345,7 @@ namespace DBTREE
         virtual void analyze_keyword_for_write( const std::string& html ){}
 
         // 書き込み時のリファラ
-        virtual const std::string get_write_referer(){ return url_boardbase(); }
+        virtual std::string get_write_referer(){ return url_boardbase(); }
 
         // basic認証
         const std::string& get_basicauth() const { return m_basicauth; }
@@ -356,50 +356,50 @@ namespace DBTREE
         // もしurlが移転前の旧ホストのものだったら対応するarticlebaseクラスに旧ホスト名を知らせる
         // (例) url =  "http://www.hoge2ch.net/test/read.cgi/hogeboard/12345/12-15"のとき、
         // "http://www.hoge2ch.net/hogeboard/dat/12345.dat",  num_from = 12, num_to = 15, num_str = "12-15"
-        virtual const std::string url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str ); 
+        virtual std::string url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str ); 
 
         // スレの url を read.cgi型のurlに変換
         // url がスレッドのURLで無い時はempty()が返る
         // num_from と num_to が 0 で無い時はスレ番号を付ける
         // (例) "http://www.hoge2ch.net/hogeboard/dat/12345.dat",  num_from = 12, num_to = 15 のとき
         // "http://www.hoge2ch.net/test/read.cgi/hogeboard/12345/12-15"
-        virtual const std::string url_readcgi( const std::string& url, int num_from, int num_to );
+        virtual std::string url_readcgi( const std::string& url, int num_from, int num_to );
 
         // subject.txt の URLを取得
         // (例) "http://www.hoge2ch.net/hogeboard/subject.txt"
-        const std::string url_subject();
+        std::string url_subject();
 
         // ルートアドレス
         // (例) "http://www.hoge2ch.net/hogeboard/" なら "http://www.hoge2ch.net/"
-        const std::string url_root();
+        std::string url_root();
 
         // 板のベースアドレス
         // (例) "http://www.hoge2ch.net/hogeboard/"
-        const std::string url_boardbase();
+        std::string url_boardbase();
 
         // dat ファイルのURLのベースアドレスを返す
         // (例) "http://www.hoge2ch.net/hogeboard/dat/12345.dat" なら "http://www.hoge2ch.net/hogeboard/dat/"
-        const std::string url_datbase();
+        std::string url_datbase();
 
         // dat ファイルのURLのパスを返す
         // (例) "http://www.hoge2ch.net/hogeboard/dat/12345.dat" なら "/hogeboard/dat/"
-        virtual const std::string url_datpath();
+        virtual std::string url_datpath();
 
         // read.cgi のURLのベースアドレスを返す
         // (例) "http://www.hoge2ch.net/test/read.cgi/hogeboard/12345" なら "http://www.hoge2ch.net/test/read.cgi/hogeboard/"
-        const std::string url_readcgibase();        
+        std::string url_readcgibase();
 
         // read.cgi のURLのパスを返す
         // (例) "http://www.hoge2ch.net/test/read.cgi/hogeboard/12345" なら "/test/read.cgi/hogeboard/"
-        const std::string url_readcgipath();
+        std::string url_readcgipath();
 
         // bbscgi のURLのベースアドレス
         // (例) "http://www.hoge2ch.net/test/bbs.cgi/" ( 最後に '/' がつく )
-        const std::string url_bbscgibase();
-        
+        std::string url_bbscgibase();
+
         // subbbscgi のURLのベースアドレス
         // (例) "http://www.hoge2ch.net/test/subbbs.cgi/"  ( 最後に '/' がつく )
-        const std::string url_subbbscgibase();
+        std::string url_subbbscgibase();
 
         // article クラスのポインタ取得
         ArticleBase* get_article_fromURL( const std::string& url );
@@ -410,17 +410,17 @@ namespace DBTREE
         virtual void download_subject( const std::string& url_update_view, const bool read_from_cache );
 
         // 新スレ作成用のメッセージ変換
-        virtual const std::string create_newarticle_message( const std::string& subject,
-                                                             const std::string& name, const std::string& mail, const std::string& msg )
+        virtual std::string create_newarticle_message( const std::string& subject, const std::string& name,
+                                                       const std::string& mail, const std::string& msg )
         {
-            return std::string();
+            return {};
         }
 
         // 新スレ作成用のbbscgi のURL
-        virtual const std::string url_bbscgi_new() { return std::string(); }
+        virtual std::string url_bbscgi_new() { return {}; }
         
         // 新スレ作成用のsubbbscgi のURL
-        virtual const std::string url_subbbscgi_new() { return std::string(); }
+        virtual std::string url_subbbscgi_new() { return {}; }
 
         // 配下の全articlebaseクラスのあぼーん状態の更新
         void update_abone_all_article();
@@ -546,7 +546,7 @@ namespace DBTREE
 
         // datファイルのインポート
         // 成功したらdat型のurlを返す
-        virtual const std::string import_dat( const std::string& filename );
+        virtual std::string import_dat( const std::string& filename );
 
         // 更新可能状態にしてお気に入りやスレ一覧のタブのアイコンに更新マークを表示
         // update == true の時に表示。falseなら戻す

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -81,7 +81,7 @@ ArticleBase* BoardJBBS::append_article( const std::string& datbase, const std::s
 //
 // (例) "/bbs/rawmode.cgi/board/"  (最初と最後に '/' がつく)
 //
-const std::string BoardJBBS::url_datpath()
+std::string BoardJBBS::url_datpath()
 {
     if( empty() ) return std::string();
 
@@ -90,8 +90,8 @@ const std::string BoardJBBS::url_datpath()
 
 
 
-const std::string BoardJBBS::create_newarticle_message( const std::string& subject,
-                                                        const std::string& name, const std::string& mail, const std::string& msg )
+std::string BoardJBBS::create_newarticle_message( const std::string& subject, const std::string& name,
+                                                  const std::string& mail, const std::string& msg )
 {
     if( subject.empty() ) return std::string();
     if( msg.empty() ) return std::string();
@@ -127,7 +127,7 @@ const std::string BoardJBBS::create_newarticle_message( const std::string& subje
 // (例) "http://jbbs.shitaraba.net/bbs/write.cgi/computer/123/new/"
 //
 //
-const std::string BoardJBBS::url_bbscgi_new()
+std::string BoardJBBS::url_bbscgi_new()
 {
     return url_bbscgibase() + get_id() + "/new/";
 }
@@ -138,7 +138,7 @@ const std::string BoardJBBS::url_bbscgi_new()
 //
 // (例) "http://jbbs.shitaraba.net/bbs/write.cgi/computer/123/new/"
 //
-const std::string BoardJBBS::url_subbbscgi_new()
+std::string BoardJBBS::url_subbbscgi_new()
 {
     return url_subbbscgibase() + get_id() + "/new/";
 }

--- a/src/dbtree/boardjbbs.h
+++ b/src/dbtree/boardjbbs.h
@@ -17,17 +17,17 @@ namespace DBTREE
 
         BoardJBBS( const std::string& root, const std::string& path_board,const std::string& name );
 
-        const std::string url_datpath() override;
+        std::string url_datpath() override;
 
         // 新スレ作成用のメッセージ変換
-        const std::string create_newarticle_message( const std::string& subject, const std::string& name,
-                                                     const std::string& mail, const std::string& msg ) override;
+        std::string create_newarticle_message( const std::string& subject, const std::string& name,
+                                               const std::string& mail, const std::string& msg ) override;
 
         // 新スレ作成用のbbscgi のURL
-        const std::string url_bbscgi_new() override;
+        std::string url_bbscgi_new() override;
         
         // 新スレ作成用のsubbbscgi のURL
-        const std::string url_subbbscgi_new() override;
+        std::string url_subbbscgi_new() override;
 
       private:
 

--- a/src/dbtree/boardlocal.cpp
+++ b/src/dbtree/boardlocal.cpp
@@ -40,7 +40,7 @@ bool BoardLocal::equal( const std::string& url )
 
 
 // そのまま出力
-const std::string BoardLocal::url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str )
+std::string BoardLocal::url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str )
 {
     num_from = 0;
     num_to = 0;
@@ -51,7 +51,7 @@ const std::string BoardLocal::url_dat( const std::string& url, int& num_from, in
 
 
 // そのまま出力
-const std::string BoardLocal::url_readcgi( const std::string& url, int num_from, int num_to )
+std::string BoardLocal::url_readcgi( const std::string& url, int num_from, int num_to )
 {
     JDLIB::Regex regex;
     const size_t offset = 0;
@@ -101,7 +101,7 @@ ArticleBase* BoardLocal::append_article( const std::string& datbase, const std::
 
 
 // datファイルのインポート
-const std::string BoardLocal::import_dat( const std::string& filename )
+std::string BoardLocal::import_dat( const std::string& filename )
 {
     if( empty() ) return FALSE;
     if( CACHE::file_exists( filename ) != CACHE::EXIST_FILE ) return std::string();

--- a/src/dbtree/boardlocal.h
+++ b/src/dbtree/boardlocal.h
@@ -21,8 +21,8 @@ namespace DBTREE
         // url がこの板のものかどうか
         bool equal( const std::string& url ) override;
 
-        const std::string url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str ) override;
-        const std::string url_readcgi( const std::string& url, int num_from, int num_to ) override;
+        std::string url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str ) override;
+        std::string url_readcgi( const std::string& url, int num_from, int num_to ) override;
 
         void download_subject( const std::string& url_update_view, const bool ) override;
 
@@ -35,7 +35,7 @@ namespace DBTREE
                            const bool& ) override {}
 
         // datファイルのインポート
-        const std::string import_dat( const std::string& filename ) override;
+        std::string import_dat( const std::string& filename ) override;
 
       private:
 

--- a/src/dbtree/boardlocal.h
+++ b/src/dbtree/boardlocal.h
@@ -32,7 +32,7 @@ namespace DBTREE
 
         // キャッシュサーチをキャンセル
         void search_cache( std::vector< ArticleBase* >&, const std::string&, const bool, const bool,
-                           const bool& ) override {}
+                           const bool ) override {}
 
         // datファイルのインポート
         std::string import_dat( const std::string& filename ) override;

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -98,7 +98,7 @@ ArticleBase* BoardMachi::append_article( const std::string& datbase, const std::
 // (例) "http://hoge.machi.to/bbs/read.cgi?BBS=board&KEY=12345&START=12&END=15"" のとき
 // 戻り値 : "http://hoge.machi.to/bbs/read.cgi?BBS=board&KEY=12345", num_from = 12, num_to = 15, num_str = 12-15
 //
-const std::string BoardMachi::url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str )
+std::string BoardMachi::url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str )
 {
     if( empty() ) return std::string();
 
@@ -167,7 +167,7 @@ const std::string BoardMachi::url_dat( const std::string& url, int& num_from, in
 //
 // (例) "/bbs/read.cgi?BBS=board&KEY=" (最初に '/' がつく)
 //
-const std::string BoardMachi::url_datpath()
+std::string BoardMachi::url_datpath()
 {
     if( empty() ) return std::string();
 
@@ -175,8 +175,8 @@ const std::string BoardMachi::url_datpath()
 }
 
 
-const std::string BoardMachi::create_newarticle_message( const std::string& subject,
-                                                        const std::string& name, const std::string& mail, const std::string& msg )
+std::string BoardMachi::create_newarticle_message( const std::string& subject, const std::string& name,
+                                                   const std::string& mail, const std::string& msg )
 {
     if( subject.empty() ) return std::string();
     if( msg.empty() ) return std::string();
@@ -189,7 +189,7 @@ const std::string BoardMachi::create_newarticle_message( const std::string& subj
 //
 // 新スレ作成時のbbscgi(write.cgi) のURL
 //
-const std::string BoardMachi::url_bbscgi_new()
+std::string BoardMachi::url_bbscgi_new()
 {
     return std::string();
 }
@@ -198,7 +198,7 @@ const std::string BoardMachi::url_bbscgi_new()
 //
 // 新スレ作成時のsubbbscgi のURL
 //
-const std::string BoardMachi::url_subbbscgi_new()
+std::string BoardMachi::url_subbbscgi_new()
 {
     return std::string();
 }

--- a/src/dbtree/boardmachi.h
+++ b/src/dbtree/boardmachi.h
@@ -23,19 +23,19 @@ namespace DBTREE
         // スレの url を dat型のurlに変換して出力
         // (例) "http://hoge.machi.to/bbs/read.cgi?BBS=board&KEY=12345&START=12&END=15"" のとき
         // 戻り値 : "http://hoge.machi.to/bbs/read.cgi?BBS=board&KEY=12345", num_from = 12, num_to = 15, num_str = 12-15
-        const std::string url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str ) override;
+        std::string url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str ) override;
 
-        const std::string url_datpath() override;
+        std::string url_datpath() override;
 
         // 新スレ作成用のメッセージ変換
-        const std::string create_newarticle_message( const std::string& subject, const std::string& name,
-                                                     const std::string& mail, const std::string& msg ) override;
+        std::string create_newarticle_message( const std::string& subject, const std::string& name,
+                                               const std::string& mail, const std::string& msg ) override;
 
         // 新スレ作成用のbbscgi のURL
-        const std::string url_bbscgi_new() override;
-        
+        std::string url_bbscgi_new() override;
+
         // 新スレ作成用のsubbbscgi のURL
-        const std::string url_subbbscgi_new() override;
+        std::string url_subbbscgi_new() override;
 
       private:
 

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -619,7 +619,7 @@ void DBTREE::board_show_updateicon( const std::string& url, const bool update )
     DBTREE::get_board( url )->show_updateicon( update );
 }
 
-const std::list< std::string > DBTREE::board_get_check_update_articles( const std::string& url )
+std::list< std::string > DBTREE::board_get_check_update_articles( const std::string& url )
 {
     return DBTREE::get_board( url )->get_check_update_articles();
 }

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -60,39 +60,39 @@ DBTREE::ArticleBase* DBTREE::get_article( const std::string& url )
 
 //////////////////////////////////////
 
-const std::string DBTREE::url_subject( const std::string& url )
+std::string DBTREE::url_subject( const std::string& url )
 {
     return DBTREE::get_board( url )->url_subject();
 }
 
 
-const std::string DBTREE::url_root( const std::string& url )
+std::string DBTREE::url_root( const std::string& url )
 {
     return DBTREE::get_board( url )->url_root();
 }
 
 
-const std::string DBTREE::url_boardbase( const std::string& url )
+std::string DBTREE::url_boardbase( const std::string& url )
 {
     return DBTREE::get_board( url )->url_boardbase();
 }
 
 
-const std::string DBTREE::url_datbase( const std::string& url )
+std::string DBTREE::url_datbase( const std::string& url )
 {
     return DBTREE::get_board( url )->url_datbase();
 }
 
 
 // urlをdat型のurlに変換
-const std::string DBTREE::url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str )
+std::string DBTREE::url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str )
 {
     return DBTREE::get_board( url )->url_dat( url, num_from, num_to, num_str );
 }
 
 
 // urlをdat型のurlに変換(簡易版)
-const std::string DBTREE::url_dat( const std::string& url )
+std::string DBTREE::url_dat( const std::string& url )
 {
     int num_from, num_to;
     std::string num_str;
@@ -101,56 +101,55 @@ const std::string DBTREE::url_dat( const std::string& url )
 
 
 // url を read.cgi型のurlに変換
-const std::string DBTREE::url_readcgi( const std::string& url, int num_from, int num_to )
+std::string DBTREE::url_readcgi( const std::string& url, int num_from, int num_to )
 {
     return DBTREE::get_board( url )->url_readcgi( url, num_from, num_to );
 }
 
 
-const std::string DBTREE::url_bbscgibase( const std::string& url )
+std::string DBTREE::url_bbscgibase( const std::string& url )
 {
     return DBTREE::get_board( url )->url_bbscgibase();
 }
 
-const std::string DBTREE::url_subbbscgibase( const std::string& url )
+std::string DBTREE::url_subbbscgibase( const std::string& url )
 {
     return DBTREE::get_board( url )->url_subbbscgibase();
 }
 
 
-const std::string DBTREE::url_bbscgi( const std::string& url )
+std::string DBTREE::url_bbscgi( const std::string& url )
 {
     return DBTREE::get_article( url )->url_bbscgi();
 }
 
-const std::string DBTREE::url_subbbscgi( const std::string& url )
+std::string DBTREE::url_subbbscgi( const std::string& url )
 {
     return DBTREE::get_article( url )->url_subbbscgi();
 }
 
-const std::string DBTREE::url_bbscgi_new( const std::string& url )
+std::string DBTREE::url_bbscgi_new( const std::string& url )
 {
     return DBTREE::get_board( url )->url_bbscgi_new();
 }
 
-const std::string DBTREE::url_subbbscgi_new( const std::string& url )
+std::string DBTREE::url_subbbscgi_new( const std::string& url )
 {
     return DBTREE::get_board( url )->url_subbbscgi_new();
 }
 
 
 // 簡易版
-const std::string  DBTREE::is_board_moved( const std::string& url )
+std::string DBTREE::is_board_moved( const std::string& url )
 {
     return get_root()->is_board_moved( url );
 }
 
-const std::string  DBTREE::is_board_moved( const std::string& url,
-                                        std::string& old_root,
-                                        std::string& old_path_board,
-                                        std::string& new_root,
-                                        std::string& new_path_board
-    )
+std::string DBTREE::is_board_moved( const std::string& url,
+                                    std::string& old_root,
+                                    std::string& old_path_board,
+                                    std::string& new_root,
+                                    std::string& new_path_board )
 {
     return get_root()->is_board_moved( url, old_root, old_path_board, new_root, new_path_board );
 }
@@ -218,7 +217,7 @@ void DBTREE::download_bbsmenu()
 
 
 // bbsmenuの更新時間( 文字列 )
-const std::string DBTREE::get_date_modified()
+std::string DBTREE::get_date_modified()
 {
     return get_root()->get_date_modified();
 }
@@ -231,13 +230,13 @@ time_t DBTREE::get_time_modified()
 }
 
 
-const std::string DBTREE::board_path( const std::string& url )
+std::string DBTREE::board_path( const std::string& url )
 {
     return DBTREE::get_board( url )->get_path_board();
 }
 
 
-const std::string DBTREE::board_id( const std::string& url )
+std::string DBTREE::board_id( const std::string& url )
 {
     return DBTREE::get_board( url )->get_id();
 }
@@ -249,7 +248,7 @@ time_t DBTREE::board_time_modified( const std::string& url )
 }
 
 // 板の更新時間( 文字列 )
-const std::string DBTREE::board_date_modified( const std::string& url )
+std::string DBTREE::board_date_modified( const std::string& url )
 {
     return DBTREE::get_board( url )->get_date_modified();
 }
@@ -281,25 +280,25 @@ void DBTREE::board_set_modified_setting( const std::string& url, const std::stri
 }
 
 
-const std::string DBTREE::board_name( const std::string& url )
+std::string DBTREE::board_name( const std::string& url )
 {
     return DBTREE::get_board( url )->get_name();
 }
 
 
-const std::string DBTREE::board_subjecttxt( const std::string& url )
+std::string DBTREE::board_subjecttxt( const std::string& url )
 {
     return DBTREE::get_board( url )->get_subjecttxt();
 }
 
 
-const std::string DBTREE::board_charset( const std::string& url )
+std::string DBTREE::board_charset( const std::string& url )
 {
     return DBTREE::get_board( url )->get_charset();
 }
 
 
-const std::string DBTREE::board_cookie_for_write( const std::string& url )
+std::string DBTREE::board_cookie_for_write( const std::string& url )
 {
     return DBTREE::get_board( url )->cookie_for_write();
 }
@@ -321,7 +320,7 @@ void DBTREE::board_reset_list_cookies_for_write( const std::string& url )
     DBTREE::get_board( url )->reset_list_cookies_for_write();
 }
 
-const std::string DBTREE::board_keyword_for_write( const std::string& url )
+std::string DBTREE::board_keyword_for_write( const std::string& url )
 {
     return DBTREE::get_board( url )->get_keyword_for_write();
 }
@@ -339,13 +338,13 @@ void DBTREE::board_analyze_keyword_for_write( const std::string& url, const std:
 }
 
 
-const std::string DBTREE::board_basicauth( const std::string& url )
+std::string DBTREE::board_basicauth( const std::string& url )
 {
     return DBTREE::get_board( url )->get_basicauth();
 }
 
 
-const std::string DBTREE::board_ext( const std::string& url )
+std::string DBTREE::board_ext( const std::string& url )
 {
     return DBTREE::get_board( url )->get_ext();
 }
@@ -363,7 +362,7 @@ int DBTREE::board_code( const std::string& url )
 }
 
 
-const std::string DBTREE::board_str_code( const std::string& url )
+std::string DBTREE::board_str_code( const std::string& url )
 {
     return DBTREE::get_board( url )->get_str_code();
 }
@@ -626,7 +625,7 @@ const std::list< std::string > DBTREE::board_get_check_update_articles( const st
 }
 
 // datファイルのインポート
-const std::string DBTREE::board_import_dat( const std::string& url, const std::string& filename )
+std::string DBTREE::board_import_dat( const std::string& url, const std::string& filename )
 {
     return DBTREE::get_board( url )->import_dat( filename );
 }
@@ -785,21 +784,21 @@ bool DBTREE::article_is_cached( const std::string& url )
 
 
 // 拡張子付き
-const std::string DBTREE::article_id( const std::string& url )
+std::string DBTREE::article_id( const std::string& url )
 {
     return DBTREE::get_article( url )->get_id();
 }
 
 
 // idから拡張子を取ったもの
-const std::string DBTREE::article_key( const std::string& url )
+std::string DBTREE::article_key( const std::string& url )
 {
     return DBTREE::get_article( url )->get_key();
 }
 
 
 // 移転する前のオリジナルのURL
-const std::string DBTREE::article_org_host( const std::string& url )
+std::string DBTREE::article_org_host( const std::string& url )
 {
     return DBTREE::get_article( url )->get_org_host();
 }
@@ -811,7 +810,7 @@ time_t DBTREE::article_since_time( const std::string& url )
 }
 
 
-const std::string DBTREE::article_since_date( const std::string& url )
+std::string DBTREE::article_since_date( const std::string& url )
 {
     return DBTREE::get_article( url )->get_since_date();
 }
@@ -825,7 +824,7 @@ time_t DBTREE::article_time_modified( const std::string& url )
 
 
 // スレの更新時間( 文字列 )
-const std::string DBTREE::article_date_modified( const std::string& url )
+std::string DBTREE::article_date_modified( const std::string& url )
 {
     return DBTREE::get_article( url )->get_date_modified();
 }
@@ -849,7 +848,7 @@ time_t DBTREE::article_write_time( const std::string& url )
 }
 
 // 最終書き込み時刻(文字列)
-const std::string DBTREE::article_write_date( const std::string& url )
+std::string DBTREE::article_write_date( const std::string& url )
 {
     return DBTREE::get_article( url )->get_write_date();
 }
@@ -866,17 +865,17 @@ int DBTREE::article_code( const std::string& url )
     return DBTREE::get_article( url )->get_code();
 }
 
-const std::string DBTREE::article_str_code( const std::string& url )
+std::string DBTREE::article_str_code( const std::string& url )
 {
     return DBTREE::get_article( url )->get_str_code();
 }
 
-const std::string DBTREE::article_ext_err( const std::string& url )
+std::string DBTREE::article_ext_err( const std::string& url )
 {
     return DBTREE::get_article( url )->get_ext_err();
 }
 
-const std::string DBTREE::article_subject( const std::string& url )
+std::string DBTREE::article_subject( const std::string& url )
 {
     return DBTREE::get_article( url )->get_subject();
 }
@@ -965,7 +964,7 @@ const std::string& DBTREE::get_agent_w( const std::string& url )
 }
 
     
-const std::string DBTREE::get_proxy_host( const std::string& url )
+std::string DBTREE::get_proxy_host( const std::string& url )
 {
     return DBTREE::get_board( url )->get_proxy_host();
 }
@@ -975,12 +974,12 @@ int DBTREE::get_proxy_port( const std::string& url )
     return DBTREE::get_board( url )->get_proxy_port();
 }
 
-const std::string DBTREE::get_proxy_basicauth( const std::string& url )
+std::string DBTREE::get_proxy_basicauth( const std::string& url )
 {
     return DBTREE::get_board( url )->get_proxy_basicauth();
 }
 
-const std::string DBTREE::get_proxy_host_w( const std::string& url )
+std::string DBTREE::get_proxy_host_w( const std::string& url )
 {
     return DBTREE::get_board( url )->get_proxy_host_w();
 }
@@ -990,25 +989,25 @@ int DBTREE::get_proxy_port_w( const std::string& url )
     return DBTREE::get_board( url )->get_proxy_port_w();
 }
 
-const std::string DBTREE::get_proxy_basicauth_w( const std::string& url )
+std::string DBTREE::get_proxy_basicauth_w( const std::string& url )
 {
     return DBTREE::get_board( url )->get_proxy_basicauth_w();
 }
 
 
-const std::string DBTREE::localrule( const std::string& url )
+std::string DBTREE::localrule( const std::string& url )
 {
     return DBTREE::get_board( url )->localrule();
 }
 
 
-const std::string DBTREE::settingtxt( const std::string& url )
+std::string DBTREE::settingtxt( const std::string& url )
 {
     return DBTREE::get_board( url )->settingtxt();
 }
 
 
-const std::string DBTREE::default_noname( const std::string& url )
+std::string DBTREE::default_noname( const std::string& url )
 {
     return DBTREE::get_board( url )->default_noname();
 }
@@ -1024,7 +1023,7 @@ int DBTREE::message_count( const std::string& url )
 }
 
 // 特殊文字書き込み可能か( pass なら可能、 change なら不可 )
-const std::string DBTREE::get_unicode( const std::string& url )
+std::string DBTREE::get_unicode( const std::string& url )
 {
     return DBTREE::get_board( url )->get_unicode();
 }
@@ -1070,21 +1069,22 @@ void DBTREE::set_write_fixmail( const std::string& url, bool set )
 }
 
 
-const std::string DBTREE::create_write_message( const std::string& url,
-                                        const std::string& name, const std::string& mail, const std::string& msg )
+std::string DBTREE::create_write_message( const std::string& url, const std::string& name, const std::string& mail,
+                                          const std::string& msg )
 {
     return DBTREE::get_article( url )->create_write_message( name, mail, msg );
 }
 
 
-const std::string DBTREE::create_newarticle_message( const std::string& url, const std::string& subject,
-                                                     const std::string& name, const std::string& mail, const std::string& msg )
+std::string DBTREE::create_newarticle_message( const std::string& url, const std::string& subject,
+                                               const std::string& name, const std::string& mail,
+                                               const std::string& msg )
 {
     return DBTREE::get_board( url )->create_newarticle_message( subject, name, mail, msg );
 }
 
 
-const std::string DBTREE::get_write_referer( const std::string& url )
+std::string DBTREE::get_write_referer( const std::string& url )
 {
     return DBTREE::get_board( url )->get_write_referer();
 }

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -573,13 +573,13 @@ void DBTREE::read_boardinfo_all()
 }
 
 void DBTREE::search_cache_all( std::vector< DBTREE::ArticleBase* >& list_article,
-                               const std::string& query, const bool mode_or, const bool bm, const bool& stop )
+                               const std::string& query, const bool mode_or, const bool bm, const bool stop )
 {
     DBTREE::get_root()->search_cache( list_article, query, mode_or, bm, stop );
 }
 
 void DBTREE::search_cache( const std::string& url, std::vector< DBTREE::ArticleBase* >& list_article, const std::string& query,
-                           const bool mode_or, const bool bm, const bool& stop )
+                           const bool mode_or, const bool bm, const bool stop )
 {
     DBTREE::get_board( url )->search_cache( list_article, query, mode_or, bm, stop );
 }

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -193,9 +193,9 @@ namespace DBTREE
     // query が空の時はキャッシュにあるログを全てヒットさせる
     // bm がtrueの時、しおりが付いている(スレ一覧でしおりを付けた or レスに一つでもしおりが付いている)スレのみを対象に検索する
     void search_cache_all( std::vector< DBTREE::ArticleBase* >& list_article,
-                           const std::string& query, const bool mode_or, const bool bm, const bool& stop );
+                           const std::string& query, const bool mode_or, const bool bm, const bool stop );
     void search_cache( const std::string& url, std::vector< DBTREE::ArticleBase* >& list_article,
-                       const std::string& query, const bool mode_or, const bool bm, const bool& stop );
+                       const std::string& query, const bool mode_or, const bool bm, const bool stop );
 
     // article 系
     bool article_is_cached( const std::string& url ); // キャッシュにあるかどうか

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -163,7 +163,7 @@ namespace DBTREE
 
     // 板の更新チェック時に、更新チェックを行うスレのアドレスのリスト
     // キャッシュが存在し、かつdat落ちしていないで新着数が0のスレを速度の順でソートして返す
-    const std::list< std::string > board_get_check_update_articles( const std::string& url );
+    std::list< std::string > board_get_check_update_articles( const std::string& url );
 
     // datファイルのインポート
     // 成功したらdat型のurlを返す

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -36,37 +36,36 @@ namespace DBTREE
     ArticleBase* get_article( const std::string& url );
 
     // urlの変換関係
-    const std::string url_subject( const std::string& url ); // 板の subject.txt の URL
-    const std::string url_root( const std::string& url );
-    const std::string url_boardbase( const std::string& url );
-    const std::string url_datbase( const std::string& url );
+    std::string url_subject( const std::string& url ); // 板の subject.txt の URL
+    std::string url_root( const std::string& url );
+    std::string url_boardbase( const std::string& url );
+    std::string url_datbase( const std::string& url );
 
     // dat型のurlに変換
-    const std::string url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str );
+    std::string url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str );
 
     // dat型のurlに変換(簡易版)
-    const std::string url_dat( const std::string& url );
+    std::string url_dat( const std::string& url );
 
     // read.cgi型のurlに変換
-    const std::string url_readcgi( const std::string& url, int num_from, int num_to );
+    std::string url_readcgi( const std::string& url, int num_from, int num_to );
 
-    const std::string url_bbscgibase( const std::string& url );
-    const std::string url_subbbscgibase( const std::string& url );
-    const std::string url_bbscgi( const std::string& url );
-    const std::string url_subbbscgi( const std::string& url );
-    const std::string url_bbscgi_new( const std::string& url );
-    const std::string url_subbbscgi_new( const std::string& url );
+    std::string url_bbscgibase( const std::string& url );
+    std::string url_subbbscgibase( const std::string& url );
+    std::string url_bbscgi( const std::string& url );
+    std::string url_subbbscgi( const std::string& url );
+    std::string url_bbscgi_new( const std::string& url );
+    std::string url_subbbscgi_new( const std::string& url );
 
     // 板が移転したかチェックする
     // 移転した時は移転後のURLを返す
-    const std::string is_board_moved( const std::string& url );
+    std::string is_board_moved( const std::string& url );
 
-    const std::string is_board_moved( const std::string& url,
-                                        std::string& old_root,
-                                        std::string& old_path_board,
-                                        std::string& new_root,
-                                        std::string& new_path_board
-        );
+    std::string is_board_moved( const std::string& url,
+                                std::string& old_root,
+                                std::string& old_path_board,
+                                std::string& new_root,
+                                std::string& new_path_board );
 
     // 板移転
     bool move_board( const std::string& url_old, const std::string& url_new );
@@ -87,34 +86,34 @@ namespace DBTREE
     bool remove_etc( const std::string& url, const std::string& name );
     void save_etc();
     void download_bbsmenu();
-    const std::string get_date_modified(); // bbsmenuの更新時間( 文字列 )
+    std::string get_date_modified(); // bbsmenuの更新時間( 文字列 )
     time_t get_time_modified(); // bbsmenuの更新時間( time_t )
 
     // board 系
-    const std::string board_path( const std::string& url );
-    const std::string board_id( const std::string& url );
+    std::string board_path( const std::string& url );
+    std::string board_id( const std::string& url );
     time_t board_time_modified( const std::string& url ); // 板の更新時間( time_t )
-    const std::string board_date_modified( const std::string& url ); // 板の更新時間( 文字列 )
+    std::string board_date_modified( const std::string& url ); // 板の更新時間( 文字列 )
     void board_set_date_modified( const std::string& url, const std::string& date ); // 板の更新時間( 文字列 )をセット
     const std::string& board_get_modified_localrule( const std::string& url );
     void board_set_modified_localrule( const std::string& url, const std::string& modified );
     const std::string& board_get_modified_setting( const std::string& url );
     void board_set_modified_setting( const std::string& url, const std::string& modified );
-    const std::string board_name( const std::string& url );
-    const std::string board_subjecttxt( const std::string& url );
-    const std::string board_charset( const std::string& url );
-    const std::string board_cookie_for_write( const std::string& url );
+    std::string board_name( const std::string& url );
+    std::string board_subjecttxt( const std::string& url );
+    std::string board_charset( const std::string& url );
+    std::string board_cookie_for_write( const std::string& url );
     const std::list< std::string >& board_list_cookies_for_write( const std::string& url );
     void board_set_list_cookies_for_write( const std::string& url, const std::list< std::string>& list_cookies );
     void board_reset_list_cookies_for_write( const std::string& url );
-    const std::string board_keyword_for_write( const std::string& url );
+    std::string board_keyword_for_write( const std::string& url );
     void board_set_keyword_for_write( const std::string& url, const std::string& keyword );
     void board_analyze_keyword_for_write( const std::string& url, const std::string& html );
-    const std::string board_basicauth( const std::string& url );
-    const std::string board_ext( const std::string& url );
+    std::string board_basicauth( const std::string& url );
+    std::string board_ext( const std::string& url );
     int board_status( const std::string& url );
     int board_code( const std::string& url );
-    const std::string board_str_code( const std::string& url );
+    std::string board_str_code( const std::string& url );
     void board_save_info( const std::string& url );
     void board_download_subject( const std::string& url, const std::string& url_update_view );
     void board_read_subject_from_cache( const std::string& url );
@@ -168,7 +167,7 @@ namespace DBTREE
 
     // datファイルのインポート
     // 成功したらdat型のurlを返す
-    const std::string board_import_dat( const std::string& url, const std::string& filename );
+    std::string board_import_dat( const std::string& url, const std::string& filename );
 
     // 各板に属する全スレの書き込み履歴のリセット
     void board_clear_all_post_history( const std::string& url );
@@ -200,22 +199,22 @@ namespace DBTREE
 
     // article 系
     bool article_is_cached( const std::string& url ); // キャッシュにあるかどうか
-    const std::string article_id( const std::string& url ); // 拡張子込み "12345.dat" みたいに
-    const std::string article_key( const std::string& url ); // idから拡張子を取ったもの。書き込み用
-    const std::string article_org_host( const std::string& url ); // 移転する前のオリジナルのURL
+    std::string article_id( const std::string& url ); // 拡張子込み "12345.dat" みたいに
+    std::string article_key( const std::string& url ); // idから拡張子を取ったもの。書き込み用
+    std::string article_org_host( const std::string& url ); // 移転する前のオリジナルのURL
     time_t article_since_time( const std::string& url );
-    const std::string article_since_date( const std::string& url );
+    std::string article_since_date( const std::string& url );
     time_t article_time_modified( const std::string& url ); // スレの更新時間( time_t )
-    const std::string article_date_modified( const std::string& url ); // スレの更新時間( 文字列 )
+    std::string article_date_modified( const std::string& url ); // スレの更新時間( 文字列 )
     void article_set_date_modified( const std::string& url, const std::string& date ); // スレの更新時間( 文字列 )をセット
     int article_hour( const std::string& url );
     time_t article_write_time( const std::string& url );
-    const std::string article_write_date( const std::string& url );
+    std::string article_write_date( const std::string& url );
     int article_status( const std::string& url );
     int article_code( const std::string& url );
-    const std::string article_str_code( const std::string& url );
-    const std::string article_ext_err( const std::string& url );
-    const std::string article_subject( const std::string& url );
+    std::string article_str_code( const std::string& url );
+    std::string article_ext_err( const std::string& url );
+    std::string article_subject( const std::string& url );
     int article_number( const std::string& url );
     int article_number_load( const std::string& url );
     int article_number_seen( const std::string& url );
@@ -250,25 +249,25 @@ namespace DBTREE
     const std::string& get_agent_w( const std::string& url ); // 書き込み用
 
     // 読み込み用プロキシ
-    const std::string get_proxy_host( const std::string& url );
+    std::string get_proxy_host( const std::string& url );
     int get_proxy_port( const std::string& url );
-    const std::string get_proxy_basicauth( const std::string& url );
+    std::string get_proxy_basicauth( const std::string& url );
 
     // 書き込み用プロキシ
-    const std::string get_proxy_host_w( const std::string& url );
+    std::string get_proxy_host_w( const std::string& url );
     int get_proxy_port_w( const std::string& url );
-    const std::string get_proxy_basicauth_w( const std::string& url );
+    std::string get_proxy_basicauth_w( const std::string& url );
 
     // ローカルルール
-    const std::string localrule( const std::string& url );
+    std::string localrule( const std::string& url );
 
     // setting.txt
-    const std::string settingtxt( const std::string& url );
+    std::string settingtxt( const std::string& url );
 
     // 書き込み関係
 
     // デフォルトの名無し名
-    const std::string default_noname( const std::string& url );
+    std::string default_noname( const std::string& url );
 
     // 最大改行数/2
     int line_number( const std::string& url );
@@ -277,7 +276,7 @@ namespace DBTREE
     int message_count( const std::string& url );
 
     // 特殊文字書き込み可能か( pass なら可能、 change なら不可 )
-    const std::string get_unicode( const std::string& url );
+    std::string get_unicode( const std::string& url );
 
     // 書き込み時の名前とメール
     const std::string& write_name( const std::string& url );
@@ -291,13 +290,14 @@ namespace DBTREE
     void set_write_fixmail( const std::string& url, bool set );
 
     // ポストするメッセージの作成
-    const std::string create_write_message( const std::string& url,
-                                            const std::string& name, const std::string& mail, const std::string& msg );
-    const std::string create_newarticle_message( const std::string& url, const std::string& subject,
-                                                 const std::string& name, const std::string& mail, const std::string& msg );
+    std::string create_write_message( const std::string& url, const std::string& name, const std::string& mail,
+                                      const std::string& msg );
+    std::string create_newarticle_message( const std::string& url, const std::string& subject,
+                                           const std::string& name, const std::string& mail,
+                                           const std::string& msg );
 
     // 書き込み時のリファラ
-    const std::string get_write_referer( const std::string& url );
+    std::string get_write_referer( const std::string& url );
 
     // あぼーん関係
 

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -547,7 +547,7 @@ std::list< ANCINFO* > NodeTreeBase::get_res_anchors( const int number )
 //
 // mode_or == true なら OR抽出
 //
-const std::list< int > NodeTreeBase::get_res_query( const std::string& query, const bool mode_or )
+std::list< int > NodeTreeBase::get_res_query( const std::string& query, const bool mode_or )
 {
     std::list< int > list_resnum;
     if( query.empty() ) return list_resnum;

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -626,7 +626,7 @@ else if( node->text ) str_res += node->text; \
 node = node->next_node; \
 } }while(0) \
         
-const std::string NodeTreeBase::get_res_str( int number, bool ref )
+std::string NodeTreeBase::get_res_str( int number, bool ref )
 {
     std::string str_res;
 
@@ -667,7 +667,7 @@ const std::string NodeTreeBase::get_res_str( int number, bool ref )
 //
 // number　番のレスの生文字列を返す
 //
-const std::string NodeTreeBase::get_raw_res_str( int number )
+std::string NodeTreeBase::get_raw_res_str( int number )
 {
 #ifdef _DEBUG
     std::cout << "NodeTreeBase::get_raw_res_str : num = " << number << std::endl;
@@ -714,7 +714,7 @@ const std::string NodeTreeBase::get_raw_res_str( int number )
 //
 // number番を書いた人の名前を取得
 //
-const std::string NodeTreeBase::get_name( int number )
+std::string NodeTreeBase::get_name( int number )
 {
     NODE* head = res_header( number );
     if( ! head ) return std::string();
@@ -762,7 +762,7 @@ std::list< int > NodeTreeBase::get_res_name( const std::string& name )
 // number番のレスの時刻を文字列で取得
 // 内部で regex　を使っているので遅い
 //
-const std::string NodeTreeBase::get_time_str( int number )
+std::string NodeTreeBase::get_time_str( int number )
 {
     std::string res_str = get_res_str( number );
     if( res_str.empty() ) return std::string();
@@ -786,7 +786,7 @@ const std::string NodeTreeBase::get_time_str( int number )
 //
 // number番の ID 取得
 //
-const std::string NodeTreeBase::get_id_name( int number )
+std::string NodeTreeBase::get_id_name( int number )
 {
     NODE* head = res_header( number );
     if( ! head ) return std::string();

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -204,7 +204,7 @@ namespace DBTREE
 
         // query を含むレス番号をリストにして取得
         // mode_or == true なら OR抽出
-        const std::list< int > get_res_query( const std::string& query, const bool mode_or );
+        std::list< int > get_res_query( const std::string& query, const bool mode_or );
 
 
         // number番のレスの文字列を返す

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -160,7 +160,7 @@ namespace DBTREE
         NODE* res_header( int number );
 
         // number番の名前
-        const std::string get_name( int number );
+        std::string get_name( int number );
 
         // number番の名前の重複数( = 発言数 )
         int get_num_name( int number );
@@ -170,10 +170,10 @@ namespace DBTREE
 
         // number番のレスの時刻を文字列で取得
         // 内部で regex　を使っているので遅い
-        const std::string get_time_str( int number );
+        std::string get_time_str( int number );
 
         // number番のID
-        const std::string get_id_name( int number );
+        std::string get_id_name( int number );
 
         // 指定したID の重複数( = 発言数 )
         // 下のget_num_id_name( int number )と違って検索するので遅い
@@ -209,10 +209,10 @@ namespace DBTREE
 
         // number番のレスの文字列を返す
         // ref == true なら先頭に ">" を付ける        
-        const std::string get_res_str( int number, bool ref = false );
+        std::string get_res_str( int number, bool ref = false );
 
         // number　番のレスの生文字列を返す
-        const std::string get_raw_res_str( int number );
+        std::string get_raw_res_str( int number );
         
         // 明示的にhtml を加える
         // パースして追加したノードのポインタを返す

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -1485,7 +1485,7 @@ void Root::save_articleinfo_all()
 
 // 全ログ検索
 void Root::search_cache( std::vector< ArticleBase* >& list_article,
-                         const std::string& query, const bool mode_or, const bool bm, const bool& stop )
+                         const std::string& query, const bool mode_or, const bool bm, const bool stop )
 {
     std::list< BoardBase* >::iterator it;
     for( it = m_list_board.begin(); it != m_list_board.end(); ++it ){

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -1315,7 +1315,7 @@ void Root::load_movetable()
 //
 // 移転した時は移転後のURLを返す
 //
-const std::string Root::is_board_moved( const std::string& url ) // 簡易版
+std::string Root::is_board_moved( const std::string& url ) // 簡易版
 {
     std::string old_root;
     std::string old_path_board;
@@ -1325,13 +1325,12 @@ const std::string Root::is_board_moved( const std::string& url ) // 簡易版
 }
 
 
-const std::string Root::is_board_moved( const std::string& url,
-                                        std::string& old_root,
-                                        std::string& old_path_board,
-                                        std::string& new_root,
-                                        std::string& new_path_board,
-                                        const int count
-    )
+std::string Root::is_board_moved( const std::string& url,
+                                  std::string& old_root,
+                                  std::string& old_path_board,
+                                  std::string& new_root,
+                                  std::string& new_path_board,
+                                  const int count )
 {
     const int max_count = 50;
 

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -123,15 +123,14 @@ namespace DBTREE
 
         // 板が移転したかチェックする
         // 移転した時は移転後のURLを返す
-        const std::string is_board_moved( const std::string& url ); // 簡易版
+        std::string is_board_moved( const std::string& url ); // 簡易版
 
-        const std::string is_board_moved( const std::string& url,
-                                          std::string& old_root,
-                                          std::string& old_path_board,
-                                          std::string& new_root,
-                                          std::string& new_path_board,
-                                          const int count = 0
-            );
+        std::string is_board_moved( const std::string& url,
+                                    std::string& old_root,
+                                    std::string& old_path_board,
+                                    std::string& new_root,
+                                    std::string& new_path_board,
+                                    const int count = 0 );
 
         // 移転情報保存の有効切り替え
         void set_enable_save_movetable( const bool set ){ m_enable_save_movetable = set; }

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -145,7 +145,7 @@ namespace DBTREE
         void save_articleinfo_all();
 
         // 全ログ検索
-        void search_cache( std::vector< ArticleBase* >& list_article, const std::string& query, const bool mode_or, const bool bm, const bool& stop );
+        void search_cache( std::vector< ArticleBase* >& list_article, const std::string& query, const bool mode_or, const bool bm, const bool stop );
 
         // 全てのスレの書き込み履歴削除
         void clear_all_post_history();

--- a/src/dbtree/ruleloader.cpp
+++ b/src/dbtree/ruleloader.cpp
@@ -37,19 +37,19 @@ RuleLoader::~RuleLoader()
 }
 
 
-const std::string RuleLoader::get_url()
+std::string RuleLoader::get_url()
 {
     return m_url_boadbase + HEAD_TXT;
 }
 
 
-const std::string RuleLoader::get_path()
+std::string RuleLoader::get_path()
 {
     return CACHE::path_board_root( m_url_boadbase ) + HEAD_TXT;
 }
 
 
-const std::string RuleLoader::get_charset()
+std::string RuleLoader::get_charset()
 {
     return DBTREE::board_charset( m_url_boadbase );
 }

--- a/src/dbtree/ruleloader.h
+++ b/src/dbtree/ruleloader.h
@@ -28,9 +28,9 @@ namespace DBTREE
 
       protected:
 
-        const std::string get_url() override;
-        const std::string get_path() override;
-        const std::string get_charset() override;
+        std::string get_url() override;
+        std::string get_path() override;
+        std::string get_charset() override;
 
         // ロード用データ作成
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;

--- a/src/dbtree/settingloader.cpp
+++ b/src/dbtree/settingloader.cpp
@@ -39,19 +39,19 @@ SettingLoader::~SettingLoader()
 }
 
 
-const std::string SettingLoader::get_url()
+std::string SettingLoader::get_url()
 {
     return m_url_boadbase + SETTING_TXT;
 }
 
 
-const std::string SettingLoader::get_path()
+std::string SettingLoader::get_path()
 {
     return CACHE::path_board_root( m_url_boadbase ) + SETTING_TXT;
 }
 
 
-const std::string SettingLoader::get_charset()
+std::string SettingLoader::get_charset()
 {
     return DBTREE::board_charset( m_url_boadbase );
 }

--- a/src/dbtree/settingloader.h
+++ b/src/dbtree/settingloader.h
@@ -45,9 +45,9 @@ namespace DBTREE
 
       protected:
 
-        const std::string get_url() override;
-        const std::string get_path() override;
-        const std::string get_charset() override;
+        std::string get_url() override;
+        std::string get_path() override;
+        std::string get_charset() override;
 
         // ロード用データ作成
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -181,7 +181,7 @@ int ImageAdmin::get_tab_nums()
 //
 // 含まれているページのURLのリスト取得
 //
-const std::list< std::string > ImageAdmin::get_URLs()
+std::list< std::string > ImageAdmin::get_URLs()
 {
     std::list< std::string > urls;
     m_iconbox.foreach( [&urls]( Gtk::Widget& w ) {

--- a/src/image/imageadmin.h
+++ b/src/image/imageadmin.h
@@ -50,7 +50,7 @@ namespace IMAGE
         int get_tab_nums() override;
 
         // 含まれているページのURLのリスト取得
-        const std::list< std::string > get_URLs() override;
+        std::list< std::string > get_URLs() override;
 
         // 現在表示してるページ番号
         int get_current_page() override;

--- a/src/jdlib/confloader.cpp
+++ b/src/jdlib/confloader.cpp
@@ -143,7 +143,7 @@ void ConfLoader::update( const std::string& name, const double value )
 // string 型
 //
 // dflt はデフォルト値, デフォルト引数 maxlength = 0
-const std::string ConfLoader::get_option_str( const std::string& name, const std::string& dflt, const size_t maxlength )
+std::string ConfLoader::get_option_str( const std::string& name, const std::string& dflt, const size_t maxlength )
 {
     if( name.empty() ) return std::string();
 

--- a/src/jdlib/confloader.h
+++ b/src/jdlib/confloader.h
@@ -48,7 +48,7 @@ namespace JDLIB
         void update( const std::string& name, const double value );
 
         // 値取得
-        const std::string get_option_str( const std::string& name, const std::string& dflt, const size_t maxlength = 0 );
+        std::string get_option_str( const std::string& name, const std::string& dflt, const size_t maxlength = 0 );
         bool get_option_bool( const std::string& name, const bool dflt );
         int get_option_int( const std::string& name, const int dflt, const int min, const int max );
         double get_option_double( const std::string& name, const double dflt, const double min , const double max );

--- a/src/jdlib/jdregex.cpp
+++ b/src/jdlib/jdregex.cpp
@@ -227,7 +227,7 @@ bool Regex::exec( const std::string reg, const std::string& target,
 }
 
 
-const std::string Regex::str( const size_t num )
+std::string Regex::str( const size_t num )
 {
     if( m_results.size() > num  ) return m_results[ num ];
 

--- a/src/jdlib/jdregex.h
+++ b/src/jdlib/jdregex.h
@@ -52,7 +52,7 @@ namespace JDLIB
                    const bool newline, const bool usemigemo, const bool wchar );
 
         int pos( const size_t num );
-        const std::string str( const size_t num );
+        std::string str( const size_t num );
     };
 }
 

--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -1105,7 +1105,7 @@ struct addrinfo* Loader::get_addrinfo( const std::string& hostname, const int po
 //
 // 送信メッセージ作成
 //
-const std::string Loader::create_msg_send()
+std::string Loader::create_msg_send()
 {
     bool post_msg = ( !m_data.str_post.empty() && !m_data.head );
     bool use_proxy = ( ! m_data.host_proxy.empty() );

--- a/src/jdlib/loader.h
+++ b/src/jdlib/loader.h
@@ -102,7 +102,7 @@ namespace JDLIB
         void clear();
         void run_main();
         struct addrinfo* get_addrinfo( const std::string& hostname, const int port );
-        const std::string create_msg_send();
+        std::string create_msg_send();
         bool wait_recv_send( const int fd, const bool recv );
         bool send_connect( const int soc, std::string& errmsg );
 

--- a/src/jdlib/misctime.cpp
+++ b/src/jdlib/misctime.cpp
@@ -126,7 +126,7 @@ time_t MISC::datetotime( const std::string& date )
 //
 // time_t を月日の文字列に変換
 //
-std::string MISC::timettostr( const time_t& time_from, const int mode )
+std::string MISC::timettostr( const time_t time_from, const int mode )
 {
     const int lng = 64;
     struct tm tm_tmp;

--- a/src/jdlib/misctime.cpp
+++ b/src/jdlib/misctime.cpp
@@ -27,7 +27,7 @@
 //
 // gettimeofday()の秒を文字列で取得
 //
-const std::string MISC::get_sec_str()
+std::string MISC::get_sec_str()
 {
 	std::ostringstream sec_str;
 
@@ -44,7 +44,7 @@ const std::string MISC::get_sec_str()
 //
 // timeval を str に変換
 //
-const std::string MISC::timevaltostr( const struct timeval& tv )
+std::string MISC::timevaltostr( const struct timeval& tv )
 {
     std::ostringstream sstr;
     sstr << ( tv.tv_sec >> 16 ) << " " << ( tv.tv_sec & 0xffff ) << " " << tv.tv_usec;
@@ -126,7 +126,7 @@ time_t MISC::datetotime( const std::string& date )
 //
 // time_t を月日の文字列に変換
 //
-const std::string MISC::timettostr( const time_t& time_from, const int mode )
+std::string MISC::timettostr( const time_t& time_from, const int mode )
 {
     const int lng = 64;
     struct tm tm_tmp;

--- a/src/jdlib/misctime.h
+++ b/src/jdlib/misctime.h
@@ -37,7 +37,7 @@ namespace MISC
 
     // time_t を月日の文字列に変換
     // (例) mode == TIME_NORMAL なら 1135785252 -> 2005/12/29 0:54
-    std::string timettostr( const time_t& time_from, const int mode );
+    std::string timettostr( const time_t time_from, const int mode );
 
     // 実行時間測定用
     void start_measurement( const int id );

--- a/src/jdlib/misctime.h
+++ b/src/jdlib/misctime.h
@@ -26,10 +26,10 @@ namespace MISC
     };
 
     // gettimeofday()の秒を文字列で取得
-    const std::string get_sec_str();
+    std::string get_sec_str();
 
     // timeval を str に変換
-    const std::string timevaltostr( const struct timeval& tv );
+    std::string timevaltostr( const struct timeval& tv );
 
     // 時刻の文字列を紀元からの経過秒に直す
     // (例) Tue, 27 Dec 2005 14:28:10 GMT -> 1135693690
@@ -37,7 +37,7 @@ namespace MISC
 
     // time_t を月日の文字列に変換
     // (例) mode == TIME_NORMAL なら 1135785252 -> 2005/12/29 0:54
-    const std::string timettostr( const time_t& time_from, const int mode );
+    std::string timettostr( const time_t& time_from, const int mode );
 
     // 実行時間測定用
     void start_measurement( const int id );

--- a/src/jdlib/misctrip.cpp
+++ b/src/jdlib/misctrip.cpp
@@ -28,13 +28,13 @@
 // ローカル関数の宣言
 
 // SHA1を計算
-const std::string create_sha1( const std::string& key );
+std::string create_sha1( const std::string& key );
 
 // トリップを計算(新方式)
-const std::string create_trip_newtype( const std::string& key );
+std::string create_trip_newtype( const std::string& key );
 
 // トリップを計算(従来方式)
-const std::string create_trip_conventional( const std::string& key );
+std::string create_trip_conventional( const std::string& key );
 /*--------------------------------------------------------------------*/
 
 
@@ -45,7 +45,7 @@ const std::string create_trip_conventional( const std::string& key );
 // param1: 元となる文字列
 // return: SHA1文字列
 /*--------------------------------------------------------------------*/
-const std::string create_sha1( const std::string& key )
+std::string create_sha1( const std::string& key )
 {
     if( key.empty() ) return std::string();
 
@@ -97,7 +97,7 @@ const std::string create_sha1( const std::string& key )
 // param1: 元となる文字列
 // return: トリップ文字列
 /*--------------------------------------------------------------------*/
-const std::string create_trip_newtype( const std::string& key )
+std::string create_trip_newtype( const std::string& key )
 {
     if( key.empty() ) return std::string();
 
@@ -190,7 +190,7 @@ const std::string create_trip_newtype( const std::string& key )
 // param1: 元となる文字列
 // return: トリップ文字列
 /*--------------------------------------------------------------------*/
-const std::string create_trip_conventional( const std::string& key )
+std::string create_trip_conventional( const std::string& key )
 {
     if( key.empty() ) return std::string();
 
@@ -241,7 +241,7 @@ const std::string create_trip_conventional( const std::string& key )
 // param2: 書き込む掲示板の文字コード
 // return: トリップ文字列
 /*--------------------------------------------------------------------*/
-const std::string MISC::get_trip( const std::string& str, const std::string& charset )
+std::string MISC::get_trip( const std::string& str, const std::string& charset )
 {
     if( str.empty() ) return std::string();
 

--- a/src/jdlib/misctrip.h
+++ b/src/jdlib/misctrip.h
@@ -10,7 +10,7 @@
 namespace MISC
 {
     // トリップを取得 (SHA1等の新方式対応)
-    const std::string get_trip( const std::string& str, const std::string& charset );
+    std::string get_trip( const std::string& str, const std::string& charset );
 }
 
 #endif

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -276,7 +276,7 @@ const std::list< std::string > MISC::strtolist( const std::string& str_in )
 //
 // (例)  "aaa" "bbb" "\"ccc\""
 //
-const std::string MISC::listtostr( const std::list< std::string >& list_in )
+std::string MISC::listtostr( const std::list< std::string >& list_in )
 {
     std::string str_out;
     std::list< std::string >::const_iterator it = list_in.begin();
@@ -292,7 +292,7 @@ const std::string MISC::listtostr( const std::list< std::string >& list_in )
 //
 // strの前後の空白削除
 //
-const std::string MISC::remove_space( const std::string& str )
+std::string MISC::remove_space( const std::string& str )
 {
     std::string str_space = "　";
     size_t lng_space = str_space.length();
@@ -338,7 +338,7 @@ const std::string MISC::remove_space( const std::string& str )
 //
 // str前後の改行、タブ、スペースを削除
 //
-const std::string MISC::remove_spaces( const std::string& str )
+std::string MISC::remove_spaces( const std::string& str )
 {
     if( str.empty() ) return std::string();
 
@@ -366,7 +366,7 @@ const std::string MISC::remove_spaces( const std::string& str )
 //
 // str1からstr2で示された文字列を除く
 //
-const std::string MISC::remove_str( const std::string& str1, const std::string& str2 )
+std::string MISC::remove_str( const std::string& str1, const std::string& str2 )
 {
     return MISC::replace_str( str1, str2, "" );
 }
@@ -375,7 +375,7 @@ const std::string MISC::remove_str( const std::string& str1, const std::string& 
 //
 // start 〜 end の範囲をstrから取り除く ( /* コメント */ など )
 //
-const std::string MISC::remove_str( const std::string& str, const std::string& start, const std::string& end )
+std::string MISC::remove_str( const std::string& str, const std::string& start, const std::string& end )
 {
     std::string str_out = str;
 
@@ -397,7 +397,7 @@ const std::string MISC::remove_str( const std::string& str, const std::string& s
 //
 // 正規表現を使ってstr1からqueryで示された文字列を除く
 //
-const std::string MISC::remove_str_regex( const std::string& str1, const std::string& query )
+std::string MISC::remove_str_regex( const std::string& str1, const std::string& query )
 {
     JDLIB::Regex regex;
     const size_t offset = 0;
@@ -413,7 +413,7 @@ const std::string MISC::remove_str_regex( const std::string& str1, const std::st
 //
 // str1, str2 に囲まれた文字列を切り出す
 //
-const std::string MISC::cut_str( const std::string& str, const std::string& str1, const std::string& str2 )
+std::string MISC::cut_str( const std::string& str, const std::string& str1, const std::string& str2 )
 {
     size_t i = str.find( str1 );
     if( i == std::string::npos ) return std::string();
@@ -428,7 +428,7 @@ const std::string MISC::cut_str( const std::string& str, const std::string& str1
 //
 // str1 を str2 に置き換え
 //
-const std::string MISC::replace_str( const std::string& str, const std::string& str1, const std::string& str2 )
+std::string MISC::replace_str( const std::string& str, const std::string& str1, const std::string& str2 )
 {
     size_t i, pos = 0;
     if( ( i = str.find( str1 , pos ) ) == std::string::npos ) return str;
@@ -464,7 +464,7 @@ const std::list< std::string > MISC::replace_str_list( const std::list< std::str
 //
 // str_in に含まれる改行文字を replace に置き換え
 //
-const std::string MISC::replace_newlines_to_str( const std::string& str_in, const std::string& replace )
+std::string MISC::replace_newlines_to_str( const std::string& str_in, const std::string& replace )
 {
     if( str_in.empty() || replace.empty() ) return str_in;
 
@@ -491,7 +491,7 @@ const std::string MISC::replace_newlines_to_str( const std::string& str_in, cons
 //
 // " を \" に置き換え
 //
-const std::string MISC::replace_quot( const std::string& str )
+std::string MISC::replace_quot( const std::string& str )
 {
     return MISC::replace_str( str, "\"", "\\\"" );
 }
@@ -500,7 +500,7 @@ const std::string MISC::replace_quot( const std::string& str )
 //
 // \" を " に置き換え
 //
-const std::string MISC::recover_quot( const std::string& str )
+std::string MISC::recover_quot( const std::string& str )
 {
     return MISC::replace_str( str, "\\\"", "\"" );
 }
@@ -591,7 +591,7 @@ int MISC::str_to_uint( const char* str, size_t& dig, size_t& n )
 //
 // 数字　-> 文字変換
 //
-const std::string MISC::itostr( const int n )
+std::string MISC::itostr( const int n )
 {
     std::ostringstream ss;
     ss << n;
@@ -603,7 +603,7 @@ const std::string MISC::itostr( const int n )
 //
 // listで指定した数字を文字に変換
 //
-const std::string MISC::intlisttostr( const std::list< int >& list_num )
+std::string MISC::intlisttostr( const std::list< int >& list_num )
 {
     std::ostringstream comment;
 
@@ -676,7 +676,7 @@ size_t MISC::chrtobin( const char* chr_in, char* chr_out )
 //
 // strが半角でmaxsize文字を超えたらカットして後ろに...を付ける
 //
-const std::string MISC::cut_str( const std::string& str, const unsigned int maxsize )
+std::string MISC::cut_str( const std::string& str, const unsigned int maxsize )
 {
     std::string outstr = str;
     unsigned int pos, lng_str;
@@ -745,7 +745,7 @@ bool MISC::has_regex_metachar( const std::string& str, const bool escape )
 //
 // escape == true ならエスケープを考慮 (例)  escape == true なら \+ → \+ のまま、falseなら \+ → \\\+
 //
-const std::string MISC::regex_escape( const std::string& str, const bool escape )
+std::string MISC::regex_escape( const std::string& str, const bool escape )
 {
     if( ! has_regex_metachar( str, escape ) ) return str;
 
@@ -802,7 +802,7 @@ const std::string MISC::regex_escape( const std::string& str, const bool escape 
 //
 // 正規表現のメタ文字をアンエスケープ
 //
-const std::string MISC::regex_unescape( const std::string& str )
+std::string MISC::regex_unescape( const std::string& str )
 {
 #ifdef _DEBUG
     std::cout << "MISC::regex_unescape" << std::endl;
@@ -844,7 +844,7 @@ const std::string MISC::regex_unescape( const std::string& str )
 //
 // include_url : URL中でもエスケープする( デフォルト = true )
 //
-const std::string MISC::html_escape( const std::string& str, const bool include_url )
+std::string MISC::html_escape( const std::string& str, const bool include_url )
 {
     if( str.empty() ) return str;
 
@@ -908,7 +908,7 @@ const std::string MISC::html_escape( const std::string& str, const bool include_
 //
 // HTMLアンエスケープ
 //
-const std::string MISC::html_unescape( const std::string& str )
+std::string MISC::html_unescape( const std::string& str )
 {
     if( str.empty() ) return str;
     if( str.find( "&" ) == std::string::npos ) return str;
@@ -1054,7 +1054,7 @@ bool MISC::is_url_char( const char* str_in, const bool loose_url )
 //
 // URLデコード
 //
-const std::string MISC::url_decode( const std::string& url )
+std::string MISC::url_decode( const std::string& url )
 {
     if( url.empty() ) return std::string();
 
@@ -1099,7 +1099,7 @@ const std::string MISC::url_decode( const std::string& url )
 //
 // url エンコード
 //
-const std::string MISC::url_encode( const char* str, const size_t n )
+std::string MISC::url_encode( const char* str, const size_t n )
 {
     if( str[ n ] != '\0' ){
         ERRMSG( "url_encode : invalid input." );
@@ -1137,7 +1137,7 @@ const std::string MISC::url_encode( const char* str, const size_t n )
 }
 
 
-const std::string MISC::url_encode( const std::string& str )
+std::string MISC::url_encode( const std::string& str )
 {
     return url_encode( str.c_str(), str.length() );
 }
@@ -1148,7 +1148,7 @@ const std::string MISC::url_encode( const std::string& str )
 //
 // str は UTF-8 であること
 //
-const std::string MISC::charset_url_encode( const std::string& str, const std::string& charset )
+std::string MISC::charset_url_encode( const std::string& str, const std::string& charset )
 {
     if( charset.empty() || charset == "UTF-8" ) return MISC::url_encode( str.c_str(), str.length() );
 
@@ -1162,7 +1162,7 @@ const std::string MISC::charset_url_encode( const std::string& str, const std::s
 //
 // ただし半角スペースのところを+に置き換えて区切る
 //
-const std::string MISC::charset_url_encode_split( const std::string& str, const std::string& charset )
+std::string MISC::charset_url_encode_split( const std::string& str, const std::string& charset )
 {
     std::list< std::string > list_str = MISC::split_line( str );
     std::list< std::string >::iterator it = list_str.begin();
@@ -1180,7 +1180,7 @@ const std::string MISC::charset_url_encode_split( const std::string& str, const 
 //
 // BASE64
 //
-const std::string MISC::base64( const std::string& str )
+std::string MISC::base64( const std::string& str )
 {
     char table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
@@ -1230,7 +1230,7 @@ const std::string MISC::base64( const std::string& str )
 //
 // 遅いので連続的な処理が必要な時は使わないこと
 //
-const std::string MISC::Iconv( const std::string& str, const std::string& coding_from, const std::string& coding_to )
+std::string MISC::Iconv( const std::string& str, const std::string& coding_from, const std::string& coding_to )
 {
     if( coding_from == coding_to ) return str;
 
@@ -1338,7 +1338,7 @@ int MISC::decode_spchar_number( const char* in_char, const int offset, const int
 //
 // str に含まれる「&#数字;」形式の数字参照文字列を全てユニーコード文字に変換する
 //
-const std::string MISC::decode_spchar_number( const std::string& str )
+std::string MISC::decode_spchar_number( const std::string& str )
 {
     std::string str_out;
     const size_t str_length = str.length();
@@ -1485,7 +1485,7 @@ int MISC::get_ucs2mode( const int ucs2 )
 //
 // WAVEDASHなどのWindows系UTF-8文字をUnix系文字と相互変換
 //
-const std::string MISC::utf8_fix_wavedash( const std::string& str, const int mode )
+std::string MISC::utf8_fix_wavedash( const std::string& str, const int mode )
 {
     // WAVE DASH 問題
     const size_t size = 4;
@@ -1538,7 +1538,7 @@ const std::string MISC::utf8_fix_wavedash( const std::string& str, const int mod
 //
 // str を大文字化
 //
-const std::string MISC::toupper_str( const std::string& str )
+std::string MISC::toupper_str( const std::string& str )
 {
     std::string str_out;
     const size_t str_length = str.length();
@@ -1566,7 +1566,7 @@ const std::list< std::string > MISC::toupper_list( const std::list< std::string 
 //
 // str を小文字化
 //
-const std::string MISC::tolower_str( const std::string& str )
+std::string MISC::tolower_str( const std::string& str )
 {
     std::string str_out;
     const size_t str_length = str.length();
@@ -1583,7 +1583,7 @@ const std::string MISC::tolower_str( const std::string& str )
 //
 // protocol = false のときはプロトコルを除く
 //
-const std::string MISC::get_hostname( const std::string& path, bool protocol )
+std::string MISC::get_hostname( const std::string& path, bool protocol )
 {
     int lng = 0;
     if( path.find( "http://" ) == 0 ) lng = strlen( "http://" );
@@ -1606,7 +1606,7 @@ const std::string MISC::get_hostname( const std::string& path, bool protocol )
 //
 // path からファイル名だけ取り出す
 //
-const std::string MISC::get_filename( const std::string& path )
+std::string MISC::get_filename( const std::string& path )
 {
     if( path.empty() ) return std::string();
 
@@ -1621,7 +1621,7 @@ const std::string MISC::get_filename( const std::string& path )
 //
 // path からファイル名を除いてディレクトリだけ取り出す
 //
-const std::string MISC::get_dir( const std::string& path )
+std::string MISC::get_dir( const std::string& path )
 {
     if( path.empty() ) return std::string();
 
@@ -1636,7 +1636,7 @@ const std::string MISC::get_dir( const std::string& path )
 //
 // 文字数を限定して環境変数の値を返す
 //
-const std::string MISC::getenv_limited( const char *name, const size_t size )
+std::string MISC::getenv_limited( const char *name, const size_t size )
 {
     if( ! name || ! getenv( name ) ) return std::string();
 
@@ -1654,7 +1654,7 @@ const std::string MISC::getenv_limited( const char *name, const size_t size )
 //
 // pathセパレータを / に置き換える
 //
-const std::string MISC::recover_path( const std::string& str )
+std::string MISC::recover_path( const std::string& str )
 {
 #ifdef _WIN32
     // Windowsのpathセパレータ \ を、jdの / に置き換える

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -21,7 +21,7 @@
 //
 // str を "\n" ごとに区切ってlistにして出力
 //
-const std::list< std::string > MISC::get_lines( const std::string& str ){
+std::list< std::string > MISC::get_lines( const std::string& str ){
         
     std::list< std::string > lines;
     size_t i = 0, i2 = 0, r = 0;
@@ -44,7 +44,7 @@ const std::list< std::string > MISC::get_lines( const std::string& str ){
 //
 // emacs lisp のリスト型を要素ごとにlistにして出力
 //
-const std::list< std::string > MISC::get_elisp_lists( const std::string& str )
+std::list< std::string > MISC::get_elisp_lists( const std::string& str )
 {
 #ifdef _DEBUG
     std::cout << "MISC::get_elisp_lists\n";
@@ -109,7 +109,7 @@ const std::list< std::string > MISC::get_elisp_lists( const std::string& str )
 //
 // strを空白または "" 単位で区切って list で出力
 //
-const std::list< std::string > MISC::split_line( const std::string& str )
+std::list< std::string > MISC::split_line( const std::string& str )
 {
     std::string str_space = "　";
     size_t lng_space = str_space.length();
@@ -176,7 +176,7 @@ const std::list< std::string > MISC::split_line( const std::string& str )
 
 
 // strを delimで区切って list で出力
-const std::list< std::string > MISC::StringTokenizer( const std::string& str, const char delim )
+std::list< std::string > MISC::StringTokenizer( const std::string& str, const char delim )
 {
     std::list< std::string > list_str;
 
@@ -198,7 +198,7 @@ const std::list< std::string > MISC::StringTokenizer( const std::string& str, co
 //
 // list_inから空白行を除いてリストを返す
 //
-const std::list< std::string > MISC::remove_nullline_from_list( const std::list< std::string >& list_in )
+std::list< std::string > MISC::remove_nullline_from_list( const std::list< std::string >& list_in )
 {
     std::list< std::string > list_ret;
     std::list< std::string >::const_iterator it;    
@@ -214,7 +214,7 @@ const std::list< std::string > MISC::remove_nullline_from_list( const std::list<
 //
 // list_inの各行から前後の空白を除いてリストを返す
 //
-const std::list< std::string > MISC::remove_space_from_list( const std::list< std::string >& list_in )
+std::list< std::string > MISC::remove_space_from_list( const std::list< std::string >& list_in )
 {
     std::list< std::string > list_ret;
     std::list< std::string >::const_iterator it;    
@@ -230,7 +230,7 @@ const std::list< std::string > MISC::remove_space_from_list( const std::list< st
 //
 // list_inからコメント行(#)を除いてリストを返す
 //
-const std::list< std::string > MISC::remove_commentline_from_list( const std::list< std::string >& list_in )
+std::list< std::string > MISC::remove_commentline_from_list( const std::list< std::string >& list_in )
 {
     const char commentchr = '#';
 
@@ -253,7 +253,7 @@ const std::list< std::string > MISC::remove_commentline_from_list( const std::li
 //
 // (例)  "aaa" "bbb" "\"ccc\""  → aaa と bbb と "ccc"
 //
-const std::list< std::string > MISC::strtolist( const std::string& str_in )
+std::list< std::string > MISC::strtolist( const std::string& str_in )
 {
     std::list< std::string > list_tmp;
     std::list< std::string > list_ret;
@@ -451,7 +451,7 @@ std::string MISC::replace_str( const std::string& str, const std::string& str1, 
 //
 // list_inから str1 を str2 に置き換えてリストを返す
 //
-const std::list< std::string > MISC::replace_str_list( const std::list< std::string >& list_in,
+std::list< std::string > MISC::replace_str_list( const std::list< std::string >& list_in,
                                                  const std::string& str1, const std::string& str2 )
 {
     std::list< std::string > list_out;
@@ -1552,7 +1552,7 @@ std::string MISC::toupper_str( const std::string& str )
 //
 // list 内のアイテムを全部大文字化
 //
-const std::list< std::string > MISC::toupper_list( const std::list< std::string >& list_str )
+std::list< std::string > MISC::toupper_list( const std::list< std::string >& list_str )
 {
     std::list< std::string > list_out;
     std::list< std::string >::const_iterator it = list_str.begin();

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -72,40 +72,40 @@ namespace MISC
     // list_in の文字列リストを空白と""で区切ってストリングにして出力
     // "は \" に置換される
     // (例)  "aaa" "bbb" "\"ccc\""
-    const std::string listtostr( const std::list< std::string >& list_in );
+    std::string listtostr( const std::list< std::string >& list_in );
 
     // strの前後の空白削除
-    const std::string remove_space( const std::string& str );
+    std::string remove_space( const std::string& str );
 
     // str前後の改行、タブ、スペースを削除
-    const std::string remove_spaces( const std::string& str );
+    std::string remove_spaces( const std::string& str );
 
     // str1からstr2で示された文字列を除く
-    const std::string remove_str( const std::string& str1, const std::string& str2 );
+    std::string remove_str( const std::string& str1, const std::string& str2 );
 
     // start 〜 end の範囲をstrから取り除く ( /* コメント */ など )
-    const std::string remove_str( const std::string& str, const std::string& start, const std::string& end );
+    std::string remove_str( const std::string& str, const std::string& start, const std::string& end );
 
     // 正規表現を使ってstr1からqueryで示された文字列を除く
-    const std::string remove_str_regex( const std::string& str1, const std::string& query );
+    std::string remove_str_regex( const std::string& str1, const std::string& query );
 
     // str1, str2 に囲まれた文字列を切り出す
-    const std::string cut_str( const std::string& str, const std::string& str1, const std::string& str2 );
+    std::string cut_str( const std::string& str, const std::string& str1, const std::string& str2 );
 
     // str1 を str2 に置き換え
-    const std::string replace_str( const std::string& str, const std::string& str1, const std::string& str2 );
+    std::string replace_str( const std::string& str, const std::string& str1, const std::string& str2 );
 
     // list_inから str1 を str2 に置き換えてリストを返す
     const std::list< std::string > replace_str_list( const std::list< std::string >& list_in, const std::string& str1, const std::string& str2 );
 
     // str_in に含まれる改行文字を replace に置き換え
-    const std::string replace_newlines_to_str( const std::string& str_in, const std::string& replace );
+    std::string replace_newlines_to_str( const std::string& str_in, const std::string& replace );
 
     // " を \" に置き換え
-    const std::string replace_quot( const std::string& str );
+    std::string replace_quot( const std::string& str );
 
     // \" を " に置き換え
-    const std::string recover_quot( const std::string& str );
+    std::string recover_quot( const std::string& str );
 
     // str 中に含まれている str2 の 数を返す
     int count_str( const std::string& str, const std::string& str2 );
@@ -123,10 +123,10 @@ namespace MISC
     int str_to_uint( const char* str, size_t& dig, size_t& n );
 
     // 数字　-> 文字変換
-    const std::string itostr( const int n );
+    std::string itostr( const int n );
 
     // listで指定した数字を文字に変換
-    const std::string intlisttostr( const std::list< int >& list_num );
+    std::string intlisttostr( const std::list< int >& list_num );
 
     // 16進数表記文字をバイナリに変換する( 例 "E38182" -> 0xE38182 )
     // 出力 : char_out 
@@ -134,7 +134,7 @@ namespace MISC
     size_t chrtobin( const char* chr_in, char* chr_out );
 
     // strが半角でmaxsize文字を超えたらカットして後ろに...を付ける
-    const std::string cut_str( const std::string& str, const unsigned int maxsize );
+    std::string cut_str( const std::string& str, const unsigned int maxsize );
 
     // 正規表現のメタ文字が含まれているか
     // escape == true ならエスケープを考慮 (例)  escape == true なら \+ → \+ のまま、falseなら \+ → \\\+
@@ -142,17 +142,17 @@ namespace MISC
 
     // 正規表現のメタ文字をエスケープ
     // escape == true ならエスケープを考慮 (例)  escape == true なら \+ → \+ のまま、falseなら \+ → \\\+
-    const std::string regex_escape( const std::string& str, const bool escape );
+    std::string regex_escape( const std::string& str, const bool escape );
 
     // 正規表現のメタ文字をアンエスケープ
-    const std::string regex_unescape( const std::string& str );
+    std::string regex_unescape( const std::string& str );
 
     // HTMLエスケープ
     // include_url : URL中でもエスケープする( デフォルト = true )
-    const std::string html_escape( const std::string& str, const bool include_url = true );
+    std::string html_escape( const std::string& str, const bool include_url = true );
 
     // HTMLアンエスケープ
-    const std::string html_unescape( const std::string& str );
+    std::string html_unescape( const std::string& str );
 
     // URL中のスキームを判別する
     // 戻り値 : スキームタイプ
@@ -169,26 +169,26 @@ namespace MISC
     bool is_url_char( const char* str_in, const bool loose_url );
 
     // URLデコード
-    const std::string url_decode( const std::string& url );
+    std::string url_decode( const std::string& url );
 
     // urlエンコード
-    const std::string url_encode( const char* str, const size_t n );
-    const std::string url_encode( const std::string& str );
+    std::string url_encode( const char* str, const size_t n );
+    std::string url_encode( const std::string& str );
 
     // 文字コードを変換して url エンコード
     // str は UTF-8 であること
-    const std::string charset_url_encode( const std::string& str, const std::string& charset );
+    std::string charset_url_encode( const std::string& str, const std::string& charset );
 
     // 文字コード変換して url エンコード
     // ただし半角スペースのところを+に置き換えて区切る
-    const std::string charset_url_encode_split( const std::string& str, const std::string& charset );
+    std::string charset_url_encode_split( const std::string& str, const std::string& charset );
 
     // BASE64
-    const std::string base64( const std::string& str );
+    std::string base64( const std::string& str );
 
     // 文字コードを coding_from から coding_to に変換
     // 遅いので連続的な処理が必要な時は使わないこと
-    const std::string Iconv( const std::string& str, const std::string& coding_from, const std::string& coding_to );
+    std::string Iconv( const std::string& str, const std::string& coding_from, const std::string& coding_to );
 
     // 「&#数字;」形式の数字参照文字列の中の「数字」部分の文字列長
     //
@@ -214,7 +214,7 @@ namespace MISC
     int decode_spchar_number( const char* in_char, const int offset, const int lng );
 
     // str に含まれる「&#数字;」形式の数字参照文字列を全てユニーコード文字に変換する
-    const std::string decode_spchar_number( const std::string& str );
+    std::string decode_spchar_number( const std::string& str );
 
     // utf-8 -> ucs2 変換
     // 入力 : utfstr 入力文字 (UTF-8)
@@ -231,32 +231,32 @@ namespace MISC
     int ucs2toutf8( const int ucs2, char* utfstr );
 
     // WAVEDASHなどのWindows系UTF-8文字をUnix系文字と相互変換
-    const std::string utf8_fix_wavedash( const std::string& str, const int mode );
+    std::string utf8_fix_wavedash( const std::string& str, const int mode );
 
     // str を大文字化
-    const std::string toupper_str( const std::string& str );
+    std::string toupper_str( const std::string& str );
 
     // list 内のアイテムを全部大文字化
     const std::list< std::string > toupper_list( const std::list< std::string >& list_str );
     
     //str を小文字化
-    const std::string tolower_str( const std::string& str );
+    std::string tolower_str( const std::string& str );
 
     // path からホスト名だけ取り出す
     // protocol = false のときはプロトコルを除く
-    const std::string get_hostname( const std::string& path, const bool protocol = true );
+    std::string get_hostname( const std::string& path, const bool protocol = true );
 
     // path からファイル名だけ取り出す
-    const std::string get_filename( const std::string& path );
+    std::string get_filename( const std::string& path );
 
     // path からファイル名を除いてディレクトリだけ取り出す
-    const std::string get_dir( const std::string& path );
+    std::string get_dir( const std::string& path );
 
     // 文字数を限定して環境変数の値を返す
-    const std::string getenv_limited( const char *name, const size_t size = 1 );
+    std::string getenv_limited( const char *name, const size_t size = 1 );
 
     // pathセパレータを / に置き換える
-    const std::string recover_path( const std::string& str );
+    std::string recover_path( const std::string& str );
     std::vector< std::string > recover_path( std::vector< std::string >&& list_str );
 
     // 文字列(utf-8)に全角英数字が含まれるか判定する

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -44,30 +44,30 @@ namespace MISC
      };
 
     // str を "\n" ごとに区切ってlistにして出力
-    const std::list< std::string > get_lines( const std::string& str );
+    std::list< std::string > get_lines( const std::string& str );
 
     // strを空白または "" 単位で区切って list で出力
-    const std::list< std::string > split_line( const std::string& str );
+    std::list< std::string > split_line( const std::string& str );
 
     // strを delimで区切って list で出力
-    const std::list< std::string > StringTokenizer( const std::string& str, const char delim );
+    std::list< std::string > StringTokenizer( const std::string& str, const char delim );
 
     // emacs lisp のリスト型を要素ごとにlistにして出力
-    const std::list< std::string > get_elisp_lists( const std::string& str );
+    std::list< std::string > get_elisp_lists( const std::string& str );
 
     // list_inから空白行を除いてリストを返す
-    const std::list< std::string > remove_nullline_from_list( const std::list< std::string >& list_in );
+    std::list< std::string > remove_nullline_from_list( const std::list< std::string >& list_in );
 
     // list_inの各行から前後の空白を除いてリストを返す
-    const std::list< std::string > remove_space_from_list( const std::list< std::string >& list_in );
+    std::list< std::string > remove_space_from_list( const std::list< std::string >& list_in );
 
     // list_inからコメント行(#)を除いてリストを返す
-    const std::list< std::string > remove_commentline_from_list( const std::list< std::string >& list_in );
+    std::list< std::string > remove_commentline_from_list( const std::list< std::string >& list_in );
 
     // 空白と""で区切られた str_in の文字列をリストにして出力
     // \"は " に置換される
     // (例)  "aaa" "bbb" "\"ccc\""  → aaa と bbb と "ccc"
-    const std::list< std::string > strtolist( const std::string& str_in );
+    std::list< std::string > strtolist( const std::string& str_in );
 
     // list_in の文字列リストを空白と""で区切ってストリングにして出力
     // "は \" に置換される
@@ -96,7 +96,8 @@ namespace MISC
     std::string replace_str( const std::string& str, const std::string& str1, const std::string& str2 );
 
     // list_inから str1 を str2 に置き換えてリストを返す
-    const std::list< std::string > replace_str_list( const std::list< std::string >& list_in, const std::string& str1, const std::string& str2 );
+    std::list< std::string > replace_str_list( const std::list< std::string >& list_in,
+                                               const std::string& str1, const std::string& str2 );
 
     // str_in に含まれる改行文字を replace に置き換え
     std::string replace_newlines_to_str( const std::string& str_in, const std::string& replace );
@@ -237,7 +238,7 @@ namespace MISC
     std::string toupper_str( const std::string& str );
 
     // list 内のアイテムを全部大文字化
-    const std::list< std::string > toupper_list( const std::list< std::string >& list_str );
+    std::list< std::string > toupper_list( const std::list< std::string >& list_str );
     
     //str を小文字化
     std::string tolower_str( const std::string& str );

--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -145,7 +145,7 @@ void LinkFilterPref::append_row( const std::string& url, const std::string& cmd 
 }
 
 
-const Gtk::TreeModel::iterator LinkFilterPref::get_selected_row()
+Gtk::TreeModel::iterator LinkFilterPref::get_selected_row()
 {
     Gtk::TreeModel::iterator row;
 
@@ -157,7 +157,7 @@ const Gtk::TreeModel::iterator LinkFilterPref::get_selected_row()
 }
 
 
-const Gtk::TreeModel::iterator LinkFilterPref::get_top_row()
+Gtk::TreeModel::iterator LinkFilterPref::get_top_row()
 {
     Gtk::TreeModel::iterator row;
 
@@ -169,7 +169,7 @@ const Gtk::TreeModel::iterator LinkFilterPref::get_top_row()
 }
 
 
-const Gtk::TreeModel::iterator LinkFilterPref::get_bottom_row()
+Gtk::TreeModel::iterator LinkFilterPref::get_bottom_row()
 {
     Gtk::TreeModel::iterator row;
 

--- a/src/linkfilterpref.h
+++ b/src/linkfilterpref.h
@@ -26,8 +26,8 @@ namespace CORE
 
         LinkFilterDiag( Gtk::Window* parent, const std::string& url, const std::string& cmd );
 
-        const Glib::ustring get_url() { return m_entry_url.get_text(); }
-        const Glib::ustring get_cmd() { return m_entry_cmd.get_text(); }
+        Glib::ustring get_url() { return m_entry_url.get_text(); }
+        Glib::ustring get_cmd() { return m_entry_cmd.get_text(); }
 
       private:
         void slot_show_manual();

--- a/src/linkfilterpref.h
+++ b/src/linkfilterpref.h
@@ -78,9 +78,9 @@ namespace CORE
         void append_rows();
         void append_row( const std::string& url, const std::string& cmd );
 
-        const Gtk::TreeModel::iterator get_selected_row();
-        const Gtk::TreeModel::iterator get_top_row();
-        const Gtk::TreeModel::iterator get_bottom_row();
+        Gtk::TreeModel::iterator get_selected_row();
+        Gtk::TreeModel::iterator get_top_row();
+        Gtk::TreeModel::iterator get_bottom_row();
 
         void select_row( const Gtk::TreeModel::iterator& row );
 

--- a/src/message/logmanager.cpp
+++ b/src/message/logmanager.cpp
@@ -361,7 +361,7 @@ void Log_Manager::save( const std::string& url,
 //
 //　書き込みログ取得
 //
-const std::string Log_Manager::get_post_log( const int num )
+std::string Log_Manager::get_post_log( const int num )
 {
     std::string path = CACHE::path_postlog();
 

--- a/src/message/logmanager.h
+++ b/src/message/logmanager.h
@@ -40,7 +40,7 @@ namespace MESSAGE
                    const std::string& subject,  const std::string& msg, const std::string& name, const std::string& mail );
 
         //　書き込みログ取得
-        const std::string get_post_log( const int num );
+        std::string get_post_log( const int num );
 
         // ログファイル( log/postlog-* ) の最大数
         int get_max_num_of_log();

--- a/src/message/messageview.cpp
+++ b/src/message/messageview.cpp
@@ -48,7 +48,7 @@ MessageViewMain::~MessageViewMain()
 //
 // ポストするメッセージ作成
 //
-const std::string MessageViewMain::create_message()
+std::string MessageViewMain::create_message()
 {
     if( ! get_text_message() ) return std::string();
 
@@ -161,7 +161,7 @@ void MessageViewMain::reload()
 //
 // ポストするメッセージ作成
 //
-const std::string MessageViewNew::create_message()
+std::string MessageViewNew::create_message()
 {
     if( ! get_text_message() ) return std::string();
 

--- a/src/message/messageview.h
+++ b/src/message/messageview.h
@@ -18,7 +18,7 @@ namespace MESSAGE
 
       private:
         void write_impl( const std::string& msg ) override;
-        const std::string create_message() override;
+        std::string create_message() override;
     };
 
 
@@ -33,7 +33,7 @@ namespace MESSAGE
 
       private:
         void write_impl( const std::string& msg ) override;
-        const std::string create_message() override;
+        std::string create_message() override;
     };
 
 }

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -145,7 +145,7 @@ Gtk::Window* MessageViewBase::get_parent_win()
 //
 // メインウィンドウのURLバーなどに表示する)
 //
-const std::string MessageViewBase::url_for_copy()
+std::string MessageViewBase::url_for_copy()
 {
     return DBTREE::url_readcgi( get_url(), 0, 0 );
 }
@@ -269,7 +269,7 @@ void MessageViewBase::set_message( const std::string& msg )
 }
 
 
-const Glib::ustring MessageViewBase::get_message()
+Glib::ustring MessageViewBase::get_message()
 {
     if( m_text_message ) return m_text_message->get_text();
 

--- a/src/message/messageviewbase.h
+++ b/src/message/messageviewbase.h
@@ -96,7 +96,7 @@ namespace MESSAGE
         Gtk::Window* get_parent_win() override;
 
         // コピー用のURL
-        const std::string url_for_copy() override;
+        std::string url_for_copy() override;
 
         // コマンド
         bool set_command( const std::string& command,
@@ -157,7 +157,7 @@ namespace MESSAGE
         void slot_switch_page( GtkNotebookPage*, guint page );
         void slot_text_changed();
 
-        virtual const std::string create_message() = 0;
+        virtual std::string create_message() = 0;
 
         void show_status();
 
@@ -167,7 +167,7 @@ namespace MESSAGE
         SKELETON::Admin* get_admin() override;
 
         void set_message( const std::string& msg );
-        const Glib::ustring get_message();
+        Glib::ustring get_message();
 
         SKELETON::CompletionEntry& get_entry_name(){ return m_entry_name; }
         SKELETON::CompletionEntry& get_entry_mail(){ return m_entry_mail; }

--- a/src/searchloader.cpp
+++ b/src/searchloader.cpp
@@ -44,7 +44,7 @@ SearchLoader::~SearchLoader()
 }
 
 
-const std::string SearchLoader::get_url()
+std::string SearchLoader::get_url()
 {
     std::string url = get_usrcmd_manager()->replace_cmd( CONFIG::get_url_search_title(), "", "", m_query, 0 );
 

--- a/src/searchloader.h
+++ b/src/searchloader.h
@@ -33,9 +33,9 @@ namespace CORE
 
       protected:
 
-        const std::string get_url() override;
-        const std::string get_path() override { return {}; }
-        const std::string get_charset() override { return m_charset; }
+        std::string get_url() override;
+        std::string get_path() override { return {}; }
+        std::string get_charset() override { return m_charset; }
 
         // ロード用データ作成
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -934,7 +934,7 @@ void SESSION::set_image_locked( const std::list< bool >& locked ){ image_locked 
 
 // サイドバーのツールバーの項目
 const std::string& SESSION::get_items_sidebar_toolbar_str(){ return items_sidebar_toolbar_str; }
-const std::string SESSION::get_items_sidebar_toolbar_default_str()
+std::string SESSION::get_items_sidebar_toolbar_default_str()
 {
     return
     ITEM_NAME_SEARCHBOX + std::string ( " " ) +
@@ -951,7 +951,7 @@ int SESSION::get_item_sidebar_toolbar( const int num ){ return items_sidebar_too
 
 // メインツールバーの項目
 const std::string& SESSION::get_items_main_toolbar_str(){ return items_main_toolbar_str; }
-const std::string SESSION::get_items_main_toolbar_default_str()
+std::string SESSION::get_items_main_toolbar_default_str()
 {
     return
     ITEM_NAME_BBSLISTVIEW + std::string ( " " ) +
@@ -972,7 +972,7 @@ int SESSION::get_item_main_toolbar( const int num ){ return items_main_toolbar[ 
 
 // スレビューのツールバーの項目
 const std::string& SESSION::get_items_article_toolbar_str(){ return items_article_toolbar_str; }
-const std::string SESSION::get_items_article_toolbar_default_str()
+std::string SESSION::get_items_article_toolbar_default_str()
 {
     return
     ITEM_NAME_WRITEMSG + std::string ( " " ) +
@@ -994,7 +994,7 @@ int SESSION::get_item_article_toolbar( const int num ){ return items_article_too
 
 // 検索ビューのツールバーの項目
 const std::string& SESSION::get_items_search_toolbar_str(){ return items_search_toolbar_str; }
-const std::string SESSION::get_items_search_toolbar_default_str()
+std::string SESSION::get_items_search_toolbar_default_str()
 {
     return
     ITEM_NAME_NAME + std::string ( " " ) +
@@ -1012,7 +1012,7 @@ int SESSION::get_item_search_toolbar( const int num ){ return items_search_toolb
 
 // スレ一覧のツールバー項目
 const std::string& SESSION::get_items_board_toolbar_str(){ return items_board_toolbar_str; }
-const std::string SESSION::get_items_board_toolbar_default_str()
+std::string SESSION::get_items_board_toolbar_default_str()
 {
     return
     ITEM_NAME_NEWARTICLE + std::string ( " " ) +
@@ -1034,7 +1034,7 @@ int SESSION::get_item_board_toolbar( const int num ){ return items_board_toolbar
 
 // 書き込みビューのツールバー項目
 const std::string& SESSION::get_items_msg_toolbar_str(){ return items_msg_toolbar_str; }
-const std::string SESSION::get_items_msg_toolbar_default_str()
+std::string SESSION::get_items_msg_toolbar_default_str()
 {
     return
     ITEM_NAME_PREVIEW + std::string ( " " ) +
@@ -1054,7 +1054,7 @@ int SESSION::get_item_msg_toolbar( const int num ){ return items_msg_toolbar[ nu
 
 // スレ一覧の列項目
 const std::string& SESSION::get_items_board_col_str(){ return items_board_col_str; }
-const std::string SESSION::get_items_board_col_default_str()
+std::string SESSION::get_items_board_col_default_str()
 {
     return
     ITEM_NAME_MARK + std::string ( " " ) +
@@ -1076,7 +1076,7 @@ int SESSION::get_item_board_col( const int num ){ return items_board_col[ num ];
 
 // スレ一覧のコンテキストメニュー項目
 const std::string& SESSION::get_items_board_menu_str(){ return items_board_menu_str; }
-const std::string SESSION::get_items_board_menu_default_str()
+std::string SESSION::get_items_board_menu_default_str()
 {
     return
     ITEM_NAME_BOOKMARK + std::string ( " " ) +
@@ -1106,7 +1106,7 @@ int SESSION::get_item_board_menu( const int num ){ return items_board_menu[ num 
 
 // スレビューのコンテキストメニュー項目
 const std::string& SESSION::get_items_article_menu_str(){ return items_article_menu_str; }
-const std::string SESSION::get_items_article_menu_default_str()
+std::string SESSION::get_items_article_menu_default_str()
 {
     return
     ITEM_NAME_DRAWOUT + std::string ( " " ) +
@@ -1166,7 +1166,7 @@ int SESSION::get_sidebar_current_page()
 }
 
 // 現在開いているサイドバーのurl
-const std::string SESSION::get_sidebar_current_url()
+std::string SESSION::get_sidebar_current_url()
 {
     return BBSLIST::get_admin()->get_current_url();
 }
@@ -1202,7 +1202,7 @@ ARTICLE::DrawAreaBase* SESSION::get_base_drawarea()
 
 
 // 現在開いているarticle のurl
-const std::string SESSION::get_article_current_url()
+std::string SESSION::get_article_current_url()
 {
     return ARTICLE::get_admin()->get_current_url();
 }
@@ -1360,7 +1360,7 @@ void SESSION::get_sidebar_threads( const std::string& url, const int dirid, std:
 
 
 // サイドバーの指定したidのディレクトリの名前を取得
-const std::string SESSION::get_sidebar_dirname( const std::string& url, const int dirid )
+std::string SESSION::get_sidebar_dirname( const std::string& url, const int dirid )
 {
     return BBSLIST::get_admin()->get_dirname( url, dirid );
 }

--- a/src/session.h
+++ b/src/session.h
@@ -301,62 +301,62 @@ namespace SESSION
     int get_sidebar_current_page();
 
     // 現在開いているサイドバーのurl
-    const std::string get_sidebar_current_url();
+    std::string get_sidebar_current_url();
 
     // ツールバー等の項目名 -> ID 変換
     int parse_item( const std::string& item_name );
 
     // サイドバーのツールバー項目
     const std::string& get_items_sidebar_toolbar_str();
-    const std::string get_items_sidebar_toolbar_default_str();
+    std::string get_items_sidebar_toolbar_default_str();
     void set_items_sidebar_toolbar_str( const std::string& items );
     int get_item_sidebar_toolbar( const int num );
 
     // メインツールバーの項目
     const std::string& get_items_main_toolbar_str();
-    const std::string get_items_main_toolbar_default_str();
+    std::string get_items_main_toolbar_default_str();
     void set_items_main_toolbar_str( const std::string& items_str );
     int get_item_main_toolbar( const int num );
 
     // スレビューのツールバーの項目
     const std::string& get_items_article_toolbar_str();
-    const std::string get_items_article_toolbar_default_str();
+    std::string get_items_article_toolbar_default_str();
     void set_items_article_toolbar_str( const std::string& items_str );
     int get_item_article_toolbar( const int num );
 
     // 検索ビューのツールバーの項目
     const std::string& get_items_search_toolbar_str();
-    const std::string get_items_search_toolbar_default_str();
+    std::string get_items_search_toolbar_default_str();
     void set_items_search_toolbar_str( const std::string& items_str );
     int get_item_search_toolbar( const int num );
 
     // スレ一覧のツールバー項目
     const std::string& get_items_board_toolbar_str();
-    const std::string get_items_board_toolbar_default_str();
+    std::string get_items_board_toolbar_default_str();
     void set_items_board_toolbar_str( const std::string& items );
     int get_item_board_toolbar( const int num );
 
     // 書き込みビューのツールバー項目
     const std::string& get_items_msg_toolbar_str();
-    const std::string get_items_msg_toolbar_default_str();
+    std::string get_items_msg_toolbar_default_str();
     void set_items_msg_toolbar_str( const std::string& items );
     int get_item_msg_toolbar( const int num );
 
     // スレ一覧の列項目
     const std::string& get_items_board_col_str();
-    const std::string get_items_board_col_default_str();
+    std::string get_items_board_col_default_str();
     void set_items_board_col_str( const std::string& items );
     int get_item_board_col( const int num );
 
     // スレ一覧のコンテキストメニュー項目
     const std::string& get_items_board_menu_str();
-    const std::string get_items_board_menu_default_str();
+    std::string get_items_board_menu_default_str();
     void set_items_board_menu_str( const std::string& items_str );
     int get_item_board_menu( const int num );
 
     // スレビューのコンテキストメニュー項目
     const std::string& get_items_article_menu_str();
-    const std::string get_items_article_menu_default_str();
+    std::string get_items_article_menu_default_str();
     void set_items_article_menu_str( const std::string& items_str );
     int get_item_article_menu( const int num );
 
@@ -402,7 +402,7 @@ namespace SESSION
     ARTICLE::DrawAreaBase* get_base_drawarea();
 
     // 現在開いているarticle のurl
-    const std::string get_article_current_url();
+    std::string get_article_current_url();
 
 
     // 埋め込みimage使用
@@ -460,7 +460,7 @@ namespace SESSION
     void get_sidebar_threads( const std::string& url, const int dirid, std::vector< std::string >& list_url );
 
     // サイドバーの指定したidのディレクトリの名前を取得
-    const std::string get_sidebar_dirname( const std::string& url, const int dirid );
+    std::string get_sidebar_dirname( const std::string& url, const int dirid );
 }
 
 

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -324,7 +324,7 @@ int Admin::get_tab_nums()
 //
 // 含まれているページのURLのリスト取得
 //
-const std::list<std::string> Admin::get_URLs()
+std::list<std::string> Admin::get_URLs()
 {
     std::list<std::string> urls;
     

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -2055,7 +2055,7 @@ int Admin::get_current_page()
 //
 // 現在表示されているページのURL
 //
-const std::string Admin::get_current_url()
+std::string Admin::get_current_url()
 {
     SKELETON::View* view = get_current_view();
     if( ! view ) return std::string();
@@ -2856,7 +2856,7 @@ void Admin::remove_switchhistory( const std::string& url )
 //   また、その不一致なタブの切り替え履歴を、セッション情報 ( article_switchhistoryなど ) に
 //   保存してしまっていたため、ここで不一致な履歴の削除を行うことで、履歴を修復する。
 //
-const std::string Admin::get_valid_switchhistory()
+std::string Admin::get_valid_switchhistory()
 {
     if( ! m_use_switchhistory ) return std::string();
 

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -125,7 +125,7 @@ namespace SKELETON
         // 現在表示してるページ番号およびURL
         // 表示ページを指定したいときは "set_page" コマンドを使う
         virtual int get_current_page();
-        const std::string get_current_url();
+        std::string get_current_url();
 
         // urlで指定されるタブがロックされているか
         bool is_locked( const std::string& url );
@@ -177,7 +177,7 @@ namespace SKELETON
         virtual COMMAND_ARGS url_to_openarg( const std::string& url, const bool tab, const bool lock ) = 0; 
 
         // COMMAND_ARGS からビューの URL を取得する
-        virtual const std::string command_to_url( const COMMAND_ARGS& command ){ return command.url; }
+        virtual std::string command_to_url( const COMMAND_ARGS& command ){ return command.url; }
 
         // view_modeに該当するページを探す
         virtual int find_view( const std::string& view_mode ){ return -1; };
@@ -344,7 +344,7 @@ namespace SKELETON
         // タブの切り替え履歴を更新
         void append_switchhistory( const std::string& url );
         void remove_switchhistory( const std::string& url );
-        const std::string get_valid_switchhistory();
+        std::string get_valid_switchhistory();
     };
 }
 

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -86,7 +86,7 @@ namespace SKELETON
         virtual int get_tab_nums();
 
         // 含まれているページのURLのリスト取得
-        virtual const std::list< std::string > get_URLs();
+        virtual std::list< std::string > get_URLs();
 
         // Core からのクロック入力。
         // Coreでタイマーをひとつ動かして全体の同期を取るようにしているので

--- a/src/skeleton/dragnote.cpp
+++ b/src/skeleton/dragnote.cpp
@@ -153,7 +153,7 @@ bool DragableNoteBook::on_expose_event( GdkEventExpose* event )
 // 及びタブの高さと位置を取得 ( 枠の描画用 )
 //
 #if !GTKMM_CHECK_VERSION(3,0,0)
-const Alloc_NoteBook DragableNoteBook::get_alloc_notebook()
+Alloc_NoteBook DragableNoteBook::get_alloc_notebook()
 {
     Alloc_NoteBook alloc;
 

--- a/src/skeleton/dragnote.h
+++ b/src/skeleton/dragnote.h
@@ -177,7 +177,7 @@ namespace SKELETON
 #if !GTKMM_CHECK_VERSION(3,0,0)
         // DragableNoteBook を構成している各Notebookの高さ
         // 及びタブの高さと位置を取得 ( 枠の描画用 )
-        const Alloc_NoteBook get_alloc_notebook();
+        Alloc_NoteBook get_alloc_notebook();
 #endif
 
         // ツールバー取得

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -207,7 +207,7 @@ void DragTreeView::set_str_tooltip( const std::string& text )
 //
 // ツールチップ最小幅設定
 //
-void DragTreeView::set_tooltip_min_width( const int& min_width )
+void DragTreeView::set_tooltip_min_width( const int min_width )
 {
     m_tooltip.set_min_width( min_width);
 }

--- a/src/skeleton/dragtreeview.h
+++ b/src/skeleton/dragtreeview.h
@@ -93,7 +93,7 @@ namespace SKELETON
         // ツールチップ表示
         // set_tooltip_min_width()で指定した幅よりもツールチップが広い場合は表示
         void set_str_tooltip( const std::string& str );
-        void set_tooltip_min_width( const int& min_width );
+        void set_tooltip_min_width( const int min_width );
         void hide_tooltip();
         void show_tooltip();
 

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -511,7 +511,7 @@ Gtk::TreeViewColumn* EditTreeView::create_column( const int ypad )
 //
 // 新規ディレクトリ作成
 //
-const Gtk::TreePath EditTreeView::create_newdir( const Gtk::TreePath& path )
+Gtk::TreePath EditTreeView::create_newdir( const Gtk::TreePath& path )
 {
     CORE::DATA_INFO_LIST list_info;
     CORE::DATA_INFO info;
@@ -541,7 +541,7 @@ const Gtk::TreePath EditTreeView::create_newdir( const Gtk::TreePath& path )
 
 
 // ディレクトリIDとパスを相互変換
-const Gtk::TreePath EditTreeView::dirid_to_path( const size_t dirid )
+Gtk::TreePath EditTreeView::dirid_to_path( const size_t dirid )
 {
     if( ! dirid ) return Gtk::TreePath();
 
@@ -572,7 +572,7 @@ size_t EditTreeView::path_to_dirid( const Gtk::TreePath path )
 //
 // コメント挿入
 //
-const Gtk::TreePath EditTreeView::create_newcomment( const Gtk::TreePath& path )
+Gtk::TreePath EditTreeView::create_newcomment( const Gtk::TreePath& path )
 {
     CORE::DATA_INFO_LIST list_info;
     CORE::DATA_INFO info;
@@ -1567,8 +1567,9 @@ void EditTreeView::path2info( CORE::DATA_INFO& info, const Gtk::TreePath& path )
 //
 // (4) そうでなければ path_dest の後に追加
 //
-const Gtk::TreePath EditTreeView::append_one_row( const std::string& url, const std::string& name, const int type, const size_t dirid, const std::string& data,
-                                                  const Gtk::TreePath& path_dest, const bool before, const bool subdir )
+Gtk::TreePath EditTreeView::append_one_row( const std::string& url, const std::string& name, const int type,
+                                            const size_t dirid, const std::string& data,
+                                            const Gtk::TreePath& path_dest, const bool before, const bool subdir )
 {
     Glib::RefPtr< Gtk::TreeStore > treestore = Glib::RefPtr< Gtk::TreeStore >::cast_dynamic( get_model() );
     if( ! treestore ) return Gtk::TreePath();

--- a/src/skeleton/edittreeview.h
+++ b/src/skeleton/edittreeview.h
@@ -131,14 +131,14 @@ namespace SKELETON
         void select_all_dir( Gtk::TreePath path_dir );
 
         // 新規ディレクトリ作成
-        const Gtk::TreePath create_newdir( const Gtk::TreePath& path );
+        Gtk::TreePath create_newdir( const Gtk::TreePath& path );
 
         // ディレクトリIDとパスを相互変換
-        const Gtk::TreePath dirid_to_path( const size_t dirid );
+        Gtk::TreePath dirid_to_path( const size_t dirid );
         size_t path_to_dirid( const Gtk::TreePath path );
 
         // コメント挿入
-        const Gtk::TreePath create_newcomment( const Gtk::TreePath& path );
+        Gtk::TreePath create_newcomment( const Gtk::TreePath& path );
 
         // pathで指定した行の名前の変更
         void rename_row( const Gtk::TreePath& path );
@@ -182,8 +182,9 @@ namespace SKELETON
         // (2) before = true なら前に作る
         // (3) path_dest がディレクトリかつ sudir == true なら path_dest の下に追加。
         // (4) そうでなければ path_dest の後に追加
-        const Gtk::TreePath append_one_row( const std::string& url, const std::string& name, const int type, const size_t dirid, const std::string& data,
-                                            const Gtk::TreePath& path_dest,const bool before, const bool subdir );
+        Gtk::TreePath append_one_row( const std::string& url, const std::string& name, const int type,
+                                      const size_t dirid, const std::string& data,
+                                      const Gtk::TreePath& path_dest, const bool before, const bool subdir );
 
         // ソート実行
         void sort( const Gtk::TreePath& path, const int mode );
@@ -282,7 +283,7 @@ namespace SKELETON
         EditTreeViewIterator( EditTreeView& treeview, EditColumns& columns, const Gtk::TreePath path );
 
         Gtk::TreeModel::Row operator * ();
-        const Gtk::TreePath get_path() const { return m_path; }
+        Gtk::TreePath get_path() const { return m_path; }
 
         void operator ++ ();
 

--- a/src/skeleton/label_entry.cpp
+++ b/src/skeleton/label_entry.cpp
@@ -70,7 +70,7 @@ void LabelEntry::set_text( const std::string& text )
 }
 
 
-const Glib::ustring LabelEntry::get_text()
+Glib::ustring LabelEntry::get_text() const
 {
     if( m_editable ) return m_entry.get_text();
     return m_info.get_text();

--- a/src/skeleton/label_entry.h
+++ b/src/skeleton/label_entry.h
@@ -36,7 +36,7 @@ namespace SKELETON
         void set_label( const std::string& label );
 
         void set_text( const std::string& text );
-        const Glib::ustring get_text();
+        Glib::ustring get_text() const;
 
         void grab_focus();
         bool has_grab();

--- a/src/skeleton/loadable.cpp
+++ b/src/skeleton/loadable.cpp
@@ -212,7 +212,7 @@ int Loadable::get_loader_code()
 }
 
 
-const std::string Loadable::get_loader_str_code()
+std::string Loadable::get_loader_str_code()
 {
     if( ! m_loader ) return std::string();
 
@@ -220,7 +220,7 @@ const std::string Loadable::get_loader_str_code()
 }
 
 
-const std::string Loadable::get_loader_contenttype()
+std::string Loadable::get_loader_contenttype()
 {
     if( ! m_loader ) return std::string();
 
@@ -228,7 +228,7 @@ const std::string Loadable::get_loader_contenttype()
 }
 
 
-const std::string Loadable::get_loader_modified()
+std::string Loadable::get_loader_modified()
 {
     if( ! m_loader ) return std::string();
 
@@ -244,7 +244,7 @@ const std::list< std::string > Loadable::get_loader_cookies()
 }
 
 
-const std::string Loadable::get_loader_location()
+std::string Loadable::get_loader_location()
 {
     if( ! m_loader ) return std::string();
 

--- a/src/skeleton/loadable.cpp
+++ b/src/skeleton/loadable.cpp
@@ -236,7 +236,7 @@ std::string Loadable::get_loader_modified()
 }
 
 
-const std::list< std::string > Loadable::get_loader_cookies()
+std::list< std::string > Loadable::get_loader_cookies()
 {
     if( ! m_loader ) return std::list< std::string >();
 

--- a/src/skeleton/loadable.h
+++ b/src/skeleton/loadable.h
@@ -142,11 +142,11 @@ namespace SKELETON
         void callback_dispatch() override;
 
         int get_loader_code();
-        const std::string get_loader_str_code();
-        const std::string get_loader_contenttype();
-        const std::string get_loader_modified();
+        std::string get_loader_str_code();
+        std::string get_loader_contenttype();
+        std::string get_loader_modified();
         const std::list< std::string > get_loader_cookies();
-        const std::string get_loader_location();
+        std::string get_loader_location();
         size_t get_loader_length();
     };
 }

--- a/src/skeleton/loadable.h
+++ b/src/skeleton/loadable.h
@@ -145,7 +145,7 @@ namespace SKELETON
         std::string get_loader_str_code();
         std::string get_loader_contenttype();
         std::string get_loader_modified();
-        const std::list< std::string > get_loader_cookies();
+        std::list< std::string > get_loader_cookies();
         std::string get_loader_location();
         size_t get_loader_length();
     };

--- a/src/skeleton/textloader.h
+++ b/src/skeleton/textloader.h
@@ -47,9 +47,9 @@ namespace SKELETON
 
       protected:
 
-        virtual const std::string get_url() = 0;
-        virtual const std::string get_path() = 0;
-        virtual const std::string get_charset() = 0;
+        virtual std::string get_url() = 0;
+        virtual std::string get_path() = 0;
+        virtual std::string get_charset() = 0;
 
         // ロード用データ作成
         virtual void create_loaderdata( JDLIB::LOADERDATA& data ) = 0;

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -521,7 +521,7 @@ void ToolBar::add_search_control_mode( const int mode )
 }
 
 
-const std::string ToolBar::get_search_text()
+std::string ToolBar::get_search_text()
 {
     if( ! m_entry_search ) return std::string();
 

--- a/src/skeleton/toolbar.h
+++ b/src/skeleton/toolbar.h
@@ -143,7 +143,7 @@ namespace SKELETON
         // CompletionEntry の入力コントローラのモード設定
         void add_search_control_mode( const int mode );
 
-        const std::string get_search_text();
+        std::string get_search_text();
 
         // 上検索
         Gtk::ToolButton* get_button_up_search();

--- a/src/skeleton/tooltip.h
+++ b/src/skeleton/tooltip.h
@@ -26,7 +26,7 @@ namespace SKELETON
         void modify_font_label( const std::string& fontname );
 
         void set_text( const std::string& text );
-        void set_min_width( const int& min_width ){ m_min_width = min_width; }
+        void set_min_width( const int min_width ){ m_min_width = min_width; }
 
         void show_tooltip();
         void hide_tooltip();

--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -275,7 +275,7 @@ void View::slot_hide_popupmenu()
 //
 // ラベルやステータスバーの色
 //
-const std::string View::get_color()
+std::string View::get_color()
 {
     if( is_broken() ) return "red";
     else if( is_old() ) return "blue";

--- a/src/skeleton/view.h
+++ b/src/skeleton/view.h
@@ -210,7 +210,7 @@ namespace SKELETON
                                   const std::string& arg2 = {} ) { return true; }
 
         // コピー用のURL
-        virtual const std::string url_for_copy(){ return m_url; }
+        virtual std::string url_for_copy(){ return m_url; }
 
         // ツールバーのラベルに表示する文字列
         const std::string& get_label(){ return m_label; }
@@ -259,7 +259,7 @@ namespace SKELETON
         virtual bool is_broken(){ return false; }
 
         // ラベルやステータスバーの色
-        const std::string get_color();
+        std::string get_color();
 
         // キーを押した
         virtual bool slot_key_press( GdkEventKey* event ){ return false; }

--- a/src/urlreplacemanager.h
+++ b/src/urlreplacemanager.h
@@ -42,21 +42,21 @@ namespace CORE
         virtual ~Urlreplace_Manager() noexcept {}
 
         // URLを任意の正規表現で変換する
-        bool exec( std::string &url );
+        bool exec( std::string& url );
 
         // URLからリファラを求める
-        bool referer( const std::string &url, std::string &referer );
+        bool referer( const std::string& url, std::string& referer );
 
         // URLの画像コントロールを取得する
-        int get_imgctrl( const std::string &url );
+        int get_imgctrl( const std::string& url );
 
       private:
 
         void conf2list( const std::string& conf );
-        int get_imgctrl_impl( const std::string &url );
+        int get_imgctrl_impl( const std::string& url );
 
         // 置換文字列を変換
-        void replace( JDLIB::Regex &regex, std::string &str );
+        void replace( JDLIB::Regex& regex, std::string& str );
     };
 
     ///////////////////////////////////////

--- a/src/usrcmdmanager.cpp
+++ b/src/usrcmdmanager.cpp
@@ -291,12 +291,11 @@ bool Usrcmd_Manager::show_replacetextdiag( std::string& texti, const std::string
 // コマンド置換
 // cmdの$URLをurl, $LINKをlink, $TEXT*をtext, $NUMBERをnumberで置き換えて出力
 // text は UTF-8 であること
-const std::string Usrcmd_Manager::replace_cmd( const std::string& cmd,
-                                               const std::string& url,
-                                               const std::string& link,
-                                               const std::string& text,
-                                               const int number
-    )
+std::string Usrcmd_Manager::replace_cmd( const std::string& cmd,
+                                         const std::string& url,
+                                         const std::string& link,
+                                         const std::string& text,
+                                         const int number )
 {
     std::string cmd_out = cmd;
     const std::string oldhostl = DBTREE::article_org_host( link );
@@ -490,7 +489,7 @@ bool Usrcmd_Manager::is_hide( int num, const std::string& url )
 //
 // ユーザコマンドの登録とメニュー作成
 //
-const std::string Usrcmd_Manager::create_usrcmd_menu( Glib::RefPtr< Gtk::ActionGroup >& action_group )
+std::string Usrcmd_Manager::create_usrcmd_menu( Glib::RefPtr< Gtk::ActionGroup >& action_group )
 {
     int dirno = 0;
     int cmdno = 0;
@@ -499,8 +498,8 @@ const std::string Usrcmd_Manager::create_usrcmd_menu( Glib::RefPtr< Gtk::ActionG
 }
 
 // ユーザコマンドの登録とメニュー作成(再帰用)
-const std::string Usrcmd_Manager::create_usrcmd_menu( Glib::RefPtr< Gtk::ActionGroup >& action_group,
-                                                      XML::Dom* dom, int& dirno, int& cmdno )
+std::string Usrcmd_Manager::create_usrcmd_menu( Glib::RefPtr< Gtk::ActionGroup >& action_group,
+                                                XML::Dom* dom, int& dirno, int& cmdno )
 {
     std::string menu;
     if( ! dom ) return menu;

--- a/src/usrcmdmanager.h
+++ b/src/usrcmdmanager.h
@@ -54,17 +54,16 @@ namespace CORE
         // コマンド置換
         // cmdの$URLをurl, $LINKをlink, $TEXT*をtext, $NUMBERをnumberで置き換えて出力
         // text は UTF-8 であること
-        const std::string replace_cmd( const std::string& cmd,
-                                       const std::string& url,
-                                       const std::string& link,
-                                       const std::string& text,
-                                       const int number
-            );
+        std::string replace_cmd( const std::string& cmd,
+                                 const std::string& url,
+                                 const std::string& link,
+                                 const std::string& text,
+                                 const int number );
 
         // ユーザコマンドメニューの作成
-        const std::string create_usrcmd_menu( Glib::RefPtr< Gtk::ActionGroup >& action_group );
-        const std::string create_usrcmd_menu( Glib::RefPtr< Gtk::ActionGroup >& action_group,
-                                              XML::Dom* dom, int& dirno, int& cmdno );
+        std::string create_usrcmd_menu( Glib::RefPtr< Gtk::ActionGroup >& action_group );
+        std::string create_usrcmd_menu( Glib::RefPtr< Gtk::ActionGroup >& action_group,
+                                        XML::Dom* dom, int& dirno, int& cmdno );
 
         Glib::RefPtr< Gtk::Action > get_action( Glib::RefPtr< Gtk::ActionGroup >& action_group, const int num );
 

--- a/src/usrcmdpref.h
+++ b/src/usrcmdpref.h
@@ -27,8 +27,8 @@ namespace CORE
 
         UsrCmdDiag( Gtk::Window* parent, const Glib::ustring& name, const Glib::ustring& cmd );
 
-        const Glib::ustring get_name() { return m_entry_name.get_text(); }
-        const Glib::ustring get_cmd() { return m_entry_cmd.get_text(); }
+        Glib::ustring get_name() { return m_entry_name.get_text(); }
+        Glib::ustring get_cmd() { return m_entry_cmd.get_text(); }
 
       private:
         void slot_show_manual();

--- a/src/xml/dom.cpp
+++ b/src/xml/dom.cpp
@@ -535,7 +535,7 @@ int Dom::nodeType()
     return m_nodeType;
 }
 
-const std::string Dom::nodeName()
+std::string Dom::nodeName()
 {
     return m_nodeName;
 }

--- a/src/xml/dom.cpp
+++ b/src/xml/dom.cpp
@@ -26,7 +26,7 @@ std::set< std::string > Dom::m_static_html_elements;
 
 
 // コンストラクタ
-Dom::Dom( const int& type, const std::string& name, const bool html )
+Dom::Dom( const int type, const std::string& name, const bool html )
     : m_html( html ),
       m_nodeType( type ),
       m_nodeName( name ),
@@ -914,7 +914,7 @@ bool Dom::setAttribute( const std::string& name, const std::string& value )
 //
 // 属性：setAttribute( int )
 //
-bool Dom::setAttribute( const std::string& name, const int& value )
+bool Dom::setAttribute( const std::string& name, const int value )
 {
     if( name.empty()
      || m_nodeType != NODE_TYPE_ELEMENT ) return false;

--- a/src/xml/dom.h
+++ b/src/xml/dom.h
@@ -86,7 +86,7 @@ namespace XML
       public:
 
         // コンストラクタ、デストラクタ
-        Dom( const int& type, const std::string& name, const bool html = false );
+        Dom( const int type, const std::string& name, const bool html = false );
         virtual ~Dom();
 
         // クリア
@@ -133,7 +133,7 @@ namespace XML
         bool hasAttribute( const std::string& name );
         std::string getAttribute( const std::string& name );
         bool setAttribute( const std::string& name, const std::string& value );
-        bool setAttribute( const std::string& name, const int& value );
+        bool setAttribute( const std::string& name, const int value );
         bool removeAttribute( const std::string& name );
     };
 }

--- a/src/xml/dom.h
+++ b/src/xml/dom.h
@@ -101,7 +101,7 @@ namespace XML
 
         // プロパティを扱うアクセッサ
         int nodeType();
-        const std::string nodeName();
+        std::string nodeName();
         std::string nodeValue();
         void nodeValue( const std::string& value );
 


### PR DESCRIPTION
C++11モードではmoveの妨げになるので戻り値の型からconstを取り除きます。実際のところmoveではなくコピーの省略(Return value optimization)へすでに最適化されているパターンが多いので体感できるほどのパフォーマンスの変化はありません。