### PR TITLE
Fix #80: Deprecate configure option for CPU optimization

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -72,6 +72,7 @@
     --with-[native|core2duo|athlon64|atom|ppc7400|ppc7450]
 
        CPUに合わせた最適化
+       --with-native以外のオプションは非推奨: かわりに ./configure CXXFLAGS="-march=ARCH" を使用してください。
 
     --with-openssl
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ yay -S jdim-git
   make するときに `-j job数`(並列処理の数) を指定すれば高速にコンパイルできます。
   使用するCPUのコア数と相談して決めてください。
 
+* **CPUに合わせた最適化**
+
+  `./configure`を実行するときにCPUの種類(`-march=ARCH`や`-mcpu=CPU`)と最適化レベル(`-O`)を`CXXFLAGS`に設定します。
+  ###### 例 (Intel Core 2)
+  ```sh
+  ./configure CXXFLAGS="-march=core2 -O2"
+  ```
+
+  マシンのCPUは下のコマンドで調べることができます。([GCCの最適化][gentoo-gcc] - Gentoo Wikiより)
+  ```sh
+  gcc -Q -c -march=native --help=target -o /dev/null | grep "march\|mtune\|mcpu"
+  ```
+
 * **configureチェック中に `AX_CXX_COMPILE_STDCXX_11(noext, mandatory)` に関連したエラーがでた場合**
 
   ubuntuでは `autoconf-archive` をインストールして `autoreconf -i` からやり直してみてください。
@@ -148,6 +161,8 @@ yay -S jdim-git
 
   もしこれで駄目な場合はgccのversionが古すぎるので、
   gccのバージョンアップをするか、ディストリをバージョンアップしてください。
+
+[gentoo-gcc]: https://wiki.gentoo.org/wiki/GCC_optimization/ja#-march
 
 
 ### GTK3版について

--- a/configure.ac
+++ b/configure.ac
@@ -455,6 +455,7 @@ if test "$use_gprof" = "no"; then
     AC_ARG_WITH(core2duo,[ --with-core2duo    (use core2duo)],
         [ if test "$withval" != "no"; then
             echo "use core2duo"
+            AC_MSG_WARN([--with-core2duo is deprecated. Use ./configure CXXFLAGS="-march=core2"])
             CXXFLAGS="$CXXFLAGS -march=pentium-m -msse3"
         fi ])
 
@@ -464,6 +465,7 @@ if test "$use_gprof" = "no"; then
     AC_ARG_WITH(athlon64,[ --with-athlon64    (use athlon64)],
         [ if test "$withval" != "no"; then
             echo "use athlon64"
+            AC_MSG_WARN([--with-athlon64 is deprecated. Use ./configure CXXFLAGS="-march=athlon64"])
             CXXFLAGS="$CXXFLAGS -march=athlon64"
         fi ])
 
@@ -473,6 +475,7 @@ if test "$use_gprof" = "no"; then
     AC_ARG_WITH(atom,[ --with-atom    (use atom)],
         [ if test "$withval" != "no"; then
             echo "use atom"
+            AC_MSG_WARN([--with-atom is deprecated. Use ./configure CXXFLAGS="-march=prescott"])
             CXXFLAGS="$CXXFLAGS -march=prescott"
         fi ])
 
@@ -482,6 +485,7 @@ if test "$use_gprof" = "no"; then
     AC_ARG_WITH(ppc7400,[ --with-ppc7400    (use PowerPC7400)],
         [ if test "$withval" != "no"; then
             echo "use ppc7400"
+            AC_MSG_WARN([--with-ppc7400 is deprecated. Use ./configure CXXFLAGS="-mcpu=7400 -maltivec -mabi=altivec"])
             CXXFLAGS="$CXXFLAGS -mcpu=7400 -maltivec -mabi=altivec"
         fi ])
 
@@ -491,6 +495,7 @@ if test "$use_gprof" = "no"; then
     AC_ARG_WITH(ppc7450,[ --with-ppc7450    (use PowerPC7450)],
         [ if test "$withval" != "no"; then
             echo "use ppc7450"
+            AC_MSG_WARN([--with-ppc7450 is deprecated. Use ./configure CXXFLAGS="-mcpu=7450 -maltivec -mabi=altivec"])
             CXXFLAGS="$CXXFLAGS -mcpu=7450 -maltivec -mabi=altivec"
         fi ])
 fi

--- a/docs/manual/2019.md
+++ b/docs/manual/2019.md
@@ -10,6 +10,8 @@ layout: default
 
 <a name="0.1.0-unreleased"></a>
 ### [0.1.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.1.0...master) (unreleased)
+- Fix #80: Deprecate configure option for CPU optimization
+  ([#83](https://github.com/JDimproved/JDim/pull/83))
 - README.mdの整理
   ([#77](https://github.com/JDimproved/JDim/pull/77))
 - Update manual to remove login and simplify history

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -84,7 +84,10 @@ OSやディストリビューション別の解説は[OS/ディストリビュ�
   <dt>--with-migemo</dt>
   <dd>migemo による検索が有効になる。migemoがUTF-8の辞書でインストールされている必要がある。</dd>
   <dt>--with-[native|core2duo|athlon64|atom|ppc7400|ppc7450]</dt>
-  <dd>CPUに合わせた最適化</dd>
+  <dd>
+    CPUに合わせた最適化。<strong><code>--with-native</code>以外のオプションは非推奨:</strong>
+    かわりに <code>./configure CXXFLAGS=&quot;-march=ARCH&quot;</code> を使用してください。
+  </dd>
   <dt>--with-openssl</dt>
   <dd>GNU TLS ではなく OpenSSL を使用する。ライセンス上バイナリ配布が出来なくなることに注意すること。</dd>
   <dt>--with-alsa</dt>


### PR DESCRIPTION
#80 のPRです。CPUに合わせた最適化を設定するconfigureオプションを廃止予定にします。

###### 廃止予定の理由
- 対象のCPUは古い世代になっており最近の世代に対応していない。
- 最適化に関心のあるユーザーならコンパイラのオプションを調べてCXXFLAGSなどを設定できるはず。

###### 廃止予定にするconfigureオプション
`--with-native`はどのCPUでも有効なためこの提案では廃止しません。

- `--with-core2duo`
- `--with-athlon64`
- `--with-atom`
- `--with-ppc7400`
- `--with-ppc7450`
