### PR TITLE
Fix configure args info to include "without" and "disable" options

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -69,12 +69,17 @@ std::string ENVIRONMENT::get_configure_args( const int mode )
     bool multi = false;
 
     // 省略形として"--with-"や"--enable-"などを取り出す
-    while( ( found_pos = args.find( "'--with-", search_pos ) ) != std::string::npos ||
-            ( found_pos = args.find( "'--enable-", search_pos ) ) != std::string::npos )
+    while( ( found_pos = args.find( "'--", search_pos ) ) != std::string::npos )
     {
-        size_t quote_pos = args.find( "'", found_pos + 1 );
+        const size_t quote_pos = args.find( "'", found_pos + 1 );
 
-        if( quote_pos != std::string::npos && quote_pos != end_quote_pos)
+        if( args.compare( found_pos + 3, 4, "with" ) != 0
+            && args.compare( found_pos + 3, 6, "enable" ) != 0
+            && args.compare( found_pos + 3, 7, "disable" ) != 0 )
+        {
+            search_pos = quote_pos + 1;
+        }
+        else if( quote_pos != std::string::npos && quote_pos != end_quote_pos )
         {
             // 項目が複数の場合は改行かスペースを付与
             if( multi )


### PR DESCRIPTION
動作環境の記入で参照されるconfigureオプションの検索条件を変更して`--without-*`や`--disable-*`ではじまるオプションを引数情報に含めるようにします。

#### 動機
新しく導入されたconfigureオプション`--disable-compat-cache-dir`がオプション情報に載らない問題を修正します。
