### PR TITLE
Fix markdown format for the table of cache directory priority

### DIFF
--- a/docs/manual/start.md
+++ b/docs/manual/start.md
@@ -45,6 +45,7 @@ $ JDIM_LOCK=~/mylock jdim
 ```
 
 #### キャッシュディレクトリの優先順位
+
 | `~/.jd` | `$XDG_CACHE_HOME/jdim` | 使われるのは… |
 | --- | --- | --- |
 | 存在する | any | `~/.jd` |


### PR DESCRIPTION
マニュアルの表のフォーマット崩れを修正する。