### PR TITLE
Use range-based for instead of MISC::count_chr()

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -525,18 +525,6 @@ int MISC::count_str( const std::string& str, const std::string& str2  )
 
 
 //
-// str 中に含まれている chr の 数を返す
-//
-int MISC::count_chr( const std::string& str, const char chr )
-{
-    int count = 0;
-    const int size = str.size();
-    for( int i = 0; i < size; ++i ) if( str.c_str()[i] == chr ) ++count;
-    return count;
-}
-
-
-//
 // 文字列(utf-8も) -> 整数変換
 //
 // (例) "12３" -> 123

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -110,9 +110,6 @@ namespace MISC
 
     // str 中に含まれている str2 の 数を返す
     int count_str( const std::string& str, const std::string& str2 );
-    
-    // str 中に含まれている chr の 数を返す
-    int count_chr( const std::string& str, const char chr );
 
     // 文字列(utf-8も) -> 整数変換
     // (例) "12３" -> 123

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -1019,10 +1019,16 @@ void MessageViewBase::show_status()
         m_lng_str_enc = str_enc.length();
 
         // 特殊文字の文字数を計算
-        m_lng_str_enc += MISC::count_chr( str_enc, '\n' ) * 5; // " <br> " = 6バイト
-        m_lng_str_enc += MISC::count_chr( str_enc, '"' ) * 5; // &quot; = 6バイト
-        m_lng_str_enc += MISC::count_chr( str_enc, '<' ) * 3; // &lt; = 4バイト
-        m_lng_str_enc += MISC::count_chr( str_enc, '>' ) * 3; // &gt; = 4バイト
+        for( const char c : str_enc ) {
+            if( c == '\n' || c == '"' ) {
+                // " <br> " = 6バイト,  &quot; = 6バイト
+                m_lng_str_enc += 5;
+            }
+            else if( c == '<' || c == '>' ) {
+                // &lt; = 4バイト, &gt; = 4バイト
+                m_lng_str_enc += 3;
+            }
+        }
 
         ss << m_lng_str_enc;
     }


### PR DESCRIPTION
* 文字列の走査を整理します。
* `MISC::count_chr()`は未使用になるので削除します。

文字の種類ごとにループを回していたので修正では１つのループにまとめました。