### PR TITLE
#46 の(とりあえずの)修正

### DIFF
--- a/src/jdlib/jdregex.cpp
+++ b/src/jdlib/jdregex.cpp
@@ -83,7 +83,7 @@ bool Regex::compile( const std::string reg, const bool icase, const bool newline
     if( m_wchar && MISC::has_widechar( asc_reg ) ){
 
         if( ! m_target_asc ) m_target_asc = ( char* )malloc( MAX_TARGET_SIZE );
-        if( ! m_table_pos ) m_table_pos = ( int* )malloc( MAX_TARGET_SIZE );
+        if( ! m_table_pos ) m_table_pos = ( int* )malloc( sizeof( int ) * MAX_TARGET_SIZE );
 
         MISC::asc( asc_reg, m_target_asc, m_table_pos, MAX_TARGET_SIZE );
         asc_reg = m_target_asc;
@@ -149,7 +149,7 @@ bool Regex::exec( const std::string& target, const size_t offset )
 #endif
 
         if( ! m_target_asc ) m_target_asc = ( char* )malloc( MAX_TARGET_SIZE );
-        if( ! m_table_pos ) m_table_pos = ( int* )malloc( MAX_TARGET_SIZE );
+        if( ! m_table_pos ) m_table_pos = ( int* )malloc( sizeof( int ) * MAX_TARGET_SIZE );
 
         MISC::asc( asc_target, m_target_asc, m_table_pos, MAX_TARGET_SIZE );
         exec_asc = true;

--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -1513,8 +1513,8 @@ bool Loader::init_unzip()
 
     assert( m_buf_zlib_in == NULL );
     assert( m_buf_zlib_out == NULL );
-    m_buf_zlib_in = ( Bytef* )malloc( m_lng_buf_zlib_in + 64 );
-    m_buf_zlib_out = ( Bytef* )malloc( m_lng_buf_zlib_out + 64 );
+    m_buf_zlib_in = ( Bytef* )malloc( sizeof( Bytef ) * m_lng_buf_zlib_in + 64 );
+    m_buf_zlib_out = ( Bytef* )malloc( sizeof( Bytef ) * m_lng_buf_zlib_out + 64 );
 
     return true;
 }


### PR DESCRIPTION
現在一部のmalloc()で
foo *bar = ( foo * ) malloc( buzz ) ;
という形で"buffバイト"のヒープを確保したあとそのポインタに対して
bar[ buzz ] ;
のように"buff個目の要素"としてアクセスしているため、fooが1バイト場合を除き要素の後ろの部分でオーバーフローが発生しています。

例)
buzz=5、fooが1要素当たり4バイトの場合、確保されたメモリは5バイトなのに対して bar[5] は 4*5=20 バイト目となる

foo *bar = ( foo * ) malloc( sizeof( foo ) * buzz ) ;
として正しいバイトを確保するように修正します。

また、charは1バイトが保証されているため変更せず
Bytefは現状1バイトのようですがその保証が有るのか確認できなかったためsizeof(Bytef)に
末尾の +64 は番兵のようなので変更せず
としました。