### PR TITLE
Tweak config dialog layout for GTK+3

### DIFF
--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -301,11 +301,11 @@ MouseKeyDiag::MouseKeyDiag( Gtk::Window* parent, const std::string& url,
     m_vbuttonbox.set_layout( Gtk::BUTTONBOX_START );
     m_vbuttonbox.set_spacing( 4 );
 
-    m_hbox.pack_start( m_scrollwin, Gtk::PACK_SHRINK );
+    m_hbox.pack_start( m_scrollwin, Gtk::PACK_EXPAND_WIDGET );
     m_hbox.pack_start( m_vbuttonbox, Gtk::PACK_SHRINK );
 
     get_vbox()->set_spacing( 8 );
-    get_vbox()->pack_start( m_label );
+    get_vbox()->pack_start( m_label, Gtk::PACK_SHRINK );
     get_vbox()->pack_start( m_hbox );
 
     show_all_children();

--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -107,11 +107,11 @@ LinkFilterPref::LinkFilterPref( Gtk::Window* parent, const std::string& url )
     m_vbuttonbox.set_layout( Gtk::BUTTONBOX_START );
     m_vbuttonbox.set_spacing( 4 );
 
-    m_hbox.pack_start( m_scrollwin, Gtk::PACK_SHRINK );
+    m_hbox.pack_start( m_scrollwin, Gtk::PACK_EXPAND_WIDGET );
     m_hbox.pack_start( m_vbuttonbox, Gtk::PACK_SHRINK );
 
     get_vbox()->set_spacing( 8 );
-    get_vbox()->pack_start( m_label );
+    get_vbox()->pack_start( m_label, Gtk::PACK_SHRINK );
     get_vbox()->pack_start( m_hbox );
 
     show_all_children();

--- a/src/usrcmdpref.cpp
+++ b/src/usrcmdpref.cpp
@@ -90,9 +90,10 @@ UsrCmdPref::UsrCmdPref( Gtk::Window* parent, const std::string& url )
 
     m_scrollwin.add( m_treeview );
     m_scrollwin.set_policy( Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS );
+    m_scrollwin.set_size_request( 640, 400 );
 
     get_vbox()->set_spacing( 8 );
-    get_vbox()->pack_start( m_label );
+    get_vbox()->pack_start( m_label, Gtk::PACK_SHRINK );
     get_vbox()->pack_start( m_scrollwin );
 
 #if !GTKMM_CHECK_VERSION(2,7,0)


### PR DESCRIPTION
GTK3版の設定ダイアログで子ウィジェット(設定のリスト)が隠れてしまうレイアウト崩れを修正します。