### PR TITLE
Update history

### DIFF
--- a/docs/manual/2019.md
+++ b/docs/manual/2019.md
@@ -9,7 +9,17 @@ layout: default
 
 
 <a name="0.3.0-unreleased"></a>
-### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.2.0...master) (unreleased)
+### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/362b797d53f...master) (unreleased)
+- Update history
+  ([#143](https://github.com/JDimproved/JDim/pull/143))
+- Deprecate `--with-sessionlib=gnomeui` option
+  ([#142](https://github.com/JDimproved/JDim/pull/142))
+- Deprecate gtkmm version less than 2.24
+  ([#141](https://github.com/JDimproved/JDim/pull/141))
+
+
+<a name="0.2.0-20191027"></a>
+### [0.2.0-20191027](https://github.com/JDimproved/JDim/compare/JDim-v0.2.0...362b797d53f) (2019-10-27)
 - Remove deprecated cpu optimization options
   ([#140](https://github.com/JDimproved/JDim/pull/140))
 - Fix scrollbar behaviors for thread view on GTK3


### PR DESCRIPTION
`src/jdversion.h` の `JDDATE_FALLBACK` を更新しましたので履歴の項目を区切ります。

#### `JDDATE_FALLBACK` の更新ルール？
jdimリリースの方法自体がまだはっきりと決まっていませんが、リリースとリリースの中間点あたり考えています。
（今のところは：１月リリース -- ４月 -- ７月リリース -- 10月 -- １月リリース)
