### PR TITLE
Release 0.2.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,32 +83,32 @@ JDimがリリースされた時には以下の作業を行います。
 
 1. `docs/manual/YYYY.md`にある先頭の見出しをコピーします。例:
    ```markdown
-   <a name="1.0.0-unreleased"></a>
-   ### [1.0.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.1.0...master) (unreleased)
+   <a name="0.2.0-unreleased"></a>
+   ### [0.2.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.1.0...master) (unreleased)
 
-   <a name="1.0.0-unreleased"></a>
-   ### [1.0.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.1.0...master) (unreleased)
+   <a name="0.2.0-unreleased"></a>
+   ### [0.2.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.1.0...master) (unreleased)
    ...
    ```
 2. バージョン番号、日付、リンクを修正します。例:
    ```markdown
-   <a name="2.0.0-unreleased"></a>
-   ### [2.0.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v1.0.0...master) (unreleased)
+   <a name="0.3.0-unreleased"></a>
+   ### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.2.0...master) (unreleased)
 
-   <a name="1.0.0-20190430"></a>
-   ### [1.0.0-20190430](https://github.com/JDimproved/JDim/compare/JDim-v0.1.0...JDim-v1.0.0) (2019-04-30)
+   <a name="0.2.0-20190720"></a>
+   ### [0.2.0-20190720](https://github.com/JDimproved/JDim/compare/JDim-v0.1.0...JDim-v0.2.0) (2019-07-20)
    ...
    ```
 3. リリースの見出しとリンクを追加します。例:
    ```markdown
-   <a name="2.0.0-unreleased"></a>
-   ### [2.0.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v1.0.0...master) (unreleased)
+   <a name="0.3.0-unreleased"></a>
+   ### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.2.0...master) (unreleased)
 
-   <a name="JDim-v1.0.0"></a>
-   ### [**JDim-v1.0.0** Release](https://github.com/JDimproved/JDim/releases/tag/JDim-v1.0.0) (2019-05-01)
+   <a name="JDim-v0.2.0"></a>
+   ### [**JDim-v0.2.0** Release](https://github.com/JDimproved/JDim/releases/tag/JDim-v0.2.0) (2019-07-20)
 
-   <a name="1.0.0-20190430"></a>
-   ### [1.0.0-20190430](https://github.com/JDimproved/JDim/compare/JDim-v0.1.0...JDim-v1.0.0) (2019-04-30)
+   <a name="0.2.0-20190720"></a>
+   ### [0.2.0-20190720](https://github.com/JDimproved/JDim/compare/JDim-v0.1.0...JDim-v0.2.0) (2019-07-20)
    ...
    ```
 

--- a/docs/manual/2019.md
+++ b/docs/manual/2019.md
@@ -8,8 +8,23 @@ layout: default
 ## {{ page.title }}
 
 
-<a name="0.1.0-unreleased"></a>
-### [0.1.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.1.0...master) (unreleased)
+<a name="0.3.0-unreleased"></a>
+### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.2.0...master) (unreleased)
+
+
+<a name="JDim-v0.2.0"></a>
+### [**JDim-v0.2.0** Release](https://github.com/JDimproved/JDim/releases/tag/JDim-v0.2.0) (2019-07-20)
+主な変更点
+- GTK3版をビルドするオプションを追加した(デフォルトはGTK2版)
+- 最大表示可能レス数を固定(11000)から変更可能にした
+- スレタイ検索のデフォルト設定を変更した(ff5ch.syoboi.jp)
+- 動作環境の表示にTLSライブラリを追加した
+- 旧設定ファイル(version < 1.9.5)のサポートを削除した
+
+<a name="0.2.0-20190720"></a>
+### [0.2.0-20190720](https://github.com/JDimproved/JDim/compare/79e90c8b2d...JDim-v0.2.0) (2019-07-20)
+- Minor fixes
+  ([#96](https://github.com/JDimproved/JDim/pull/96))
 - Fix #90: Implement ENVIRONMENT::get_tlslib_version
   ([#94](https://github.com/JDimproved/JDim/pull/94))
 - Tweak UI and configuration
@@ -42,6 +57,10 @@ layout: default
   ([#72](https://github.com/JDimproved/JDim/pull/72))
 - Create online manual [1/2]
   ([#69](https://github.com/JDimproved/JDim/pull/69))
+
+
+<a name="0.1.0-20190430"></a>
+### [0.1.0-20190430](https://github.com/JDimproved/JDim/compare/JDim-v0.1.0...79e90c8b2d) (2019-04-30)
 - Fix #71: Deprecate gtkmm version less than 2.18
   ([#73](https://github.com/JDimproved/JDim/pull/73))
 - Fix check button for usrcmdpref

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -18,9 +18,9 @@
 // SEE ALSO: ENVIRONMENT::get_jdversion()
 
 #define MAJORVERSION 0
-#define MINORVERSION 1
+#define MINORVERSION 2
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20190413"
+#define JDDATE_FALLBACK    "20190720"
 #define JDTAG     ""
 
 //---------------------------------


### PR DESCRIPTION
次期バージョンのリリースのため変更履歴やバージョン番号を修正します。

- マニュアル更新の例を修正
- 変更履歴にリリースを追加する
- バージョン番号を修正する

TODO
- [ ] PRのマージ
- [ ] タグ付け `JDim-v0.2.0`
- [ ] Releaseページの更新
- [ ] Projectページの更新
- [ ] 関連のissueを更新