### PR TITLE
Fix variable type for assigning from std::string::find()

### DIFF
--- a/src/control/controlutil.cpp
+++ b/src/control/controlutil.cpp
@@ -358,10 +358,8 @@ std::string CONTROL::get_label( const int id )
 // 例えば id == CONTROL::Save の時は "名前を付けて保存(_S)..." を返す
 std::string CONTROL::get_label_with_mnemonic( const int id )
 {
-    unsigned int pos;
-
     std::string label = CONTROL::get_label ( id );
-    pos = label.find( "...", 0);
+    const auto pos = label.find( "...", 0);
     if ( pos != std::string::npos )
     {
         switch ( id )


### PR DESCRIPTION
```
warning: result of comparison of constant 18446744073709551615 with expression of type 'unsigned int' is always true [-Wtautological-constant-out-of-range-compare]
```
上記のコンパイル時警告を修正します。`std::string::find()`の戻り値を`unsigned int`の変数に代入している箇所があり、`std::string::npos`が返ったときにオーバーフローが発生する可能性があります。
標準では`std::string::size_type`型ですがこのPRでは`auto`を使っています。