### PR TITLE
Fix #109: Remove cache root config providing compatible with old version

### DIFF
--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -109,9 +109,6 @@ bool ConfigItems::load( const bool restore )
     // レスにアスキーアートがあると判定する正規表現
     regex_res_aa = cf.get_option_str( "regex_res_aa", CONF_REGEX_RES_AA );
 
-    // キャッシュのルートディレクトリ(旧バージョンとの互換のため残している)
-    path_cacheroot = cf.get_option_str( "path_cacheroot", CONF_PATH_CACHEROOT );
-
     // 読み込み用プロクシとポート番号
     use_proxy_for2ch = cf.get_option_bool( "use_proxy_for2ch", CONF_USE_PROXY_FOR2CH );
     str_tmp = cf.get_option_str( "proxy_for2ch", "" );
@@ -680,8 +677,6 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "ref_prefix_space", ref_prefix_space );
 
     cf.update( "regex_res_aa", regex_res_aa );
-
-    cf.update( "path_cacheroot", path_cacheroot );
 
     cf.update( "agent_for2ch", agent_for2ch );
 

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -47,10 +47,6 @@ namespace CONFIG
         std::string regex_res_aa;
         bool aafont_enabled;
 
-        // キャッシュのルートディレクトリ
-        // 旧バージョンとの互換のため残しているだけで使用していない
-        std::string path_cacheroot;
-
         // 読み込み用プロクシとポート番号
         bool use_proxy_for2ch;
         std::string proxy_for2ch;

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -190,9 +190,6 @@ namespace CONFIG
 #define CONF_REGEX_RES_AA_DEFAULT "　 "
 #define CONF_REGEX_RES_AA "\"" CONF_REGEX_RES_AA_DEFAULT "\""
 
-// キャッシュのルートディレクトリ(旧バージョンとの互換のため残している)
-#define CONF_PATH_CACHEROOT "~/.jd/"
-
 // 2ch にアクセスするときのエージェント名
 #define CONF_AGENT_FOR2CH "Monazilla/1.00 JD"
 


### PR DESCRIPTION
#109 のPRです。
旧バージョン(1.9.0未満, 2006-2007年頃)との互換のため残してある未使用のキャッシュのルートディレクトリ設定 `path_cacheroot` を削除することを提案します。
