### PR TITLE
Fix to save thread list column width for GTK3

### DIFF
--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -652,6 +652,10 @@ void BoardViewBase::update_columns()
 
         // ヘッダをクリックしたときに呼ぶslot
         column->signal_clicked().connect( sigc::bind< int >( sigc::mem_fun( *this, &BoardViewBase::slot_col_clicked ), id ) );
+#if GTKMM_CHECK_VERSION(3,0,0)
+        // 列の幅が変わったらセッション情報に記憶する
+        column->connect_property_changed( "width", [this]{ save_column_width(); } );
+#endif
 
         // ヘッダの位置
         switch( id ){


### PR DESCRIPTION
GTK3版のスレ一覧で列の幅が記憶されない不具合(次回起動時に前回の列の幅が復元されない)を修正します。

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1551889442/43-47