### PR TITLE
Fix #98: Add travis-ci.com configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,94 @@
+dist: xenial
+language: cpp
+
+branches:
+  only:
+    - master
+
+cache:
+  apt: true
+
+matrix:
+  include:
+    - name: "COMPILER=gcc CONFIG_ARG=\"--with-migemo --with-alsa --with-pangolayout\" CXXFLAGS=\"-D_DEBUG\""
+      os: linux
+      compiler: gcc
+      env: CONFIG_ARG="--with-migemo --with-alsa --with-pangolayout" CXXFLAGS="-D_DEBUG"
+      addons:
+        apt:
+          update: true
+          packages:
+            - autoconf-archive
+            - libgtkmm-2.4-dev
+            - zlib1g-dev
+            - libgnutls28-dev
+            - libgcrypt20-dev
+            - libmigemo-dev
+            - libasound2-dev
+
+    - name: "COMPILER=clang CONFIG_ARG=\"--with-sessionlib=gnomeui --with-regex=pcre --with-tls=openssl\""
+      os: linux
+      compiler: clang
+      env: CONFIG_ARG="--with-sessionlib=gnomeui --with-regex=pcre --with-tls=openssl"
+      addons:
+        apt:
+          update: true
+          packages:
+            - autoconf-archive
+            - libgtkmm-2.4-dev
+            - zlib1g-dev
+            - libgnomeui-dev
+            - libssl-dev
+            - libpcre3-dev
+
+    - name: "COMPILER=gcc CONFIG_ARG=\"--with-gtkmm3 --with-regex=oniguruma --with-thread=std\""
+      os: linux
+      compiler: gcc
+      env: CONFIG_ARG="--with-gtkmm3 --with-regex=oniguruma --with-thread=std"
+      addons:
+        apt:
+          update: true
+          packages:
+            - autoconf-archive
+            - libgtkmm-3.0-dev
+            - zlib1g-dev
+            - libgnutls28-dev
+            - libgcrypt20-dev
+            - libonig-dev
+
+    - name: "COMPILER=clang CONFIG_ARG=\"--with-gtkmm3 --with-xdgopen\" CXXFLAGS=\"-D_DEBUG\""
+      os: linux
+      compiler: clang
+      env: CONFIG_ARG="--with-gtkmm3 --with-xdgopen" CXXFLAGS="-D_DEBUG"
+      addons:
+        apt:
+          update: true
+          packages:
+            - autoconf-archive
+            - libgtkmm-3.0-dev
+            - zlib1g-dev
+            - libgnutls28-dev
+            - libgcrypt20-dev
+
+    - name: "manual build"
+      os: linux
+      language: ruby
+      rvm: 2.4.5
+      cache: bundler
+      sudo: false
+      env: NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+      addons:
+        apt:
+          packages:
+            - libcurl4-openssl-dev
+      script: make -j3 -C docs build
+
+install:
+  - travis_retry git clone --depth 1 --branch master https://github.com/google/googletest.git test/googletest
+
+script:
+  - autoreconf -i
+  - ./configure $CONFIG_ARG
+  - make -j3
+  - make test -j3
+  - ./src/jdim -V

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # JDim - 2ch browser for linux
 
+[![Build Status](https://travis-ci.com/JDimproved/JDim.svg?branch=master)](https://travis-ci.com/JDimproved/JDim)
+
 ここに書かれていない詳細については[オンラインマニュアル][manual]や[リポジトリ][repository]を参照してください。
 
 [manual]: https://jdimproved.github.io/JDim/

--- a/docs/manual/2019.md
+++ b/docs/manual/2019.md
@@ -10,6 +10,8 @@ layout: default
 
 <a name="0.3.0-unreleased"></a>
 ### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.2.0...master) (unreleased)
+- Fix #98: Add travis-ci.com configuration
+  ([#99](https://github.com/JDimproved/JDim/pull/99))
 
 
 <a name="JDim-v0.2.0"></a>
@@ -23,6 +25,8 @@ layout: default
 
 <a name="0.2.0-20190720"></a>
 ### [0.2.0-20190720](https://github.com/JDimproved/JDim/compare/79e90c8b2d...JDim-v0.2.0) (2019-07-20)
+- Release 0.2.0
+  ([#97](https://github.com/JDimproved/JDim/pull/97))
 - Minor fixes
   ([#96](https://github.com/JDimproved/JDim/pull/96))
 - Fix #90: Implement ENVIRONMENT::get_tlslib_version


### PR DESCRIPTION
CIサービスを利用したJDimのビルドとテストを設定します。

##### 設定
- 環境はxenial
- 対象ブランチはmaster

##### ビルドの組み合わせ
- gtkmm2 + gcc (migemo, alsa, PangoLayout) DEBUG
- gtkmm2 + clang (gnomeui, PCRE, OpenSSL)
- gtkmm3 + gcc (Oniguruma, std::thread)
- gtkmm3 + clang (xdg-open) DEBUG
- manual build