### PR TITLE
Fix #60: Change default thread title search site (ff5ch.syoboi.jp)

### DIFF
--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -221,11 +221,11 @@ namespace CONFIG
 #define CONF_URL_BBSMENU "http://menu.5ch.net/bbsmenu.html"
 
 // スレタイ検索用メニュータイトルアドレス
-#define CONF_MENU_SEARCH_TITLE  "スレタイ検索 (dig.5ch.net)"
-#define CONF_URL_SEARCH_TITLE "http://dig.5ch.net/?maxResult=100&atLeast=1&Link=1&AndOr=0&Sort=5&Bbs=all&924=1&password=dig&keywords=$TEXTU"
+#define CONF_MENU_SEARCH_TITLE  "スレタイ検索 (ff5ch.syoboi.jp)"
+#define CONF_URL_SEARCH_TITLE "https://ff5ch.syoboi.jp/?q=$TEXTU"
 
 // スレタイ検索用正規表現
-#define CONF_REGEX_SEARCH_TITLE "<a href=\"(https?[^\"]*)\">([^<]+) \\(([0-9]{1,4})\\)</a>"
+#define CONF_REGEX_SEARCH_TITLE R"=(<a href="(http[^"]+)">([^<]+)</a><span class="count"> \(([0-9]{1,4})\)</span>)="
 
 // WEB検索用メニュータイトルアドレス
 #define CONF_MENU_SEARCH_WEB  "WEB検索 (google)"

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -20,7 +20,7 @@
 #define MAJORVERSION 0
 #define MINORVERSION 1
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20190316"
+#define JDDATE_FALLBACK    "20190330"
 #define JDTAG     ""
 
 //---------------------------------


### PR DESCRIPTION
デフォルトのスレタイ検索サイトを壊れたままの https://dig.5ch.net からhttps://ff5ch.syoboi.jp へ変更します。
私が利用していたサイトというだけなので別の検索サイトの提案があればそちらへ変更しても大丈夫です。