### PR TITLE
Fix mouse button config to set Button5 correctly

### DIFF
--- a/docs/manual/2019.md
+++ b/docs/manual/2019.md
@@ -10,6 +10,12 @@ layout: default
 
 <a name="0.3.0-unreleased"></a>
 ### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.2.0...master) (unreleased)
+- Fix mouse button config to set Button5 correctly
+  ([#123](https://github.com/JDimproved/JDim/pull/123))
+- Implement tilt wheel for DragTreeView on GTK3
+  ([#122](https://github.com/JDimproved/JDim/pull/122))
+- Fix bug which is applied ascii art font falsely on GTK3
+  ([#121](https://github.com/JDimproved/JDim/pull/121))
 - Replace `gcry_md_hash_buffer` with `gnutls_hash_fast`
   ([#120](https://github.com/JDimproved/JDim/pull/120))
 - Add a note of bug which is applied AA font falsely to thread view

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -148,7 +148,7 @@ bool InputDiag::on_button_press_event( GdkEventButton* event )
         else if( button == 6 ) buttonname = "Tilt_Left";
         else if( button == 7 ) buttonname = "Tilt_Right";
         else if( button == 8 ) buttonname = "Button4";
-        else if( button == 9 ) buttonname = "Button6";
+        else if( button == 9 ) buttonname = "Button5";
 
         if( ! buttonname.empty() ){
             if( ctrl )  m_str_motion += "Ctrl+";


### PR DESCRIPTION
マウスボタン設定でマウスの拡張ボタン2(次のページへ進む)を入力したときに正しいボタン番号を割り当てるように修正します。
