### PR TITLE
Deprecate --with-sessionlib=gnomeui option

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -33,7 +33,7 @@
   オプション
 
   ・alsa-lib (--with-alsa)
-  ・libgnomeui (--with-sessionlib=gnomeui) (GTK2版)
+  ・libgnomeui (--with-sessionlib=gnomeui) (GTK2版、廃止予定)
   ・openssl (--with-tls=openssl)
   ・oniguruma (--with-regex=oniguruma)
   ・libpcre (--with-regex=pcre)
@@ -58,8 +58,9 @@
 
     --with-sessionlib=[xsmp|gnomeui|no]
 
-       GNOMEUIを使ってセッション管理をするには「gnomeui」を。セッション管理を無効にするには「no」を選択。
-       デフォルトでは XSMPを使用する。「gnomeui」はGTK2版のみ利用できる。
+       XSMP を使ってセッション管理をするには「xsmp」を、セッション管理を無効にするには「no」を選択する。
+       デフォルトでは XSMP を使用する。「gnomeui」はGTK2版のみ利用できる。
+       --with-sessionlib=gnomeui は非推奨: かわりに --with-sessionlib=xsmp を使用してください。
 
     --with-pangolayout
 

--- a/configure.ac
+++ b/configure.ac
@@ -204,6 +204,7 @@ AS_IF(
   [test "x$with_sessionlib" = xgnomeui],
   [PKG_CHECK_MODULES(GNOMEUI, [libgnomeui-2.0 >= 2.0])
    AC_DEFINE(USE_GNOMEUI, , [use gnomeui])
+   AC_MSG_WARN([--with-sessionlib=gnomeui is deprecated. Use --with-sessionlib=xsmp instead.])
    AC_SUBST(GNOMEUI_CFLAGS)
    AC_SUBST(GNOMEUI_LIBS)],
 

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -46,7 +46,7 @@ layout: default
 
 #### オプション
 - alsa-lib (`--with-alsa`)
-- libgnomeui (`--with-sessionlib=gnomeui`) GTK2版のみ
+- libgnomeui (`--with-sessionlib=gnomeui`) GTK2版のみ、廃止予定
 - openssl (`--with-tls=openssl`)
 - oniguruma (`--with-regex=oniguruma`)
 - libpcre (`--with-regex=pcre`)
@@ -75,9 +75,11 @@ OSやディストリビューション別の解説は[OS/ディストリビュ�
 <dl>
   <dt>--with-sessionlib=[xsmp|gnomeui|no]</dt>
   <dd>
-    GNOMEUI を使ってセッション管理をするには <code>gnomeui</code> を、セッション管理
-    を無効にするには <code>no</code> を選択。デフォルトでは XSMP を使用する。
-    <code>gnomeui</code>はGTK2版のみ有効。
+    XSMP を使ってセッション管理をするには <code>xsmp</code> を、
+    セッション管理を無効にするには <code>no</code> を選択する。デフォルトでは XSMP を使用する。
+    <code>gnomeui</code> はGTK2版のみ有効。
+    <strong><code>--with-sessionlib=gnomeui</code> は非推奨</strong>:
+    かわりに <code>--with-sessionlib=xsmp</code> を使用してください。
   </dd>
   <dt>--with-pangolayout</dt>
   <dd>描画に PangoLayout を使う。デフォルトでは PangoGlyphString を使用する。</dd>


### PR DESCRIPTION
Fixes #139.

セッション管理ライブラリ [libgnomeui][2] を利用するオプション(`--with-sessionlib=gnomeui`)を廃止予定にします。
libgnomeuiはgtk3で[廃止されており][1]、2019年にリリースされたディストロからもパッケージが削除されました。

[2]: https://developer.gnome.org/libgnomeui/
[1]: https://wiki.gnome.org/Attic/LibgnomeMustDie
