### PR TITLE
Improve tab switch by mouse wheel for image view

### DIFF
--- a/docs/manual/2019.md
+++ b/docs/manual/2019.md
@@ -10,6 +10,8 @@ layout: default
 
 <a name="0.3.0-unreleased"></a>
 ### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.2.0...master) (unreleased)
+- Improve tab switch by mouse wheel for image view
+  ([#117](https://github.com/JDimproved/JDim/pull/117))
 - Implement tab switch by mouse wheel for GTK3
   ([#114](https://github.com/JDimproved/JDim/pull/114))
 - Add smooth scroll event to enable mouse wheel on GTK3

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -192,7 +192,7 @@ namespace ARTICLE
 
         // スクロール情報
 #if GTKMM_CHECK_VERSION(3,3,18)
-        double m_smooth_dy; // GDK_SMOOTH_SCROLL のスクロール変化量
+        double m_smooth_dy; // GDK_SCROLL_SMOOTH のスクロール変化量
 #endif
         SCROLLINFO m_scrollinfo;
         guint32 m_wheel_scroll_time; // 前回ホイールを回した時刻

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -68,6 +68,12 @@ ImageAdmin::ImageAdmin( const std::string& url )
     m_left.signal_released().connect( sigc::mem_fun( *this, &ImageAdmin::slot_release_left ) );
     m_right.signal_released().connect( sigc::mem_fun( *this, &ImageAdmin::slot_release_right ) );
 
+    // マウスホイールによる画像ビューのタブ切り替えを設定する
+    m_tab.add_events( Gdk::SCROLL_MASK );
+#if GTKMM_CHECK_VERSION(3,3,18)
+    m_tab.add_events( Gdk::SMOOTH_SCROLL_MASK );
+#endif
+    m_tab.signal_scroll_event().connect( sigc::mem_fun( *this, &ImageAdmin::slot_scroll_event ) );
 
     m_tab.pack_start( m_scrwin );
     m_tab.pack_end( m_right, Gtk::PACK_SHRINK );
@@ -1017,6 +1023,37 @@ void ImageAdmin::slot_release_left()
 void ImageAdmin::slot_release_right()
 {
     m_scroll = SCROLL_NO;
+}
+
+
+//
+// タブのマウスホイールイベント
+//
+bool ImageAdmin::slot_scroll_event( GdkEventScroll* event )
+{
+    // 回転したらタブ切り替え
+    const char* command_name = nullptr;
+    if( event->direction == GDK_SCROLL_UP ) command_name = "tab_left";
+    else if( event->direction == GDK_SCROLL_DOWN ) command_name = "tab_right";
+#if GTKMM_CHECK_VERSION(3,3,18)
+    else if( event->direction == GDK_SCROLL_SMOOTH ) {
+        constexpr double smooth_scroll_factor{ 2.0 };
+        m_smooth_dy += smooth_scroll_factor * event->delta_y;
+        if( m_smooth_dy < -1.0 ) {
+            command_name = "tab_left";
+            m_smooth_dy = 0.0;
+        }
+        else if( m_smooth_dy > 1.0 ) {
+            command_name = "tab_right";
+            m_smooth_dy = 0.0;
+        }
+    }
+#endif // GTKMM_CHECK_VERSION(3,3,18)
+
+    if( command_name ) set_command( command_name );
+    set_command( "switch_admin" );
+
+    return true;
 }
 
 

--- a/src/image/imageadmin.h
+++ b/src/image/imageadmin.h
@@ -33,6 +33,10 @@ namespace IMAGE
         int m_scroll;
         int m_counter_scroll;
 
+#if GTKMM_CHECK_VERSION(3,3,18)
+        double m_smooth_dy{ 0.0 }; // GDK_SCROLL_SMOOTH のスクロール変化量
+#endif
+
       public:
 
         ImageAdmin( const std::string& url );
@@ -117,6 +121,8 @@ namespace IMAGE
         void slot_press_right();
         void slot_release_left();
         void slot_release_right();
+        // マウスホイールによるタブ切り替え
+        bool slot_scroll_event( GdkEventScroll* event );
 
         bool copy_file( const std::string& url, const std::string& path_from, const std::string& path_to );
         void save_all();

--- a/src/image/imageviewicon.cpp
+++ b/src/image/imageviewicon.cpp
@@ -192,24 +192,6 @@ Gtk::Menu* ImageViewIcon::get_popupmenu( const std::string& url )
 
 
 //
-// マウスホイールイベント
-//
-bool ImageViewIcon::slot_scroll_event( GdkEventScroll* event )
-{
-    // 回転したらタブ切り替え
-    int control = CONTROL::None;
-    if( event->direction == GDK_SCROLL_UP ) control = CONTROL::TabLeft;
-    if( event->direction == GDK_SCROLL_DOWN ) control = CONTROL::TabRight;
-
-    ImageViewBase::operate_view( control );
-    IMAGE::get_admin()->set_command( "switch_admin" );
-
-    return true;
-}
-
-
-
-//
 // D&D開始
 //
 void ImageViewIcon::slot_drag_begin( const Glib::RefPtr<Gdk::DragContext>& context )

--- a/src/image/imageviewicon.h
+++ b/src/image/imageviewicon.h
@@ -27,7 +27,8 @@ namespace IMAGE
       protected:
 
         Gtk::Menu* get_popupmenu( const std::string& url ) override;
-        bool slot_scroll_event( GdkEventScroll* event ) override;
+        // マウスホイールのイベント(タブ切り替え)は親ウィジェットで処理する
+        bool slot_scroll_event( GdkEventScroll* event ) override { return false; }
 
       private:
 

--- a/src/skeleton/dragnote.h
+++ b/src/skeleton/dragnote.h
@@ -103,7 +103,7 @@ namespace SKELETON
         Alloc_NoteBook m_alloc_old;
 
 #if GTKMM_CHECK_VERSION(3,3,18)
-        double m_smooth_dy{ 0.0 }; // GDK_SMOOTH_SCROLL のスクロール変化量
+        double m_smooth_dy{ 0.0 }; // GDK_SCROLL_SMOOTH のスクロール変化量
 #endif
 
       public:

--- a/src/skeleton/dragtreeview.h
+++ b/src/skeleton/dragtreeview.h
@@ -67,7 +67,7 @@ namespace SKELETON
         SIG_DROPPED_URI_LIST m_sig_dropped_url_list;
 
 #if GTKMM_CHECK_VERSION(3,3,18)
-        double m_smooth_dy{ 0.0 }; // GDK_SMOOTH_SCROLL のスクロール変化量
+        double m_smooth_dy{ 0.0 }; // GDK_SCROLL_SMOOTH のスクロール変化量
 #endif
 
       public:


### PR DESCRIPTION
Fixes #110.

マウスホイール関連の追加PRです。
画像ビューのマウスホイールによるタブ切り替えを画像アイコンの境目やタブの空白領域でも操作が効くように修正します。

また、GTK 3.3.18以降ではタブ切り替え処理で `GDK_SCROOL_SMOOTH` を扱うように修正します。この修正によってGTK3版でマウスホイールによる切り替え操作が使えるようになります。

その他
- コメントの訂正: `GDK_SMOOTH_SCROLL` → `GDK_SCROOL_SMOOTH`
