### PR TITLE
Fix gnutls reception

### DIFF
--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -20,7 +20,7 @@
 #define MAJORVERSION 0
 #define MINORVERSION 1
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20190202"
+#define JDDATE_FALLBACK    "20190217"
 #define JDTAG     ""
 
 //---------------------------------


### PR DESCRIPTION
GnuTLSを使うとchunked transfer encoding方式の受信がエラーになる不具合を修正します。この不具合の影響でスレタイ検索の結果が0件になる問題がありました。
このエラーはチャンク長を処理せず受信するデータがゼロになるまで通信していることが原因ですがこのコミットでは受信の方法自体は修正していません。

* データを受信するとき特定のエラーを受信データ無し(=通信終了)に変換する。
* 新しいバージョンで導入された機能を使って初期化するように修正する。([gnutls公式のサンプルコード][1])
* データの送受信をリトライするように修正する。

[1]: https://gnutls.org/manual/html_node/Client-example-with-X_002e509-certificate-support.html