### PR TITLE
Fix #40: Make --with-gthread deprecated

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -104,6 +104,7 @@
     --with-[gthread|stdthread]
 
        pthreadの代わりにgthreadまたはstd::threadを使用する。
+       gthreadは非推奨: かわりにstd::threadを使用してください。
 
     --with-gtkmm3
 

--- a/configure.ac
+++ b/configure.ac
@@ -430,7 +430,8 @@ AS_IF(
   [test "x$with_gthread" = xyes -a "x$with_stdthread" = xyes],
   [AC_MSG_ERROR([cannot configure both gthread and stdthread.])],
   [test "x$with_gthread" = xyes],
-  [AC_DEFINE(USE_GTHREAD, , [use gthread instead of pthread])],
+  [AC_MSG_WARN([--with-gthread is deprecated. Use --with-stdthread instead.])
+   AC_DEFINE(USE_GTHREAD, , [use gthread instead of pthread])],
   [test "x$with_stdthread" = xyes],
   [AC_DEFINE(WITH_STD_THREAD, 1, [Use std::thread instead of pthread])]
 )

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -20,7 +20,7 @@
 #define MAJORVERSION 0
 #define MINORVERSION 1
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20190309"
+#define JDDATE_FALLBACK    "20190316"
 #define JDTAG     ""
 
 //---------------------------------


### PR DESCRIPTION
#40 の修正です。

glibmm 2.47からGlib::Threadは非推奨になりました。JDimでもgthreadのサポートを終了するためにconfigureオプションを非推奨にします。

いつ削除されるか言及していませんが少なくとも次のリリースまでは`--with-gthread`オプションは維持されると思います。
