### PR TITLE
Improve ENVIRONMENT::get_wm() and ENVIRONMENT::get_wm_str()

### DIFF
--- a/src/environment.h
+++ b/src/environment.h
@@ -8,15 +8,20 @@
 namespace ENVIRONMENT
 {
     // WM
-    enum
+    enum class DesktopType
     {
-        WM_GNOME = 0,
-        WM_XFCE,
-        WM_KDE,
-        WM_LXDE,
-        WM_MATE,
-        WM_CINNAMON,
-        WM_UNKNOWN
+        gnome = 0,
+        xfce,
+        kde,
+        lxde,
+        unity,
+        cinnamon,
+        mate,
+        budgie,
+        pantheon,
+        enlightenment,
+        lxqt,
+        unknown
     };
 
     // configure_argsのモード
@@ -39,7 +44,7 @@ namespace ENVIRONMENT
 
     std::string get_jdversion();
     std::string get_distname();
-    int get_wm();
+    DesktopType get_wm();
     std::string get_wm_str();
 	std::string get_gtkmm_version();
 	std::string get_glibmm_version();

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -246,8 +246,9 @@ void JDWindow::clock_in()
         // メインウィンドウと画像ウィンドウが同時にフォーカスアウトしたら
         // 一時的に transient 指定を外す。メインウィンドウがフォーカスインしたときに
         // Admin::focus_out() で transient 指定を戻す
-        const auto wm = ENVIRONMENT::get_wm();
-        if( ( wm == ENVIRONMENT::WM_GNOME || wm == ENVIRONMENT::WM_MATE || wm == ENVIRONMENT::WM_CINNAMON )
+        using ENVIRONMENT::DesktopType;
+        const DesktopType wm = ENVIRONMENT::get_wm();
+        if( ( wm == DesktopType::gnome || wm == DesktopType::mate || wm == DesktopType::cinnamon )
             && ! SESSION::is_iconified_win_main() // メインウィンドウが最小化しているときに transient を外すとウィンドウが表示されなくなる
             && ! SESSION::is_focus_win_main() && ! is_focus_win() ){
 
@@ -548,7 +549,7 @@ void JDWindow::set_enable_fold( bool enable )
         // XFCE 環境の場合はここでpresent()しておかないとフォーカスが外れる
         if( m_mode == JDWIN_NORMAL && m_enable_fold ){
 
-            if( ENVIRONMENT::get_wm() == ENVIRONMENT::WM_KDE ) switch_admin();
+            if( ENVIRONMENT::get_wm() == ENVIRONMENT::DesktopType::kde ) switch_admin();
             else present();
         }
     }


### PR DESCRIPTION
デスクトップ環境を調べる方法を修正し、表示可能な環境を追加します。
追加するデスクトップ: unity, budgie, pantheon, environment, lxqt
