### PR TITLE
Refactor SKELETON namespace

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,7 +17,7 @@ AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: false
+AlwaysBreakTemplateDeclarations: No
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
@@ -39,6 +39,7 @@ BraceWrapping:
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Custom
 BreakBeforeInheritanceComma: true
+BreakInheritanceList: BeforeComma
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeComma
@@ -63,7 +64,7 @@ IncludeBlocks:   Preserve
 IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
-  - Regex:           '^(<|"(gtest|isl|json)/)'
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
     Priority:        3
   - Regex:           '.*'
     Priority:        1
@@ -79,6 +80,7 @@ MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 3
 NamespaceIndentation: All
+ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
@@ -87,20 +89,21 @@ PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
-RawStringFormats:
-  - Delimiter:       pb
-    Language:        TextProto
-    BasedOnStyle:    google
 ReflowComments:  true
 SortIncludes:    true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: Never
+SpaceBeforeRangeBasedForLoopColon: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles:  true
@@ -109,6 +112,9 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: true
 SpacesInSquareBrackets: true
 Standard:        Cpp11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
 TabWidth:        8
 UseTab:          Never
 ...

--- a/docs/manual/2019.md
+++ b/docs/manual/2019.md
@@ -10,6 +10,12 @@ layout: default
 
 <a name="0.1.0-unreleased"></a>
 ### [0.1.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.1.0...master) (unreleased)
+- Refactor SKELETON namespace
+  ([#89](https://github.com/JDimproved/JDim/pull/89))
+- Update constractor and destructor
+  ([#88](https://github.com/JDimproved/JDim/pull/88))
+- Improve ENVIRONMENT::get_wm() and ENVIRONMENT::get_wm_str()
+  ([#87](https://github.com/JDimproved/JDim/pull/87))
 - Fix test program build
   ([#85](https://github.com/JDimproved/JDim/pull/85))
 - Fix #81: Add grouped configure option

--- a/src/skeleton/Makefile.am
+++ b/src/skeleton/Makefile.am
@@ -26,6 +26,7 @@ libskeleton_a_SOURCES = \
 	menubutton.cpp \
 	toolmenubutton.cpp \
 	backforwardbutton.cpp \
+	popupwinbase.cpp \
 	popupwin.cpp \
 	tooltip.cpp \
 	entry.cpp \

--- a/src/skeleton/Makefile.am
+++ b/src/skeleton/Makefile.am
@@ -89,6 +89,7 @@ noinst_HEADERS = \
 	msgdiag.h \
 	aboutdiag.h \
 	detaildiag.h \
+	editviewdialog.h \
 	filediag.h \
 	login.h \
 	panecontrol.h \

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -205,33 +205,6 @@ void DragTreeView::set_str_tooltip( const std::string& text )
 
 
 //
-// ツールチップ最小幅設定
-//
-void DragTreeView::set_tooltip_min_width( const int min_width )
-{
-    m_tooltip.set_min_width( min_width);
-}
-
-
-//
-// ツールチップを表示
-//
-void DragTreeView::show_tooltip()
-{
-    m_tooltip.show_tooltip();
-}
-
-
-//
-// ツールチップ隠す
-//
-void DragTreeView::hide_tooltip()
-{
-    m_tooltip.hide_tooltip();
-}
-
-
-//
 // ポップアップが表示されていてかつマウスがその上にあるか
 //
 bool DragTreeView::is_mouse_on_popup()

--- a/src/skeleton/dragtreeview.h
+++ b/src/skeleton/dragtreeview.h
@@ -91,11 +91,11 @@ namespace SKELETON
         void init_font( const std::string& fontname );
         
         // ツールチップ表示
-        // set_tooltip_min_width()で指定した幅よりもツールチップが広い場合は表示
         void set_str_tooltip( const std::string& str );
-        void set_tooltip_min_width( const int min_width );
-        void hide_tooltip();
-        void show_tooltip();
+        // ツールチップ最小幅設定(指定した幅よりもツールチップが広い場合は表示)
+        void set_tooltip_min_width( const int min_width ){ m_tooltip.set_min_width( min_width ); }
+        void hide_tooltip(){ m_tooltip.hide_tooltip(); }
+        void show_tooltip(){ m_tooltip.show_tooltip(); }
 
         // ポップアップウィンドウ表示
         const std::string& pre_popup_url() const { return m_pre_popup_url; }

--- a/src/skeleton/editview.cpp
+++ b/src/skeleton/editview.cpp
@@ -718,6 +718,24 @@ void EditTextView::slot_hide_aamenu()
 }
 
 
+//////////////////////////////////////////////
+
+EditView::EditView()
+    : Gtk::ScrolledWindow()
+{
+    set_policy( Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC );
+    add( m_textview );
+#if GTKMM_CHECK_VERSION(3,0,0)
+    auto context = m_textview.get_style_context();
+    context->add_class( s_css_classname );
+    context->add_provider( m_provider, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION );
+#endif
+    show_all_children();
+}
+
+
+EditView::~EditView() noexcept = default;
+
 
 #if GTKMM_CHECK_VERSION(3,0,0)
 constexpr const char* EditView::s_css_classname;

--- a/src/skeleton/editview.h
+++ b/src/skeleton/editview.h
@@ -130,19 +130,8 @@ namespace SKELETON
 
     public:
 
-        EditView(){
-            set_policy( Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC );
-
-            add( m_textview );
-#if GTKMM_CHECK_VERSION(3,0,0)
-            auto context = m_textview.get_style_context();
-            context->add_class( s_css_classname );
-            context->add_provider( m_provider, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION );
-#endif
-
-            show_all_children();
-        }
-        ~EditView() noexcept {}
+        EditView();
+        ~EditView() noexcept;
 
         SIG_BUTTON_PRESS sig_button_press(){ return m_textview.sig_button_press(); }
         SIG_KEY_PRESS sig_key_press(){ return m_textview.sig_key_press(); }

--- a/src/skeleton/jdtoolbar.cpp
+++ b/src/skeleton/jdtoolbar.cpp
@@ -178,10 +178,27 @@ customized_gtk_toolbar_expose (GtkWidget      *widget,
 
 ///////////////////////////////////////////////////
 
+#endif // !GTKMM_CHECK_VERSION(3,0,0)
+
 
 using namespace SKELETON;
 
 
+JDToolbar::JDToolbar()
+    : Gtk::Toolbar()
+{
+#if GTKMM_CHECK_VERSION(3,0,0)
+    // 子ウィジェットの配色がGTKテーマと違うことがある。
+    // ツールバーのcssクラスを削除し配色を修正する。
+    get_style_context()->remove_class( GTK_STYLE_CLASS_TOOLBAR );
+#endif
+}
+
+
+JDToolbar::~JDToolbar() noexcept = default;
+
+
+#if !GTKMM_CHECK_VERSION(3,0,0)
 bool JDToolbar::on_expose_event( GdkEventExpose* event )
 {
 #ifdef _DEBUG
@@ -199,5 +216,4 @@ bool JDToolbar::on_expose_event( GdkEventExpose* event )
 
     return FALSE;
 }
-
 #endif // !GTKMM_CHECK_VERSION(3,0,0)

--- a/src/skeleton/jdtoolbar.h
+++ b/src/skeleton/jdtoolbar.h
@@ -15,14 +15,8 @@ namespace SKELETON
     class JDToolbar : public Gtk::Toolbar
     {
     public:
-        JDToolbar()
-        {
-#if GTKMM_CHECK_VERSION(3,0,0)
-            // 子ウィジェットの配色がGTKテーマと違うことがある。
-            // ツールバーのcssクラスを削除し配色を修正する。
-            get_style_context()->remove_class( GTK_STYLE_CLASS_TOOLBAR );
-#endif
-        }
+        JDToolbar();
+        ~JDToolbar() noexcept;
 
         // GTK+3ではデフォルトの描画処理に任せる
 #if !GTKMM_CHECK_VERSION(3,0,0)

--- a/src/skeleton/popupwinbase.cpp
+++ b/src/skeleton/popupwinbase.cpp
@@ -1,0 +1,81 @@
+// ライセンス: GPL2
+
+//#define _DEBUG
+#include "jddebug.h"
+
+#include "popupwinbase.h"
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+#include "command.h"
+#endif
+
+
+using namespace SKELETON;
+
+
+PopupWinBase::PopupWinBase( bool draw_frame )
+    : Gtk::Window( Gtk::WINDOW_POPUP )
+    , m_draw_frame( draw_frame )
+{
+#ifdef _DEBUG
+    std::cout << "PopupWinBase::PopupWinBase\n";
+#endif
+
+    if( m_draw_frame ) set_border_width( 1 );
+#if GTKMM_CHECK_VERSION(3,0,0)
+    if ( auto main_window = CORE::get_mainwindow() ) {
+        set_transient_for( *main_window );
+    }
+#endif
+}
+
+
+PopupWinBase::~PopupWinBase() noexcept = default;
+
+
+void PopupWinBase::on_realize()
+{
+    Gtk::Window::on_realize();
+
+#if !GTKMM_CHECK_VERSION(3,0,0)
+    const Glib::RefPtr< Gdk::Window > window = get_window();
+    m_gc = Gdk::GC::create( window );
+#endif
+}
+
+
+#if GTKMM_CHECK_VERSION(3,0,0)
+bool PopupWinBase::on_draw( const Cairo::RefPtr< Cairo::Context >& cr )
+{
+    const bool ret = Gtk::Window::on_draw( cr );
+    if( m_draw_frame ) {
+        Gdk::Cairo::set_source_rgba( cr, Gdk::RGBA( "black" ) );
+        cr->set_line_width( 1.0 );
+        cr->rectangle( 0.0, 0.0, get_width(), get_height() );
+        cr->stroke();
+    }
+    return ret;
+}
+#else
+bool PopupWinBase::on_expose_event( GdkEventExpose* event )
+{
+    const bool ret = Gtk::Window::on_expose_event( event );
+
+    // 枠の描画
+    if( m_draw_frame ) {
+        m_gc->set_foreground( Gdk::Color( "black" ) );
+        get_window()->draw_rectangle( m_gc, false, 0, 0, get_width()-1, get_height()-1 );
+    }
+
+    return ret;
+}
+#endif // GTKMM_CHECK_VERSION(3,0,0)
+
+
+bool PopupWinBase::on_configure_event( GdkEventConfigure* event )
+{
+    const bool ret = Gtk::Window::on_configure_event( event );
+    m_sig_configured.emit( get_width(), get_height() );
+
+    return ret;
+}

--- a/src/skeleton/popupwinbase.h
+++ b/src/skeleton/popupwinbase.h
@@ -4,30 +4,23 @@
 // ポップアップウィンドウの基底クラス
 //
 
-#ifndef _POPUPWINBASE_H
-#define _POPUPWINBASE_H
+#ifndef POPUPWINBASE_H
+#define POPUPWINBASE_H
 
 #include "gtkmmversion.h"
 
 #include <gtkmm.h>
 
-#if GTKMM_CHECK_VERSION(3,0,0)
-#include "command.h"
-#endif
-
 namespace SKELETON
 {
-    enum
-    {
-        POPUPWIN_DRAWFRAME = true,
-        POPUPWIN_NOFRAME = false
-    };
+    constexpr bool POPUPWIN_DRAWFRAME = true;
+    constexpr bool POPUPWIN_NOFRAME = false;
 
     //
     // Gtk::Windows は signal_configure_event()を発行しないようなので
     // 自前でconfigureイベントをフックしてシグナルを発行する
     //
-    typedef sigc::signal< void, int, int > SIG_CONFIGURED_POPUP;
+    using SIG_CONFIGURED_POPUP = sigc::signal< void, int, int >;
 
     class PopupWinBase : public Gtk::Window
     {
@@ -36,70 +29,25 @@ namespace SKELETON
         Glib::RefPtr< Gdk::GC > m_gc;
 #endif
 
-        bool m_draw_frame;
+        const bool m_draw_frame;
 
       public:
 
         // draw_frame == true なら枠を描画する
-        PopupWinBase( bool draw_frame ) : Gtk::Window( Gtk::WINDOW_POPUP ), m_draw_frame( draw_frame ){
-            if( m_draw_frame ) set_border_width( 1 );
-
-#if GTKMM_CHECK_VERSION(3,0,0)
-            if ( auto main_window = CORE::get_mainwindow() ) {
-                set_transient_for( *main_window );
-            }
-#endif
-        }
-        ~PopupWinBase() noexcept {}
+        PopupWinBase( bool draw_frame );
+        ~PopupWinBase() noexcept;
 
         SIG_CONFIGURED_POPUP sig_configured(){ return m_sig_configured; }
 
       protected:
 
-        void on_realize() override
-        {
-            Gtk::Window::on_realize();
-
-#if !GTKMM_CHECK_VERSION(3,0,0)
-            Glib::RefPtr< Gdk::Window > window = get_window();
-            m_gc = Gdk::GC::create( window );    
-#endif
-        }
-
+        void on_realize() override;
 #if GTKMM_CHECK_VERSION(3,0,0)
-        bool on_draw( const Cairo::RefPtr< Cairo::Context >& cr ) override
-        {
-            const bool ret = Gtk::Window::on_draw( cr );
-            if( m_draw_frame ) {
-                Gdk::Cairo::set_source_rgba( cr, Gdk::RGBA( "black" ) );
-                cr->set_line_width( 1.0 );
-                cr->rectangle( 0.0, 0.0, get_width(), get_height() );
-                cr->stroke();
-            }
-            return ret;
-        }
+        bool on_draw( const Cairo::RefPtr< Cairo::Context >& cr ) override;
 #else
-        bool on_expose_event( GdkEventExpose* event ) override
-        {
-            bool ret = Gtk::Window::on_expose_event( event );
-
-            // 枠の描画
-            if( m_draw_frame ){
-                m_gc->set_foreground( Gdk::Color( "black" ) );
-                get_window()->draw_rectangle( m_gc, false, 0, 0, get_width()-1, get_height()-1 );
-            }
-
-            return ret;
-        }
-#endif // GTKMM_CHECK_VERSION(3,0,0)
-
-        bool on_configure_event( GdkEventConfigure* event ) override
-        {
-            bool ret = Gtk::Window::on_configure_event( event );
-            m_sig_configured.emit( get_width(), get_height() );
-
-            return ret;
-        }
+        bool on_expose_event( GdkEventExpose* event ) override;
+#endif
+        bool on_configure_event( GdkEventConfigure* event ) override;
     };
 }
 


### PR DESCRIPTION
SKELETON名前空間にあるクラスのメンバー関数の定義を移動します。

- メンバーのメソッドを呼び出すラッパーはヘッダーに移動する。
- 複数の命令文があるメンバー関数はcppファイルに移動する。
- `.clang-format`の設定をバージョン8.0に合うように更新する。
