### PR TITLE
Fix #101 Remove subversion support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,29 +49,6 @@ $(jdim_BUILDINFO_HEADER):
 	fi
 
 	@echo '' >> $@.new
-	@echo '// Version information of SVN.' >> $@.new
-
-	@if test -n "$(SVN)" -a -n "$(AWK)"; \
-	then \
-	    SVN_REPOSITORY=`LANG=C "$(SVN)" info 2>/dev/null | $(AWK) '/^URL/ {print $$2}' 2>/dev/null`; \
-	    if test -n "$${SVN_REPOSITORY}"; \
-	    then \
-	        echo "SVN: Repository = \"$${SVN_REPOSITORY}\""; \
-	        echo "#define SVN_REPOSITORY \"$${SVN_REPOSITORY}\"" >> $@.new; \
-	    fi \
-	fi
-
-	@if test -n "$(SVNVERSION)"; \
-	then \
-	    SVN_REVISION=`LANG=C "$(SVNVERSION)" -n 2>/dev/null`; \
-	    if test -n "$${SVN_REVISION}" -a "$${SVN_REVISION}" != "exported"; \
-	    then \
-	        echo "SVN: Revision = \"$${SVN_REVISION}\""; \
-	        echo "#define SVN_REVISION \"$${SVN_REVISION}\"" >> $@.new; \
-	    fi \
-	fi
-
-	@echo '' >> $@.new
 	@echo '// Version information of GIT.' >> $@.new
 
 	@GIT_HASH="" ; \

--- a/configure.ac
+++ b/configure.ac
@@ -22,8 +22,6 @@ dnl
 dnl buildinfo.h
 dnl
 AC_DEFINE(HAVE_BUILDINFO_H, 1, Define to 1 if you have the 'buildinfo.h' header file.)
-AC_PATH_PROG(SVN, svn)
-AC_PATH_PROG(SVNVERSION, svnversion)
 AC_PATH_PROG(GIT, git)
 AC_PATH_PROG(XSUM, md5sum, [cksum])
 AC_SUBST(ac_configure_args)

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -101,41 +101,6 @@ std::string ENVIRONMENT::get_configure_args( const int mode )
 
 
 //
-// SVNリビジョンとして表示する文字列を返す
-//
-std::string get_svn_revision( const char* rev = NULL )
-{
-    std::string svn_revision = "SVN:";
-
-    if( rev )
-    {
-        // "2000:2002MS"など[0-9:MS]の形式かどうか
-        bool valid = true;
-        unsigned int n;
-        const size_t rev_length = strlen( rev );
-        for( n = 0; n < rev_length; ++n )
-        {
-            if( (unsigned char)( rev[n] - 0x30 ) > 0x0A
-                && rev[n] != 'M'
-                && rev[n] != 'S' )
-            {
-                valid = false;
-                break;
-            }
-        }
-
-        if( valid ) svn_revision.append( std::string( "Rev." ) + std::string( rev ) );
-    }
-
-    if( svn_revision.compare( "SVN:" ) == 0 )
-    {
-        svn_revision.append( std::string( __DATE__ ) + "-" + std::string( __TIME__ ) );
-    }
-
-    return svn_revision;
-}
-
-//
 // GITリビジョンとして表示する文字列を返す
 // リビジョンが得られなかった場合（tarballのソース等）は、fallbackの日付を返す
 // git_dirtyは、まだcommitされてない変更があるかどうか
@@ -215,20 +180,10 @@ std::string ENVIRONMENT::get_jdversion()
 {
     std::stringstream jd_version;
 
-#ifdef JDVERSION_SVN
-
-#ifdef SVN_REVISION
-    jd_version << get_svn_revision( SVN_REVISION );
-#else
-    jd_version << get_svn_revision( NULL );
-#endif // SVN_REVISION
-
-#else
     jd_version << MAJORVERSION << "."
                 << MINORVERSION << "."
                 << MICROVERSION << "-"
                 << JDTAG << get_git_revision(GIT_DATE, GIT_HASH, GIT_DIRTY, JDDATE_FALLBACK);
-#endif // JDVERSION_SVN
 
     return jd_version.str();
 }
@@ -658,9 +613,6 @@ std::string ENVIRONMENT::get_jdinfo()
 
     jd_info <<
     "[バージョン] " << progname << " " << version << "\n" <<
-//#ifdef SVN_REPOSITORY
-//    "[リポジトリ ] " << SVN_REPOSITORY << "\n" <<
-//#endif
     "[ディストリ ] " << distribution << "\n" <<
     "[パッケージ] " << "バイナリ/ソース( <配布元> )" << "\n" <<
     "[ DE／WM ] " << desktop << "\n" <<

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -10,9 +10,6 @@
 #include "buildinfo.h"
 #endif
 
-// svn 版の時は JDVERSION_SVN をdefineする
-//#define JDVERSION_SVN
-
 // gitのリポジトリを使ってビルドしているときはリビジョンから日付を取得する
 // リビジョンが参照できない場合はJDDATE_FALLBACKを使う
 // SEE ALSO: ENVIRONMENT::get_jdversion()
@@ -71,11 +68,7 @@
 
 // Two macros expansion is gcc preprocessor technic
 #define JDRC_VERSION_EXP(a,b,c,d,e) JDRC_VERSION_FMT(a,b,c,d,e)
-#ifdef JDVERSION_SVN
-#define JDRC_VERSION_FMT(a,b,c,d,e) #a "." #b "." #c "-svnversion"
-#else
 #define JDRC_VERSION_FMT(a,b,c,d,e) #a "." #b "." #c "-" d e
-#endif
 #define JDRC_VERSION_STR JDRC_VERSION_EXP( \
             MAJORVERSION, MINORVERSION, MICROVERSION, JDTAG, JDDATE_FALLBACK)
 


### PR DESCRIPTION
#101 のPRです。
subversion対応機能はgitに移行してから使われておらずメンテナンスされていないため削除します。
これによりReproducible builds(ビルド再現性)を妨げるコードの一部が修正されますが、[問題の箇所][salsa]がまだ残っているためDebianパッケージのreprotestには成功しません。

[salsa]: https://salsa.debian.org/debian/jdim/commit/a3a95960f87597d55c2ffe358896d3cef78f879d#note_103083
