### PR TITLE
Implement tilt wheel for DragTreeView on GTK3

### DIFF
--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -525,6 +525,11 @@ void DragTreeView::wheelscroll( GdkEventScroll* event )
             val += std::copysign( scr_inc, m_smooth_dy );
             m_smooth_dy = 0.0;
         }
+
+        // チルトホイール(横スクロール)対応
+        constexpr double smooth_scroll_factor_x = 0.5;
+        auto hadj = get_hadjustment();
+        hadj->set_value( hadj->get_value() + scr_inc * smooth_scroll_factor_x * event->delta_x );
     }
 #endif
     adj->set_value( val );


### PR DESCRIPTION
GTK3版のスレ一覧や板一覧でマウスのチルトホイール(横スクロール)を使えるようにします。
スクロール量はabout:configのツリービュー（板一覧、スレ一覧）にある「ツリービューでマウスホイールを回したときのスクロール量(行数)」で変更できます（[設定値に補正がかかる][factor]）。

#### 現時点での制限 (GTK2/GTK3共通)
GTKのシグナル処理や構成設定の都合によりチルトホイールへの動作割当ては横スクロール固定となり設定変更しても反映されません。
今後の更新次第ですが横スクロール固定を仕様にすることも考えております。

[factor]: https://github.com/ma8ma/JDim/blob/ace0517ffb141678aa0045b341d06c6d56f3b888/src/skeleton/dragtreeview.cpp#L530