### PR TITLE
Fix manual link (a.k.a. Create online manual [2/2])

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,1 @@
-https://jd4linux.osdn.jp/manual/ を見てください。
+https://jdimproved.github.io/JDim/ を見てください。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ JDimへのコントリビュート方法を案内します。
 ## :question: 質問をしたい
 Issueを開いて質問をします。 → [New issue][new-issue]
 
-使い方や設定方法の情報は[オンラインマニュアル (JD)][manual]や
+使い方や設定方法の情報は[オンラインマニュアル][manual]や
 2ch/5chのスレッド・過去ログにありますのでそちらも参照してください。
 
 
@@ -42,6 +42,7 @@ Pull requestは`master`ブランチに対してお願いいたします。
 
 * 文書やソースコードのタイプミス修正、バグ修正、文書の改善、機能の改善などは直接PRを受け付けています。
 * ユーザーインタフェースの変更や互換性に影響が出る修正は最初にissueを開いて意見・要望をお伝えいただければ幸いです。
+* オンラインマニュアルの編集については [docs/README.md][docs-readme] を参照してください。
 
 #### :pencil: C++ソースコードを修正するときの注意
 
@@ -56,5 +57,6 @@ Pull requestは`master`ブランチに対してお願いいたします。
 [pull-requests]: https://github.com/JDimproved/JDim/pulls
 [linux-5ch]: https://mao.5ch.net/linux/
 [new-issue]: https://github.com/JDimproved/JDim/issues/new
-[manual]: https://jd4linux.osdn.jp/manual/289/
+[manual]: https://jdimproved.github.io/JDim/
+[docs-readme]: https://github.com/JDimproved/JDim/tree/master/docs/README.md
 [isocpp]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 [ 更新履歴 ]
 
-  以前の更新履歴は"https://jd4linux.osdn.jp/manual/"を参照してください。
+  以前の更新履歴は"https://jdimproved.github.io/JDim/"を参照してください。
 
   svnのコミットログを知りたい場合は
 

--- a/INSTALL
+++ b/INSTALL
@@ -37,6 +37,7 @@
   ・openssl (--with-openssl)
   ・oniguruma (--with-oniguruma)
   ・libpcre (--with-pcre)
+  ・migemo (--with-migemo)
 
   OSやディストリビューション別の解説は"OS/ディストリビューション別インストール方法 [https://ja.osdn.net/projects/jd4linux/wiki/OS%2f%E3%83%87%E3%82%A3%E3%82%B9%E3%83%88%E3%83%AA%E3%83%93%E3%83%A5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E5%88%A5%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95]"(wiki) を参照。
 
@@ -78,7 +79,7 @@
 
     --with-alsa
 
-       ALSAによる効果音再生機能を有効にする。詳しくは"https://jd4linux.osdn.jp/manual/"の項を参照すること。
+       ALSAによる効果音再生機能を有効にする。詳しくは"https://jdimproved.github.io/JDim/"の項を参照すること。
 
     --with-xdgopen
 

--- a/NEWS
+++ b/NEWS
@@ -1,1 +1,1 @@
-https://jd4linux.osdn.jp/manual/ を見てください。
+https://jdimproved.github.io/JDim/ を見てください。

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # JDim - 2ch browser for linux
 
-ここに書かれていない詳細については[リポジトリ][repository]を参照してください。
+ここに書かれていない詳細については[オンラインマニュアル][manual]や[リポジトリ][repository]を参照してください。
 
+[manual]: https://jdimproved.github.io/JDim/
 [repository]: https://github.com/JDimproved/JDim
 
 * [概要](#概要)

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -769,10 +769,10 @@ void Core::run( const bool init, const bool skip_setupdiag )
     m_action_group->add( Gtk::Action::create( "OldLog", "2chスレ過去ログ(_L)" ), sigc::mem_fun( *this, &Core::slot_show_old2ch ) );
     Gtk::AccelKey jdhelpKey = CONTROL::get_accelkey( CONTROL::JDHelp );
     if( jdhelpKey.is_null() ){
-        m_action_group->add( Gtk::Action::create( "Manual", "JD オンラインマニュアル(_M)..." ),
+        m_action_group->add( Gtk::Action::create( "Manual", "オンラインマニュアル(_M)..." ),
                              sigc::mem_fun( *this, &Core::slot_show_manual ) );
     }else{
-        m_action_group->add( Gtk::Action::create( "Manual", "JD オンラインマニュアル(_M)..." ),
+        m_action_group->add( Gtk::Action::create( "Manual", "オンラインマニュアル(_M)..." ),
                              jdhelpKey,
                              sigc::mem_fun( *this, &Core::slot_show_manual ) );
     }

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -25,20 +25,14 @@
 
 //---------------------------------
 
-// FIXME: オンラインマニュアルはfork元のURLを参照している
-#define JDVERSION ( 289 )
-#define JDVERSION_FULL ( JDVERSION * 1000000 + atoi( JDDATE_FALLBACK ) )
-
-//---------------------------------
-
 #define JDCOMMENT "JDim (JD improved) は gtkmm/GTK+ を用いた2chブラウザです。"
 #define JDCOPYRIGHT "(c) 2006-2015 JD project" "\n" \
                     "(c) 2017-2019 yama-natuki" "\n" \
                     "(c) 2019 JDimproved project"
 #define JDBBS CONFIG::get_url_jdhp()+"cgi-bin/bbs/support/"
 #define JD2CHLOG CONFIG::get_url_jdhp()+"old2ch/"
-#define JDHELP CONFIG::get_url_jdhp()+"manual/"+MISC::itostr( JDVERSION )+"/"
-#define JDHELPCMD CONFIG::get_url_jdhp()+"manual/"+MISC::itostr( JDVERSION )+"/usrcmd.html"
+#define JDHELP "https://jdimproved.github.io/JDim/"
+#define JDHELPCMD JDHELP "usrcmd/"
 
 // [ ライセンス表記 ]
 //


### PR DESCRIPTION
#66 の修正としてオンラインマニュアルのリンクをJDからJDimへ変更します。
修正後は下の２つがリンクとして使われます。

- JDimのホームページは <https://github.com/JDimproved/JDim> (設定で変更可)
- オンラインマニュアルは <https://jdimproved.github.io/JDim/> (jdversion.hにハードコーディング)