### PR TITLE
Fix runtime warning for opening a thread since GTK+ 3.20

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -827,6 +827,23 @@ void DrawAreaBase::redraw_view()
 
     configure_impl();
 
+#if GTKMM_CHECK_VERSION(3,20,0)
+    // 実行時の警告を修正する
+    // Gtk-WARNING **: HH:MM:SS.sss: Drawing a gadget with negative dimensions. Did you forget to allocate a size?
+    // (node tab owner gtkmm__GtkNotebook)
+    // FIXME: 起動時に隠れているタブのスレビューを開くとこの警告が出る
+    const auto alloc_view = m_view.get_allocation();
+#ifdef _DEBUG
+    std::cout << "DrawAreaBase::redraw_view "
+              << " m_view.x = " << alloc_view.get_x()
+              << " m_view.y = " << alloc_view.get_y()
+              << " m_view.width = " << alloc_view.get_width()
+              << " m_view.height = " << alloc_view.get_height()
+              << std::endl;
+#endif
+    if( alloc_view.get_x() < 0 || alloc_view.get_y() < 0 ) return;
+#endif
+
     m_view.queue_draw();
     if( m_window ) m_window->process_updates( false );
 }

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -20,7 +20,7 @@
 #define MAJORVERSION 0
 #define MINORVERSION 1
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20190302"
+#define JDDATE_FALLBACK    "20190309"
 #define JDTAG     ""
 
 //---------------------------------


### PR DESCRIPTION
スレビューの描画領域の座標が割り当てられていないときに再描画を実行するとGTKの実行時警告が出るので修正します。

##### 動作環境
GTK+ 3.20以上?

##### 症状があらわれる手順
スレ一覧からスレッドを選択してスレビューで開く

##### 実行時警告の内容
```
Gtk-WARNING **: HH:MM:SS.sss: Drawing a gadget with negative dimensions. Did you forget to allocate a size? (node tab owner gtkmm__GtkNotebook)
```

##### 未修正の問題
起動時に隠れているタブのスレビューを開くとこの警告が出る