### PR TITLE
Remove deprecated cpu optimization options

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -69,10 +69,10 @@
 
        migemoによる検索が有効になる。migemoがUTF-8の辞書でインストールされている必要がある。
 
-    --with-[native|core2duo|athlon64|atom|ppc7400|ppc7450]
+    --with-native
 
        CPUに合わせた最適化
-       --with-native以外のオプションは非推奨: かわりに ./configure CXXFLAGS="-march=ARCH" を使用してください。
+       CPUを指定する場合は ./configure CXXFLAGS="-march=ARCH" を利用してください。
 
     --with-tls=[gnutls|openssl]
 

--- a/configure.ac
+++ b/configure.ac
@@ -451,69 +451,18 @@ AS_IF(
 
 
 dnl
-dnl CPU別の最適化オプション
+dnl CPUの最適化オプション
 dnl
-if test "x$enable_gprof" = "xno"; then
-
-    dnl
-    dnl checking native (gcc >= 4.2 x86 & x86_64)
-    dnl
-	AC_ARG_WITH(native,[ --with-native    (use native)],
-        [ if test "$withval" != "no"; then
-            echo "use native"
-            CXXFLAGS="$CXXFLAGS -march=native"
-        fi ])
-
-    dnl
-    dnl checking core2duo
-    dnl
-    AC_ARG_WITH(core2duo,[ --with-core2duo    (use core2duo)],
-        [ if test "$withval" != "no"; then
-            echo "use core2duo"
-            AC_MSG_WARN([--with-core2duo is deprecated. Use ./configure CXXFLAGS="-march=core2"])
-            CXXFLAGS="$CXXFLAGS -march=pentium-m -msse3"
-        fi ])
-
-    dnl
-    dnl checking athlon64
-    dnl
-    AC_ARG_WITH(athlon64,[ --with-athlon64    (use athlon64)],
-        [ if test "$withval" != "no"; then
-            echo "use athlon64"
-            AC_MSG_WARN([--with-athlon64 is deprecated. Use ./configure CXXFLAGS="-march=athlon64"])
-            CXXFLAGS="$CXXFLAGS -march=athlon64"
-        fi ])
-
-    dnl
-    dnl checking atom
-    dnl
-    AC_ARG_WITH(atom,[ --with-atom    (use atom)],
-        [ if test "$withval" != "no"; then
-            echo "use atom"
-            AC_MSG_WARN([--with-atom is deprecated. Use ./configure CXXFLAGS="-march=prescott"])
-            CXXFLAGS="$CXXFLAGS -march=prescott"
-        fi ])
-
-    dnl
-    dnl checking ppc7400
-    dnl
-    AC_ARG_WITH(ppc7400,[ --with-ppc7400    (use PowerPC7400)],
-        [ if test "$withval" != "no"; then
-            echo "use ppc7400"
-            AC_MSG_WARN([--with-ppc7400 is deprecated. Use ./configure CXXFLAGS="-mcpu=7400 -maltivec -mabi=altivec"])
-            CXXFLAGS="$CXXFLAGS -mcpu=7400 -maltivec -mabi=altivec"
-        fi ])
-
-    dnl
-    dnl checking ppc7450
-    dnl
-    AC_ARG_WITH(ppc7450,[ --with-ppc7450    (use PowerPC7450)],
-        [ if test "$withval" != "no"; then
-            echo "use ppc7450"
-            AC_MSG_WARN([--with-ppc7450 is deprecated. Use ./configure CXXFLAGS="-mcpu=7450 -maltivec -mabi=altivec"])
-            CXXFLAGS="$CXXFLAGS -mcpu=7450 -maltivec -mabi=altivec"
-        fi ])
-fi
+AS_IF(
+  dnl gprofを利用する場合最適化オプションは無視される
+  [test "x$enable_gprof" = xno],
+  [AC_MSG_CHECKING(for --with-native)
+   AC_ARG_WITH(native, AC_HELP_STRING([--with-native], [produce code optimized for the local machine]),
+               [with_native="$withval"], [with_native=no])
+   AC_MSG_RESULT($with_native)
+   AS_IF([test "x$with_native" != xno],
+         [CXXFLAGS="$CXXFLAGS -march=native"])]
+)
 
 
 AC_ARG_VAR(GTEST_SRCDIR, [path overriding googletest framework source directory])

--- a/docs/manual/2019.md
+++ b/docs/manual/2019.md
@@ -10,6 +10,8 @@ layout: default
 
 <a name="0.3.0-unreleased"></a>
 ### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.2.0...master) (unreleased)
+- Remove deprecated cpu optimization options
+  ([#140](https://github.com/JDimproved/JDim/pull/140))
 - Fix scrollbar behaviors for thread view on GTK3
   ([#136](https://github.com/JDimproved/JDim/pull/136))
 - Set ellipsize to dialog info label

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -83,11 +83,8 @@ OSやディストリビューション別の解説は[OS/ディストリビュ�
   <dd>描画に PangoLayout を使う。デフォルトでは PangoGlyphString を使用する。</dd>
   <dt>--with-migemo</dt>
   <dd>migemo による検索が有効になる。migemoがUTF-8の辞書でインストールされている必要がある。</dd>
-  <dt>--with-[native|core2duo|athlon64|atom|ppc7400|ppc7450]</dt>
-  <dd>
-    CPUに合わせた最適化。<strong><code>--with-native</code>以外のオプションは非推奨:</strong>
-    かわりに <code>./configure CXXFLAGS=&quot;-march=ARCH&quot;</code> を使用してください。
-  </dd>
+  <dt>--with-native</dt>
+  <dd>CPUに合わせた最適化。CPUを指定する場合は <code>./configure CXXFLAGS="-march=ARCH"</code> を利用する。</dd>
 
   <dt>--with-tls=[gnutls|openssl]</dt>
   <dd>使用するSSL/TLSライブラリを設定する。デフォルトでは GnuTLS を使用する。</dd>

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -17,7 +17,7 @@
 #define MAJORVERSION 0
 #define MINORVERSION 2
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20190720"
+#define JDDATE_FALLBACK    "20191027"
 #define JDTAG     ""
 
 //---------------------------------


### PR DESCRIPTION
廃止予定になっている特定のCPUに最適化したコードを生成するためのconfigureオプションを削除します。
最近1〜2年の間に2/5chスレッドに投稿された動作環境で対象のオプションを利用しているものはありませんでした。

#### 削除するconfigureオプション

- `--with-core2duo`
- `--with-athlon64`
- `--with-atom`
- `--with-ppc7400`
- `--with-ppc7450`

#### 代替手段

最適化のCPUを指定する場合は `./configure CXXFLAGS="-march=ARCH"` を利用してください。
