### PR TITLE
Improve displaying tooltip for bbs list/thread list

### DIFF
--- a/docs/manual/2019.md
+++ b/docs/manual/2019.md
@@ -10,6 +10,12 @@ layout: default
 
 <a name="0.3.0-unreleased"></a>
 ### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.2.0...master) (unreleased)
+- Improve displaying tooltip for bbs list/thread list
+  ([#133](https://github.com/JDimproved/JDim/pull/133))
+- Improve displaying manual on github.com
+  ([#132](https://github.com/JDimproved/JDim/pull/132))
+- Fix GTKMM_CHECK_VERSION macro
+  ([#131](https://github.com/JDimproved/JDim/pull/131))
 - Fix tooltips which are not near mouse pointer on bbs list/thread list for GTK3
   ([#128](https://github.com/JDimproved/JDim/pull/128))
 - Add github links for previous version manuals


### PR DESCRIPTION
スレ一覧・板一覧のツールチップを列や一覧の幅より内容が長いときにだけ表示するように修正します。
スレ一覧はさらにマウスオーバーしたセルの内容をツールチップに表示するように変更します。

0e29f3d2 と 5774f110 からマウスオーバーしたときいつもツールチップが表示されるように変更されていました。
修正にあたり報告をしていただきありがとうございました。
<https://mao.5ch.net/test/read.cgi/linux/1551889442/319-320>
