### PR TITLE
Fix GTKMM_CHECK_VERSION macro

### DIFF
--- a/src/gtkmmversion.h
+++ b/src/gtkmmversion.h
@@ -7,8 +7,8 @@
 #ifndef GTKMM_CHECK_VERSION
 #define GTKMM_CHECK_VERSION(major,minor,micro) \
     (GTKMM_MAJOR_VERSION > (major) || \
-     (GTKMM_MAJOR_VERSION == (major) && GTK_MINOR_VERSION > (minor)) || \
-     (GTKMM_MAJOR_VERSION == (major) && GTK_MINOR_VERSION == (minor) && \
+     (GTKMM_MAJOR_VERSION == (major) && GTKMM_MINOR_VERSION > (minor)) || \
+     (GTKMM_MAJOR_VERSION == (major) && GTKMM_MINOR_VERSION == (minor) && \
       GTKMM_MICRO_VERSION >= (micro)))
 #endif
 

--- a/src/jddebug.h
+++ b/src/jddebug.h
@@ -39,8 +39,8 @@ system( com.str().c_str() ); \
 #ifndef GTKMM_CHECK_VERSION
 #define GTKMM_CHECK_VERSION(major,minor,micro) \
     (GTKMM_MAJOR_VERSION > (major) || \
-     (GTKMM_MAJOR_VERSION == (major) && GTK_MINOR_VERSION > (minor)) || \
-     (GTKMM_MAJOR_VERSION == (major) && GTK_MINOR_VERSION == (minor) && \
+     (GTKMM_MAJOR_VERSION == (major) && GTKMM_MINOR_VERSION > (minor)) || \
+     (GTKMM_MAJOR_VERSION == (major) && GTKMM_MINOR_VERSION == (minor) && \
       GTKMM_MICRO_VERSION >= (micro)))
 #endif
 


### PR DESCRIPTION
引数minorの値を比較するマクロを`GTK_MINOR_VERSION`から`GTKMM_MINOR_VERSION`に修正します。

修正にあたり報告をしていただきありがとうございました。
<https://mao.5ch.net/test/read.cgi/linux/1540656394/645>
