### PR TITLE
 Add MATE and Cinnamon to ENVIRONMENT::get_wm() 

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -517,12 +517,14 @@ int ENVIRONMENT::get_wm()
 {
     if( window_manager != WM_UNKNOWN ) return window_manager;
 
-    const std::string str_wm = MISC::getenv_limited( "DESKTOP_SESSION", 5 );
+    const std::string str_wm = MISC::getenv_limited( "DESKTOP_SESSION", 8 );
 
     if( str_wm.find( "xfce" ) != std::string::npos ) window_manager = WM_XFCE;
     else if( str_wm.find( "gnome" ) != std::string::npos ) window_manager = WM_GNOME;
     else if( str_wm.find( "kde" ) != std::string::npos ) window_manager = WM_KDE;
     else if( str_wm.find( "LXDE" ) != std::string::npos ) window_manager = WM_LXDE;
+    else if( str_wm.find( "mate" ) != std::string::npos ) window_manager = WM_MATE;
+    else if( str_wm.find( "cinnamon" ) != std::string::npos ) window_manager = WM_CINNAMON;
 
     if( window_manager == WM_UNKNOWN )
     {
@@ -561,6 +563,8 @@ std::string ENVIRONMENT::get_wm_str()
         case WM_XFCE  : desktop = "XFCE";  break;
         case WM_KDE   : desktop = "KDE";   break;
         case WM_LXDE  : desktop = "LXDE";  break;
+        case WM_MATE  : desktop = "MATE";  break;
+        case WM_CINNAMON  : desktop = "Cinnamon";  break;
     }
 #endif
 

--- a/src/environment.h
+++ b/src/environment.h
@@ -14,6 +14,8 @@ namespace ENVIRONMENT
         WM_XFCE,
         WM_KDE,
         WM_LXDE,
+        WM_MATE,
+        WM_CINNAMON,
         WM_UNKNOWN
     };
 

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -20,7 +20,7 @@
 #define MAJORVERSION 0
 #define MINORVERSION 1
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20190223"
+#define JDDATE_FALLBACK    "20190302"
 #define JDTAG     ""
 
 //---------------------------------

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -246,7 +246,8 @@ void JDWindow::clock_in()
         // メインウィンドウと画像ウィンドウが同時にフォーカスアウトしたら
         // 一時的に transient 指定を外す。メインウィンドウがフォーカスインしたときに
         // Admin::focus_out() で transient 指定を戻す
-        if( ENVIRONMENT::get_wm() == ENVIRONMENT::WM_GNOME
+        const auto wm = ENVIRONMENT::get_wm();
+        if( ( wm == ENVIRONMENT::WM_GNOME || wm == ENVIRONMENT::WM_MATE || wm == ENVIRONMENT::WM_CINNAMON )
             && ! SESSION::is_iconified_win_main() // メインウィンドウが最小化しているときに transient を外すとウィンドウが表示されなくなる
             && ! SESSION::is_focus_win_main() && ! is_focus_win() ){
 


### PR DESCRIPTION
GTK+ベースのデスクトップ環境(MATE, Cinnamon)を動作環境の表示に追加します。
どちらもGNOMEの挙動に準じるように設定します。

**注意:** Cinnamonは画像ビューをウインドウ表示したときの挙動(ウインドウ切り替え)に疑わしさが残ります。ウインドウ切り替え時に画像ビューウインドウが出ていると開く挙動は修正前後で変わっていません。しかし、これはGNOMEやMATEと異なります(画像ビューウインドウは閉じたまま)。