### PR TITLE
Set ellipsize to window status label since GTK+ 2.6

### DIFF
--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -73,6 +73,9 @@ JDWindow::JDWindow( const bool fold_when_focusout, const bool need_mginfo )
     m_label_stat.set_alignment( Gtk::ALIGN_START );
     m_label_stat.set_selectable( true );
     m_label_stat.set_single_line_mode( true );
+#if GTKMM_CHECK_VERSION(2,6,0)
+    m_label_stat.set_ellipsize( Pango::ELLIPSIZE_END );
+#endif
 
     m_label_stat_ebox.add( m_label_stat );
     m_label_stat_ebox.set_visible_window( false );


### PR DESCRIPTION
ステータスバーのテキストが長いときはウインドウの幅に収まるように末尾を省略する。GTK3版は省略設定がないとテキストの長さに合わせてウインドウの幅が広がる問題があった。

修正にあたり不具合報告や動作検証をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1540656394/627-639