### PR TITLE
Fix released-event misfire for GtkGestureMultiPress

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -5702,10 +5702,11 @@ void DrawAreaBase::slot_multipress_pressed( int n_press, double, double )
     if( !event || event->type != GDK_BUTTON_PRESS ) return;
 
     const unsigned int n_points = m_gesture_multipress->property_n_points();
+    const unsigned int button = m_gesture_multipress->get_current_button();
 #ifdef _DEBUG
     std::cout << "DrawAreaBase::slot_multipress_pressed "
               << "n_press = " << n_press << ", event = " << event->type << ", n_points = " << n_points
-              << std::endl;
+              << ", button = " << button << std::endl;
 #endif
 
     const auto device = m_gesture_multipress->get_device();
@@ -5721,6 +5722,15 @@ void DrawAreaBase::slot_multipress_pressed( int n_press, double, double )
         button_event.button = GDK_BUTTON_SECONDARY;
     }
     slot_button_press_event( &button_event );
+
+    if( button >= 4 ) {
+        // GtkGestureMultiPressを使うとButton4以上のマウスボタンで
+        // button-release-eventの反応が悪くなる環境がある。
+        // そのためpressedから直接releasedの処理を実行することによって問題を回避する。
+        button_event.type = GDK_BUTTON_RELEASE;
+        slot_button_release_event( &button_event );
+        m_gesture_multipress->set_sequence_state( sequence, Gtk::EVENT_SEQUENCE_DENIED );
+    }
 }
 
 void DrawAreaBase::slot_multipress_released( int n_press, double, double )


### PR DESCRIPTION
#### 動作環境
JDim 0.1.0-20190309(git:e649cc2f0c)
GTK3版 (--with-gtkmm3)

#### 不具合
GTK3版を使っているとき、スレビューでマウスボタンのButton4をクリックしても割り当てた動作が実行されないことがある。ボタンの反応が悪い。

#### 原因と修正
`GtkGestureMultiPress`を使うとButton4以上のマウスボタン(>=Button4)でbutton-release-eventの反応が悪くなる環境があります。そのためpressedから直接releasedの処理を実行することによって問題を回避します。

#### 互換性に関する注意
修正後は>=Button4にダブルクリックの設定を割り当てても無効となります。(私が確認したマウスではButton4,5はダブルクリックに対応していませんでした。)

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1540656394/988-989
https://mao.5ch.net/test/read.cgi/linux/1551877588/11
