### PR TITLE
Add github links for previous version manuals

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -111,6 +111,9 @@ JDimがリリースされた時には以下の作業を行います。
    ### [0.2.0-20190720](https://github.com/JDimproved/JDim/compare/JDim-v0.1.0...JDim-v0.2.0) (2019-07-20)
    ...
    ```
+4. 前のバージョンのマニュアルを更新します。<br>
+   リンク集のファイル `link-YYYYMMDD` をコピーして日付やバージョン番号、URLなどを改めます。
+   そして `index.md` の「前のバージョンのマニュアル (GitHubリンク)」に新しいページへのリンクを追加します。
 
 
 [gh-pages]: https://pages.github.com/

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,8 +27,14 @@ layout: default
 - [その他]({{ site.baseurl }}/info/)
 - [更新履歴]({{ site.baseurl }}/history/)
 
+### 前のバージョンのマニュアル (GitHubリンク)
+- [JDim 0.2.0-20190720](./link-20190720)
+- [JDim 0.1.0-20190122](./link-20190122)
+- [JD 2.8.9-150226][jd-289] (jd4linux)
+
 © 2019 JDimproved project
 
 [wiki-install]: https://ja.osdn.net/projects/jd4linux/wiki/OS%2F%E3%83%87%E3%82%A3%E3%82%B9%E3%83%88%E3%83%AA%E3%83%93%E3%83%A5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E5%88%A5%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95
 [wiki-faq]: https://ja.osdn.net/projects/jd4linux/wiki/FAQ
 [wiki-tips]: https://ja.osdn.net/projects/jd4linux/wiki/Tips
+[jd-289]: https://jd4linux.osdn.jp/manual/289/

--- a/docs/manual/link-20190122.md
+++ b/docs/manual/link-20190122.md
@@ -1,0 +1,83 @@
+---
+title: JDim 0.1.0-20190122
+layout: default
+---
+
+&gt; [Top](../) &gt; 前のバージョンのマニュアル (GitHubリンク) &gt; {{ page.title }}
+
+
+## 前のバージョンのマニュアル ( {{ page.title }} )
+
+括弧書きのないリンクは[GitHubリポジトリ][gh]のページです。<br>
+**注意**: 原稿のMarkdownはHTMLに変換する前提で書かれているので一部の表示やリンクが機能しません。
+
+- [README.md][readme]
+- [COPYING][copying]
+- [INSTALL][install]
+- [docs/README.md][docs-readme]
+- [test/README.md][test-readme]
+- [CONTRIBUTING.md][contributing]
+
+---
+
+- [JDimについて][about]
+- [make、実行方法について][make]
+- [OS/ディストリビューション別インストール方法][jdwiki-install] (JD wiki)
+- [起動について][start]
+- [datファイルのインポート、エクスポートについて][dat]
+- [バックアップ、アンインストールについて][backup]
+
+- [操作方法について][operation]
+- [マウスジェスチャについて][mouse]
+
+- [お気に入りについて][favorite]
+- [外部板について][external]
+- [実況モードについて][live]
+- [ユーザーコマンド、リンクフィルタについて][usrcmd]
+- [アスキーアート(AA)の入力について][asciiart]
+- [次スレ検索について][next]
+
+- [FAQ][jdwiki-faq] (JD wiki)
+- [Tips][jdwiki-tips] (JD wiki)
+- その他
+  - [板移転について][move]
+  - [ユーザーコマンド設定集][jdwiki-usrcmd] (JD wiki)
+  - [テーマについて][skin]
+  - [動作環境の記入について][environment]
+  - [効果音の再生について][sound]
+  - [URL変換について][urlreplace]
+
+[gh]: https://github.com/JDimproved/JDim
+
+[readme]: https://github.com/JDimproved/JDim/blob/JDim-v0.1.0/README.md
+[copying]: https://github.com/JDimproved/JDim/blob/JDim-v0.1.0/COPYING
+[install]: https://github.com/JDimproved/JDim/blob/JDim-v0.1.0/INSTALL
+[docs-readme]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/README.md
+[test-readme]: https://github.com/JDimproved/JDim/blob/923ea662c47cef6ff9874e1d33f87197e0a98eb7/test/README.md
+[contributing]: https://github.com/JDimproved/JDim/blob/e8cc28c993039363153c3e0631cc76b61ed38566/CONTRIBUTING.md
+
+[about]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/about.md
+[make]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/make.md
+[jdwiki-install]: https://ja.osdn.net/projects/jd4linux/wiki/OS%2F%E3%83%87%E3%82%A3%E3%82%B9%E3%83%88%E3%83%AA%E3%83%93%E3%83%A5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E5%88%A5%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95
+[start]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/start.md
+[dat]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/dat.md
+[backup]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/backup.md
+
+[operation]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/operation.md
+[mouse]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/mouse.md
+
+[favorite]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/favorite.md
+[external]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/external.md
+[live]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/live.md
+[usrcmd]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/usrcmd.md
+[asciiart]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/asciiart.md
+[next]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/next.md
+
+[jdwiki-faq]: https://ja.osdn.net/projects/jd4linux/wiki/FAQ
+[jdwiki-tips]: https://ja.osdn.net/projects/jd4linux/wiki/Tips
+[move]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/move.md
+[jdwiki-usrcmd]: https://ja.osdn.net/projects/jd4linux/wiki/%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89%E8%A8%AD%E5%AE%9A%E9%9B%86
+[skin]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/skin.md
+[environment]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/environment.md
+[sound]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/sound.md
+[urlreplace]: https://github.com/JDimproved/JDim/blob/a279663014d8ddd621b95a8c5fab22c83f6484c8/docs/manual/urlreplace.md

--- a/docs/manual/link-20190720.md
+++ b/docs/manual/link-20190720.md
@@ -1,0 +1,83 @@
+---
+title: JDim 0.2.0-20190720
+layout: default
+---
+
+&gt; [Top](../) &gt; 前のバージョンのマニュアル (GitHubリンク) &gt; {{ page.title }}
+
+
+## 前のバージョンのマニュアル ( {{ page.title }} )
+
+括弧書きのないリンクは[GitHubリポジトリ][gh]のページです。<br>
+**注意**: 原稿のMarkdownはHTMLに変換する前提で書かれているので一部の表示やリンクが機能しません。
+
+- [README.md][readme]
+- [COPYING][copying]
+- [INSTALL][install]
+- [docs/README.md][docs-readme]
+- [test/README.md][test-readme]
+- [CONTRIBUTING.md][contributing]
+
+---
+
+- [JDimについて][about]
+- [make、実行方法について][make]
+- [OS/ディストリビューション別インストール方法][jdwiki-install] (JD wiki)
+- [起動について][start]
+- [datファイルのインポート、エクスポートについて][dat]
+- [バックアップ、アンインストールについて][backup]
+
+- [操作方法について][operation]
+- [マウスジェスチャについて][mouse]
+
+- [お気に入りについて][favorite]
+- [外部板について][external]
+- [実況モードについて][live]
+- [ユーザーコマンド、リンクフィルタについて][usrcmd]
+- [アスキーアート(AA)の入力について][asciiart]
+- [次スレ検索について][next]
+
+- [FAQ][jdwiki-faq] (JD wiki)
+- [Tips][jdwiki-tips] (JD wiki)
+- その他
+  - [板移転について][move]
+  - [ユーザーコマンド設定集][jdwiki-usrcmd] (JD wiki)
+  - [テーマについて][skin]
+  - [動作環境の記入について][environment]
+  - [効果音の再生について][sound]
+  - [URL変換について][urlreplace]
+
+[gh]: https://github.com/JDimproved/JDim
+
+[readme]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/README.md
+[copying]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/COPYING
+[install]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/INSTALL
+[docs-readme]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/README.md
+[test-readme]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/test/README.md
+[contributing]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/CONTRIBUTING.md
+
+[about]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/about.md
+[make]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/make.md
+[jdwiki-install]: https://ja.osdn.net/projects/jd4linux/wiki/OS%2F%E3%83%87%E3%82%A3%E3%82%B9%E3%83%88%E3%83%AA%E3%83%93%E3%83%A5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E5%88%A5%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95
+[start]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/start.md
+[dat]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/dat.md
+[backup]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/backup.md
+
+[operation]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/operation.md
+[mouse]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/mouse.md
+
+[favorite]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/favorite.md
+[external]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/external.md
+[live]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/live.md
+[usrcmd]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/usrcmd.md
+[asciiart]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/asciiart.md
+[next]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/next.md
+
+[jdwiki-faq]: https://ja.osdn.net/projects/jd4linux/wiki/FAQ
+[jdwiki-tips]: https://ja.osdn.net/projects/jd4linux/wiki/Tips
+[move]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/move.md
+[jdwiki-usrcmd]: https://ja.osdn.net/projects/jd4linux/wiki/%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89%E8%A8%AD%E5%AE%9A%E9%9B%86
+[skin]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/skin.md
+[environment]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/environment.md
+[sound]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/sound.md
+[urlreplace]: https://github.com/JDimproved/JDim/blob/JDim-v0.2.0/docs/manual/urlreplace.md


### PR DESCRIPTION
前のバージョンのマニュアルを参照しやすくするためgithub.comの原稿へのリンクをオンラインマニュアルに追加します。
ただし、原稿のMarkdownファイルはHTMLに変換される前提で書かれているので一部の表示やリンクが機能しません。

#### 代替案
- オンラインマニュアルに前バージョンの内容を追加する。
  →作業の手間とブランチ内のファイル増加によるgitコマンドの速度低下が気になる。
- github wikiに前バージョンの内容orリンクを追加する。
  →wikiが未作成。今後の状況で移動を検討する。
