### PR TITLE
Revert "[WORKAROUND] Fix build error for manual"

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,8 +1,3 @@
 source 'https://rubygems.org'
-
-# NOTE: This is workaround for error on octokit (from faraday 0.16.1).
-# https://github.com/lostisland/faraday/issues/1033
-gem 'faraday', '<=0.15.4'
-
 gem 'github-pages', group: :jekyll_plugins
 gem 'jekyll-redirect-from'


### PR DESCRIPTION
This reverts commit 0f121542fee72c4968a7e6f40329e2035254609e.
faradayの修正が[リリースされた][rubygems]のでマニュアルビルドの依存関係を戻します。

[rubygems]: https://rubygems.org/gems/faraday/versions/0.16.2
