### PR TITLE
[WORKAROUND] Fix build error for manual

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,3 +1,8 @@
 source 'https://rubygems.org'
+
+# NOTE: This is workaround for error on octokit (from faraday 0.16.1).
+# https://github.com/lostisland/faraday/issues/1033
+gem 'faraday', '<=0.15.4'
+
 gem 'github-pages', group: :jekyll_plugins
 gem 'jekyll-redirect-from'

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -13,7 +13,7 @@ all: run
 build: $(BUNDLE_DIR)
 	$(JEKYLL) build -d $(DEST_DIR)
 
-clean: $(DEST_DIR)
+clean:
 	$(JEKYLL) clean -d $(DEST_DIR)
 
 distclean: clean
@@ -27,6 +27,6 @@ run: $(BUNDLE_DIR)
 
 
 $(GEMFILE_LOCK):
-	$(BUNDLE) install --path $(BUNDLE_DIR)
+	$(BUNDLE) install --jobs $(shell nproc) --path $(BUNDLE_DIR)
 
 $(BUNDLE_DIR): $(GEMFILE_LOCK)


### PR DESCRIPTION
マニュアルビルドで使うjekyllの実行時エラーを回避します。[travis-ciのjob log](https://travis-ci.com/JDimproved/JDim/jobs/240017015), https://github.com/JDimproved/JDim/pull/124#issuecomment-536258187
NOTE: oktokitまたはfaradayの修正がリリースされたらこのパッチは不要になります。