### PR TITLE
Fix #79: Remove support for old version config files

### DIFF
--- a/docs/manual/2019.md
+++ b/docs/manual/2019.md
@@ -10,6 +10,8 @@ layout: default
 
 <a name="0.1.0-unreleased"></a>
 ### [0.1.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.1.0...master) (unreleased)
+- Fix #79: Remove support for old version config files
+  ([#82](https://github.com/JDimproved/JDim/pull/82))
 - README.mdの整理
   ([#77](https://github.com/JDimproved/JDim/pull/77))
 - Update manual to remove login and simplify history

--- a/src/bbslist/favoriteview.cpp
+++ b/src/bbslist/favoriteview.cpp
@@ -56,12 +56,7 @@ void FavoriteListView::show_view()
 {
     std::string xml;
 
-    // ファイルが存在しなければ入力を旧ファイル名にする
     std::string file_in = CACHE::path_xml_favorite();
-    if( CACHE::file_exists( file_in ) != CACHE::EXIST_FILE )
-    {
-    	file_in = CACHE::path_xml_favorite_old();
-    }
 
     CACHE::load_rawdata( file_in, xml );
 

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -51,15 +51,6 @@ std::string CACHE::path_conf_bkup()
 }
 
 
-// 旧設定ファイル
-std::string CACHE::path_conf_old()
-{
-    std::string home = MISC::getenv_limited( ENV_HOME, MAX_SAFE_PATH );
-
-    return home + "/.jdrc";
-}
-
-
 // セッション情報ファイル
 std::string CACHE::path_session()
 {
@@ -114,11 +105,6 @@ std::string CACHE::path_xml_listmain_bkup()
 {
     return CACHE::path_xml_listmain() + ".bkup";
 }
-// 1.9.5-beta070611以前
-std::string CACHE::path_xml_listmain_old()
-{
-    return CACHE::path_root() +  "list_main.xml";
-}
 
 
 // お気に入り
@@ -130,11 +116,6 @@ std::string CACHE::path_xml_favorite()
 std::string CACHE::path_xml_favorite_bkup()
 {
     return CACHE::path_xml_favorite() + ".bkup";
-}
-// 1.9.5-beta070611以前
-std::string CACHE::path_xml_favorite_old()
-{
-    return CACHE::path_root() +  "favorite.xml";
 }
 
 
@@ -149,11 +130,6 @@ std::string CACHE::path_etcboard()
 std::string CACHE::path_usrcmd()
 {
     return CACHE::path_root() +  "usrcmd.xml";
-}
-
-std::string CACHE::path_usrcmd_old()
-{
-    return CACHE::path_root() +  "usrcmd.txt";
 }
 
 
@@ -536,24 +512,6 @@ std::string CACHE::path_css()
 std::string CACHE::path_reshtml()
 {
     return CACHE::path_theme_root() +  "Res.html";
-}
-
-
-//
-// css (旧バージョンとの互換性のため)
-//
-std::string CACHE::path_css_old()
-{
-    return CACHE::path_root() +  "jd.css";
-}
-
-
-//
-// res.html (旧バージョンとの互換性のため)
-//
-std::string CACHE::path_reshtml_old()
-{
-    return CACHE::path_root() +  "Res.html";
 }
 
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -44,7 +44,6 @@ namespace CACHE
     // 設定ファイル
     std::string path_conf();
     std::string path_conf_bkup();
-    std::string path_conf_old();  // 旧ファイル
 
     // セッション情報ファイル
     std::string path_session();
@@ -61,19 +60,16 @@ namespace CACHE
     // 板
     std::string path_xml_listmain();
     std::string path_xml_listmain_bkup();
-    std::string path_xml_listmain_old();
 
     // お気に入り
     std::string path_xml_favorite();
     std::string path_xml_favorite_bkup();
-    std::string path_xml_favorite_old();
 
     // 外部板設定ファイル( navi2ch 互換 )
     std::string path_etcboard();
 
     // ユーザーコマンド設定ファイル
     std::string path_usrcmd();
-    std::string path_usrcmd_old();
 
     // リンクフィルタ
     std::string path_linkfilter();
@@ -148,11 +144,9 @@ namespace CACHE
 
     // css
     std::string path_css();
-    std::string path_css_old();
 
     // html
     std::string path_reshtml();
-    std::string path_reshtml_old();
 
     // ログ
     std::string path_logroot();

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -72,25 +72,8 @@ ConfigItems::~ConfigItems() noexcept
 // 設定読み込み
 bool ConfigItems::load( const bool restore )
 {
-    std::string path_conf;
-
     // restoreモード
-    if( restore )
-    {
-        path_conf = CACHE::path_conf_bkup();
-    }
-    else
-    {
-        path_conf = CACHE::path_conf();
-
-        // 新設定ファイルが無く、かつキャッシュディレクトリが存在していたら旧ファイルから設定を引き継ぐ
-        if( CACHE::file_exists( path_conf ) != CACHE::EXIST_FILE
-            && CACHE::file_exists( CACHE::path_root() ) == CACHE::EXIST_DIR
-            && CACHE::file_exists( CACHE::path_conf_old() ) == CACHE::EXIST_FILE ){
-
-                path_conf = CACHE::path_conf_old();
-        }
-    }
+    const std::string path_conf = restore ? CACHE::path_conf_bkup() : CACHE::path_conf();
 
     JDLIB::ConfLoader cf( path_conf, std::string() );
 
@@ -653,7 +636,6 @@ bool ConfigItems::load( const bool restore )
 void ConfigItems::save()
 {
     save_impl( CACHE::path_conf() );
-    if( CACHE::file_exists( CACHE::path_conf_old() ) == CACHE::EXIST_FILE ) save_impl( CACHE::path_conf_old() );
 }
 
 

--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -218,11 +218,7 @@ bool Css_Manager::read_css()
 #endif    
 
     std::string css_data;
-    if( ! CACHE::load_rawdata( css_file, css_data ) ){
-
-        // 旧バージョンとの互換性のため
-        if( ! CACHE::load_rawdata( CACHE::path_css_old(), css_data ) ) return false;
-    }
+    if( ! CACHE::load_rawdata( css_file, css_data ) ) return false;
 
 #ifdef _DEBUG
     std::cout << "css : \n" << css_data << "--------------\n\n";
@@ -719,11 +715,7 @@ bool Css_Manager::read_html()
 #endif    
 
     std::string html;
-    if( ! CACHE::load_rawdata( htmlfile, html ) ){
-
-        // 旧バージョンとの互換性のため
-        if( ! CACHE::load_rawdata( CACHE::path_reshtml_old(), html ) ) return false;
-    }
+    if( ! CACHE::load_rawdata( htmlfile, html ) ) return false;
 
 #ifdef _DEBUG
     std::cout << "html : \n" << html << "--------------\n\n";

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -277,12 +277,7 @@ void Root::load_cache()
 {
     clear();
 
-    // ファイルが存在しなければ入力を旧ファイル名にする
     std::string file_in = CACHE::path_xml_listmain();
-    if( CACHE::file_exists( file_in ) != CACHE::EXIST_FILE )
-    {
-        file_in = CACHE::path_xml_listmain_old();
-    }
 
 #ifdef _DEBUG
     std::cout << "Root::load_cache xml  = " << file_in << std::endl;

--- a/src/usrcmdmanager.cpp
+++ b/src/usrcmdmanager.cpp
@@ -76,60 +76,8 @@ Usrcmd_Manager::Usrcmd_Manager()
 {
     std::string xml;
     if( CACHE::load_rawdata( CACHE::path_usrcmd(), xml ) ) m_document.init( xml );
-    else txt2xml();
 
     analyze_xml();
-}
-
-
-//
-// 旧式の設定ファイル(テキスト形式)をxmlに変換する
-//
-void Usrcmd_Manager::txt2xml()
-{
-    m_document.clear();
-
-    // 旧設定ファイルからユーザーコマンドを読み込み
-    const std::string file_usrcmd = CACHE::path_usrcmd_old();
-    std::string usrcmd;
-
-    if( CACHE::load_rawdata( file_usrcmd, usrcmd ) ){
-
-        XML::Dom* root = m_document.appendChild( XML::NODE_TYPE_ELEMENT, std::string( ROOT_NODE_NAME_USRCMD ) );
-        XML::Dom* subdir = root;
-
-        std::list< std::string > list_usrcmd = MISC::get_lines( usrcmd );
-        list_usrcmd = MISC::remove_commentline_from_list( list_usrcmd );
-        list_usrcmd = MISC::remove_space_from_list( list_usrcmd );
-        list_usrcmd = MISC::remove_nullline_from_list( list_usrcmd );
-
-        // ユーザコマンドが 3つ以上 (廃止した max_show_usrcmd 設定の初期値 )より
-        // 大きい場合はサブディレクトリ化する
-        if( list_usrcmd.size() >= 3 * 2 ){
-            subdir = root->appendChild( XML::NODE_TYPE_ELEMENT, XML::get_name( TYPE_DIR ) );
-            subdir->setAttribute( "name", "ユーザコマンド" );
-            subdir->setAttribute( "open", "y" );
-        }
-
-        std::list< std::string >::iterator it;
-        for( it = list_usrcmd.begin(); it != list_usrcmd.end(); ++it ){
-
-            const std::string name = *( it++ );
-            if( it == list_usrcmd.end() ) break;
-            const std::string cmd = *it;
-
-            XML::Dom* usrcmd = subdir->appendChild( XML::NODE_TYPE_ELEMENT, XML::get_name( TYPE_USRCMD ) );
-            usrcmd->setAttribute( "name", name );
-            usrcmd->setAttribute( "data", cmd );
-        }
-
-#ifdef _DEBUG
-        std::cout << "Usrcmd_Manager::txt2xml\n";
-        std::cout << "nodes = " << m_document.childNodes().size() << std::endl;
-        std::cout << m_document.get_xml() << std::endl;
-#endif
-        save_xml();
-    }
 }
 
 

--- a/src/usrcmdmanager.h
+++ b/src/usrcmdmanager.h
@@ -74,8 +74,6 @@ namespace CORE
                                const std::string& str_select );
       private:
 
-        void txt2xml();
-
         bool show_replacetextdiag( std::string& texti, const std::string& title );
         void set_cmd( const std::string& cmd );
 


### PR DESCRIPTION
#79 のPRです。バージョン1.9.5未満の書式の設定ファイルをサポート終了します。
現行の設定ファイルが読み込めなかった場合に古い設定ファイルを読み込めるか試す処理を削除します。
修正後は古い設定ファイル自体は無視されるだけで削除はされません。

###### サポートを終了する設定ファイル
- `~/.jdrc`
-  `$JDIM_CACHE/list_main.xml`
- `$JDIM_CACHE/favorite.xml`
- `$JDIM_CACHE/usrcmd.txt`
- `$JDIM_CACHE/jd.css`
- `$JDIM_CACHE/Res.html`