### PR TITLE
Add snapcraft.yaml

### DIFF
--- a/docs/manual/2019.md
+++ b/docs/manual/2019.md
@@ -10,6 +10,8 @@ layout: default
 
 <a name="0.3.0-unreleased"></a>
 ### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.2.0...master) (unreleased)
+- Add snapcraft.yaml
+  ([#118](https://github.com/JDimproved/JDim/pull/118))
 - Improve tab switch by mouse wheel for image view
   ([#117](https://github.com/JDimproved/JDim/pull/117))
 - Implement tab switch by mouse wheel for GTK3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,6 +36,12 @@ parts:
       - --disable-compat-cache-dir
       - --with-gtkmm3
       - --with-xdgopen
+    build-environment:
+      # https://wiki.debian.org/Hardening
+      - CFLAGS: "$(dpkg-buildflags --get CFLAGS)"
+      - CPPFLAGS: "$(dpkg-buildflags --get CPPFLAGS)"
+      - CXXFLAGS: "$(dpkg-buildflags --get CXXFLAGS)"
+      - LDFLAGS: "$(dpkg-buildflags --get LDFLAGS)"
     build-packages:
       # https://packages.ubuntu.com/source/disco/jdim
       - build-essential

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,118 @@
+name: jdim
+version: "0.2.0-git"
+summary: 2ch browser for Linux
+license: "GPL-2.0"
+description: |
+  JDim (JD improved) is a browser for Japanese textboard "2channel".
+  The software has been forked from JD released under the terms of GPL-2.0,
+  having look-and-feel and environment settings compatible.
+
+  Various features which are better viewing 2ch: Fetching updated posts,
+  Hide NG word posts, Message posting, ASCII art input, Play-by-play mode,
+  Display linked images, Bookmark and History, Filters for URL, Thread title search,
+  Keyword search in thread, External boards support, Highly customizations and more...
+
+confinement: strict
+base: core18
+grade: devel
+icon: jdim.png
+
+plugs:
+  gnome-3-28-1804:
+    interface: content
+    target: $SNAP/gnome-platform
+    default-provider: gnome-3-28-1804
+  gtk-3-themes:
+    interface: content
+    target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes
+
+parts:
+  jdim:
+    plugin: autotools
+    source: https://github.com/JDimproved/JDim.git
+    source-type: git
+    source-branch: master
+    source-depth: 1
+    configflags:
+      - --disable-compat-cache-dir
+      - --with-gtkmm3
+      - --with-xdgopen
+    build-packages:
+      # https://packages.ubuntu.com/source/disco/jdim
+      - build-essential
+      - git
+      - libc6-dev
+      - libgnutls28-dev
+      - libgcrypt20-dev
+      - libgtkmm-3.0-dev
+      - zlib1g-dev
+      - autoconf-archive
+    stage-packages:
+      # https://packages.ubuntu.com/disco/net/jdim
+      - libatkmm-1.6-1v5
+      - libgcc1
+      - libgcrypt20
+      - libglib2.0-0
+      - libglibmm-2.4-1v5
+      - libgnutls30
+      - libgtkmm-3.0-1v5
+      - libpango-1.0-0
+      - libpangomm-1.4-1v5
+      - libsigc++-2.0-0v5
+      - libstdc++6
+      - libx11-6
+      - libice6
+      - libsm6
+      - zlib1g
+      - libappindicator3-1
+    override-prime: |
+      set -eu
+      snapcraftctl prime
+      sed --in-place -e 's|^Icon=.*|Icon=\${SNAP}/share/icons/hicolor/48x48/apps/jdim.png|' \
+      share/applications/jdim.desktop
+    after: [desktop-gnome-platform]
+    stage:
+      - -./usr/share/**
+
+  # https://hackmd.io/0I09MG1FRKqO0ehIdLHpoQ#
+  desktop-gnome-platform:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-depth: 1
+    source-subdir: gtk
+
+    plugin: make
+    build-packages:
+    - build-essential
+    - libgtk-3-dev
+    override-build: |
+      snapcraftctl build
+      mkdir -pv $SNAPCRAFT_PART_INSTALL/gnome-platform
+
+  my-desktop:
+    # gtk-common-themes does not provide breeze icon theme.
+    plugin: nil
+    stage-packages:
+      - breeze-icon-theme
+
+apps:
+  jdim:
+    command: bin/desktop-launch $SNAP/bin/jdim
+    desktop: share/applications/jdim.desktop
+    plugs:
+      - desktop
+      - desktop-legacy
+      - gsettings
+      - home
+      - network
+      - unity7
+      - wayland
+      - x11

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,16 +1,7 @@
 name: jdim
+adopt-info: jdim
 version: "0.2.0-git"
-summary: 2ch browser for Linux
 license: "GPL-2.0"
-description: |
-  JDim (JD improved) is a browser for Japanese textboard "2channel".
-  The software has been forked from JD released under the terms of GPL-2.0,
-  having look-and-feel and environment settings compatible.
-
-  Various features which are better viewing 2ch: Fetching updated posts,
-  Hide NG word posts, Message posting, ASCII art input, Play-by-play mode,
-  Display linked images, Bookmark and History, Filters for URL, Thread title search,
-  Keyword search in thread, External boards support, Highly customizations and more...
 
 confinement: strict
 base: core18
@@ -82,6 +73,7 @@ parts:
     after: [desktop-gnome-platform]
     stage:
       - -./usr/share/**
+    parse-info: [jdim.metainfo.xml]
 
   # https://hackmd.io/0I09MG1FRKqO0ehIdLHpoQ#
   desktop-gnome-platform:
@@ -106,6 +98,7 @@ parts:
 apps:
   jdim:
     command: bin/desktop-launch $SNAP/bin/jdim
+    common-id: com.github.jdimproved.JDim
     desktop: share/applications/jdim.desktop
     plugs:
       - desktop

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: jdim
 adopt-info: jdim
-version: "0.2.0-git"
 license: "GPL-2.0"
 
 confinement: strict
@@ -65,6 +64,12 @@ parts:
       - libsm6
       - zlib1g
       - libappindicator3-1
+    override-build: |
+      set -eu
+      snapcraftctl build
+      VER="$(./src/jdim -V | sed -n -e '1s%^[^0-9]*\([^-]\+\)-\([^(]\+\).*$%\1-\2%p')"
+      echo "version ${VER}"
+      snapcraftctl set-version "${VER}"
     override-prime: |
       set -eu
       snapcraftctl prime


### PR DESCRIPTION
#116 のPRです。
snapパッケージのビルドやランタイムの要件を定めたsnapcraft.yamlを追加します。

#### パッケージの設定内容
| 項目 | 値 |
| --- | --- |
| base | core18 |
| confinement | strict |
| grade | devel (今のところstable, candidateチャンネルには公開しません) |
| 依存plugs | [gnome-3-28-1804][gnome] and [gtk-3-themes][themes] |
| configureオプション | `--disable-compat-cache-dir` `--with-gtkmm3` `--with-xdgopen` |
| ビルドの環境変数 | [dpkg-buildflags][dpkg]を使ってHardening(セキュリティ強化)する |

- KDE環境下でアイコンがうまく表示されないため、gtk-3-themesに収録されていないbreeze-icon-themesをバンドルします。

[gnome]: https://gitlab.gnome.org/Community/Ubuntu/gnome-3-28-1804
[themes]: https://gitlab.gnome.org/Community/Ubuntu/gtk-common-themes
[dpkg]: https://wiki.debian.org/Hardening#Using_Hardening_Options


#### snapアプリケーションの注意

- JDのキャッシュディレクトリ `~/.jd` は使えません。
- 環境変数 `JDIM_CACHE` でキャッシュディレクトリを変更する場合、
  ホームディレクトリ以下の隠しファイルでないパスを指定する必要があります。
- [`gtk-common-themes`](https://gitlab.gnome.org/Community/Ubuntu/gtk-common-themes)に収録されてる[GTKテーマ][list]のみ使えます。
- デフォルトのキャッシュディレクトリはアプリ削除(`snap remove jdim`)とともに消去されます。
- 外部コマンドの呼び出しは制限されます。(xdg-openのみ)
- 環境によってはGTKテーマ、アイコン、マウスカーソルがうまく表示されない場合があります。
  環境変数 `GTK_THEME` や 設定ファイル `$XDG_CONFIG_HOME/gtk-3.0/settings.ini` を調整することで改善されるかもしれません。

[list]: https://gitlab.gnome.org/Community/Ubuntu/gtk-common-themes/blob/master/snap/snapcraft.yaml#L43-69

