### PR TITLE
#53 の修正

### DIFF
--- a/src/article/articleview.cpp
+++ b/src/article/articleview.cpp
@@ -215,6 +215,12 @@ bool ArticleViewMain::is_broken()
     return ( get_article()->get_status() & STATUS_BROKEN );
 }
 
+//レス数が最大表示可能数以上か
+bool ArticleViewMain::is_overflow() const noexcept
+{
+    return ( get_article()->get_status() & STATUS_OVERFLOW );
+}
+
 //
 // 再読み込み実行
 //
@@ -469,6 +475,7 @@ void ArticleViewMain::update_finish()
     std::string str_tablabel;
     if( is_broken() ) str_tablabel = "[ 壊れています ]  ";
     else if( is_old() ) str_tablabel = "[ DAT落ち ]  ";
+    else if( is_overflow() ) str_tablabel = "[ レス数が最大表示可能数以上です ]  ";
 
     if( get_label().empty() || ! str_tablabel.empty() ) set_label( str_tablabel + DBTREE::article_subject( url_article() ) );
     ARTICLE::get_admin()->set_command( "redraw_toolbar" );
@@ -626,6 +633,7 @@ void ArticleViewMain::create_status_message()
     if( is_old() ) str_stat = "[ DAT落ち 又は 移転しました ] ";
     if( is_check_update() ) str_stat += "[ 更新可能です ] ";
     if( is_broken() ) str_stat += "[ 壊れています ] ";
+    if( is_overflow() ) str_stat += "[ レス数が最大表示可能数以上です ] ";
 
     if( ! DBTREE::article_ext_err( url_article() ).empty() ) str_stat += "[ " + DBTREE::article_ext_err( url_article() ) + " ] ";
 

--- a/src/article/articleview.h
+++ b/src/article/articleview.h
@@ -50,6 +50,7 @@ namespace ARTICLE
         bool is_check_update() override;
         bool is_old() override;
         bool is_broken() override;
+        bool is_overflow() const noexcept override;
 
         void show_view() override;
         void update_view() override;

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -3183,23 +3183,11 @@ int DrawAreaBase::set_num_id( LAYOUT* layout )
     int num_id = layout->header->node->headinfo->num_id_name;
     if( num_id >= 2 ){
 
-        layout->node->text[ pos++] = ' ';
-        layout->node->text[ pos++] = '(';
-        int div_tmp = 1;
-        if( num_id / 1000 ) div_tmp = 1000;
-        else if( num_id / 100 ) div_tmp = 100;
-        else if( num_id / 10 ) div_tmp = 10;
-        while( div_tmp ){
+        const auto &tmp_str = std::string( " (" ) + std::to_string( num_id ) + ")" ;
+        std::memcpy( layout->node->text, tmp_str.c_str(), tmp_str.size() + 1 );
 
-            int tmp_val = num_id / div_tmp;
-            num_id -= tmp_val * div_tmp;
-            div_tmp /= 10;
-
-            layout->node->text[ pos++] = '0' + tmp_val;
-        }
-        layout->node->text[ pos++] = ')';
-        layout->node->text[ pos ] = '\0';
-        layout->lng_text = pos;
+        pos = tmp_str.size();
+        layout->lng_text = pos ;
     }
 
     return pos;

--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -508,6 +508,9 @@ void LayoutTree::append_html( const std::string& html )
 
     if( ! m_local_nodetree ) m_local_nodetree = new DBTREE::NodeTreeDummy( m_url );
     DBTREE::NODE* node_header = m_local_nodetree->append_html( html );
+    if( !node_header ) {
+        return;
+    }
 
     LAYOUT* header = create_layout_header();
     header->node = node_header;

--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -55,7 +55,6 @@ using namespace ARTICLE;
 LayoutTree::LayoutTree( const std::string& url, const bool show_abone, const bool show_multispace )
     : m_heap( SIZE_OF_HEAP ),
       m_url( url ),
-      m_vec_header( NULL ),
       m_local_nodetree( 0 ),
       m_separator_header( NULL ),
       m_show_abone( show_abone ),
@@ -88,7 +87,7 @@ void LayoutTree::clear()
 {
     m_heap.clear();
 
-    m_vec_header = NULL;
+    m_map_header.clear();
     
     m_last_header = NULL;
     m_max_res_number = 0;
@@ -326,8 +325,7 @@ void LayoutTree::append_node( DBTREE::NODE* node_header, const bool joint )
         header->res_number = res_number;
         header->node = node_header;
         if( res_number > m_max_res_number ) m_max_res_number = res_number;
-        if( ! m_vec_header ) m_vec_header = ( LAYOUT** ) m_heap.heap_alloc( sizeof( LAYOUT* ) * MAX_RESNUMBER );
-        m_vec_header[ res_number ] = header;
+        m_map_header[ res_number ] = header;
 
         while( dom ){
             m_last_dom_attr = dom->attr;
@@ -466,7 +464,6 @@ void LayoutTree::append_abone_node( DBTREE::NODE* node_header )
 {
     const int res_number = node_header->id_header;
     if( res_number > m_max_res_number ) m_max_res_number = res_number;
-    if( ! m_vec_header ) m_vec_header = ( LAYOUT** ) m_heap.heap_alloc( sizeof( LAYOUT* ) * MAX_RESNUMBER );
 
 #ifdef _DEBUG
     std::cout << "LayoutTree::append_abone_node num = " << res_number << std::endl;
@@ -476,7 +473,7 @@ void LayoutTree::append_abone_node( DBTREE::NODE* node_header )
     if( ! m_show_abone && m_article->get_abone_transparent() ) return;
 
     LAYOUT* head = create_layout_header();
-    m_vec_header[ res_number ] = head;
+    m_map_header[ res_number ] = head;
 
     head->res_number = res_number;
 
@@ -559,10 +556,10 @@ const LAYOUT* LayoutTree::get_header_of_res_const( const int number ){ return ge
 
 LAYOUT* LayoutTree::get_header_of_res( const int number )
 {
-    if( ! m_vec_header ) return NULL;
+    if( m_map_header.empty() ) return NULL;
     if( number > m_max_res_number || number <= 0 ) return NULL;
 
-    return m_vec_header[ number ];
+    return m_map_header[ number ];
 }
 
 

--- a/src/article/layouttree.h
+++ b/src/article/layouttree.h
@@ -7,6 +7,7 @@
 #define _LAYOUTTREE_H
 
 #include <string>
+#include <unordered_map>
 
 #include "jdlib/refptr_lock.h"
 #include "jdlib/heap.h"
@@ -83,7 +84,7 @@ namespace ARTICLE
         JDLIB::HEAP m_heap;
         std::string m_url;
 
-        LAYOUT** m_vec_header;  // ヘッダのポインタの配列
+        std::unordered_map< int, LAYOUT* > m_map_header;  // ヘッダのポインタの連想配列
 
         // コメントノードやプレビュー表示時に使うローカルなノードツリー
         DBTREE::NodeTreeBase* m_local_nodetree; 

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -160,7 +160,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     // 最大レス数
     const int max_res = DBTREE::board_get_number_max_res( get_url() );
     m_label_maxres.set_text( "最大レス数 (0 : 未設定)：" );
-    m_spin_maxres.set_range( 0, MAX_RESNUMBER );
+    m_spin_maxres.set_range( 0, CONFIG::get_max_resnumber() );
     m_spin_maxres.set_increments( 1, 1 );
     m_spin_maxres.set_value( max_res );
     m_spin_maxres.set_sensitive( true );

--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -219,6 +219,7 @@ void AboutConfig::append_rows()
     append_row( "デフォルトで連鎖あぼーん", get_confitem()->abone_chain, CONF_ABONE_CHAIN );
     append_row( "書き込み履歴のあるスレを削除する時にダイアログを表示", get_confitem()->show_del_written_thread_diag, CONF_SHOW_DEL_WRITTEN_THREAD_DIAG );
     append_row( "スレを削除する時に画像キャッシュも削除する ( 0: ダイアログ表示 1: 削除 2: 削除しない )", get_confitem()->delete_img_in_thread, CONF_DELETE_IMG_IN_THREAD );
+    append_row( "最大表示可能レス数", get_confitem()->max_resnumber, CONF_MAX_RESNUMBER );
 
     // 書き込みウィンドウ
     append_row( "" );

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -600,6 +600,9 @@ bool ConfigItems::load( const bool restore )
     // スレを削除する時に画像キャッシュも削除する ( 0: ダイアログ表示 1: 削除 2: 削除しない )
     delete_img_in_thread = cf.get_option_int( "delete_img_in_thread", CONF_DELETE_IMG_IN_THREAD, 0, 2 );
 
+    //最大表示可能レス数
+    max_resnumber = cf.get_option_int( "max_resnumber", CONF_MAX_RESNUMBER, 1, std::numeric_limits< int >::max() - 1 );
+
     // FIFOの作成などにエラーがあったらダイアログを表示する
     show_diag_fifo_error = cf.get_option_bool( "show_diag_fifo_error", CONF_SHOW_DIAG_FIFO_ERROR );
 
@@ -949,6 +952,7 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "use_machi_offlaw", use_machi_offlaw );
     cf.update( "show_del_written_thread_diag", show_del_written_thread_diag );
     cf.update( "delete_img_in_thread", delete_img_in_thread );
+    cf.update( "max_resnumber", max_resnumber );
     cf.update( "show_diag_fifo_error", show_diag_fifo_error );
     cf.update( "save_session", save_session );
 

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -519,6 +519,9 @@ namespace CONFIG
         // スレを削除する時に画像キャッシュも削除する ( 0: ダイアログ表示 1: 削除 2: 削除しない )
         int delete_img_in_thread;
 
+        //最大表示可能レス数
+        int max_resnumber;
+
         // FIFOの作成などにエラーがあったらダイアログを表示する
         bool show_diag_fifo_error;
 

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -159,6 +159,7 @@ namespace CONFIG
         CONF_USE_MACHI_OFFLAW = 0, // まちBBSの取得に offlaw.cgi を使用する
         CONF_SHOW_DEL_WRITTEN_THREAD_DIAG = 1, // 書き込み履歴のあるスレを削除する時にダイアログを表示
         CONF_DELETE_IMG_IN_THREAD = 0, // スレを削除する時に画像キャッシュも削除する ( 0: ダイアログ表示 1: 削除 2: 削除しない )
+        CONF_MAX_RESNUMBER = 65536, //最大表示可能レス数
         CONF_SHOW_DIAG_FIFO_ERROR = 1, // FIFOの作成などにエラーがあったらダイアログを表示する
         CONF_SAVE_SESSION = 0, // 指定した分ごとにセッションを自動保存 (0: 保存しない)
     };

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -598,6 +598,11 @@ void CONFIG::set_del_written_thread_diag( const bool set ){ get_confitem()->show
 int CONFIG::get_delete_img_in_thread(){ return get_confitem()->delete_img_in_thread; }
 void CONFIG::set_delete_img_in_thread( const int set ){ get_confitem()->delete_img_in_thread = set; }
 
+//最大表示可能レス数
+int CONFIG::get_max_resnumber(){ return get_confitem()->max_resnumber; }
+void CONFIG::set_max_resnumber( const int set ){ get_confitem()->max_resnumber = set; }
+
+
 // FIFOの作成などにエラーがあったらダイアログを表示する
 bool CONFIG::get_show_diag_fifo_error(){ return get_confitem()->show_diag_fifo_error; }
 void CONFIG::set_show_diag_fifo_error( const bool set ){ get_confitem()->show_diag_fifo_error = set; }

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -588,6 +588,10 @@ namespace CONFIG
     int get_delete_img_in_thread();
     void set_delete_img_in_thread( const int set );
 
+    //最大表示可能レス数
+    int get_max_resnumber();
+    void set_max_resnumber( const int set );
+
     // FIFOの作成などにエラーがあったらダイアログを表示する
     bool get_show_diag_fifo_error();
     void set_show_diag_fifo_error( const bool set );

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -1325,6 +1325,13 @@ void ArticleBase::slot_load_finished()
     // 壊れている
     if( m_nodetree->is_broken() ) m_status |= STATUS_BROKEN;
 
+    // レス数最大表示可能数以上か
+    if( get_number_load() >= CONFIG::get_max_resnumber() )
+        m_status |= STATUS_OVERFLOW;
+    else {
+        m_status &= ~STATUS_OVERFLOW;
+    }
+
     // 状態が変わっていたら情報保存
     if( old_status != m_status ) m_save_info = true;
 

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -793,7 +793,7 @@ void ArticleBase::set_abone_res( const int num_from, const int num_to, const boo
 {
     if( empty() ) return;
     if( num_from > num_to ) return;
-    if( num_from <= 0 || num_to >= CONFIG::get_max_resnumber() ) return;
+    if( num_from <= 0 || num_to > CONFIG::get_max_resnumber() ) return;
 
 #ifdef _DEBUG
     std::cout << "ArticleBase::set_abone_res num_from = " << num_from << " num_to = " << num_to << " set = " << set << std::endl;
@@ -1325,7 +1325,7 @@ void ArticleBase::slot_load_finished()
     // 壊れている
     if( m_nodetree->is_broken() ) m_status |= STATUS_BROKEN;
 
-    // レス数最大表示可能数以上か
+    // レス数が最大表示可能数以上か
     if( get_number_load() >= CONFIG::get_max_resnumber() )
         m_status |= STATUS_OVERFLOW;
     else {

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -793,7 +793,7 @@ void ArticleBase::set_abone_res( const int num_from, const int num_to, const boo
 {
     if( empty() ) return;
     if( num_from > num_to ) return;
-    if( num_from <= 0 || num_to >= MAX_RESNUMBER ) return;
+    if( num_from <= 0 || num_to >= CONFIG::get_max_resnumber() ) return;
 
 #ifdef _DEBUG
     std::cout << "ArticleBase::set_abone_res num_from = " << num_from << " num_to = " << num_to << " set = " << set << std::endl;
@@ -917,7 +917,7 @@ bool ArticleBase::is_bookmarked( const int number )
 void ArticleBase::set_bookmark( const int number, const bool set )
 {
     if( m_bookmarks.empty() ) get_nodetree();
-    if( number <= 0 || number > MAX_RESNUMBER ) return;
+    if( number <= 0 || number > CONFIG::get_max_resnumber() ) return;
 
     m_save_info = true;
     if( set ) {
@@ -1826,13 +1826,13 @@ void ArticleBase::read_info()
         // 取得数
         m_number_load = 0;
         GET_INFOVALUE( str_tmp, "load = " );
-        if( ! str_tmp.empty() ) m_number_load = atoi( str_tmp.c_str() );
+        if( ! str_tmp.empty() ) m_number_load = std::stoi( str_tmp );
         m_number_before_load = m_number_load;
 
         // 見た場所
         m_number_seen = 0;
         GET_INFOVALUE( str_tmp, "seen = " );
-        if( ! str_tmp.empty() ) m_number_seen = atoi( str_tmp.c_str() );
+        if( ! str_tmp.empty() ) m_number_seen = std::stoi( str_tmp );
 
         // 更新時間 (time)
         GET_INFOVALUE( m_date_modified, "modified = " );

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -415,7 +415,7 @@ void Board2chCompati::parse_subject( const char* str_subject_txt )
         }
 
         const auto num = std::atoi( str_num );
-        artinfo.number = ( num < CONFIG::get_max_resnumber() ) ? num : CONFIG::get_max_resnumber() - 1 ;
+        artinfo.number = ( num < CONFIG::get_max_resnumber() ) ? num : CONFIG::get_max_resnumber();
 
         get_list_artinfo().push_back( artinfo );
 

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -413,8 +413,9 @@ void Board2chCompati::parse_subject( const char* str_subject_txt )
             artinfo.subject = MISC::replace_str( artinfo.subject, "&lt;", "<" );
             artinfo.subject = MISC::replace_str( artinfo.subject, "&gt;", ">" );
         }
-        
-        artinfo.number = atol( str_num );
+
+        const auto num = std::atoi( str_num );
+        artinfo.number = ( num < CONFIG::get_max_resnumber() ) ? num : CONFIG::get_max_resnumber() - 1 ;
 
         get_list_artinfo().push_back( artinfo );
 

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -494,7 +494,7 @@ void BoardBase::set_number_max_res( const int number )
     std::cout << "BoardBase::set_number_max_res " << m_number_max_res << " -> " << number << std::endl;
 #endif
 
-    m_number_max_res = MAX( 0, MIN( MAX_RESNUMBER, number ) );
+    m_number_max_res = MAX( 0, MIN( CONFIG::get_max_resnumber(), number ) );
 
     ArticleHashIterator it = m_hash_article->begin();
     for( ; it != m_hash_article->end(); ++it ) ( *it )->set_number_max( m_number_max_res );
@@ -631,7 +631,7 @@ std::string BoardBase::url_dat( const std::string& url, int& num_from, int& num_
             num_from = MAX( 1, num_from );
 
             // 12- みたいな場合はとりあえず大きい数字を入れとく
-            if( !regex.str( 5 ).empty() && !num_to ) num_to = MAX_RESNUMBER + 1;
+            if( !regex.str( 5 ).empty() && !num_to ) num_to = CONFIG::get_max_resnumber() + 1;
         }
 
         // -15 みたいな場合
@@ -2088,7 +2088,7 @@ void BoardBase::read_board_info()
     m_status = cf.get_option_int( "status", STATUS_UNKNOWN, 0, 8192 );
 
     // 最大レス数
-    m_number_max_res = cf.get_option_int( "max_res", get_default_number_max_res(), 0, MAX_RESNUMBER );
+    m_number_max_res = cf.get_option_int( "max_res", get_default_number_max_res(), 0, CONFIG::get_max_resnumber() );
 
 #ifdef _DEBUG
     std::cout << "modified = " << get_date_modified() << std::endl;

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -217,7 +217,7 @@ void BoardJBBS::parse_subject( const char* str_subject_txt )
         artinfo.subject = MISC::replace_str( artinfo.subject, "&gt;", ">" );
 
         const auto num = std::atoi( str_num );
-        artinfo.number = ( num < CONFIG::get_max_resnumber() ) ? num : CONFIG::get_max_resnumber() - 1 ;
+        artinfo.number = ( num < CONFIG::get_max_resnumber() ) ? num : CONFIG::get_max_resnumber();
 
         get_list_artinfo().push_back( artinfo );
 

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -11,6 +11,8 @@
 #include "jdlib/miscmsg.h"
 #include "jdlib/loaderdata.h"
 
+#include "config/globalconf.h"
+
 #include "global.h"
 
 #include <sstream>
@@ -213,8 +215,9 @@ void BoardJBBS::parse_subject( const char* str_subject_txt )
         artinfo.subject = MISC::remove_space( artinfo.subject );
         artinfo.subject = MISC::replace_str( artinfo.subject, "&lt;", "<" );
         artinfo.subject = MISC::replace_str( artinfo.subject, "&gt;", ">" );
-        
-        artinfo.number = atol( str_num );
+
+        const auto num = std::atoi( str_num );
+        artinfo.number = ( num < CONFIG::get_max_resnumber() ) ? num : CONFIG::get_max_resnumber() - 1 ;
 
         get_list_artinfo().push_back( artinfo );
 

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -12,6 +12,8 @@
 #include "jdlib/loaderdata.h"
 #include "jdlib/jdregex.h"
 
+#include "config/globalconf.h"
+
 #include "global.h"
 
 #include <sstream>
@@ -273,8 +275,9 @@ void BoardMachi::parse_subject( const char* str_subject_txt )
         artinfo.subject = MISC::remove_space( artinfo.subject );
         artinfo.subject = MISC::replace_str( artinfo.subject, "&lt;", "<" );
         artinfo.subject = MISC::replace_str( artinfo.subject, "&gt;", ">" );
-        
-        artinfo.number = atol( str_num );
+
+        const auto num = std::atoi( str_num );
+        artinfo.number = ( num < CONFIG::get_max_resnumber() ) ? num : CONFIG::get_max_resnumber() - 1 ;
 
         get_list_artinfo().push_back( artinfo );        
 

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -277,7 +277,7 @@ void BoardMachi::parse_subject( const char* str_subject_txt )
         artinfo.subject = MISC::replace_str( artinfo.subject, "&gt;", ">" );
 
         const auto num = std::atoi( str_num );
-        artinfo.number = ( num < CONFIG::get_max_resnumber() ) ? num : CONFIG::get_max_resnumber() - 1 ;
+        artinfo.number = ( num < CONFIG::get_max_resnumber() ) ? num : CONFIG::get_max_resnumber();
 
         get_list_artinfo().push_back( artinfo );        
 

--- a/src/dbtree/node.h
+++ b/src/dbtree/node.h
@@ -79,7 +79,6 @@ namespace DBTREE
         bool sage; // メール欄がsageか
 
         int num_id_name; // 同じIDのレスの個数( = 発言数 )
-        NODE* pre_id_name_header; // 同じIDを持つ一つ前のヘッダノードのアドレス
 
         NODE* block[ BLOCK_NUM ];
     };

--- a/src/dbtree/node.h
+++ b/src/dbtree/node.h
@@ -113,7 +113,7 @@ namespace DBTREE
     {
         unsigned char type;
 
-        short id_header; // ヘッダID ( つまりレス番号、ルートヘッダは0 )
+        int id_header; // ヘッダID ( つまりレス番号、ルートヘッダは0 )
         NODE* next_node; // 最終ノードはNULL
         
         char* text;

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -102,7 +102,8 @@ NodeTreeBase::NodeTreeBase( const std::string& url, const std::string& modified 
 
     // ルートヘッダ作成。中は空。
     m_id_header = -1; // ルートヘッダIDが 0 になるように -1
-    NODE* tmpnode = create_node_header(); 
+    NODE* tmpnode = create_node_header();
+    assert( tmpnode );
     m_vec_header[ m_id_header ] = tmpnode;
 
     m_default_noname = DBTREE::default_noname( m_url );
@@ -816,8 +817,13 @@ NODE* NodeTreeBase::create_node()
 //
 // ヘッダノード作成
 //
+// 要素数が(MAX_RESNUMBER - 1)以上の場合nullptrを返す
 NODE* NodeTreeBase::create_node_header()
 {
+    if( m_id_header >= MAX_RESNUMBER - 1 ) {
+        return nullptr;
+    }
+
     ++m_id_header;
     m_node_previous = NULL;
 
@@ -1068,6 +1074,9 @@ NODE* NodeTreeBase::append_html( const std::string& html )
 #endif
 
     NODE* header = create_node_header();
+    if( !header ) {
+        return nullptr;
+    }
     m_vec_header[ m_id_header ] = header;
 
     init_loading();
@@ -1517,7 +1526,7 @@ void NodeTreeBase::add_raw_lines( char* rawlines, size_t size )
     int num_before = m_id_header;
     const char* pos = datlines;
 
-    while( * ( pos = add_one_dat_line( pos ) ) != '\0' ) ++pos;
+    while( ( pos = add_one_dat_line( pos ) ) && *pos != '\0' ) ++pos;
 
     if( num_before != m_id_header ){
 
@@ -1555,6 +1564,9 @@ const char* NodeTreeBase::add_one_dat_line( const char* datline )
 
     size_t i;
     NODE* header = create_node_header();
+    if( !header ) {
+        return nullptr;
+    }
     m_vec_header[ m_id_header ] =  header;
 
     // レス番号

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -29,6 +29,7 @@
 
 #include <sstream>
 #include <fstream>
+#include <limits>
 
 
 #ifndef MAX
@@ -47,7 +48,7 @@ constexpr int LNG_ID = 256;
 constexpr size_t LNG_LINK = 256;
 constexpr size_t MAX_ANCINFO = 64;
 constexpr int RANGE_REF = 20;
-constexpr size_t MAX_LINK_DIGIT = 4;  // レスアンカーでMAX_LINK_DIGIT 桁までリンクにする
+constexpr size_t MAX_LINK_DIGIT = std::numeric_limits< int >::digits10 + 1;  // レスアンカーでMAX_LINK_DIGIT 桁までリンクにする
 
 constexpr size_t MAXSISE_OF_LINES = 512 * 1024;  // ロード時に１回の呼び出しで読み込まれる最大データサイズ
 constexpr size_t SIZE_OF_HEAP = MAXSISE_OF_LINES + 64;
@@ -815,10 +816,10 @@ NODE* NodeTreeBase::create_node()
 //
 // ヘッダノード作成
 //
-// 要素数が(MAX_RESNUMBER - 1)以上の場合nullptrを返す
+// 要素数が(CONFIG::get_max_resnumber() - 1)以上の場合nullptrを返す
 NODE* NodeTreeBase::create_node_header()
 {
-    if( m_id_header >= MAX_RESNUMBER - 1 ) {
+    if( m_id_header >= CONFIG::get_max_resnumber() - 1 ) {
         return nullptr;
     }
 
@@ -3332,7 +3333,7 @@ void NodeTreeBase::check_reference( const int number )
                         if( anc_from == 0 ) break;
                         ++anc;
 
-                        anc_to = MIN( anc_to, MAX_RESNUMBER );
+                        anc_to = MIN( anc_to, CONFIG::get_max_resnumber() );
 
                         // >>1-1000 みたいなアンカーは弾く
                         if( anc_to - anc_from >= RANGE_REF ) continue;

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -816,10 +816,10 @@ NODE* NodeTreeBase::create_node()
 //
 // ヘッダノード作成
 //
-// 要素数が(CONFIG::get_max_resnumber() - 1)以上の場合nullptrを返す
+// 要素数が(CONFIG::get_max_resnumber())より多くなる場合nullptrを返す
 NODE* NodeTreeBase::create_node_header()
 {
-    if( m_id_header >= CONFIG::get_max_resnumber() - 1 ) {
+    if( m_id_header >= CONFIG::get_max_resnumber() ) {
         return nullptr;
     }
 

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -48,7 +48,7 @@ constexpr int LNG_ID = 256;
 constexpr size_t LNG_LINK = 256;
 constexpr size_t MAX_ANCINFO = 64;
 constexpr int RANGE_REF = 20;
-constexpr size_t MAX_LINK_DIGIT = std::numeric_limits< int >::digits10 + 1;  // レスアンカーでMAX_LINK_DIGIT 桁までリンクにする
+constexpr size_t MAX_RES_DIGIT = std::numeric_limits< int >::digits10 + 1;  // レスアンカーや発言数で使われるレスの桁数
 
 constexpr size_t MAXSISE_OF_LINES = 512 * 1024;  // ロード時に１回の呼び出しで読み込まれる最大データサイズ
 constexpr size_t SIZE_OF_HEAP = MAXSISE_OF_LINES + 64;
@@ -1047,7 +1047,7 @@ NODE* NodeTreeBase::create_node_ntext( const char* text, const int n, const int 
     if( tmpnode ){
         tmpnode->type = NODE_TEXT;
 
-        tmpnode->text = ( char* )m_heap.heap_alloc( n +8 );
+        tmpnode->text = ( char* )m_heap.heap_alloc( n + MAX_RES_DIGIT + 4 );
         memcpy( tmpnode->text, text, n ); tmpnode->text[ n ] = '\0';
         tmpnode->color_text = color_text;
         tmpnode->bold = bold;
@@ -2594,10 +2594,10 @@ bool NodeTreeBase::check_anchor( const int mode, const char* str_in,
     // 数字かチェック
     size_t n, dig;
     int num = MISC::str_to_uint( pos, dig, n );
-    if( dig == 0 || dig > MAX_LINK_DIGIT || num == 0 ){
+    if( dig == 0 || dig > MAX_RES_DIGIT || num == 0 ){
 
         // モード2で数字が長すぎるときは飛ばす
-        if( mode == 2 && dig > MAX_LINK_DIGIT ) n_in = ( int )( pos - str_in ) + n; 
+        if( mode == 2 && dig > MAX_RES_DIGIT ) n_in = ( int )( pos - str_in ) + n;
 
         return false;
     }
@@ -2620,7 +2620,7 @@ bool NodeTreeBase::check_anchor( const int mode, const char* str_in,
         // >>1１ を書き込むと <a href="..">&gt;&gt;1</a>１ となるため
         size_t n2, dig2;
         const int num2 = MISC::str_to_uint( pos, dig2, n2 );
-        if( dig2 > 0 && dig2 <= MAX_LINK_DIGIT ){
+        if( dig2 > 0 && dig2 <= MAX_RES_DIGIT ){
 
             for( size_t i = 0; i < dig2; ++i ) num *= 10;
             num += num2;
@@ -2652,7 +2652,7 @@ bool NodeTreeBase::check_anchor( const int mode, const char* str_in,
     if( offset ){
         
         ancinfo->anc_to = MAX( ancinfo->anc_from, MISC::str_to_uint( pos + offset, dig, n ) );
-        if( dig && dig <= MAX_LINK_DIGIT && ancinfo->anc_to ){
+        if( dig && dig <= MAX_RES_DIGIT && ancinfo->anc_to ){
 
             // 画面に表示する文字            
             memcpy( str_out + lng_out, pos, offset + n );

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -97,14 +97,12 @@ NodeTreeBase::NodeTreeBase( const std::string& url, const std::string& modified 
 
     clear();
 
-    // ヘッダのポインタの配列作成
-    m_vec_header = ( NODE** ) m_heap.heap_alloc( sizeof( NODE* ) * MAX_RESNUMBER );
-
     // ルートヘッダ作成。中は空。
     m_id_header = -1; // ルートヘッダIDが 0 になるように -1
     NODE* tmpnode = create_node_header();
     assert( tmpnode );
-    m_vec_header[ m_id_header ] = tmpnode;
+    assert( m_vec_header.size() == static_cast< decltype( m_vec_header.size() ) >( m_id_header ) );
+    m_vec_header.push_back( tmpnode );
 
     m_default_noname = DBTREE::default_noname( m_url );
 
@@ -1077,7 +1075,8 @@ NODE* NodeTreeBase::append_html( const std::string& html )
     if( !header ) {
         return nullptr;
     }
-    m_vec_header[ m_id_header ] = header;
+    assert( m_vec_header.size() == static_cast< decltype( m_vec_header.size() ) >( m_id_header ) );
+    m_vec_header.push_back( header );
 
     init_loading();
     header->headinfo->block[ BLOCK_MES ] = create_node_block();
@@ -1567,7 +1566,8 @@ const char* NodeTreeBase::add_one_dat_line( const char* datline )
     if( !header ) {
         return nullptr;
     }
-    m_vec_header[ m_id_header ] =  header;
+    assert( m_vec_header.size() == static_cast< decltype( m_vec_header.size() ) >( m_id_header ) );
+    m_vec_header.push_back( header );
 
     // レス番号
     char tmplink[ LNG_RES ], tmpstr[ LNG_RES ];

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -16,6 +16,7 @@
 
 #include <map>
 #include <cstring>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace JDLIB
@@ -127,6 +128,9 @@ namespace DBTREE
 
         // その他のエラーメッセージ
         std::string m_ext_err;
+
+        // 各IDと発言数、レス番号のマッピング
+        std::unordered_map< std::string, std::unordered_set< int > > m_map_id_name_resnumber;
 
       protected:
 
@@ -370,7 +374,7 @@ namespace DBTREE
 
         // 発言数( num_id_name )の更新
         // IDノードの色も変更する
-        void set_num_id_name( NODE* header, const int num_id_name, NODE* pre_id_name_header );
+        void set_num_id_name( NODE* header, const int num_id_name );
 
 
         // from_number番から to_number 番までのレスのフォント判定を更新

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -66,7 +66,7 @@ namespace DBTREE
         bool m_broken;  
 
         JDLIB::HEAP m_heap;
-        NODE** m_vec_header;  // レスのヘッダのポインタの配列
+        std::vector< NODE* > m_vec_header;  // レスのヘッダのポインタの配列
         
         std::string m_subject;
 

--- a/src/global.h
+++ b/src/global.h
@@ -210,13 +210,13 @@ enum
 // 板やスレッドの状態
 enum
 {
-    STATUS_UNKNOWN = 0,  // 不明
-    STATUS_NORMAL = 1,   // 通常
-    STATUS_OLD = 2,      // DAT落ち or 板が移転した
-    STATUS_BROKEN = 4,   // あぼーんなどで壊れている
-    STATUS_UPDATE = 8,   // 更新可能
-    STATUS_UPDATED = 16,   // 更新済み
-    STATUS_BROKEN_SUBJECT = 32  // subject.txt が壊れている( subject.txt に示されたレス数よりも実際の取得数の方が多い )
+    STATUS_UNKNOWN =        0, // 不明
+    STATUS_NORMAL =         1 << 0, // 通常
+    STATUS_OLD =            1 << 1, // DAT落ち or 板が移転した
+    STATUS_BROKEN =         1 << 2, // あぼーんなどで壊れている
+    STATUS_UPDATE =         1 << 3, // 更新可能
+    STATUS_UPDATED =        1 << 4, // 更新済み
+    STATUS_BROKEN_SUBJECT = 1 << 5  // subject.txt が壊れている( subject.txt に示されたレス数よりも実際の取得数の方が多い )
 };
 
 

--- a/src/global.h
+++ b/src/global.h
@@ -11,8 +11,6 @@ enum{
     TIMER_TIMEOUT = 50, // msec  内部クロックの周期
     TIMER_TIMEOUT_SMOOTH_SCROLL = 33, // msec  スレビューのスムーススクロール描画用クロック周期
 
-    MAX_RESNUMBER = 11000, // 最大表示可能レス数
-
     MAX_MG_LNG = 5,  // マウスジェスチャの最大ストローク
 
     ICON_SIZE = 32 // 画像アイコンの大きさ

--- a/src/global.h
+++ b/src/global.h
@@ -216,7 +216,8 @@ enum
     STATUS_BROKEN =         1 << 2, // あぼーんなどで壊れている
     STATUS_UPDATE =         1 << 3, // 更新可能
     STATUS_UPDATED =        1 << 4, // 更新済み
-    STATUS_BROKEN_SUBJECT = 1 << 5  // subject.txt が壊れている( subject.txt に示されたレス数よりも実際の取得数の方が多い )
+    STATUS_BROKEN_SUBJECT = 1 << 5, // subject.txt が壊れている( subject.txt に示されたレス数よりも実際の取得数の方が多い )
+    STATUS_OVERFLOW =       1 << 6  // レス数が最大表示可能数以上
 };
 
 

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -122,7 +122,7 @@ void ToolBar::set_view( SKELETON::View* view )
 
     // ラベル表示更新
     set_label( view->get_label() );
-    if( view->is_broken() || view->is_old() ) set_color( view->get_color() );
+    if( view->is_broken() || view->is_old() || view->is_overflow() ) set_color( view->get_color() );
 
     // 閉じるボタンの表示更新
     if( m_button_close ){

--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -279,6 +279,7 @@ std::string View::get_color()
 {
     if( is_broken() ) return "red";
     else if( is_old() ) return "blue";
+    else if( is_overflow() ) return "green";
 
     return "";
 }

--- a/src/skeleton/view.h
+++ b/src/skeleton/view.h
@@ -258,6 +258,9 @@ namespace SKELETON
         // 壊れているか
         virtual bool is_broken(){ return false; }
 
+        // レス数が最大表示可能数以上か
+        virtual bool is_overflow() const noexcept { return false; }
+
         // ラベルやステータスバーの色
         std::string get_color();
 


### PR DESCRIPTION
#53 の修正及びそれに伴う変更です。

- 大きな変更点1
これまで固定長だったNodeTree及びLayoutTreeの各NODE*、LAYOUT*の配列をそれぞれvector、unordered_mapにすることで要素数の上限を取り除きます。
また上限は無くなりますがあまりに巨大なレス数で動作がままならなくなっては困るので表示上の上限を設け要素の挿入時にそれをチェックします。

- 大きな変更点2
表示上の上限を設定から変更可能にします。
また上限を越えたスレではその旨を表示するようにします。

- 大きな変更点3
レス数の増加に伴って特定の関数の計算時間が爆発的に増加するのでそのロジックを変更することで改善します。



修正にともないma8maさん、5chのスレの方にご協力いただきました。
ありがとうございました。
