### PR TITLE
Avoid crash on extraction

### DIFF
--- a/src/jdlib/jdregex.cpp
+++ b/src/jdlib/jdregex.cpp
@@ -14,7 +14,7 @@
 
 enum
 {
-    MAX_TARGET_SIZE = 64 * 1024,   // 全角半角変換のバッファサイズ
+    MAX_TARGET_SIZE = 64 * 2048,   // 全角半角変換のバッファサイズ
     REGEX_MAX_NMATCH = 32
 };
 


### PR DESCRIPTION
https://github.com/JDimproved/JDim/issues/46 に対処するパッチです
容量の大きなレスを含むスレッドではキーワード抽出を行うと
検索処理中にバッファが足りずにオーバーフローを起こしてしまうので
バッファの容量を増やして回避します。