### PR TITLE
Fix check button for usrcmdpref

### DIFF
--- a/src/usrcmdpref.cpp
+++ b/src/usrcmdpref.cpp
@@ -96,7 +96,7 @@ UsrCmdPref::UsrCmdPref( Gtk::Window* parent, const std::string& url )
     get_vbox()->pack_start( m_label, Gtk::PACK_SHRINK );
     get_vbox()->pack_start( m_scrollwin );
 
-#if !GTKMM_CHECK_VERSION(2,7,0)
+#if GTKMM_CHECK_VERSION(2,7,0)
     m_ckbt_hide_usrcmd.set_active( CONFIG::get_hide_usrcmd() );
     get_vbox()->pack_start( m_ckbt_hide_usrcmd, Gtk::PACK_SHRINK );
 #endif


### PR DESCRIPTION
バージョン条件の真偽値が逆になっていてダイアログに配置されないままになっているチェックボタンを修正します。

gitログを読んだところ https://github.com/JDimproved/JDim/commit/0e58affd83f57d99b921b42194177de7b382f733#diff-aa4eba76ca7df8a6a93b201665220f49 から条件が逆になったようです。