### PR TITLE
Set ellipsize to dialog info label

### DIFF
--- a/src/skeleton/label_entry.cpp
+++ b/src/skeleton/label_entry.cpp
@@ -20,6 +20,7 @@ LabelEntry::LabelEntry( const bool editable, const std::string& label, const std
     m_info.set_size_request( 0, 0 );
     m_info.set_alignment( Gtk::ALIGN_START );
     m_info.set_selectable( true );
+    m_info.set_ellipsize( Pango::ELLIPSIZE_END );
 
     setup();
     set_text( text );


### PR DESCRIPTION
ダイアログ内の情報テキストが長いときはウインドウの幅に収まるように末尾を省略します。
GTK3版は省略設定がないとテキストの長さに合わせてダイアログの幅が広がり縮小できない問題がありました。
