### PR TITLE
Fix unable for initialization by JDIM_CACHE on compat mode

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -83,26 +83,26 @@ std::string CACHE::path_root()
 {
     if( root_path.empty() ){
 
-        root_path = MISC::getenv_limited( "JDIM_CACHE", MAX_SAFE_PATH );
-        if( root_path.empty() ) {
+        std::string jdim_cache = MISC::getenv_limited( "JDIM_CACHE", MAX_SAFE_PATH );
+        if( jdim_cache.empty() ) {
 #ifdef ENABLE_COMPAT_CACHE_DIR
             root_path = MISC::getenv_limited( ENV_HOME, MAX_SAFE_PATH ) + "/.jd/";
-#else
-            root_path = Glib::get_user_cache_dir() + "/jdim/";
+            if( CACHE::file_exists( root_path ) != CACHE::EXIST_DIR )
 #endif
+            {
+                root_path = Glib::get_user_cache_dir() + "/jdim/";
+            }
         }
-        else if( root_path[ 0 ] == '~' ){
+        else {
+            root_path = std::move( jdim_cache );
+        }
+
+        if( root_path.front() == '~' ) {
             std::string home = MISC::getenv_limited( ENV_HOME , MAX_SAFE_PATH );
             root_path.replace( 0, 1, home );
         }
 
         if( root_path.back() != '/' ) root_path.push_back( '/' );
-
-#ifdef ENABLE_COMPAT_CACHE_DIR
-        if( CACHE::file_exists( root_path ) != CACHE::EXIST_DIR ) {
-            root_path = Glib::get_user_cache_dir() + "/jdim/";
-        }
-#endif
     }
 
     return root_path;


### PR DESCRIPTION
JD互換機能が有効なとき環境変数 `JDIM_CACHE` で指定したキャシュディレクトリが初期化(\*)できない問題を修正します。
条件を間違えていたためディレクトリ未作成のパスを指定すると `XDG_CACHE_HOME` を使う挙動になっていました。

##### (\*)キャッシュディレクトリの初期化とは
JDim起動時、デフォルトまたは`JDIM_CACHE`による指定のキャッシュディレクトリが存在しないときにディレクトリと設定ファイルが生成されます。
