### PR TITLE
Replace NULL and 0 for being assigned to pointer with nullptr

### DIFF
--- a/src/aamanager.cpp
+++ b/src/aamanager.cpp
@@ -14,7 +14,7 @@
 #include "cache.h"
 #include "type.h"
 
-CORE::AAManager* instance_aamanager = NULL;
+CORE::AAManager* instance_aamanager = nullptr;
 
 CORE::AAManager* CORE::get_aamanager()
 {
@@ -26,7 +26,7 @@ CORE::AAManager* CORE::get_aamanager()
 void CORE::delete_aamanager()
 {
     if( instance_aamanager ) delete instance_aamanager;
-    instance_aamanager = NULL;
+    instance_aamanager = nullptr;
 }
 
 

--- a/src/article/articleadmin.cpp
+++ b/src/article/articleadmin.cpp
@@ -33,7 +33,7 @@
 #include "config/globalconf.h"
 #include "dndmanager.h"
 
-ARTICLE::ArticleAdmin *instance_articleadmin = NULL;
+ARTICLE::ArticleAdmin *instance_articleadmin = nullptr;
 
 ARTICLE::ArticleAdmin* ARTICLE::get_admin()
 {
@@ -46,14 +46,14 @@ ARTICLE::ArticleAdmin* ARTICLE::get_admin()
 void ARTICLE::delete_admin()
 {
     if( instance_articleadmin ) delete instance_articleadmin;
-    instance_articleadmin = NULL;
+    instance_articleadmin = nullptr;
 }
 
 
 using namespace ARTICLE;
 
 ArticleAdmin::ArticleAdmin( const std::string& url )
-    : SKELETON::Admin( url ), m_toolbar( NULL ), m_toolbarsimple( NULL ), m_search_toolbar( NULL )
+    : SKELETON::Admin( url ), m_toolbar( nullptr ), m_toolbarsimple( nullptr ), m_search_toolbar( nullptr )
 {
     set_use_viewhistory( true );
     set_use_switchhistory( true );
@@ -544,10 +544,10 @@ SKELETON::View* ArticleAdmin::create_view( const COMMAND_ARGS& command )
         view_args.arg1 = command.arg6;  // exec
     }
 
-    else return NULL;
+    else return nullptr;
 
     SKELETON::View* view = CORE::ViewFactory( type,  command_to_url( command ), view_args );
-    assert( view != NULL );
+    assert( view != nullptr );
 
     return view;
 }

--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -69,7 +69,7 @@ using namespace ARTICLE;
 ArticleViewBase::ArticleViewBase( const std::string& url, const std::string& url_article )
     : SKELETON::View( url ),
       m_url_article( url_article ),
-      m_popup_win( NULL ),
+      m_popup_win( nullptr ),
       m_popup_shown( false ),
       m_hidepopup_counter( 0 ),
       m_enable_menuslot( true ),
@@ -2120,7 +2120,7 @@ bool ArticleViewBase::slot_key_release( GdkEventKey* event )
 #endif
 
     // ポップアップはキーフォーカスを取れないのでキー入力を送ってやる
-    ArticleViewBase* popup_article = NULL;
+    ArticleViewBase* popup_article = nullptr;
     if( is_popup_shown() ) popup_article = dynamic_cast< ArticleViewBase* >( m_popup_win->view() );
     if( popup_article ) return popup_article->slot_key_release( event );
 
@@ -2135,7 +2135,7 @@ bool ArticleViewBase::slot_key_release( GdkEventKey* event )
 bool ArticleViewBase::slot_scroll_event( GdkEventScroll* event )
 {
     // ポップアップしているときはそちらにイベントを送ってやる
-    ArticleViewBase* popup_article = NULL;
+    ArticleViewBase* popup_article = nullptr;
     if( is_popup_shown() ) popup_article = dynamic_cast< ArticleViewBase* >( m_popup_win->view() );
     if( popup_article ) return popup_article->slot_scroll_event( event );
 
@@ -2174,7 +2174,7 @@ void ArticleViewBase::slot_on_url( std::string url, std::string imgurl, int res_
     }
 
     CORE::VIEWFACTORY_ARGS args;
-    SKELETON::View* view_popup = NULL;
+    SKELETON::View* view_popup = nullptr;
     int margin_popup_x = 0;
     int margin_popup_y = CONFIG::get_margin_popup();
 
@@ -2893,7 +2893,7 @@ void ArticleViewBase::hide_popup( const bool force )
 #endif
 
     // ArticleView をポップアップ表示している場合
-    ArticleViewBase* popup_article = NULL;
+    ArticleViewBase* popup_article = nullptr;
     popup_article = dynamic_cast< ArticleViewBase* >( m_popup_win->view() );
 
     if( popup_article ){
@@ -2933,7 +2933,7 @@ void ArticleViewBase::delete_popup()
 #endif
 
     if( m_popup_win ) delete m_popup_win;
-    m_popup_win = NULL;
+    m_popup_win = nullptr;
     m_popup_shown = false;
 }
 
@@ -2953,7 +2953,7 @@ void ArticleViewBase::activate_act_before_popupmenu( const std::string& url )
     m_enable_menuslot = false;
 
     // 子ポップアップが表示されていて、かつポインタがその上だったら表示しない
-    ArticleViewBase* popup_article = NULL;
+    ArticleViewBase* popup_article = nullptr;
     if( is_popup_shown() ) popup_article = dynamic_cast< ArticleViewBase* >( m_popup_win->view() );
     if( popup_article && popup_article->is_mouse_on_view() ) return;
     hide_popup();
@@ -3297,7 +3297,7 @@ void ArticleViewBase::activate_act_before_popupmenu( const std::string& url )
 Gtk::Menu* ArticleViewBase::get_popupmenu( const std::string& url )
 {
     // 表示
-    Gtk::Menu* popupmenu = NULL;
+    Gtk::Menu* popupmenu = nullptr;
 
     // 削除サブメニュー
     if( url == "popup_menu_delete" ){
@@ -4144,7 +4144,7 @@ void ArticleViewBase::slot_deleteimage()
 //
 void ArticleViewBase::slot_saveimage()
 {
-    DBIMG::save( m_url_tmp, NULL, std::string() );
+    DBIMG::save( m_url_tmp, nullptr, std::string() );
 }
 
 

--- a/src/article/articleviewbase.h
+++ b/src/article/articleviewbase.h
@@ -57,7 +57,7 @@ namespace ARTICLE
 
         // ポップアップ
         SKELETON::PopupWin* m_popup_win;
-        bool m_popup_shown; // 表示されているならtrue, falseでもdeleteしない限りは m_popup_win != NULLに注意
+        bool m_popup_shown; // 表示されているならtrue, falseでもdeleteしない限りは m_popup_win != nullptrに注意
         int m_hidepopup_counter; // ポップアップを消すまでのカウンタ
         std::string m_popup_url; // 表示中のポップアップのアドレス
 

--- a/src/article/articleviewinfo.h
+++ b/src/article/articleviewinfo.h
@@ -22,7 +22,7 @@ namespace ARTICLE
       protected:
 
         // ポップアップメニューは表示しない
-        Gtk::Menu* get_popupmenu( const std::string& url ) override { return NULL; }
+        Gtk::Menu* get_popupmenu( const std::string& url ) override { return nullptr; }
 
       private:
 

--- a/src/article/caret.h
+++ b/src/article/caret.h
@@ -18,7 +18,7 @@ namespace ARTICLE
         LAYOUT* layout; // キャレットの属するレイアウトノードへのポインタ
         long byte; // 何バイト目の文字の「前」か
 
-        CARET_POSITION() : x( 0 ), y( 0 ), layout( 0 ), byte( 0 ){}
+        CARET_POSITION() : x( 0 ), y( 0 ), layout( nullptr ), byte( 0 ){}
         ~CARET_POSITION(){}
         
         // キャレット座標計算関数

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -100,24 +100,24 @@ struct LAYOUT_TABLE
 
 DrawAreaBase::DrawAreaBase( const std::string& url )
     : m_url( url )
-    , m_vscrbar( 0 )
-    , m_layout_tree( 0 )
+    , m_vscrbar( nullptr )
+    , m_layout_tree( nullptr )
     , m_seen_current( 0 )
-    , m_window( 0 )
+    , m_window( nullptr )
 #if GTKMM_CHECK_VERSION(3,0,0)
     , m_cr( nullptr, cairo_destroy )
     , m_backscreen( nullptr, cairo_surface_destroy )
 #else
-    , m_gc( 0 )
-    , m_backscreen( NULL )
+    , m_gc( nullptr )
+    , m_backscreen( nullptr )
 #endif
-    , m_pango_layout( 0 )
+    , m_pango_layout( nullptr )
     , m_draw_frame( false )
 #if GTKMM_CHECK_VERSION(3,0,0)
     , m_back_frame_top( nullptr, cairo_surface_destroy )
     , m_back_frame_bottom( nullptr, cairo_surface_destroy )
 #else
-    , m_back_frame( NULL )
+    , m_back_frame( nullptr )
 #endif
     , m_ready_back_frame( false )
     , m_aafont_initialized( false )
@@ -131,7 +131,7 @@ DrawAreaBase::DrawAreaBase( const std::string& url )
 #if GTKMM_CHECK_VERSION(3,0,0)
     , m_back_marker( nullptr, cairo_surface_destroy )
 #else
-    , m_back_marker( NULL )
+    , m_back_marker( nullptr )
 #endif
     , m_ready_back_marker( false )
     , m_wait_scroll( 0 )
@@ -166,7 +166,7 @@ DrawAreaBase::~DrawAreaBase()
     cancel_deceleration();
 #endif
     if( m_layout_tree ) delete m_layout_tree;
-    m_layout_tree = NULL;
+    m_layout_tree = nullptr;
     clear();
 }
 
@@ -181,7 +181,7 @@ DrawAreaBase::~DrawAreaBase()
 void DrawAreaBase::setup( const bool show_abone, const bool show_scrbar, const bool show_multispace )
 {
     if( m_layout_tree ) delete m_layout_tree;
-    m_layout_tree = NULL;
+    m_layout_tree = nullptr;
     clear();
 
     m_article = DBTREE::get_article( m_url );
@@ -273,7 +273,7 @@ void DrawAreaBase::clear()
 
     m_selection.select = false;
     m_multi_selection.clear();
-    m_layout_current = NULL;
+    m_layout_current = nullptr;
     m_width_client = 0;
     m_height_client = 0;
     m_clicked = false;
@@ -987,7 +987,7 @@ bool DrawAreaBase::exec_layout_impl( const bool is_popup, const int offset_y )
         x += header->css->padding_left;
         y += header->css->padding_top;
 
-        LAYOUT* current_div = NULL;
+        LAYOUT* current_div = nullptr;
         int br_size = m_font->br_size; // 現在行の改行サイズ
 
         // 先頭の子ノードから順にレイアウトしていく
@@ -1253,7 +1253,7 @@ bool DrawAreaBase::exec_layout_impl( const bool is_popup, const int offset_y )
 void DrawAreaBase::adjust_layout_baseline( LAYOUT* header )
 {
     int top_y = -1, max_height = 0;
-    LAYOUT* line_layout = NULL;
+    LAYOUT* line_layout = nullptr;
     bool line_onsssp = false;
 
     LAYOUT* layout = header->next_layout;
@@ -1363,10 +1363,10 @@ void DrawAreaBase::set_align( LAYOUT* div, int id_end, int align )
 //    std::cout << "DrawAreaBase::set_align width = " << div->rect->width << std::endl;
 #endif
 
-    LAYOUT* layout_from = NULL;
-    LAYOUT* layout_to = NULL;
-    RECTANGLE* rect_from = NULL;
-    RECTANGLE* rect_to = NULL;
+    LAYOUT* layout_from = nullptr;
+    LAYOUT* layout_to = nullptr;
+    RECTANGLE* rect_from = nullptr;
+    RECTANGLE* rect_to = nullptr;
 
     LAYOUT* layout = div->next_layout;
     int width_line = 0;
@@ -1393,7 +1393,7 @@ void DrawAreaBase::set_align( LAYOUT* div, int id_end, int align )
 
             // wrap
             set_align_line( div, layout_from, layout_to, rect_from, rect_to, width_line, align );
-            layout_from = NULL;
+            layout_from = nullptr;
 
             rect = rect->next_rect;
         }
@@ -1401,7 +1401,7 @@ void DrawAreaBase::set_align( LAYOUT* div, int id_end, int align )
         // 改行
         if( layout_from && ( ! layout->next_layout || layout->type == DBTREE::NODE_BR || layout->id == id_end -1 ) ){
             set_align_line( div, layout_from, layout_to, rect_from, rect_to, width_line, align );
-            layout_from = NULL;
+            layout_from = nullptr;
         }
 
         layout = layout->next_layout;
@@ -2003,7 +2003,7 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
     gettimeofday( &tv_before, &tz );
 
     // 2分探索で画面に表示されているノードの先頭を探す
-    LAYOUT* header = NULL;
+    LAYOUT* header = nullptr;
     int top = 1;
     int back = max_res_number;
     while( top <= back ){
@@ -2032,7 +2032,7 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
         if( header->rect->y > pos_y ) back = pivot -1;
         else top = pivot + 1;
 
-        header = NULL;
+        header = nullptr;
     }
     if( ! header ){
 #ifdef _DEBUG
@@ -2892,7 +2892,7 @@ bool DrawAreaBase::draw_one_img_node( LAYOUT* layout, const CLIPINFO& ci )
 
         delete layout->eimg;
         m_eimgs.remove( layout->eimg );
-        layout->eimg = NULL;
+        layout->eimg = nullptr;
 
         relayout = true;
     }
@@ -3009,7 +3009,7 @@ bool DrawAreaBase::draw_one_img_node( LAYOUT* layout, const CLIPINFO& ci )
 void DrawAreaBase::draw_string( LAYOUT* node, const CLIPINFO& ci,
                                 const int color, const int color_back, const int byte_from, const int byte_to )
 {
-    assert( node->text != NULL );
+    assert( node->text != nullptr );
     assert( m_layout_tree );
 
     if( ! node->lng_text ) return;
@@ -3847,7 +3847,7 @@ int DrawAreaBase::search( const std::list< std::string >& list_query, const bool
 
     std::vector< LAYOUT_TABLE > layout_table;
     const char *target;
-    char *buffer = NULL;
+    char *buffer = nullptr;
     size_t buffer_lng = 0;
 
     // 先頭ノードから順にサーチして m_multi_selection に選択箇所をセットしていく
@@ -4169,11 +4169,11 @@ bool DrawAreaBase::is_pointer_on_rect( const RECTANGLE* rect, const char* text, 
 //
 // CARET_POSITION& caret_pos : キャレットの位置が計算されて入る
 //
-// 戻り値: 座標(x,y)の下のレイアウトノード。ノード外にある場合はNULL
+// 戻り値: 座標(x,y)の下のレイアウトノード。ノード外にある場合はnullptr
 //
 LAYOUT* DrawAreaBase::set_caret( CARET_POSITION& caret_pos, int x, int y )
 {
-    if( ! m_layout_tree ) return NULL;
+    if( ! m_layout_tree ) return nullptr;
 
 #ifdef _DEBUG_CARETMOVE
     std::cout << "DrawAreaBase::set_caret x = " << x << " y = " << y << std::endl;
@@ -4181,11 +4181,11 @@ LAYOUT* DrawAreaBase::set_caret( CARET_POSITION& caret_pos, int x, int y )
 
     // 先頭のレイアウトブロックから順に調べる
     LAYOUT* header = m_layout_tree->top_header();
-    if( ! header ) return NULL;
+    if( ! header ) return nullptr;
 
     // まだレイアウト計算していない
-    if( ! header->rect ) return NULL;
-    if( header->next_header && ! header->next_header->rect ) return NULL;
+    if( ! header->rect ) return nullptr;
+    if( header->next_header && ! header->next_header->rect ) return nullptr;
 
     while( header ){
 
@@ -4265,11 +4265,11 @@ LAYOUT* DrawAreaBase::set_caret( CARET_POSITION& caret_pos, int x, int y )
                         // 左端にキャレットをセットして終了
                         caret_pos.set( layout, pos_start, x, tmp_x, tmp_y );
 
-                        return NULL;
+                        return nullptr;
                     }
 
                     // 右のマージンの上にポインタがある場合
-                    else if( layout->next_layout == NULL || layout->next_layout->type == DBTREE::NODE_BR ){
+                    else if( layout->next_layout == nullptr || layout->next_layout->type == DBTREE::NODE_BR ){
 
 #ifdef _DEBUG_CARETMOVE
                         std::cout << "found: right\n";
@@ -4280,7 +4280,7 @@ LAYOUT* DrawAreaBase::set_caret( CARET_POSITION& caret_pos, int x, int y )
 
                         // 右端にキャレットをセットして終わり
                         caret_pos.set( layout, pos_start + n_byte, x, tmp_x + width, tmp_y );
-                        return NULL;
+                        return nullptr;
                     }
                 }
 
@@ -4346,7 +4346,7 @@ LAYOUT* DrawAreaBase::set_caret( CARET_POSITION& caret_pos, int x, int y )
                 // 現在のノードの右端にキャレットをセット
                 caret_pos.set( layout, pos_start + n_byte, x, tmp_x + width, tmp_y );
 
-                return NULL;
+                return nullptr;
             }
 
             // 次のノードへ
@@ -4357,7 +4357,7 @@ LAYOUT* DrawAreaBase::set_caret( CARET_POSITION& caret_pos, int x, int y )
         header = header->next_header;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 
@@ -4442,7 +4442,7 @@ bool DrawAreaBase::set_carets_dclick( CARET_POSITION& caret_left, CARET_POSITION
                 if( ! layout->text || ! rect ){
                     layout = layout->next_layout;
                     if( layout && layout->text ) layout_before = layout;
-                    else layout_before = NULL;
+                    else layout_before = nullptr;
                     continue;
                 }
 
@@ -4579,7 +4579,7 @@ bool DrawAreaBase::set_selection( const CARET_POSITION& caret_left, const CARET_
     m_caret_pos_pre = caret_left;
     m_caret_pos = caret_left;
     m_caret_pos_dragstart = caret_left;
-    return set_selection( caret_right, NULL );
+    return set_selection( caret_right, nullptr );
 }
 
 
@@ -4590,11 +4590,11 @@ bool DrawAreaBase::set_selection( const CARET_POSITION& caret_left, const CARET_
 //
 bool DrawAreaBase::set_selection( const CARET_POSITION& caret_pos )
 {
-    return set_selection( caret_pos, NULL );
+    return set_selection( caret_pos, nullptr );
 }
 
 
-// rect に再描画範囲を計算して入れる( NULL なら入らない )
+// rect に再描画範囲を計算して入れる( nullptr なら入らない )
 // その後 draw_screen( rect.y, rect.height ) で選択範囲を描画する
 bool DrawAreaBase::set_selection( const CARET_POSITION& caret_pos, RECTANGLE* rect )
 {
@@ -4881,8 +4881,8 @@ void DrawAreaBase::select_all()
 #endif
 
     CARET_POSITION caret_left, caret_right;
-    LAYOUT* layout = NULL;
-    LAYOUT* layout_back = NULL;
+    LAYOUT* layout = nullptr;
+    LAYOUT* layout_back = nullptr;
 
     // 先頭
     LAYOUT* header = m_layout_tree->top_header();
@@ -5070,7 +5070,7 @@ bool DrawAreaBase::slot_draw( const Cairo::RefPtr< Cairo::Context >& cr )
         draw_frame();
     }
     // レイアウトがセットされていない or まだリサイズしていない
-    // ( m_backscreen == NULL )なら画面消去
+    // ( m_backscreen == nullptr )なら画面消去
     else if( !m_layout_tree->top_header() || !m_backscreen ) {
 #ifdef _DEBUG
         std::cout << "clear window\n";
@@ -5142,7 +5142,7 @@ bool DrawAreaBase::slot_expose_event( GdkEventExpose* event )
         draw_frame();
     }
 
-    // レイアウトがセットされていない or まだリサイズしていない( m_backscreen == NULL )なら画面消去
+    // レイアウトがセットされていない or まだリサイズしていない( m_backscreen == nullptr )なら画面消去
     else if( ! m_layout_tree->top_header() || ! m_backscreen ){
 
 #ifdef _DEBUG

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -220,7 +220,7 @@ namespace ARTICLE
         bool m_drugging;  // ドラッグ中
         bool m_r_drugging; // 右ドラッグ中
         std::string m_link_current; // 現在マウスポインタの下にあるリンクの文字列
-        LAYOUT* m_layout_current; // 現在マウスポインタの下にあるlayoutノード(下が空白ならNULL)
+        LAYOUT* m_layout_current; // 現在マウスポインタの下にあるlayoutノード(下が空白ならnullptr)
         Gdk::CursorType m_cursor_type; // カーソルの形状
 
         // 入力コントローラ
@@ -530,7 +530,7 @@ namespace ARTICLE
     //
     // 文字列を wrap するか判定する関数
     //
-    // str != NULL なら禁則処理も考える
+    // str != nullptr なら禁則処理も考える
     //
     inline bool DrawAreaBase::is_wrapped( const int x, const int border, const char* str )
     {

--- a/src/article/embeddedimage.cpp
+++ b/src/article/embeddedimage.cpp
@@ -50,7 +50,7 @@ void* eimg_launcher( void* dat )
     std::cout << "end" << std::endl;
 #endif
 
-    return 0;
+    return nullptr;
 }
 
 

--- a/src/article/font.cpp
+++ b/src/article/font.cpp
@@ -52,7 +52,7 @@ void ARTICLE::init_font()
             delete[] width_of_char[ i ];
         }
 
-        width_of_char[ i ] = NULL;
+        width_of_char[ i ] = nullptr;
     }
 }
 

--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -55,8 +55,8 @@ using namespace ARTICLE;
 LayoutTree::LayoutTree( const std::string& url, const bool show_abone, const bool show_multispace )
     : m_heap( SIZE_OF_HEAP ),
       m_url( url ),
-      m_local_nodetree( 0 ),
-      m_separator_header( NULL ),
+      m_local_nodetree( nullptr ),
+      m_separator_header( nullptr ),
       m_show_abone( show_abone ),
       m_show_multispace( show_multispace ),
       m_last_dom_attr( 0 )
@@ -89,16 +89,16 @@ void LayoutTree::clear()
 
     m_map_header.clear();
     
-    m_last_header = NULL;
+    m_last_header = nullptr;
     m_max_res_number = 0;
 
     m_id_header = -STEP_ID; // ルートヘッダのIDが 0 になるように -STEP_ID を入れておく
     m_root_header = create_layout_header();
     
     if( m_local_nodetree ) delete m_local_nodetree;
-    m_local_nodetree = NULL;
+    m_local_nodetree = nullptr;
 
-    m_last_div = NULL;
+    m_last_div = nullptr;
 
     // 新着セパレータ作成
     m_separator_new = 0;
@@ -140,7 +140,7 @@ LAYOUT* LayoutTree::create_layout( const int type )
 //
 LAYOUT* LayoutTree::create_layout_header()
 {
-    m_last_layout = NULL;
+    m_last_layout = nullptr;
     m_id_layout = 0;
     m_id_header += STEP_ID;
 
@@ -206,7 +206,7 @@ LAYOUT* LayoutTree::create_layout_idnum( const char* text, const unsigned char* 
 LAYOUT* LayoutTree::create_layout_br( const bool nobr )
 {
     if( nobr ){
-        return create_layout_text( " ", NULL, false );
+        return create_layout_text( " ", nullptr, false );
     }
     LAYOUT* tmplayout = create_layout( DBTREE::NODE_BR );
     m_last_layout->next_layout = tmplayout;
@@ -311,7 +311,7 @@ void LayoutTree::append_node( DBTREE::NODE* node_header, const bool joint )
     // 本文ブロックだけ追加
     if( joint ){
         create_layout_br( m_last_dom_attr & CORE::DOMATTR_NOBR );
-        append_block( headinfo->block[ DBTREE::BLOCK_MES ], res_number, NULL, m_last_dom_attr );
+        append_block( headinfo->block[ DBTREE::BLOCK_MES ], res_number, nullptr, m_last_dom_attr );
     }
     else{
 
@@ -341,7 +341,7 @@ void LayoutTree::append_node( DBTREE::NODE* node_header, const bool joint )
                     break;
 
                 case CORE::DOMNODE_TEXT:
-                    create_layout_text( dom->chardat, NULL, false );
+                    create_layout_text( dom->chardat, nullptr, false );
                     break;
 
                 case CORE::DOMNODE_IMAGE: // インライン画像
@@ -388,7 +388,7 @@ void LayoutTree::append_block( DBTREE::NODE* block, const int res_number, IMGDAT
 
     while( tmpnode ){
 
-        LAYOUT* tmplayout = NULL;
+        LAYOUT* tmplayout = nullptr;
 
         switch( tmpnode->type ){
         
@@ -482,12 +482,12 @@ void LayoutTree::append_abone_node( DBTREE::NODE* node_header )
 
     DBTREE::NODE* node = node_header->headinfo->block[ DBTREE::BLOCK_NUMBER ]->next_node;
     create_layout_link( node->text, node->linkinfo->link, &node->color_text, node->bold );
-    create_layout_text( " ", NULL, false );
-    create_layout_link( "あぼ〜ん", PROTO_ABONE, NULL, false );
+    create_layout_text( " ", nullptr, false );
+    create_layout_link( "あぼ〜ん", PROTO_ABONE, nullptr, false );
 
     classid = CORE::get_css_manager()->get_classid( "mes" );
     create_layout_div( classid );
-    create_layout_link( "あぼ〜ん", PROTO_ABONE, NULL, false );
+    create_layout_link( "あぼ〜ん", PROTO_ABONE, nullptr, false );
 }
 
 
@@ -556,8 +556,8 @@ const LAYOUT* LayoutTree::get_header_of_res_const( const int number ){ return ge
 
 LAYOUT* LayoutTree::get_header_of_res( const int number )
 {
-    if( m_map_header.empty() ) return NULL;
-    if( number > m_max_res_number || number <= 0 ) return NULL;
+    if( m_map_header.empty() ) return nullptr;
+    if( number > m_max_res_number || number <= 0 ) return nullptr;
 
     return m_map_header[ number ];
 }
@@ -568,7 +568,7 @@ LAYOUT* LayoutTree::get_header_of_res( const int number )
 //
 LAYOUT* LayoutTree::create_separator()
 {
-    m_last_layout = NULL;
+    m_last_layout = nullptr;
     m_id_layout = 0;
 
     int classid = CORE::get_css_manager()->get_classid( "separator" );
@@ -581,7 +581,7 @@ LAYOUT* LayoutTree::create_separator()
 
     if( header->css->bg_color < 0 ) header->css->bg_color = COLOR_SEPARATOR_NEW;
 
-    LAYOUT* layout = create_layout_text( "ここまで読んだ", NULL, false );
+    LAYOUT* layout = create_layout_text( "ここまで読んだ", nullptr, false );
     layout->header = header;
 
     return header;

--- a/src/article/layouttree.h
+++ b/src/article/layouttree.h
@@ -54,8 +54,8 @@ namespace ARTICLE
 
         LAYOUT* header;      // 親ヘッダーへのポインタ
         LAYOUT* div;         // 所属するdivへのポインタ
-        LAYOUT* next_layout; // 次のノード、最終ノードではNULL
-        LAYOUT* next_header; // 次のヘッダノード、ヘッダノード以外ではNULL
+        LAYOUT* next_layout; // 次のノード、最終ノードではnullptr
+        LAYOUT* next_header; // 次のヘッダノード、ヘッダノード以外ではnullptr
 
         RECTANGLE* rect; // 描画時のノード座標、幅、高さ情報
         CORE::CSS_PROPERTY* css; // cssプロパティ
@@ -137,7 +137,7 @@ namespace ARTICLE
         // joint == true の時はヘッダを作らないで、本文を前のツリーの続きに連結する
         void append_node( DBTREE::NODE* node_header, const bool joint );
 
-        void append_block( DBTREE::NODE* block, const int res_number, IMGDATA* imgdata = NULL, const int dom_attr = 0 );
+        void append_block( DBTREE::NODE* block, const int res_number, IMGDATA* imgdata = nullptr, const int dom_attr = 0 );
 
         // html をパースして追加
         void append_html( const std::string& html );

--- a/src/article/preference.cpp
+++ b/src/article/preference.cpp
@@ -265,7 +265,7 @@ void Preferences::slot_clear_post_history()
 {
     if( m_label_write.get_text().empty() ) return;
 
-    SKELETON::MsgDiag mdiag( NULL, "書き込み履歴を削除しますか？", false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
+    SKELETON::MsgDiag mdiag( nullptr, "書き込み履歴を削除しますか？", false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
     if( mdiag.run() != Gtk::RESPONSE_YES ) return;
 
     DBTREE::article_clear_post_history( get_url() );

--- a/src/article/toolbar.cpp
+++ b/src/article/toolbar.cpp
@@ -29,7 +29,7 @@ ArticleToolBar::ArticleToolBar() :
     m_button_drawout_and( ICON::SEARCH_AND ),
     m_button_drawout_or( ICON::SEARCH_OR ),
 
-    m_button_live_play_stop( NULL )
+    m_button_live_play_stop( nullptr )
 {
     // 検索バー
     set_tooltip( m_button_drawout_and, CONTROL::get_label_motions( CONTROL::DrawOutAnd ) );

--- a/src/article/toolbarsearch.cpp
+++ b/src/article/toolbarsearch.cpp
@@ -20,7 +20,7 @@ using namespace ARTICLE;
 
 SearchToolBar::SearchToolBar() :
     SKELETON::ToolBar( ARTICLE::get_admin() ),
-    m_searchview( NULL ),
+    m_searchview( nullptr ),
     m_check_bm( "しおり" )
 {
     m_tool_bm.add( m_check_bm );

--- a/src/articleitemmenupref.cpp
+++ b/src/articleitemmenupref.cpp
@@ -56,7 +56,7 @@ ArticleItemMenuPref::ArticleItemMenuPref( Gtk::Window* parent, const std::string
 //
 void ArticleItemMenuPref::slot_ok_clicked()
 {
-    SKELETON::MsgDiag mdiag( NULL, "次に開いたスレビューから有効になります" );
+    SKELETON::MsgDiag mdiag( nullptr, "次に開いたスレビューから有効になります" );
     mdiag.run();
 
     SESSION::set_items_article_menu_str( get_items() );

--- a/src/bbslist/addetcdialog.cpp
+++ b/src/bbslist/addetcdialog.cpp
@@ -13,7 +13,7 @@ using namespace BBSLIST;
 
 
 AddEtcDialog::AddEtcDialog( const bool move, const std::string& url, const std::string& name, const std::string& id, const std::string& passwd )
-    : SKELETON::PrefDiag( NULL, url, true ),
+    : SKELETON::PrefDiag( nullptr, url, true ),
       m_entry_name( true, "板名(_N)：", name ),
       m_entry_url( true, "アドレス(_U)：", url ),
       m_entry_id( true, "ID(_I)：", id ),

--- a/src/bbslist/bbslistadmin.cpp
+++ b/src/bbslist/bbslistadmin.cpp
@@ -18,7 +18,7 @@
 
 
 // お気に入りの共通UNDOバッファ
-SKELETON::UNDO_BUFFER *instance_undo_buffer_favorite = NULL;
+SKELETON::UNDO_BUFFER *instance_undo_buffer_favorite = nullptr;
 
 SKELETON::UNDO_BUFFER* BBSLIST::get_undo_buffer_favorite()
 {
@@ -31,14 +31,14 @@ SKELETON::UNDO_BUFFER* BBSLIST::get_undo_buffer_favorite()
 void BBSLIST::delete_undo_buffer_favorite()
 {
     if( instance_undo_buffer_favorite ) delete instance_undo_buffer_favorite;
-    instance_undo_buffer_favorite = NULL;
+    instance_undo_buffer_favorite = nullptr;
 }
 
 
 //////////////////////////////////////////////
 
 
-BBSLIST::BBSListAdmin *instance_bbslistadmin = NULL;
+BBSLIST::BBSListAdmin *instance_bbslistadmin = nullptr;
 
 BBSLIST::BBSListAdmin* BBSLIST::get_admin()
 {
@@ -52,7 +52,7 @@ BBSLIST::BBSListAdmin* BBSLIST::get_admin()
 void BBSLIST::delete_admin()
 {
     if( instance_bbslistadmin ) delete instance_bbslistadmin;
-    instance_bbslistadmin = NULL;
+    instance_bbslistadmin = nullptr;
 }
 
 
@@ -62,7 +62,7 @@ void BBSLIST::delete_admin()
 using namespace BBSLIST;
 
 BBSListAdmin::BBSListAdmin( const std::string& url )
-    : SKELETON::Admin( url ), m_toolbar( NULL )
+    : SKELETON::Admin( url ), m_toolbar( nullptr )
 {
     get_notebook()->set_dragable( false );
     get_notebook()->set_fixtab( true );

--- a/src/bbslist/bbslistview.cpp
+++ b/src/bbslist/bbslistview.cpp
@@ -94,7 +94,7 @@ void BBSListViewMain::update_view()
 
     // <subdir>を挿入
     // ルート要素の有無で処理を分ける( 旧様式=無, 新様式=有 )
-    XML::Dom* subdir = 0;
+    XML::Dom* subdir = nullptr;
     if( root ) subdir = root->insertBefore( XML::NODE_TYPE_ELEMENT, "subdir", root->firstChild() );
     else subdir = get_document().insertBefore( XML::NODE_TYPE_ELEMENT, "subdir", get_document().firstChild() );
     subdir->setAttribute( "name", std::string( SUBDIR_ETCLIST ) );
@@ -203,7 +203,7 @@ void BBSListViewMain::show_preference()
 //
 Gtk::Menu* BBSListViewMain::get_popupmenu( const std::string& url )
 {
-    Gtk::Menu* popupmenu = NULL;
+    Gtk::Menu* popupmenu = nullptr;
 
     if( url.empty() ) return popupmenu;
 

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -136,7 +136,7 @@ BBSListViewBase::BBSListViewBase( const std::string& url,const std::string& arg1
       m_open_only_onedir( false ),
       m_cancel_expand( false ),
       m_expanding( 0 ),
-      m_editlistwin( NULL ),
+      m_editlistwin( nullptr ),
       m_set_bookmark( false )
 {
     m_scrwin.add( m_treeview );
@@ -515,7 +515,7 @@ BBSListViewBase::~BBSListViewBase()
 #endif
 
     if( m_editlistwin ) delete m_editlistwin;
-    m_editlistwin = NULL;
+    m_editlistwin = nullptr;
 }
 
 
@@ -3149,7 +3149,7 @@ void BBSListViewBase::slot_hide_editlistwin()
 #endif
 
     if( m_editlistwin ) delete m_editlistwin;
-    m_editlistwin = NULL;
+    m_editlistwin = nullptr;
 }
 
 

--- a/src/bbslist/favoriteview.cpp
+++ b/src/bbslist/favoriteview.cpp
@@ -73,7 +73,7 @@ void FavoriteListView::show_view()
 //
 Gtk::Menu* FavoriteListView::get_popupmenu( const std::string& url )
 {
-    Gtk::Menu* popupmenu = NULL;
+    Gtk::Menu* popupmenu = nullptr;
     if( url.empty() ) popupmenu = id2popupmenu(  "/popup_menu_favorite_space" );
     else{
         std::list< Gtk::TreeModel::iterator > list_it = get_treeview().get_selected_iterators();

--- a/src/bbslist/historyview.cpp
+++ b/src/bbslist/historyview.cpp
@@ -58,7 +58,7 @@ void HistoryViewBase::save_xml()
 //
 Gtk::Menu* HistoryViewBase::get_popupmenu( const std::string& url )
 {
-    Gtk::Menu* popupmenu = NULL;
+    Gtk::Menu* popupmenu = nullptr;
     if( ! url.empty() ){
 
         std::list< Gtk::TreeModel::iterator > list_it = get_treeview().get_selected_iterators();

--- a/src/bbslist/selectdialog.cpp
+++ b/src/bbslist/selectdialog.cpp
@@ -31,7 +31,7 @@ SelectListDialog::SelectListDialog( Gtk::Window* parent, const std::string& url,
       m_label_name( CORE::SBUF_size() == 1, "名前 ：" ),
       m_label_dirs( "ディレクトリ ：" ),
       m_bt_show_tree( "詳細" ),
-      m_selectview( NULL )
+      m_selectview( nullptr )
 {
     const int mrg = 8;
 
@@ -157,7 +157,7 @@ void SelectListDialog::slot_show_tree()
         get_vbox()->remove( *m_selectview );
         resize( get_width(), 1 );
         delete m_selectview;
-        m_selectview = NULL;
+        m_selectview = nullptr;
     }
 }
 

--- a/src/bbslist/toolbar.cpp
+++ b/src/bbslist/toolbar.cpp
@@ -29,9 +29,9 @@ using namespace BBSLIST;
 BBSListToolBar::BBSListToolBar() :
     SKELETON::ToolBar( BBSLIST::get_admin() ),
     m_button_toggle( "ページ切り替え", true, true, m_label ),
-    m_button_check_update_root( NULL ),
-    m_button_check_update_open_root( NULL ),
-    m_button_stop_check_update( NULL )
+    m_button_check_update_root( nullptr ),
+    m_button_check_update_open_root( nullptr ),
+    m_button_stop_check_update( nullptr )
 {
     m_button_toggle.get_button()->set_tooltip_arrow( "ページ切り替え\n\nマウスホイール回転でも切り替え可能" );
 
@@ -232,7 +232,7 @@ void BBSListToolBar::slot_check_update_open_root()
 
 
 EditListToolBar::EditListToolBar() :
-    SKELETON::ToolBar( NULL )
+    SKELETON::ToolBar( nullptr )
 {
     pack_buttons();
 }

--- a/src/board/boardadmin.cpp
+++ b/src/board/boardadmin.cpp
@@ -30,7 +30,7 @@
 
 
 
-BOARD::BoardAdmin *instance_boardadmin = NULL;
+BOARD::BoardAdmin *instance_boardadmin = nullptr;
 
 BOARD::BoardAdmin* BOARD::get_admin()
 {
@@ -44,14 +44,14 @@ BOARD::BoardAdmin* BOARD::get_admin()
 void BOARD::delete_admin()
 {
     if( instance_boardadmin ) delete instance_boardadmin;
-    instance_boardadmin = NULL;
+    instance_boardadmin = nullptr;
 }
 
 
 using namespace BOARD;
 
 BoardAdmin::BoardAdmin( const std::string& url )
-    : SKELETON::Admin( url ) , m_toolbar( NULL )
+    : SKELETON::Admin( url ) , m_toolbar( nullptr )
 {
     set_use_viewhistory( true );
     set_use_switchhistory( true );
@@ -384,10 +384,10 @@ SKELETON::View* BoardAdmin::create_view( const COMMAND_ARGS& command )
         view_args.arg1 = command.arg6; // "set_history" の時は板の履歴に登録する
     }
 
-    else return NULL;
+    else return nullptr;
 
     SKELETON::View* view = CORE::ViewFactory( type, command_to_url( command ), view_args );
-    assert( view != NULL );
+    assert( view != nullptr );
 
     return view;
 }

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -85,7 +85,7 @@ enum
 
 
 
-#define DELETE_COLUMN(col) do{ if( ! col ) { delete col; col = NULL; } }while(0)
+#define DELETE_COLUMN(col) do{ if( ! col ) { delete col; col = nullptr; } }while(0)
 
 // set_sizing( Gtk::TREE_VIEW_COLUMN_FIXED ) を指定して append_columnする
 #define APPEND_COLUMN(col,title,model) do{                    \
@@ -98,18 +98,18 @@ m_treeview.append_column( *col ); \
 BoardViewBase::BoardViewBase( const std::string& url, const bool show_col_board )
     : SKELETON::View( url ),
       m_treeview( url, DNDTARGET_FAVORITE, true, CONFIG::get_fontname( FONT_BOARD ), COLOR_CHAR_BOARD, COLOR_BACK_BOARD, COLOR_BACK_BOARD_EVEN ),
-      m_col_mark( NULL ),
-      m_col_id( NULL ),
-      m_col_board( NULL ),
-      m_col_subject( NULL ),
-      m_col_res( NULL ),
-      m_col_str_load( NULL ),
-      m_col_str_new( NULL ),
-      m_col_since( NULL ),
-      m_col_write( NULL ),
-      m_col_access( NULL ),
-      m_col_speed( NULL ),
-      m_col_diff( NULL ),
+      m_col_mark( nullptr ),
+      m_col_id( nullptr ),
+      m_col_board( nullptr ),
+      m_col_subject( nullptr ),
+      m_col_res( nullptr ),
+      m_col_str_load( nullptr ),
+      m_col_str_new( nullptr ),
+      m_col_since( nullptr ),
+      m_col_write( nullptr ),
+      m_col_access( nullptr ),
+      m_col_speed( nullptr ),
+      m_col_diff( nullptr ),
       m_clicked( false ),
       m_col( COL_NUM_COL ),
       m_previous_col( COL_NUM_COL ),
@@ -1728,7 +1728,7 @@ void BoardViewBase::activate_act_before_popupmenu( const std::string& url )
 //
 Gtk::Menu* BoardViewBase::get_popupmenu( const std::string& url )
 {
-    Gtk::Menu* popupmenu = NULL;
+    Gtk::Menu* popupmenu = nullptr;
 
     // 削除サブメニュー
     if( url == "popup_menu_delete" ){

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -54,7 +54,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
       m_button_clearsamba( "秒数クリア" ),
       m_check_oldlog( "過去ログを表示する" ),
       m_button_remove_old_title( "dat落ちしたスレのタイトルを削除する" ),
-      m_localrule( NULL )
+      m_localrule( nullptr )
 {
     m_edit_cookies.set_editable( false );
 
@@ -368,7 +368,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
 Preferences::~Preferences()
 {
     if( m_localrule ) delete m_localrule;
-    m_localrule = NULL;
+    m_localrule = nullptr;
 }
 
 
@@ -396,7 +396,7 @@ void Preferences::slot_clear_samba()
 
 void Preferences::slot_clear_post_history()
 {
-    SKELETON::MsgDiag mdiag( NULL, "この板にある全てのスレの書き込み履歴を削除しますか？\n\nスレ数によっては時間がかかります。",
+    SKELETON::MsgDiag mdiag( nullptr, "この板にある全てのスレの書き込み履歴を削除しますか？\n\nスレ数によっては時間がかかります。",
                              false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
     if( mdiag.run() != Gtk::RESPONSE_YES ) return;
 
@@ -443,7 +443,7 @@ void Preferences::slot_remove_old_title()
 {
 
     if( ! DBTREE::board_list_subject( get_url() ).size() ){
-        SKELETON::MsgDiag mdiag( NULL, "再読み込みしてスレ一覧を更新して下さい。", false, Gtk::MESSAGE_WARNING );
+        SKELETON::MsgDiag mdiag( nullptr, "再読み込みしてスレ一覧を更新して下さい。", false, Gtk::MESSAGE_WARNING );
         mdiag.run();
         return;
     }

--- a/src/boarditemmenupref.cpp
+++ b/src/boarditemmenupref.cpp
@@ -48,7 +48,7 @@ BoardItemMenuPref::BoardItemMenuPref( Gtk::Window* parent, const std::string& ur
 //
 void BoardItemMenuPref::slot_ok_clicked()
 {
-    SKELETON::MsgDiag mdiag( NULL, "次に開いたスレ一覧から有効になります" );
+    SKELETON::MsgDiag mdiag( nullptr, "次に開いたスレ一覧から有効になります" );
     mdiag.run();
 
     SESSION::set_items_board_menu_str( get_items() );

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -940,7 +940,7 @@ bool CACHE::jdmv( const std::string& file_from, const std::string& file_to )
 //
 // 保存ダイアログを表示して file_from を file_to に保存する
 //
-// parent == NULL の時はメインウィンドウをparentにする
+// parent == nullptr の時はメインウィンドウをparentにする
 // file_toはデフォルトの保存先
 // 戻り値は保存先(保存に失敗したらempty())
 //
@@ -1024,7 +1024,7 @@ void CACHE::add_filter_to_diag( Gtk::FileChooserDialog& diag, const int type )
 //
 // ファイル選択ダイアログを表示する
 //
-// parent == NULL の時はメインウィンドウをparentにする
+// parent == nullptr の時はメインウィンドウをparentにする
 // open_path はデフォルトの参照先
 // multi == true なら複数選択可能
 // 戻り値は選択されたファイルのpathのリスト
@@ -1054,7 +1054,7 @@ std::vector< std::string > CACHE::open_load_diag( Gtk::Window* parent, const std
 //
 // 保存ファイル選択ダイアログを表示する
 //
-// parent == NULL の時はメインウィンドウをparentにする
+// parent == nullptr の時はメインウィンドウをparentにする
 // dirとnameはデフォルトの参照先
 // 戻り値は選択されたファイルのpath
 //

--- a/src/cache.h
+++ b/src/cache.h
@@ -213,7 +213,7 @@ namespace CACHE
     void add_filter_to_diag( Gtk::FileChooserDialog& diag, const int type );
 
     // ファイル選択ダイアログを表示する
-    // parent == NULL の時はメインウィンドウをparentにする
+    // parent == nullptr の時はメインウィンドウをparentにする
     // open_path はデフォルトの参照先
     // multi == true なら複数選択可能
     // 戻り値は選択されたファイルのpathのリスト

--- a/src/compmanager.cpp
+++ b/src/compmanager.cpp
@@ -15,7 +15,7 @@ enum
     MAX_COMPLETION = 50
 };
 
-CORE::Completion_Manager* instance_completion_manager = NULL;
+CORE::Completion_Manager* instance_completion_manager = nullptr;
 
 
 CORE::Completion_Manager* CORE::get_completion_manager()
@@ -30,7 +30,7 @@ CORE::Completion_Manager* CORE::get_completion_manager()
 void CORE::delete_completion_manager()
 {
     if( instance_completion_manager ) delete instance_completion_manager;
-    instance_completion_manager = NULL;
+    instance_completion_manager = nullptr;
 }
 
 ///////////////////////////////////////////////

--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -89,7 +89,7 @@ void AboutConfig::pack_widgets()
 //
 void AboutConfig::slot_ok_clicked()
 {
-    SKELETON::MsgDiag mdiag( NULL, "一部の設定はJDimを再起動しない限り有効になりません。JDimを再起動してください。" );
+    SKELETON::MsgDiag mdiag( nullptr, "一部の設定はJDimを再起動しない限り有効になりません。JDimを再起動してください。" );
     mdiag.run();
 }
 
@@ -398,7 +398,7 @@ void AboutConfig::slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::Tre
     const int type = row[ m_columns.m_col_type ];
     if( type == CONFTYPE_COMMENT ) return;
 
-    SKELETON::PrefDiag* pref = NULL;
+    SKELETON::PrefDiag* pref = nullptr;
 
     switch( type ){
 

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -13,8 +13,8 @@
 #include "jdlib/miscutil.h"
 
 
-CONFIG::ConfigItems* instance_confitem = NULL;
-CONFIG::ConfigItems* instance_confitem_bkup = NULL;
+CONFIG::ConfigItems* instance_confitem = nullptr;
+CONFIG::ConfigItems* instance_confitem_bkup = nullptr;
 
 
 CONFIG::ConfigItems* CONFIG::get_confitem()
@@ -26,10 +26,10 @@ CONFIG::ConfigItems* CONFIG::get_confitem()
 void CONFIG::delete_confitem()
 {
     if( instance_confitem ) delete instance_confitem;
-    instance_confitem = NULL;
+    instance_confitem = nullptr;
 
     if( instance_confitem_bkup ) delete instance_confitem_bkup;
-    instance_confitem_bkup = NULL;
+    instance_confitem_bkup = nullptr;
 }
 
 

--- a/src/control/controlutil.cpp
+++ b/src/control/controlutil.cpp
@@ -25,16 +25,16 @@
 #include <cstring>
 
 
-CONTROL::KeyConfig* instance_keyconfig = NULL;
-CONTROL::KeyConfig* instance_keyconfig_bkup = NULL;
+CONTROL::KeyConfig* instance_keyconfig = nullptr;
+CONTROL::KeyConfig* instance_keyconfig_bkup = nullptr;
 
 
-CONTROL::MouseConfig* instance_mouseconfig = NULL;
-CONTROL::MouseConfig* instance_mouseconfig_bkup = NULL;
+CONTROL::MouseConfig* instance_mouseconfig = nullptr;
+CONTROL::MouseConfig* instance_mouseconfig_bkup = nullptr;
 
 
-CONTROL::ButtonConfig* instance_buttonconfig = NULL;
-CONTROL::ButtonConfig* instance_buttonconfig_bkup = NULL;
+CONTROL::ButtonConfig* instance_buttonconfig = nullptr;
+CONTROL::ButtonConfig* instance_buttonconfig_bkup = nullptr;
 
 
 //////////////////////////////////////////////////////////
@@ -58,10 +58,10 @@ CONTROL::KeyConfig* CONTROL::get_keyconfig()
 void CONTROL::delete_keyconfig()
 {
     if( instance_keyconfig ) delete instance_keyconfig;
-    instance_keyconfig = NULL;
+    instance_keyconfig = nullptr;
 
     if( instance_keyconfig_bkup ) delete instance_keyconfig_bkup;
-    instance_keyconfig_bkup = NULL;
+    instance_keyconfig_bkup = nullptr;
 }
 
 
@@ -76,10 +76,10 @@ CONTROL::MouseConfig* CONTROL::get_mouseconfig()
 void CONTROL::delete_mouseconfig()
 {
     if( instance_mouseconfig ) delete instance_mouseconfig;
-    instance_mouseconfig = NULL;
+    instance_mouseconfig = nullptr;
 
     if( instance_mouseconfig_bkup ) delete instance_mouseconfig_bkup;
-    instance_mouseconfig_bkup = NULL;
+    instance_mouseconfig_bkup = nullptr;
 }
 
 
@@ -94,10 +94,10 @@ CONTROL::ButtonConfig* CONTROL::get_buttonconfig()
 void CONTROL::delete_buttonconfig()
 {
     if( instance_buttonconfig ) delete instance_buttonconfig;
-    instance_buttonconfig = NULL;
+    instance_buttonconfig = nullptr;
 
     if( instance_buttonconfig_bkup ) delete instance_buttonconfig_bkup;
-    instance_buttonconfig_bkup = NULL;
+    instance_buttonconfig_bkup = nullptr;
 }
 
 

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -365,14 +365,14 @@ std::string MouseKeyDiag::show_inputdiag( bool is_append )
         // 1つだけしか設定できない場合
         const int count = get_count();
         if( count > 1 || ( count == 1 && is_append ) ){
-            SKELETON::MsgDiag mdiag( NULL, "この項目には、1つだけ設定できます。" );
+            SKELETON::MsgDiag mdiag( nullptr, "この項目には、1つだけ設定できます。" );
             mdiag.run();
             return std::string();
         }
     }
 
     InputDiag* diag = create_inputdiag();
-    if( diag == NULL ) return std::string();
+    if( diag == nullptr ) return std::string();
 
     while( diag->run() == Gtk::RESPONSE_OK ){
 
@@ -383,7 +383,7 @@ std::string MouseKeyDiag::show_inputdiag( bool is_append )
         for( ; it != vec_ids.end(); ++it ){
             const int id = *it;
             if( id != CONTROL::None && id != m_id ){
-                SKELETON::MsgDiag mdiag( NULL, diag->get_str_motion() + "\n\nは「" + CONTROL::get_label( id ) + "」で使用されています" );
+                SKELETON::MsgDiag mdiag( nullptr, diag->get_str_motion() + "\n\nは「" + CONTROL::get_label( id ) + "」で使用されています" );
                 mdiag.run();
                 conflict = true;
                 break;
@@ -487,7 +487,7 @@ void MouseKeyDiag::slot_reset()
             const int id = *it;
 
             if( id != CONTROL::None && id != m_id ){
-                SKELETON::MsgDiag mdiag( NULL, motion + "\n\nは「" + CONTROL::get_label( id ) + "」で使用されています" );
+                SKELETON::MsgDiag mdiag( nullptr, motion + "\n\nは「" + CONTROL::get_label( id ) + "」で使用されています" );
                 mdiag.run();
                 conflict = true;
                 break;

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -90,7 +90,7 @@ Core::Core( JDWinMain& win_main )
       m_hpaned_r( SKELETON::PANE_FIXSIZE_PAGE1 ),
       m_imagetab_shown( 0 ),
       m_vpaned_message( SKELETON::PANE_FIXSIZE_PAGE2 ),
-      m_toolbar( NULL ),
+      m_toolbar( nullptr ),
       m_enable_menuslot( true ),
       m_init( false ),
       m_count_savesession( 0 )
@@ -1768,7 +1768,7 @@ void Core::toggle_menubar()
 
     if( ! SESSION::show_menubar() && CONFIG::get_show_hide_menubar_diag() ){
 
-        SKELETON::MsgCheckDiag mdiag( NULL, "メニューバーを再表示するには\n\n" + CONTROL::get_str_motions( CONTROL::ShowMenuBar ) + "\n\nを押してください",
+        SKELETON::MsgCheckDiag mdiag( nullptr, "メニューバーを再表示するには\n\n" + CONTROL::get_str_motions( CONTROL::ShowMenuBar ) + "\n\nを押してください",
                                       "今後表示しない (_D)"
             );
 
@@ -1835,7 +1835,7 @@ void Core::toggle_draw_toolbarback()
 
     CONFIG::set_draw_toolbarback( ! CONFIG::get_draw_toolbarback() );
 
-    SKELETON::MsgDiag mdiag( NULL, "正しく表示させるためにはJDimを再起動してください。" );
+    SKELETON::MsgDiag mdiag( nullptr, "正しく表示させるためにはJDimを再起動してください。" );
     mdiag.run();
 }
 
@@ -2188,7 +2188,7 @@ void Core::set_command( const COMMAND_ARGS& command )
     else if( command.command  == "open_article_searchlog" ) { 
 
         if( CORE::get_search_manager()->is_searching() ){
-            SKELETON::MsgDiag mdiag( NULL, "他の検索スレッドが実行中です" );
+            SKELETON::MsgDiag mdiag( nullptr, "他の検索スレッドが実行中です" );
             mdiag.run();
             return;
         }
@@ -2226,7 +2226,7 @@ void Core::set_command( const COMMAND_ARGS& command )
     else if( command.command  == "open_article_searchtitle" ) { 
 
         if( CORE::get_search_manager()->is_searching() ){
-            SKELETON::MsgDiag mdiag( NULL, "他の検索スレッドが実行中です" );
+            SKELETON::MsgDiag mdiag( nullptr, "他の検索スレッドが実行中です" );
             mdiag.run();
             return;
         }
@@ -2440,7 +2440,7 @@ void Core::set_command( const COMMAND_ARGS& command )
     else if( command.command  == "open_board_showlog" || command.command  == "open_board_showalllog" ){
 
         if( CORE::get_search_manager()->is_searching() ){
-            SKELETON::MsgDiag mdiag( NULL, "他の検索スレッドが実行中です" );
+            SKELETON::MsgDiag mdiag( nullptr, "他の検索スレッドが実行中です" );
             mdiag.run();
             return;
         }
@@ -2448,7 +2448,7 @@ void Core::set_command( const COMMAND_ARGS& command )
         std::string url = command.url;
         if( command.command == "open_board_showalllog" ){
 
-            SKELETON::MsgDiag mdiag( NULL, "全ログの一覧表示はかなり時間がかかります。\n\n本当に表示しますか？",
+            SKELETON::MsgDiag mdiag( nullptr, "全ログの一覧表示はかなり時間がかかります。\n\n本当に表示しますか？",
                                      false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
             if( mdiag.run() != Gtk::RESPONSE_YES ) return;
 
@@ -2573,7 +2573,7 @@ void Core::set_command( const COMMAND_ARGS& command )
 
         if( command.arg1 == "show_diag" ){
 
-            SKELETON::MsgDiag mdiag( NULL, "「"+ DBTREE::board_name( command.url ) + "」\n\nにdatファイルをインポートしますか？",
+            SKELETON::MsgDiag mdiag( nullptr, "「"+ DBTREE::board_name( command.url ) + "」\n\nにdatファイルをインポートしますか？",
                                      false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
             if( mdiag.run() != Gtk::RESPONSE_YES ) return;
         }
@@ -2583,7 +2583,7 @@ void Core::set_command( const COMMAND_ARGS& command )
         // ダイアログを開いてファイルのリストを取得
         if( command.arg2.empty() ){
             
-            list_files = CACHE::open_load_diag( NULL, SESSION::get_dir_dat(), CACHE::FILE_TYPE_DAT, true );
+            list_files = CACHE::open_load_diag( nullptr, SESSION::get_dir_dat(), CACHE::FILE_TYPE_DAT, true );
         }
 
         // 共有バッファからファイルのリストを取得
@@ -2801,7 +2801,7 @@ void Core::set_command( const COMMAND_ARGS& command )
     else if( command.command == "open_message" ){
 
         if( ! SESSION::is_online() ){
-            SKELETON::MsgDiag mdiag( NULL, "オフラインです" );
+            SKELETON::MsgDiag mdiag( nullptr, "オフラインです" );
             mdiag.run();
         }
         else{
@@ -2828,11 +2828,11 @@ void Core::set_command( const COMMAND_ARGS& command )
     else if( command.command == "create_new_thread" ){
 
         if( ! SESSION::is_online() ){
-            SKELETON::MsgDiag mdiag( NULL, "オフラインです" );
+            SKELETON::MsgDiag mdiag( nullptr, "オフラインです" );
             mdiag.run();
         }
         else if( DBTREE::url_bbscgi_new( command.url ).empty() ){
-            SKELETON::MsgDiag mdiag( NULL, "この板では新スレを立てることは出来ません" );
+            SKELETON::MsgDiag mdiag( nullptr, "この板では新スレを立てることは出来ません" );
             mdiag.run();
         }
         else{
@@ -3280,7 +3280,7 @@ void Core::exec_command()
             if( CONFIG::get_use_image_view() ){
 
                 if( ! SESSION::is_online() ){
-                    SKELETON::MsgDiag mdiag( NULL, "オフラインです" );
+                    SKELETON::MsgDiag mdiag( nullptr, "オフラインです" );
                     mdiag.run();
                 }
                 else{
@@ -4323,7 +4323,7 @@ void Core::import_dat( const std::string& url_board, const std::vector< std::str
 void Core::check_update( const bool open )
 {
     if( ! SESSION::is_online() ){
-        SKELETON::MsgDiag mdiag( NULL, "オフラインです" );
+        SKELETON::MsgDiag mdiag( nullptr, "オフラインです" );
         mdiag.run();
         return;
     }

--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -20,7 +20,7 @@ enum
     SIZE_OF_HEAP = 16 * 1024
 };
 
-CORE::Css_Manager* instance_css_manager = NULL;
+CORE::Css_Manager* instance_css_manager = nullptr;
 
 
 CORE::Css_Manager* CORE::get_css_manager()
@@ -35,7 +35,7 @@ CORE::Css_Manager* CORE::get_css_manager()
 void CORE::delete_css_manager()
 {
     if( instance_css_manager ) delete instance_css_manager;
-    instance_css_manager = NULL;
+    instance_css_manager = nullptr;
 }
 
 
@@ -53,7 +53,7 @@ enum
 
 Css_Manager::Css_Manager()
     : m_heap( SIZE_OF_HEAP ),
-      m_last_dom( NULL )
+      m_last_dom( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "Css_Manager::Css_Manager\n";
@@ -625,7 +625,7 @@ DOM* Css_Manager::create_domnode( int type )
 DOM* Css_Manager::create_divnode( const std::string& classname )
 {
     int classid = get_classid( classname );
-    if( classid < 0 ) return NULL;
+    if( classid < 0 ) return nullptr;
 
 #ifdef _DEBUG
     std::cout << "Css_Manager::create_divnode name = " << classname << std::endl;
@@ -654,7 +654,7 @@ DOM* Css_Manager::create_blocknode( int blockid )
 DOM* Css_Manager::create_textnode( const char* text )
 {
     int lng = strlen( text );
-    if( ! lng ) return NULL;
+    if( ! lng ) return nullptr;
 
 #ifdef _DEBUG
     std::cout << "Css_Manager::create_textnode text = " << text << std::endl;

--- a/src/data_info.h
+++ b/src/data_info.h
@@ -31,7 +31,7 @@ namespace CORE
         DATA_INFO()
         {
             type = 0;
-            parent = NULL;
+            parent = nullptr;
             url = std::string();
             name = std::string();
             path = std::string();

--- a/src/dbimg/delimgcachediag.cpp
+++ b/src/dbimg/delimgcachediag.cpp
@@ -89,7 +89,7 @@ void* DelImgCacheDiag::launcher( void* dat )
 {
     DelImgCacheDiag* tt = ( DelImgCacheDiag * ) dat;
     tt->main_thread();
-    return 0;
+    return nullptr;
 }
 
 

--- a/src/dbimg/img.cpp
+++ b/src/dbimg/img.cpp
@@ -61,7 +61,7 @@ Img::Img( const std::string& url )
     : SKELETON::Loadable()
     ,m_url( url )
     ,m_count_redirect( 0 )
-    ,m_fout( 0 )
+    ,m_fout( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "Img::Img url = " << m_url <<  std::endl;
@@ -84,7 +84,7 @@ Img::~Img()
 #endif 
 
     if( m_fout ) fclose( m_fout );
-    m_fout = NULL;
+    m_fout = nullptr;
 }
 
 
@@ -287,7 +287,7 @@ void Img::download_img( const std::string refurl, const bool mosaic, const int w
     // ダウンロード開始
     std::string path = get_cache_path();
     m_fout = fopen( to_locale_cstr( path ), "wb" );
-    if( m_fout == NULL ){
+    if( m_fout == nullptr ){
         m_type = T_OPENFAILED;
         receive_finish();
         return;
@@ -522,7 +522,7 @@ void Img::receive_finish()
 #endif
 
     if( m_fout ) fclose( m_fout );
-    m_fout = NULL;
+    m_fout = nullptr;
 
     // Created は OK にしておく
     if( get_code() == HTTP_CREATED ) set_code( HTTP_OK );

--- a/src/dbimg/imginterface.cpp
+++ b/src/dbimg/imginterface.cpp
@@ -12,7 +12,7 @@
 
 
 // インスタンスは Core でひとつだけ作って、Coreのデストラクタでdeleteする
-DBIMG::ImgRoot *instance_dbimg_root = NULL;
+DBIMG::ImgRoot *instance_dbimg_root = nullptr;
 
 
 void DBIMG::create_root()
@@ -77,7 +77,7 @@ int DBIMG::get_type_real( const std::string& url )
 DBIMG::Img* DBIMG::get_img( const std::string& url )
 {
     if( instance_dbimg_root ) return instance_dbimg_root->get_img( url );
-    return NULL;
+    return nullptr;
 }
 
 

--- a/src/dbimg/imgroot.cpp
+++ b/src/dbimg/imgroot.cpp
@@ -95,7 +95,7 @@ Img* ImgRoot::get_img( const std::string& url )
     Img* img = search_img( url );
 
     // 無ければ作る
-    if( img == NULL ){
+    if( img == nullptr ){
         img = new Img( url );
         m_map_img.insert( make_pair( url, img ) );
     }
@@ -114,7 +114,7 @@ Img* ImgRoot::search_img( const std::string& url )
     std::map< std::string, Img* >::iterator it = m_map_img.find( url );
     if( it != m_map_img.end() ) return ( *it ).second;
 
-    return NULL;
+    return nullptr;
 }
 
 
@@ -302,7 +302,7 @@ void ImgRoot::delete_all_files()
     std::cout << "ImgRoot::delete_all_files\n";
 #endif
 
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_DELIMG, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_DELIMG, "" );
     int ret = pref->run();
     delete pref;
     if( ret != Gtk::RESPONSE_OK ) return;

--- a/src/dbimg/imgroot.h
+++ b/src/dbimg/imgroot.h
@@ -34,7 +34,7 @@ namespace DBIMG
         // Imgクラス取得(無ければ作成)
         Img* get_img( const std::string& url );
 
-        // 検索(無ければNULL)
+        // 検索(無ければnullptr)
         Img* search_img( const std::string& url );
 
         // 画像データの先頭のシグネチャを見て画像のタイプを取得

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -160,7 +160,7 @@ const std::string& ArticleBase::get_since_date()
 // スレ速度
 int ArticleBase::get_speed()
 {
-    time_t current_t = time( NULL );
+    time_t current_t = time( nullptr );
     return ( get_number() * 60 * 60 * 24 ) / MAX( 1, current_t - get_since_time() );
 }
 
@@ -356,7 +356,7 @@ time_t ArticleBase::get_time_modified()
 {
     time_t time_out;
     time_out = MISC::datetotime( m_date_modified );
-    if( time_out == 0 ) time_out = time( NULL ) - 600;
+    if( time_out == 0 ) time_out = time( nullptr ) - 600;
     return time_out; 
 }
 
@@ -365,7 +365,7 @@ time_t ArticleBase::get_time_modified()
 // スレが立ってからの経過時間( 時間 )
 int ArticleBase::get_hour()
 {
-    return ( time( NULL ) - get_since_time() ) / ( 60 * 60 );
+    return ( time( nullptr ) - get_since_time() ) / ( 60 * 60 );
 }
 
 
@@ -1626,7 +1626,7 @@ void ArticleBase::delete_cache( const bool cache_only )
             const std::string msg = "「" + get_subject() +
             "」にはしおりが付けられています。\n\nスレを削除しますか？\n\nしおりを解除するにはスレの上で右クリックしてしおり解除を選択してください。";
 
-            SKELETON::MsgDiag mdiag( NULL, msg, false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
+            SKELETON::MsgDiag mdiag( nullptr, msg, false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
             mdiag.set_default_response( Gtk::RESPONSE_YES );
             if( mdiag.run() != Gtk::RESPONSE_YES ) return;
         }
@@ -1635,7 +1635,7 @@ void ArticleBase::delete_cache( const bool cache_only )
 
             const std::string msg = "「" + get_subject() + "」には書き込み履歴が残っています。\n\nスレを削除しますか？";
 
-            SKELETON::MsgCheckDiag mdiag( NULL, msg,
+            SKELETON::MsgCheckDiag mdiag( nullptr, msg,
                                           "今後表示しない(常に削除)(_D)",
                                           Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
 
@@ -1665,7 +1665,7 @@ void ArticleBase::delete_cache( const bool cache_only )
 
                     const std::string msg = "「" + get_subject() + "」には画像が貼られています。\n\n画像のキャッシュも削除しますか？";
 
-                    SKELETON::MsgCheckDiag mdiag( NULL, msg,
+                    SKELETON::MsgCheckDiag mdiag( nullptr, msg,
                                                   "今後表示しない(常に削除しない)(_D)",
                                                   Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_NONE );
 
@@ -1776,7 +1776,7 @@ bool ArticleBase::save_dat( const std::string& path_to )
     std::string name = MISC::get_filename( path_to );
     if( name.empty() ) name = get_id();
 
-    std::string save_to = CACHE::copy_file( NULL, CACHE::path_dat( m_url ), dir + name, CACHE::FILE_TYPE_DAT );
+    std::string save_to = CACHE::copy_file( nullptr, CACHE::path_dat( m_url ), dir + name, CACHE::FILE_TYPE_DAT );
 
     if( ! save_to.empty() ){
         SESSION::set_dir_dat( MISC::get_dir( save_to ) );

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -304,7 +304,7 @@ namespace DBTREE
         bool is_cached() const { return m_cached; }
         void set_cached( const bool set ){ m_cached = set; }
 
-        // キャッシュがarticlebaseに読み込まれている(nodetree!=NULL)か
+        // キャッシュがarticlebaseに読み込まれている(nodetree!=nullptr)か
         bool is_cache_read() const { return ( m_nodetree ); }
 
         // キャッシュがあって、かつ新着の読み込みが可能
@@ -411,7 +411,7 @@ namespace DBTREE
         // もしNodeTreeが作られていなかったら作成
         JDLIB::ConstPtr< NodeTreeBase >& get_nodetree();
 
-        virtual NodeTreeBase* create_nodetree(){ return NULL; }
+        virtual NodeTreeBase* create_nodetree(){ return nullptr; }
 
         void reset_status();
 

--- a/src/dbtree/articlehash.cpp
+++ b/src/dbtree/articlehash.cpp
@@ -39,7 +39,7 @@ ArticleHash::~ArticleHash()
 #endif
 
     if( m_iterator ) delete m_iterator;
-    m_iterator = NULL;
+    m_iterator = nullptr;
 }
 
 
@@ -71,14 +71,14 @@ void ArticleHash::push( ArticleBase* article )
 
 ArticleBase* ArticleHash::find( const std::string& datbase, const std::string& id )
 {
-    if( ! m_table.size() ) return NULL;
+    if( ! m_table.size() ) return nullptr;
 
     const size_t hash = get_hash( id );
 
     std::vector< ArticleBase* >::iterator it = m_table[ hash ].begin();
     for( ; it != m_table[ hash ].end(); ++it ) if( ( *it )->equal( datbase, id ) ) return *it;
 
-    return NULL;
+    return nullptr;
 }
 
 
@@ -94,7 +94,7 @@ ArticleHashIterator ArticleHash::begin()
 
 ArticleBase* ArticleHash::it_get()
 {
-    if( m_it_hash >= m_table.size() ) return NULL;
+    if( m_it_hash >= m_table.size() ) return nullptr;
 
     return m_table[ m_it_hash ][ m_it_pos ];
 }

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -37,8 +37,8 @@ using namespace DBTREE;
 Board2chCompati::Board2chCompati( const std::string& root, const std::string& path_board, const std::string& name,
     const std::string& basicauth)
     : BoardBase( root, path_board, name ),
-      m_settingloader( NULL ),
-      m_ruleloader( NULL )
+      m_settingloader( nullptr ),
+      m_ruleloader( nullptr )
 {
     set_path_dat( "/dat" );
     set_path_readcgi( "/test/read.cgi" );
@@ -59,13 +59,13 @@ Board2chCompati::~Board2chCompati()
         m_settingloader->terminate_load();
         delete m_settingloader;
     }
-    m_settingloader = NULL;
+    m_settingloader = nullptr;
 
     if( m_ruleloader ){
         m_ruleloader->terminate_load();
         delete m_ruleloader;
     }
-    m_ruleloader = NULL;
+    m_ruleloader = nullptr;
 }
 
 

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -60,14 +60,14 @@ BoardBase::BoardBase( const std::string& root, const std::string& path_board, co
     , m_live_sec( 0 )
     , m_last_access_time( 0 )
     , m_number_max_res( 0 )
-    , m_iconv( NULL )
-    , m_rawdata( NULL )
-    , m_rawdata_left( NULL )
+    , m_iconv( nullptr )
+    , m_rawdata( nullptr )
+    , m_rawdata_left( nullptr )
     , m_read_info( 0 )
     , m_append_articles( false )
-    , m_get_article( NULL )
+    , m_get_article( nullptr )
     , m_cancel_remove_abone_thread( false )
-    , m_article_null( 0 )
+    , m_article_null( nullptr )
 {
     clear();
     clear_load_data();
@@ -341,10 +341,10 @@ void BoardBase::set_list_cookies_for_write( const std::list< std::string >& list
 void BoardBase::clear()
 {
     if( m_rawdata ) free( m_rawdata );
-    m_rawdata = NULL;
+    m_rawdata = nullptr;
 
     if( m_rawdata_left ) free( m_rawdata_left );
-    m_rawdata_left = NULL;
+    m_rawdata_left = nullptr;
 
     m_lng_rawdata = 0;
     m_lng_rawdata_left = 0;
@@ -352,7 +352,7 @@ void BoardBase::clear()
     m_get_article_url = std::string();
 
     if( m_iconv ) delete m_iconv;
-    m_iconv = NULL;
+    m_iconv = nullptr;
 
     m_list_artinfo.clear();
 }
@@ -876,7 +876,7 @@ std::string BoardBase::url_subbbscgibase()
 //
 // article のID を渡してハッシュから article のポインタを検索して返すだけ
 //
-// 無ければNULLクラスを返す
+// 無ければNullクラスを返す
 //
 ArticleBase* BoardBase::get_article( const std::string& datbase, const std::string& id )
 {
@@ -1177,7 +1177,7 @@ void BoardBase::receive_finish()
 
                     const std::string msg = "「" + get_name() + "」は\n\n" + new_url + " に移転しました。\n\nデータベースを更新しますか？";
 
-                    SKELETON::MsgCheckDiag mdiag( NULL,
+                    SKELETON::MsgCheckDiag mdiag( nullptr,
                                                   msg,
                                                   "今後表示しない(常に更新)(_D)",
                                                   Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
@@ -1199,7 +1199,7 @@ void BoardBase::receive_finish()
             }
         }
         else{
-            SKELETON::MsgDiag mdiag( NULL, "移転しました\n\n板一覧を更新しますか？", false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
+            SKELETON::MsgDiag mdiag( nullptr, "移転しました\n\n板一覧を更新しますか？", false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
             mdiag.set_default_response( Gtk::RESPONSE_YES );
             if( mdiag.run() == Gtk::RESPONSE_YES ) CORE::core_set_command( "reload_bbsmenu" );
         }
@@ -1357,7 +1357,7 @@ void BoardBase::receive_finish()
         // オンライン、かつcodeが200か304なら最終アクセス時刻を更新
         if( m_is_online && ( get_code() == HTTP_OK || get_code() == HTTP_NOT_MODIFIED ) ){
 
-            m_last_access_time = time( NULL );
+            m_last_access_time = time( nullptr );
 
 #ifdef _DEBUG
             std::cout << "access time " << m_last_access_time << std::endl;
@@ -1367,7 +1367,7 @@ void BoardBase::receive_finish()
         // オンライン、かつcodeが200なら情報を更新・保存して subject.txt をキャッシュに保存
         if( m_is_online && get_code() == HTTP_OK ){
 
-            m_last_access_time = time( NULL );
+            m_last_access_time = time( nullptr );
 
 #ifdef _DEBUG
             std::cout << "save info and subject.txt\n";
@@ -1629,7 +1629,7 @@ void BoardBase::remove_old_abone_thread()
 
     if( CONFIG::get_remove_old_abone_thread() == 0 ){
 
-        SKELETON::MsgCheckDiag mdiag( NULL,
+        SKELETON::MsgCheckDiag mdiag( nullptr,
                                       "NGスレタイトルに登録したスレがdat落ちしました。\n\nNGスレタイトルから除外しますか？\n後で板のプロパティから削除する事も可能です。",
                                       "今後表示しない(_D)",
                                       Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_NONE );
@@ -1943,7 +1943,7 @@ std::string BoardBase::import_dat( const std::string& filename )
 {
     if( empty() ) return std::string();
     if( CACHE::file_exists( filename ) != CACHE::EXIST_FILE ){
-        SKELETON::MsgDiag mdiag( NULL, "datファイルが存在しません" );
+        SKELETON::MsgDiag mdiag( nullptr, "datファイルが存在しません" );
         mdiag.run();
         return std::string();
     }
@@ -1951,7 +1951,7 @@ std::string BoardBase::import_dat( const std::string& filename )
     const std::string dir = MISC::get_dir( filename );
     const std::string id = MISC::get_filename( filename );
     if( id.empty() || ! is_valid( id ) ){
-        SKELETON::MsgDiag mdiag( NULL, "ファイル名が正しくありません" );
+        SKELETON::MsgDiag mdiag( nullptr, "ファイル名が正しくありません" );
         mdiag.run();
         return std::string();
     }
@@ -1973,7 +1973,7 @@ std::string BoardBase::import_dat( const std::string& filename )
             art->read_info();
         }
         else{
-            SKELETON::MsgDiag mdiag( NULL, "datファイルのコピーに失敗しました" );
+            SKELETON::MsgDiag mdiag( nullptr, "datファイルのコピーに失敗しました" );
             mdiag.run();
             return std::string();
         }

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -207,7 +207,7 @@ namespace DBTREE
         // remove_old_abone_thread() をキャンセルするか
         bool m_cancel_remove_abone_thread;
 
-        // NULL artice クラス
+        // Null artice クラス
         ArticleBase* m_article_null;
 
       protected:

--- a/src/dbtree/boardfactory.cpp
+++ b/src/dbtree/boardfactory.cpp
@@ -24,6 +24,6 @@ DBTREE::BoardBase* DBTREE::BoardFactory( int type, const std::string& root, cons
 
         case TYPE_BOARD_MACHI:return  new DBTREE::BoardMachi( root, path_board, name );
 
-        default: return NULL;
+        default: return nullptr;
     }
 }

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -237,7 +237,7 @@ void BoardJBBS::regist_article( const bool is_online )
     std::cout << "BoardJBBS::regist_article size = " << get_list_artinfo().size() << std::endl;
 #endif 
 
-    ArticleBase* article_first = NULL;
+    ArticleBase* article_first = nullptr;
 
     const std::string datbase = url_datbase();
 

--- a/src/dbtree/boardlocal.cpp
+++ b/src/dbtree/boardlocal.cpp
@@ -102,7 +102,7 @@ ArticleBase* BoardLocal::append_article( const std::string& datbase, const std::
 // datファイルのインポート
 std::string BoardLocal::import_dat( const std::string& filename )
 {
-    if( empty() ) return FALSE;
+    if( empty() ) return {};
     if( CACHE::file_exists( filename ) != CACHE::EXIST_FILE ) return std::string();
 
     int num_from, num_to;

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -297,7 +297,7 @@ void BoardMachi::regist_article( const bool is_online )
     std::cout << "BoardMachii::regist_article size = " << get_list_artinfo().size() << std::endl;
 #endif 
 
-    ArticleBase* article_first = NULL;
+    ArticleBase* article_first = nullptr;
 
     const std::string datbase = url_datbase();
 

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -13,7 +13,7 @@
 #include "global.h"
 
 // インスタンスは Core でひとつだけ作って、Coreのデストラクタでdeleteする
-DBTREE::Root *instance_dbtree_root = NULL;
+DBTREE::Root *instance_dbtree_root = nullptr;
 
 
 void DBTREE::create_root()
@@ -40,21 +40,21 @@ void DBTREE::delete_root()
 
 DBTREE::Root* DBTREE::get_root()
 {
-    assert( instance_dbtree_root != NULL );
+    assert( instance_dbtree_root != nullptr );
     return instance_dbtree_root;
 }
 
 DBTREE::BoardBase* DBTREE::get_board( const std::string& url )
 {
     DBTREE::BoardBase* board = DBTREE::get_root()->get_board( url );
-    assert( board != NULL );
+    assert( board != nullptr );
     return board;
 }
 
 DBTREE::ArticleBase* DBTREE::get_article( const std::string& url )
 {
     DBTREE::ArticleBase* article = DBTREE::get_board( url )->get_article_fromURL( url );
-    assert( article != NULL );
+    assert( article != nullptr );
     return article;
 }
 

--- a/src/dbtree/node.h
+++ b/src/dbtree/node.h
@@ -89,7 +89,7 @@ namespace DBTREE
         char* link; // リンクURL
 
         // アンカー情報のベクトル
-        // NULL なら一般のリンク
+        // nullptr なら一般のリンク
         // ancinfo->anc_from == ancinfo->anc_to == 0 が終端
         ANCINFO* ancinfo;
 
@@ -97,7 +97,7 @@ namespace DBTREE
         //
         // 画像リンクの場合、実際にリンクが画面に表示される段階でノードに DBIMG::Img
         // のポインタと色をセットする。
-        // image == true かつ img == NULL ならまだ img は未取得
+        // image == true かつ img == nullptr ならまだ img は未取得
         // 実際にノードが画面に表示された際に img のポインタを取得して画像の状態を取得する
         // 詳しくは  DrawAreaBase::draw_one_node() を参照
 
@@ -113,7 +113,7 @@ namespace DBTREE
         unsigned char type;
 
         int id_header; // ヘッダID ( つまりレス番号、ルートヘッダは0 )
-        NODE* next_node; // 最終ノードはNULL
+        NODE* next_node; // 最終ノードはnullptr
         
         char* text;
         unsigned char color_text; // 色

--- a/src/dbtree/nodetree2chcompati.cpp
+++ b/src/dbtree/nodetree2chcompati.cpp
@@ -17,7 +17,7 @@ using namespace DBTREE;
 
 NodeTree2chCompati::NodeTree2chCompati( const std::string& url, const std::string& date_modified )
     : NodeTreeBase( url, date_modified )
-    , m_iconv( NULL )
+    , m_iconv( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "NodeTree2chCompati::NodeTree2chCompati url = " << url << " modified = " << date_modified << std::endl;
@@ -51,7 +51,7 @@ void NodeTree2chCompati::clear()
 
     // iconv 削除
     if( m_iconv ) delete m_iconv;
-    m_iconv = NULL;
+    m_iconv = nullptr;
 }
 
 
@@ -136,7 +136,7 @@ char* NodeTree2chCompati::skip_status_line( char* pos, int status )
 //
 const char* NodeTree2chCompati::raw2dat( char* rawlines, int& byte )
 {
-    assert( m_iconv != NULL );
+    assert( m_iconv != nullptr );
 
     // バッファ自体はiconvクラスの中で持っているのでポインタだけもらう
     return  m_iconv->convert( rawlines, strlen( rawlines ), byte );

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -84,13 +84,13 @@ NodeTreeBase::NodeTreeBase( const std::string& url, const std::string& modified 
       m_resume_cached( false ),
       m_broken( false ),
       m_heap( SIZE_OF_HEAP ),
-      m_buffer_lines( NULL ),
-      m_parsed_text( NULL ),
-      m_buffer_write( NULL ),
+      m_buffer_lines( nullptr ),
+      m_parsed_text( nullptr ),
+      m_buffer_write( nullptr ),
       m_check_update( false ),
       m_check_write( false ),
       m_loading_newthread( false ),
-      m_fout ( NULL )
+      m_fout ( nullptr )
 {
     set_date_modified( modified );
 
@@ -175,17 +175,17 @@ void NodeTreeBase::clear()
 #endif
 
     if( m_buffer_lines ) free( m_buffer_lines );
-    m_buffer_lines = NULL;
+    m_buffer_lines = nullptr;
     m_byte_buffer_lines_left = 0;
 
     if( m_parsed_text ) free( m_parsed_text );
-    m_parsed_text = NULL;
+    m_parsed_text = nullptr;
 
     if( m_buffer_write ) free( m_buffer_write );
-    m_buffer_write = NULL;
+    m_buffer_write = nullptr;
     
     if( m_fout ) fclose( m_fout );
-    m_fout = NULL;
+    m_fout = nullptr;
 
     m_ext_err = std::string();
 }
@@ -209,7 +209,7 @@ int NodeTreeBase::get_res_number()
 //
 NODE* NodeTreeBase::res_header( int number )
 {
-    if( number > m_id_header || number <= 0 ) return NULL;
+    if( number > m_id_header || number <= 0 ) return nullptr;
     
     return m_vec_header[ number ];
 }
@@ -445,7 +445,7 @@ std::list< int > NodeTreeBase::get_res_reference( const std::list< int >& res_nu
 
                     if( node->type == NODE_LINK ){
 
-                        // アンカーノードの時は node->linkinfo->ancinfo != NULL;
+                        // アンカーノードの時は node->linkinfo->ancinfo != nullptr;
                         if( node->linkinfo->ancinfo ){
 
                             int anc = 0;
@@ -514,7 +514,7 @@ std::list< ANCINFO* > NodeTreeBase::get_res_anchors( const int number )
             NODE* node = head->headinfo->block[ block ];
             while( node ){
 
-                // アンカーノードの時は node->linkinfo->ancinfo != NULL;
+                // アンカーノードの時は node->linkinfo->ancinfo != nullptr;
                 if( node->type == NODE_LINK 
                         && node->linkinfo->ancinfo ){
 
@@ -822,7 +822,7 @@ NODE* NodeTreeBase::create_node_header()
     }
 
     ++m_id_header;
-    m_node_previous = NULL;
+    m_node_previous = nullptr;
 
     NODE* tmpnode = create_node();
     tmpnode->type =  NODE_HEADER;
@@ -842,7 +842,7 @@ NODE* NodeTreeBase::create_node_header()
 //
 NODE* NodeTreeBase::create_node_block()
 {
-    m_node_previous = NULL;
+    m_node_previous = nullptr;
 
     NODE* tmpnode = create_node();
     tmpnode->type =  NODE_BLOCK;
@@ -1038,7 +1038,7 @@ NODE* NodeTreeBase::create_node_text( const char* text, const int color_text, co
 //
 NODE* NodeTreeBase::create_node_ntext( const char* text, const int n, const int color_text, const bool bold )
 {
-    if( n <= 0 ) return NULL;
+    if( n <= 0 ) return nullptr;
     
     NODE* tmpnode = create_node();
 
@@ -1063,8 +1063,8 @@ NODE* NodeTreeBase::create_node_ntext( const char* text, const int n, const int 
 //
 NODE* NodeTreeBase::append_html( const std::string& html )
 {
-    if( is_loading() ) return NULL;
-    if( html.empty() ) return NULL;
+    if( is_loading() ) return nullptr;
+    if( html.empty() ) return nullptr;
 
 #ifdef _DEBUG
     std::cout << "NodeTreeBase::append_html url = " << m_url << " html = " << html << std::endl;
@@ -1099,8 +1099,8 @@ NODE* NodeTreeBase::append_html( const std::string& html )
 //
 NODE* NodeTreeBase::append_dat( const std::string& dat )
 {
-    if( is_loading() ) return NULL;
-    if( dat.empty() ) return NULL;
+    if( is_loading() ) return nullptr;
+    if( dat.empty() ) return nullptr;
 
     init_loading();
     receive_data( dat.c_str(), dat.length() );
@@ -1241,7 +1241,7 @@ void NodeTreeBase::download_dat( const bool check_update )
 #endif
 
             m_fout = fopen( to_locale_cstr( path_cache ), "ab" );
-            if( m_fout == NULL ){
+            if( m_fout == nullptr ){
                 MISC::ERRMSG( "fopen failed : " + path_cache );
             }
         }
@@ -3195,7 +3195,7 @@ bool NodeTreeBase::check_abone_chain( const int number )
         NODE* node = head->headinfo->block[ block ];
         while( node ){
 
-            // アンカーノードの時は node->linkinfo->ancinfo != NULL;
+            // アンカーノードの時は node->linkinfo->ancinfo != nullptr;
             if( node->type == NODE_LINK && node->linkinfo->ancinfo ){
 
                 int anc = 0;
@@ -3322,7 +3322,7 @@ void NodeTreeBase::check_reference( const int number )
 
             if( node->type == NODE_LINK ){
 
-                // アンカーノードの時は node->linkinfo->ancinfo != NULL;
+                // アンカーノードの時は node->linkinfo->ancinfo != nullptr;
                 if( node->linkinfo->ancinfo ){
 
                     int anc = 0;
@@ -3568,7 +3568,7 @@ bool NodeTreeBase::remove_imenu( char* str_link )
     if ( memcmp( p, "://", strlen( "://" ) ) != 0 ) return false;
     p += strlen( "://" );
 
-    const char *cut_sites[] = { "ime.nu/", "ime.st/", "nun.nu/", "pinktower.com/", 0 };
+    const char *cut_sites[] = { "ime.nu/", "ime.st/", "nun.nu/", "pinktower.com/", nullptr };
     const char **q = cut_sites;
     while ( *q ) {
         size_t cs_len = strlen( *q );

--- a/src/dbtree/nodetreejbbs.cpp
+++ b/src/dbtree/nodetreejbbs.cpp
@@ -29,8 +29,8 @@ using namespace DBTREE;
 
 NodeTreeJBBS::NodeTreeJBBS( const std::string& url, const std::string& date_modified )
     : NodeTreeBase( url, date_modified )
-    , m_iconv( NULL )
-    , m_decoded_lines( NULL )
+    , m_iconv( nullptr )
+    , m_decoded_lines( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "NodeTreeJBBS::NodeTreeJBBS url = " << get_url() << " modified = " << date_modified << std::endl;
@@ -60,10 +60,10 @@ void NodeTreeJBBS::clear()
 
     // iconv 削除
     if( m_iconv ) delete m_iconv;
-    m_iconv = NULL;
+    m_iconv = nullptr;
 
     if( m_decoded_lines ) free( m_decoded_lines );
-    m_decoded_lines = NULL;
+    m_decoded_lines = nullptr;
 }
 
 
@@ -129,8 +129,8 @@ enum
 
 const char* NodeTreeJBBS::raw2dat( char* rawlines, int& byte )
 {
-    assert( m_iconv != NULL );
-    assert( m_decoded_lines != NULL );
+    assert( m_iconv != nullptr );
+    assert( m_decoded_lines != nullptr );
 
     int byte_lines;
     const char* lines = m_iconv->convert( rawlines, strlen( rawlines ), byte_lines );

--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -28,11 +28,11 @@ constexpr size_t BUF_SIZE_200 = 256;
 
 NodeTreeMachi::NodeTreeMachi( const std::string& url, const std::string& date_modified )
     : NodeTreeBase( url, date_modified )
-    , m_regex( NULL )
-    , m_iconv( NULL )
-    , m_decoded_lines( NULL )
-    , m_buffer( NULL )
-    , m_buffer_for_200( NULL )
+    , m_regex( nullptr )
+    , m_iconv( nullptr )
+    , m_decoded_lines( nullptr )
+    , m_buffer( nullptr )
+    , m_buffer_for_200( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "NodeTreeMachi::NodeTreeMachi url = " << get_url() << " modified = " << date_modified << std::endl;
@@ -62,20 +62,20 @@ void NodeTreeMachi::clear()
 
     // regex 削除
     if( m_regex ) delete m_regex;
-    m_regex = NULL;
+    m_regex = nullptr;
 
     // iconv 削除
     if( m_iconv ) delete m_iconv;
-    m_iconv = NULL;
+    m_iconv = nullptr;
 
     if( m_decoded_lines ) free( m_decoded_lines );
-    m_decoded_lines = NULL;
+    m_decoded_lines = nullptr;
 
     if( m_buffer ) free( m_buffer );
-    m_buffer = NULL;
+    m_buffer = nullptr;
 
     if( m_buffer_for_200 ) free( m_buffer_for_200 );
-    m_buffer_for_200 = NULL;
+    m_buffer_for_200 = nullptr;
 }
 
 

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -61,11 +61,11 @@ enum
 
 Root::Root()
     : SKELETON::Loadable()
-    , m_rawdata ( 0 )
+    , m_rawdata ( nullptr )
     , m_lng_rawdata( 0 )
     , m_analyzing_board_xml( false )
-    , m_board_null( 0 )
-    , m_get_board( NULL )
+    , m_board_null( nullptr )
+    , m_get_board( nullptr )
     , m_enable_save_movetable( true )
 {
     m_xml_document.clear();
@@ -121,7 +121,7 @@ Root::~Root()
 void Root::clear()
 {
     if( m_rawdata ) free( m_rawdata );
-    m_rawdata = NULL;
+    m_rawdata = nullptr;
     m_lng_rawdata = 0;
 }
 
@@ -163,7 +163,7 @@ BoardBase* Root::get_board( const std::string& url, const int count )
 #endif
 
     m_get_board_url = url;
-    m_get_board = NULL;
+    m_get_board = nullptr;
 
     if( count == 0 ){
 
@@ -264,7 +264,7 @@ BoardBase* Root::get_board( const std::string& url, const int count )
     std::cout << "Root::get_board: not found url = " << url << std::endl;;
 #endif
     
-    // それでも見つからなかったらNULLクラスを返す
+    // それでも見つからなかったらNullクラスを返す
     return m_board_null;
 }
 
@@ -341,7 +341,7 @@ void Root::receive_finish()
     if( get_code() == HTTP_NOT_MODIFIED ){
 
         std::string msg = get_str_code() + "\n\nサーバー上の板一覧は更新されていません。強制的に再読み込みをしますか？";
-        SKELETON::MsgDiag mdiag( NULL, msg, false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
+        SKELETON::MsgDiag mdiag( nullptr, msg, false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
         mdiag.set_default_response( Gtk::RESPONSE_YES );
         if( mdiag.run() == Gtk::RESPONSE_YES ){
             set_date_modified( std::string() );
@@ -354,7 +354,7 @@ void Root::receive_finish()
     if( get_code() != HTTP_OK ){
 
         std::string msg = get_str_code() + "\n\n板一覧の読み込みに失敗したため板一覧は更新されませんでした。\n\nプロキシ設定や板一覧を取得するサーバのアドレスを確認して、ファイルメニューから板一覧の再読み込みをして下さい。\n板一覧取得サーバのアドレスはabout:configで確認出来ます。";
-        SKELETON::MsgDiag mdiag( NULL, msg, false, Gtk::MESSAGE_ERROR );
+        SKELETON::MsgDiag mdiag( nullptr, msg, false, Gtk::MESSAGE_ERROR );
         mdiag.run();
         MISC::ERRMSG( "bbsmenu load failed : " + get_str_code() );
 
@@ -410,7 +410,7 @@ void Root::bbsmenu2xml( const std::string& menu )
     XML::Dom* root = m_xml_document.appendChild( XML::NODE_TYPE_ELEMENT, std::string( ROOT_NODE_NAME ) );
 
     // カテゴリの要素 <subdir></subdir>
-    XML::Dom* subdir = 0;
+    XML::Dom* subdir = nullptr;
 
     // カテゴリの有効/無効
     bool enabled = true;
@@ -660,7 +660,7 @@ bool Root::set_board( const std::string& url, const std::string& name, const std
     if( type == TYPE_BOARD_UNKNOWN ) return false;
 
     // 移転チェック
-    BoardBase* board = NULL;
+    BoardBase* board = nullptr;
     const int stat = is_moved( root, path_board, name, &board, etc );
 
 #ifdef _SHOW_BOARD
@@ -802,7 +802,7 @@ bool Root::exec_move_board( BoardBase* board,
         std::string errmsg = "移転元のアドレスと移転先のアドレスが同じです\n\n"
         + old_root + old_path_board + " → " + new_root +  new_path_board;
 
-        SKELETON::MsgDiag mdiag( NULL, errmsg, false, Gtk::MESSAGE_ERROR );
+        SKELETON::MsgDiag mdiag( nullptr, errmsg, false, Gtk::MESSAGE_ERROR );
         mdiag.run();
         return false;
     }
@@ -823,7 +823,7 @@ bool Root::exec_move_board( BoardBase* board,
     MISC::MSG( ss.str() );
 
     m_get_board_url = std::string();
-    m_get_board = NULL;
+    m_get_board = nullptr;
 
     // もしキャッシュが存在したら移動して移転テーブル更新
     if( CACHE::file_exists( old_path ) == CACHE::EXIST_DIR ){
@@ -881,7 +881,7 @@ void Root::push_movetable( const std::string old_root,
         std::string errmsg = "移転元のアドレスと移転先のアドレスが同じです (Root::push_movetable)\n\n"
         + old_root + old_path_board + " → " + new_root +  new_path_board;
 
-        SKELETON::MsgDiag mdiag( NULL, errmsg, false, Gtk::MESSAGE_ERROR );
+        SKELETON::MsgDiag mdiag( nullptr, errmsg, false, Gtk::MESSAGE_ERROR );
         mdiag.run();
         return;
     }
@@ -988,7 +988,7 @@ bool Root::remove_board( const std::string& url )
     delete board;
 
     m_get_board_url = std::string();
-    m_get_board = NULL;
+    m_get_board = nullptr;
 
     return true;
 }

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -65,7 +65,7 @@ namespace DBTREE
         std::set< std::string > m_analyzed_path_board; // XML 解析中に処理済みの板のpath
         std::string m_move_info;  // 移転したときにダイアログに表示する移転済み板の一覧
 
-        // NULL board クラス
+        // Null board クラス
         BoardBase* m_board_null;
 
         // get_board()のキャッシュ

--- a/src/dbtree/spchar_decoder.cpp
+++ b/src/dbtree/spchar_decoder.cpp
@@ -33,7 +33,7 @@ bool check_spchar( const char* n_in, const char* spchar )
 // n_in : 入力で使用した文字数が返る
 // out_char : 出力文字列
 // n_out : 出力した文字数が返る
-// only_check : チェックのみ実施 ( out_char は NULL でも可 )
+// only_check : チェックのみ実施 ( out_char は nullptr でも可 )
 //
 // 戻り値 : node.h で定義したノード番号
 //
@@ -82,7 +82,7 @@ int decode_char_number( const char* in_char, int& n_in,  char* out_char, int& n_
 // n_in : 入力で使用した文字数が返る
 // out_char : 出力文字列
 // n_out : 出力した文字数が返る
-// only_check : チェックのみ実施 ( out_char は NULL でも可 )
+// only_check : チェックのみ実施 ( out_char は nullptr でも可 )
 //
 // 戻り値 : node.h で定義したノード番号
 //

--- a/src/dbtree/spchar_decoder.h
+++ b/src/dbtree/spchar_decoder.h
@@ -14,7 +14,7 @@ namespace DBTREE
     // n_in : 入力で使用した文字数が返る
     // out_char : 出力文字列
     // n_out : 出力した文字数が返る
-    // only_check : チェックのみ実施 ( out_char は NULL でも可 )
+    // only_check : チェックのみ実施 ( out_char は nullptr でも可 )
     //
     // 戻り値 : node.h で定義したノード番号
     //

--- a/src/dispatchmanager.cpp
+++ b/src/dispatchmanager.cpp
@@ -11,7 +11,7 @@
 
 
 static std::mutex dispatch_mutex;
-CORE::DispatchManager* instance_dispmanager = NULL;
+CORE::DispatchManager* instance_dispmanager = nullptr;
 
 
 CORE::DispatchManager* CORE::get_dispmanager()
@@ -23,7 +23,7 @@ CORE::DispatchManager* CORE::get_dispmanager()
 void CORE::delete_dispatchmanager()
 {
     if( instance_dispmanager ) delete instance_dispmanager;
-    instance_dispmanager = NULL;
+    instance_dispmanager = nullptr;
 }
 
 

--- a/src/dndmanager.cpp
+++ b/src/dndmanager.cpp
@@ -5,7 +5,7 @@
 #include "dndmanager.h"
 
 
-CORE::DND_Manager* instance_dnd_manager = NULL;
+CORE::DND_Manager* instance_dnd_manager = nullptr;
 
 
 CORE::DND_Manager* CORE::get_dnd_manager()
@@ -20,7 +20,7 @@ CORE::DND_Manager* CORE::get_dnd_manager()
 void CORE::delete_dnd_manager()
 {
     if( instance_dnd_manager ) delete instance_dnd_manager;
-    instance_dnd_manager = NULL;
+    instance_dnd_manager = nullptr;
 }
 
 

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -229,16 +229,16 @@ std::string ENVIRONMENT::get_distname()
             {
                 // read size of ProductName
                 rc = RegQueryValueEx( hKey, "ProductName",
-                        NULL, NULL, NULL, &dwSize );
+                        nullptr, nullptr, nullptr, &dwSize );
                 if( rc == ERROR_SUCCESS && dwSize > 0 )
                 {
                     // get buffer
                     regVal = (char *)malloc( dwSize );
-                    if( regVal != NULL )
+                    if( regVal != nullptr )
                     {
                         // read ProductName
                         rc = RegQueryValueEx( hKey, "ProductName",
-                                NULL, NULL, (LPBYTE)regVal, &dwSize );
+                                nullptr, nullptr, (LPBYTE)regVal, &dwSize );
                         if( rc == ERROR_SUCCESS && strlen( regVal ) > 0 )
                         {
                             // may be contains "Windows" in the value
@@ -251,16 +251,16 @@ std::string ENVIRONMENT::get_distname()
 
                 // read size of CSDVersion
                 rc = RegQueryValueEx( hKey, "CSDVersion",
-                        NULL, NULL, NULL, &dwSize );
+                        nullptr, nullptr, nullptr, &dwSize );
                 if( rc == ERROR_SUCCESS && dwSize > 0 )
                 {
                     // get buffer
                     regVal = (char *)malloc( dwSize );
-                    if( regVal != NULL )
+                    if( regVal != nullptr )
                     {
                         // read CSDVersion
                         rc = RegQueryValueEx( hKey, "CSDVersion",
-                                NULL, NULL, (LPBYTE)regVal, &dwSize );
+                                nullptr, nullptr, (LPBYTE)regVal, &dwSize );
                         if( rc == ERROR_SUCCESS && strlen( regVal ) > 0 )
                         {
                             // ServicePack version
@@ -435,7 +435,7 @@ std::string ENVIRONMENT::get_distname()
 
 #ifdef HAVE_SYS_UTSNAME_H
 
-    char *sysname = 0, *release = 0, *machine = 0;
+    char *sysname = nullptr, *release = nullptr, *machine = nullptr;
 
     // システムコール uname() 準拠：SVr4, POSIX.1-2001.
     struct utsname* uts;
@@ -466,7 +466,7 @@ std::string ENVIRONMENT::get_distname()
     }
 
     free( uts );
-    uts = NULL;
+    uts = nullptr;
 
 #endif
 #endif // _WIN32

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -336,7 +336,7 @@ void FontColorPref::slot_checkbutton_font_toggled()
 {
     if( m_checkbutton_font.property_active() )
     {
-        SKELETON::MsgDiag mdiag( NULL, WARNING_STRICTCHAR );
+        SKELETON::MsgDiag mdiag( nullptr, WARNING_STRICTCHAR );
         mdiag.run();
     }
 }
@@ -346,7 +346,7 @@ void FontColorPref::slot_chk_use_gtkrc_toggled()
 #if !GTKMM_CHECK_VERSION(3,0,0)
     if( m_chk_use_gtkrc_tree.property_active() )
     {
-        SKELETON::MsgDiag mdiag( NULL, WARNING_GTKRC_TREE );
+        SKELETON::MsgDiag mdiag( nullptr, WARNING_GTKRC_TREE );
         mdiag.run();
     }
 #endif
@@ -534,7 +534,7 @@ void FontColorPref::slot_reset_all_colors()
 #if !GTKMM_CHECK_VERSION(3,0,0)
     if( m_chk_use_gtkrc_tree.property_active() )
     {
-        SKELETON::MsgDiag mdiag( NULL, WARNING_GTKRC_TREE );
+        SKELETON::MsgDiag mdiag( nullptr, WARNING_GTKRC_TREE );
         mdiag.run();
     }
 #endif

--- a/src/history/historymanager.cpp
+++ b/src/history/historymanager.cpp
@@ -20,7 +20,7 @@
 #include "global.h"
 
 
-HISTORY::History_Manager* instance_history_manager = NULL;
+HISTORY::History_Manager* instance_history_manager = nullptr;
 
 
 HISTORY::History_Manager* HISTORY::get_history_manager()
@@ -35,7 +35,7 @@ HISTORY::History_Manager* HISTORY::get_history_manager()
 void HISTORY::delete_history_manager()
 {
     if( instance_history_manager ) delete instance_history_manager;
-    instance_history_manager = NULL;
+    instance_history_manager = nullptr;
 }
 
 
@@ -68,12 +68,12 @@ using namespace HISTORY;
 
 
 History_Manager::History_Manager()
-    : m_menu_thread( NULL ),
-      m_menu_board( NULL ),
-      m_menu_close( NULL ),
-      m_menu_closeboard( NULL ),
-      m_menu_closeimg( NULL ),
-      m_last_viewhistory( NULL )
+    : m_menu_thread( nullptr ),
+      m_menu_board( nullptr ),
+      m_menu_close( nullptr ),
+      m_menu_closeboard( nullptr ),
+      m_menu_closeimg( nullptr ),
+      m_last_viewhistory( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "History_Manager::History_Manager\n";
@@ -379,7 +379,7 @@ void History_Manager::viewhistory2xml()
 //
 ViewHistory* History_Manager::get_viewhistory( const std::string& url )
 {
-    if( url.empty() ) return NULL;
+    if( url.empty() ) return nullptr;
 
     // キャッシュ
     if( m_last_viewhistory && m_last_viewhistory->get_current_url() == url ) return m_last_viewhistory;
@@ -406,7 +406,7 @@ ViewHistory* History_Manager::get_viewhistory( const std::string& url )
     std::cout << "not found\n";
 #endif
 
-    return NULL;
+    return nullptr;
 }
 
 
@@ -449,7 +449,7 @@ void History_Manager::delete_viewhistory( const std::string& url )
 
                 m_view_histories.erase( it );
                 delete history;
-                m_last_viewhistory = NULL;
+                m_last_viewhistory = nullptr;
 
                 break;
             }
@@ -594,7 +594,7 @@ const ViewHistoryItem* History_Manager::back_viewhistory( const std::string& url
 #endif
 
     ViewHistory* history = get_viewhistory( url );
-    if( ! history ) return NULL;
+    if( ! history ) return nullptr;
 
     return history->back( count, exec );
 }
@@ -614,7 +614,7 @@ const ViewHistoryItem* History_Manager::forward_viewhistory( const std::string& 
 #endif
 
     ViewHistory* history = get_viewhistory( url );
-    if( ! history ) return NULL;
+    if( ! history ) return nullptr;
 
     return history->forward( count, exec );
 }

--- a/src/history/historysubmenu.cpp
+++ b/src/history/historysubmenu.cpp
@@ -169,7 +169,7 @@ bool HistorySubMenu::open_history( const int i )
             case TYPE_IMAGE:
 
                 if( DBIMG::get_abone( info_list[ i ].url )){
-                    SKELETON::MsgDiag mdiag( NULL, "あぼ〜んされています" );
+                    SKELETON::MsgDiag mdiag( nullptr, "あぼ〜んされています" );
                     mdiag.run();
                 }
                 else{
@@ -314,25 +314,25 @@ void HistorySubMenu::slot_show_property()
         std::cout << "url " << info_list[ i ].url << std::endl;
 #endif
 
-        SKELETON::PrefDiag* pref = NULL;
+        SKELETON::PrefDiag* pref = nullptr;
         switch( info_list[ i ].type ){
 
             case TYPE_THREAD: 
             case TYPE_THREAD_UPDATE:
             case TYPE_THREAD_OLD:
 
-                pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_ARTICLE, info_list[ i ].url );
+                pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_ARTICLE, info_list[ i ].url );
                 break;
 
             case TYPE_BOARD:
             case TYPE_VBOARD:
 
-                pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_BOARD, info_list[ i ].url );
+                pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BOARD, info_list[ i ].url );
                 break;
 
             case TYPE_IMAGE:
 
-                pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_IMAGE, info_list[ i ].url );
+                pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_IMAGE, info_list[ i ].url );
                 break;
         }
 

--- a/src/history/viewhistory.cpp
+++ b/src/history/viewhistory.cpp
@@ -87,7 +87,7 @@ const std::string& ViewHistory::get_current_url()
               << "top = " << m_history_top << std::endl
               << "cur = " << m_history_current << std::endl
               << "end = " << m_history_end << std::endl;
-    assert( m_items[ m_history_current ] != NULL );
+    assert( m_items[ m_history_current ] != nullptr );
 #endif
 
     return m_items[ m_history_current ]->url;
@@ -363,11 +363,11 @@ const ViewHistoryItem* ViewHistory::back_forward( const bool back, const int cou
     int tmp_current = m_history_current;
 
     if( back ){
-        if( ! can_back( count ) ) return NULL;
+        if( ! can_back( count ) ) return nullptr;
         tmp_current = ( tmp_current + MAX_LOCAL_HISTORY - count ) % MAX_LOCAL_HISTORY;
     }
     else{
-        if( ! can_forward( count ) )  return NULL;
+        if( ! can_forward( count ) )  return nullptr;
         tmp_current = ( tmp_current + count ) % MAX_LOCAL_HISTORY;
     }
 

--- a/src/icons/iconmanager.cpp
+++ b/src/icons/iconmanager.cpp
@@ -56,7 +56,7 @@
 
 #include <cstring>
 
-ICON::ICON_Manager* instance_icon_manager = NULL;
+ICON::ICON_Manager* instance_icon_manager = nullptr;
 
 
 ICON::ICON_Manager* ICON::get_icon_manager()
@@ -71,7 +71,7 @@ ICON::ICON_Manager* ICON::get_icon_manager()
 void ICON::delete_icon_manager()
 {
     if( instance_icon_manager ) delete instance_icon_manager;
-    instance_icon_manager = NULL;
+    instance_icon_manager = nullptr;
 }
 
 

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -24,7 +24,7 @@
 #include "jdlib/miscutil.h"
 #include "jdlib/miscmsg.h"
 
-IMAGE::ImageAdmin *instance_imageadmin = NULL;
+IMAGE::ImageAdmin *instance_imageadmin = nullptr;
 
 IMAGE::ImageAdmin* IMAGE::get_admin()
 {
@@ -37,7 +37,7 @@ IMAGE::ImageAdmin* IMAGE::get_admin()
 void IMAGE::delete_admin()
 {
     if( instance_imageadmin ) delete instance_imageadmin;
-    instance_imageadmin = NULL;
+    instance_imageadmin = nullptr;
 }
 
 
@@ -891,7 +891,7 @@ SKELETON::View* ImageAdmin::get_icon( const std::string& url, int& pos )
     }
 
     pos = -1;
-    return NULL;
+    return nullptr;
 }
 
 // 簡易版
@@ -921,7 +921,7 @@ SKELETON::View* ImageAdmin::get_nth_icon( const unsigned int n )
 SKELETON::View* ImageAdmin::get_current_icon()
 {
     SKELETON::View* view = get_current_view();
-    if( !view ) return NULL;
+    if( !view ) return nullptr;
     return get_icon( view->get_url() );
 }
 
@@ -941,7 +941,7 @@ SKELETON::View* ImageAdmin::get_view( const std::string& url )
         if( ( *it_view )->get_url() == url ) return ( *it_view );
     }
 
-    return NULL;
+    return nullptr;
 }
 
 

--- a/src/image/imageareabase.cpp
+++ b/src/image/imageareabase.cpp
@@ -34,7 +34,7 @@ void* imgarea_launcher( void* dat )
     std::cout << "end" << std::endl;
 #endif
 
-    return 0;
+    return nullptr;
 }
 
 

--- a/src/image/imageview.cpp
+++ b/src/image/imageview.cpp
@@ -45,7 +45,7 @@ using namespace IMAGE;
 
 ImageViewMain::ImageViewMain( const std::string& url )
     : ImageViewBase( url ),
-      m_scrwin( 0 ),
+      m_scrwin( nullptr ),
       m_length_prev( 0 ),
       m_show_status( false ),
       m_update_status( false ),

--- a/src/image/imageviewpopup.cpp
+++ b/src/image/imageviewpopup.cpp
@@ -19,7 +19,7 @@ using namespace IMAGE;
 
 ImageViewPopup::ImageViewPopup( const std::string& url )
     : ImageViewBase( url )
-    , m_label( NULL )
+    , m_label( nullptr )
     , m_length_prev( 0 )
     , m_clicked( false )
 {
@@ -159,7 +159,7 @@ void ImageViewPopup::remove_label()
     if( m_label ){
         get_event().remove();
         delete m_label;
-        m_label = NULL;
+        m_label = nullptr;
     }
 }
 

--- a/src/image/imagewin.cpp
+++ b/src/image/imagewin.cpp
@@ -18,7 +18,7 @@ using namespace IMAGE;
 
 ImageWin::ImageWin()
     : SKELETON::JDWindow( CONFIG::get_fold_image() ),
-      m_tab( NULL )
+      m_tab( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "ImageWin::ImageWin x y w h = "

--- a/src/iomonitor.cpp
+++ b/src/iomonitor.cpp
@@ -31,7 +31,7 @@ using namespace CORE;
 IOMonitor::IOMonitor()
 #ifndef _WIN32
     : m_fifo_fd( -1 )
-    , m_iochannel( NULL )
+    , m_iochannel( nullptr )
 #else
     : m_slot_hd( INVALID_HANDLE_VALUE )
 #endif // _WIN32
@@ -163,13 +163,13 @@ void IOMonitor::init()
     std::cerr << "Create slot name: " << m_slot_name << std::endl;
 #endif
     m_slot_hd = CreateMailslot( to_locale_cstr( m_slot_name.c_str() ),
-            0, FIFO_TIMEOUT_MILI, NULL );
+            0, FIFO_TIMEOUT_MILI, nullptr );
     if( m_slot_hd == INVALID_HANDLE_VALUE ){
         if( GetLastError() == ERROR_ALREADY_EXISTS ){
             // client
             m_slot_hd = CreateFile( to_locale_cstr( m_slot_name.c_str() ),
                     GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
-                    NULL, OPEN_EXISTING, 0, NULL );
+                    nullptr, OPEN_EXISTING, 0, nullptr );
             if( m_slot_hd == INVALID_HANDLE_VALUE ){
 #ifdef _DEBUG
                 std::cerr << "Open err: " << GetLastError() << std::endl;
@@ -240,7 +240,7 @@ bool IOMonitor::send_command( const char* command )
     g_assert( m_slot_hd != INVALID_HANDLE_VALUE );
 
     DWORD length = 0;
-    BOOL rc = WriteFile( m_slot_hd, command, command_length, &length, NULL );
+    BOOL rc = WriteFile( m_slot_hd, command, command_length, &length, nullptr );
 
     return rc != FALSE && ( size_t )length == command_length;
 #endif // _WIN32
@@ -275,7 +275,7 @@ bool IOMonitor::slot_ioin( Glib::IOCondition io_condition )
     memset( msg, 0, sizeof( msg ) );
     DWORD length = 0;
 
-    BOOL rc = ReadFile( m_slot_hd, msg, COMMAND_MAX_LENGTH - 1, &length, NULL );
+    BOOL rc = ReadFile( m_slot_hd, msg, COMMAND_MAX_LENGTH - 1, &length, nullptr );
     if( rc == FALSE ){
         DWORD error = GetLastError();
         if( error == ERROR_SEM_TIMEOUT ){

--- a/src/jdlib/constptr.h
+++ b/src/jdlib/constptr.h
@@ -38,7 +38,7 @@ namespace JDLIB
             reset();
         }
 
-        ConstPtr() : m_p (0){}
+        ConstPtr() : m_p (nullptr){}
         ConstPtr( T *p ) : m_p (p){}
         ConstPtr( const T *p ) : m_p (p){}
     };

--- a/src/jdlib/imgloader.cpp
+++ b/src/jdlib/imgloader.cpp
@@ -125,7 +125,7 @@ bool ImgLoader::load_imgfile( const int loadlevel )
 #endif
 
     bool ret = true;
-    FILE* f = NULL;
+    FILE* f = nullptr;
     const size_t bufsize = 8192;
     size_t readsize = 0;
     guint8 data[ bufsize ];

--- a/src/jdlib/jdiconv.cpp
+++ b/src/jdlib/jdiconv.cpp
@@ -34,7 +34,7 @@ struct iconv_cast
 using namespace JDLIB;
 
 Iconv::Iconv( const std::string& coding_from, const std::string& coding_to )
-    : m_buf_in( 0 ), m_buf_out( 0 ), m_coding_from( coding_from )
+    : m_buf_in( nullptr ), m_buf_out( nullptr ), m_coding_from( coding_from )
 {
 #ifdef _DEBUG
     std::cout << "Iconv::Iconv coding = " << m_coding_from << " to " << coding_to << std::endl;
@@ -91,7 +91,7 @@ const char* Iconv::convert( char* str_in, int size_in, int& size_out )
 #endif
 
     assert( m_byte_left_in + size_in < BUF_SIZE_ICONV_IN );
-    if( m_cd == ( iconv_t ) -1 ) return NULL;
+    if( m_cd == ( iconv_t ) -1 ) return nullptr;
     
     size_t byte_left_out = BUF_SIZE_ICONV_OUT;
     char* buf_out = m_buf_out;

--- a/src/jdlib/jdmigemo.cpp
+++ b/src/jdlib/jdmigemo.cpp
@@ -78,7 +78,7 @@ int jd_migemo_init(const char *filename)
         return 1;
     }else{
         migemo_close(migemo_object);
-        migemo_object=NULL;
+        migemo_object=nullptr;
         return 0;
     }
 }
@@ -87,7 +87,7 @@ int jd_migemo_init(const char *filename)
 int jd_migemo_close(void)
 {
     migemo_close(migemo_object);
-    migemo_object=NULL;
+    migemo_object=nullptr;
     return 1;
 }
 

--- a/src/jdlib/jdthread.cpp
+++ b/src/jdlib/jdthread.cpp
@@ -169,7 +169,7 @@ bool Thread::join()
 
 #else // pthread 使用
 
-    int status = pthread_join( m_thread, NULL );
+    int status = pthread_join( m_thread, nullptr );
     JDTH_CLEAR( m_thread );
     if( status ){
         MISC::ERRMSG( std::string( "Thread::join : " ) + strerror( status ) );

--- a/src/jdlib/jdthread.h
+++ b/src/jdlib/jdthread.h
@@ -17,8 +17,8 @@
 #elif defined( USE_GTHREAD )
 #include <gtkmm.h>
 #define JDTH_TYPE Glib::Thread*
-#define JDTH_ISRUNNING( pth ) ( ( pth ) != NULL )
-#define JDTH_CLEAR( pth ) ( ( pth ) = NULL )
+#define JDTH_ISRUNNING( pth ) ( ( pth ) != nullptr )
+#define JDTH_CLEAR( pth ) ( ( pth ) = nullptr )
 #else
 #include <pthread.h>
 #define JDTH_TYPE pthread_t

--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -132,7 +132,7 @@ void JDLIB::return_token( JDLIB::Loader* loader )
     assert( token_loader >= 0 );
 
     std::vector< JDLIB::Loader* >::iterator it = vec_loader.begin();
-    for( ; it != vec_loader.end(); ++it ) if( ( *it ) == loader ) ( *it ) = NULL;
+    for( ; it != vec_loader.end(); ++it ) if( ( *it ) == loader ) ( *it ) = nullptr;
 
 #ifdef _DEBUG
     std::cout << "JDLIB::return_token : url = " << loader->data().url << " token = " << token_loader << std::endl;
@@ -261,13 +261,13 @@ using namespace JDLIB;
 // low_priority = true の時はスレッド起動待ち状態になった時に、起動順のプライオリティを下げる
 //
 Loader::Loader( const bool low_priority )
-    : m_addrinfo( 0 ),
+    : m_addrinfo( nullptr ),
       m_stop( false ),
       m_loading( false ),
       m_low_priority( low_priority ),
-      m_buf( 0 ),
-      m_buf_zlib_in ( 0 ),
-      m_buf_zlib_out ( 0 ),
+      m_buf( nullptr ),
+      m_buf_zlib_in ( nullptr ),
+      m_buf_zlib_out ( nullptr ),
       m_use_zlib ( 0 )
 {
 #ifdef _DEBUG
@@ -309,18 +309,18 @@ void Loader::clear()
     stop();
     wait();
 
-    m_loadable = NULL;
+    m_loadable = nullptr;
     
     m_use_chunk = false;
 
     if( m_buf ) free( m_buf );
-    m_buf = NULL;
+    m_buf = nullptr;
 
     if( m_buf_zlib_in ) free( m_buf_zlib_in );
-    m_buf_zlib_in = NULL;
+    m_buf_zlib_in = nullptr;
 
     if( m_buf_zlib_out ) free( m_buf_zlib_out );
-    m_buf_zlib_out = NULL;
+    m_buf_zlib_out = nullptr;
     
     if( m_use_zlib ) inflateEnd( &m_zstream );
     m_use_zlib = false;
@@ -557,7 +557,7 @@ void* Loader::launcher( void* dat )
 {
     Loader* tt = ( Loader * ) dat;
     tt->run_main();
-    return 0;
+    return nullptr;
 }
 
 
@@ -657,7 +657,7 @@ void Loader::run_main()
 #endif
     bool use_proxy = ( ! m_data.host_proxy.empty() );
 
-    JDLIB::JDSSL* ssl = NULL;
+    JDLIB::JDSSL* ssl = nullptr;
     
     // 送信メッセージ作成
     const std::string msg_send = create_msg_send();
@@ -848,7 +848,7 @@ void Loader::run_main()
     // 受信用バッファを作ってメッセージ受信
     size_t mrg;
     mrg = 64; // 一応オーバーフロー避けのおまじない
-    assert( m_buf == NULL );
+    assert( m_buf == nullptr );
     m_buf = ( char* )malloc( m_lng_buf + mrg );
 
     bool receiving_header;
@@ -1001,7 +1001,7 @@ EXIT_LOADING:
     if( ssl ){
         ssl->close();
         delete ssl;
-        ssl = NULL;
+        ssl = nullptr;
     }
 
     if( SOC_ISVALID( soc ) ){
@@ -1050,7 +1050,7 @@ EXIT_LOADING:
 
     // addrinfo開放
     if( m_addrinfo ) freeaddrinfo( m_addrinfo );
-    m_addrinfo = NULL;
+    m_addrinfo = nullptr;
 
     // トークン返す
     return_token( this );
@@ -1072,8 +1072,8 @@ EXIT_LOADING:
 //
 struct addrinfo* Loader::get_addrinfo( const std::string& hostname, const int port )
 {
-    if( port < 0 || port > 65535 ) return NULL;
-    if( hostname.empty() ) return NULL;
+    if( port < 0 || port > 65535 ) return nullptr;
+    if( hostname.empty() ) return nullptr;
 
     int ret;
     struct addrinfo hints, *res;
@@ -1088,7 +1088,7 @@ struct addrinfo* Loader::get_addrinfo( const std::string& hostname, const int po
     ret = getaddrinfo( hostname.c_str(), port_str, &hints, &res );
     if( ret ) {
         MISC::ERRMSG( m_data.str_code );
-        return NULL;
+        return nullptr;
     }
     
 #ifdef _DEBUG    
@@ -1399,7 +1399,7 @@ bool Loader::skip_chunk( char* buf, size_t& read_size )
                     
                     *( m_pos_sizepart ) = '\0';
                     if( *( m_pos_sizepart -1 ) == '\r' ) *( m_pos_sizepart -1 ) = '\0'; // "\r\n"の場合
-                    m_lng_leftdata = strtol( m_str_sizepart, NULL, 16 );
+                    m_lng_leftdata = strtol( m_str_sizepart, nullptr, 16 );
                     m_pos_sizepart = m_str_sizepart;
                     
 #ifdef _DEBUG_CHUNKED
@@ -1511,8 +1511,8 @@ bool Loader::init_unzip()
         return false;
     }
 
-    assert( m_buf_zlib_in == NULL );
-    assert( m_buf_zlib_out == NULL );
+    assert( m_buf_zlib_in == nullptr );
+    assert( m_buf_zlib_out == nullptr );
     m_buf_zlib_in = ( Bytef* )malloc( sizeof( Bytef ) * m_lng_buf_zlib_in + 64 );
     m_buf_zlib_out = ( Bytef* )malloc( sizeof( Bytef ) * m_lng_buf_zlib_out + 64 );
 
@@ -1703,8 +1703,8 @@ bool Loader::wait_recv_send( const int fd, const bool recv )
         memset( &timeout, 0, sizeof( timeval ) );
         timeout.tv_sec = 1;
 
-        if( recv ) ret = select( fd+1 , &fdset , NULL , NULL , &timeout );
-        else ret = select( fd+1 , NULL, &fdset , NULL , &timeout );
+        if( recv ) ret = select( fd+1 , &fdset , nullptr , nullptr , &timeout );
+        else ret = select( fd+1 , nullptr, &fdset , nullptr , &timeout );
 
 #ifdef _DEBUG
         if( errno == EINTR && ret < 0 ) std::cout << "Loader::wait_recv_send : errno = EINTR " << errno << std::endl;

--- a/src/jdlib/miscgtk.cpp
+++ b/src/jdlib/miscgtk.cpp
@@ -81,13 +81,13 @@ std::string MISC::htmlcolor_to_str( const std::string& _htmlcolor )
     if( htmlcolor.find( "#" ) == 0 ) offset = 1;
 
     std::string tmpstr = htmlcolor.substr( offset, 2 );
-    rgb[ 0 ] = strtol( std::string( "0x" + tmpstr + tmpstr  ).c_str(), NULL, 16 );
+    rgb[ 0 ] = strtol( std::string( "0x" + tmpstr + tmpstr  ).c_str(), nullptr, 16 );
 
     tmpstr = htmlcolor.substr( 2 + offset, 2 );
-    rgb[ 1 ] = strtol( std::string( "0x" + tmpstr + tmpstr  ).c_str(), NULL, 16 );
+    rgb[ 1 ] = strtol( std::string( "0x" + tmpstr + tmpstr  ).c_str(), nullptr, 16 );
 
     tmpstr = htmlcolor.substr( 4 + offset, 2 );
-    rgb[ 2 ] = strtol( std::string( "0x" + tmpstr + tmpstr  ).c_str(), NULL, 16 );
+    rgb[ 2 ] = strtol( std::string( "0x" + tmpstr + tmpstr  ).c_str(), nullptr, 16 );
 
 #ifdef _DEBUG
     std::cout << "MISC::htmlcolor_to_gdkcolor color = " << htmlcolor 

--- a/src/jdlib/misctime.cpp
+++ b/src/jdlib/misctime.cpp
@@ -97,7 +97,7 @@ time_t MISC::datetotime( const std::string& date )
 #else // _WIN32
     // (注意) LC_TIMEが"C"でないと環境によってはstrptime()が失敗する
     std::string lcl;
-    char *lcl_tmp = setlocale( LC_TIME, NULL );
+    char *lcl_tmp = setlocale( LC_TIME, nullptr );
     if( lcl_tmp ) lcl = lcl_tmp;
 #ifdef _DEBUG
     std::cout << "locale = " << lcl << std::endl;
@@ -106,7 +106,7 @@ time_t MISC::datetotime( const std::string& date )
     char *ret = strptime( date.c_str(), "%a, %d %b %Y %T %Z", &tm_out );
     if( ! lcl.empty() ) setlocale( LC_TIME, lcl.c_str() ); 
 
-    if( ret == NULL ) return 0;
+    if( ret == nullptr ) return 0;
 
 #ifdef USE_MKTIME
     time_t t_ret = mktime( &tm_out );
@@ -163,7 +163,7 @@ std::string MISC::timettostr( const time_t time_from, const int mode )
     }
     else if( mode == MISC::TIME_PASSED ){
 
-        const time_t tmp_t = time( NULL ) - time_from;
+        const time_t tmp_t = time( nullptr ) - time_from;
 
         if( tmp_t < 0 ) snprintf( str_ret, lng, "未来" );
         else if( tmp_t < 60 ) snprintf( str_ret, lng, "%d 秒前", (int) tmp_t );
@@ -219,7 +219,7 @@ void MISC::start_measurement( const int id )
         tv_measurement.push_back( tv );
     }
 
-    gettimeofday( &tv_measurement[ id ], NULL );
+    gettimeofday( &tv_measurement[ id ], nullptr );
 }
 
 int MISC::measurement( const int id )
@@ -227,7 +227,7 @@ int MISC::measurement( const int id )
     if( id >= (int)tv_measurement.size() ) return 0;
 
     struct timeval tv;
-    gettimeofday( &tv, NULL );
+    gettimeofday( &tv, nullptr );
 
     int ret = ( tv.tv_sec * 1000000 + tv.tv_usec ) - ( tv_measurement[ id ].tv_sec * 1000000 + tv_measurement[ id ].tv_usec );
     tv_measurement[ id ] = tv;

--- a/src/jdlib/misctrip.cpp
+++ b/src/jdlib/misctrip.cpp
@@ -149,7 +149,7 @@ std::string create_trip_newtype( const std::string& key )
                     // crypt (key は先頭8文字しか使われない)
                     const char *crypted = crypt( key_binary, salt );
 
-                    // 末尾から10文字(cryptの戻り値はNULLでなければ必ず13文字)
+                    // 末尾から10文字(cryptの戻り値はnullptrでなければ必ず13文字)
                     if( crypted ) trip = std::string( crypted + 3 );
                     else trip.clear();
                 }
@@ -225,7 +225,7 @@ std::string create_trip_conventional( const std::string& key )
 
     std::string trip;
 
-    // 末尾10(cryptの戻り値はNULLでなければ必ず13文字)
+    // 末尾10(cryptの戻り値はnullptrでなければ必ず13文字)
     if( crypted ) trip = std::string( crypted + 3 );
 
     return trip;

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1388,7 +1388,7 @@ int MISC::decode_spchar_number( const char* in_char, const int offset, const int
 
     int num = 0;
     if( offset == 2 ) num = atoi( str_num );
-    else num = strtol( str_num, NULL, 16 );
+    else num = strtol( str_num, nullptr, 16 );
 
     return sanitize_numeric_character_reference( num );
 }

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -152,7 +152,7 @@ namespace MISC
     // URL中のスキームを判別する
     // 戻り値 : スキームタイプ
     // length    : "http://"等の文字数
-    int is_url_scheme( const char* str_in, int* length = NULL );
+    int is_url_scheme( const char* str_in, int* length = nullptr );
     int is_url_scheme_impl( const char* str_in, int* length );
 
     // URLとして扱う文字かどうか判別する

--- a/src/jdlib/miscx.cpp
+++ b/src/jdlib/miscx.cpp
@@ -33,7 +33,7 @@ void MISC::WarpPointer( Glib::RefPtr< Gdk::Window > src, Glib::RefPtr< Gdk::Wind
 
     // スクリーン座標を取得してからカーソル位置を設定する
     hWnd = (HWND)GDK_WINDOW_HWND( Glib::unwrap( dest ) );
-    if( hWnd != NULL ){
+    if( hWnd != nullptr ){
         pos.x = x;
         pos.y = y;
         if( ClientToScreen( hWnd, &pos ) ){

--- a/src/jdlib/refptr_lock.h
+++ b/src/jdlib/refptr_lock.h
@@ -21,7 +21,7 @@ namespace JDLIB
         void clear(){
             if( m_p ){
                 m_p->unlock();
-                m_p = NULL;
+                m_p = nullptr;
             }
         }
 
@@ -36,19 +36,19 @@ namespace JDLIB
         const T* operator -> () const noexcept { return m_p; }
         bool operator == ( const T *p ) const { return( m_p == p ); }
         bool operator != ( const T *p ) const { return( m_p != p ); }
-        bool operator ! () const { return ( m_p == NULL ); }
-        operator bool () const { return ( m_p != NULL ); }
+        bool operator ! () const { return ( m_p == nullptr ); }
+        operator bool () const { return ( m_p != nullptr ); }
     
         RefPtr_Lock< T >& operator = ( const RefPtr_Lock< T >& a ){ set( a.m_p ); return *this; }
         RefPtr_Lock< T >& operator = ( RefPtr_Lock< T >& a ){ set( a.m_p ); return *this; }
         RefPtr_Lock< T >& operator = ( const T *p ){ set( p ); return *this; }    
         RefPtr_Lock< T >& operator = ( T *p ){ set( p ); return *this; }
     
-        RefPtr_Lock() : m_p (0){}
-        RefPtr_Lock( const RefPtr_Lock< T >& a ): m_p (0){ set( a.m_p ); }
-        RefPtr_Lock( RefPtr_Lock< T >& a ) : m_p (0){ set( a.m_p ); }
-        RefPtr_Lock( T *p ) : m_p (0){ set( p ); }
-        RefPtr_Lock( const T *p ) : m_p (0){ set( p ); }
+        RefPtr_Lock() : m_p (nullptr){}
+        RefPtr_Lock( const RefPtr_Lock< T >& a ): m_p (nullptr){ set( a.m_p ); }
+        RefPtr_Lock( RefPtr_Lock< T >& a ) : m_p (nullptr){ set( a.m_p ); }
+        RefPtr_Lock( T *p ) : m_p (nullptr){ set( p ); }
+        RefPtr_Lock( const T *p ) : m_p (nullptr){ set( p ); }
     
         virtual ~RefPtr_Lock(){ clear();}
     };

--- a/src/jdlib/ssl.cpp
+++ b/src/jdlib/ssl.cpp
@@ -34,8 +34,8 @@ void JDLIB::deinit_ssl()
 
 
 JDSSL::JDSSL()
-    : m_session( 0 ),
-      m_cred( 0 )
+    : m_session( nullptr ),
+      m_cred( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "JDSSL::JDSSL(gnutls)\n";
@@ -94,7 +94,7 @@ bool JDSSL::connect( const int soc, const char *host )
 
 #if GNUTLS_VERSION_NUMBER >= 0x020108
     // gnutls >= 2.1.7 (unreleased)
-    gnutls_priority_set_direct( m_session, "NORMAL:%COMPAT", NULL );
+    gnutls_priority_set_direct( m_session, "NORMAL:%COMPAT", nullptr );
 #else // GNUTLS_VERSION_NUMBER >= 0x020108
     static const int priority_prot[] = { GNUTLS_SSL3, 0 };
     // DEPRECATED (gnutls >= 2.1.4 gnutls =< 2.1.6)
@@ -158,11 +158,11 @@ bool JDSSL::close()
     if( m_session ){
         gnutls_bye( m_session, GNUTLS_SHUT_RDWR );
         gnutls_deinit( m_session );
-        m_session = 0;
+        m_session = nullptr;
     }
     if( m_cred ){
         gnutls_certificate_free_credentials( m_cred );
-        m_cred = 0;
+        m_cred = nullptr;
     }
 
     return true;
@@ -229,8 +229,8 @@ void JDLIB::deinit_ssl()
 
 
 JDSSL::JDSSL()
-    : m_ctx( NULL ),
-      m_ssl( NULL )
+    : m_ctx( nullptr ),
+      m_ssl( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "JDSSL::JDSSL(openssl)\n";
@@ -299,11 +299,11 @@ bool JDSSL::close()
     if( m_ssl ){
         SSL_shutdown( m_ssl );
         SSL_free( m_ssl );
-        m_ssl = NULL;
+        m_ssl = nullptr;
     }
     if( m_ctx ){
         SSL_CTX_free( m_ctx );
-        m_ctx = NULL;
+        m_ctx = nullptr;
     }
 
     return true;

--- a/src/jdlib/timeout.cpp
+++ b/src/jdlib/timeout.cpp
@@ -39,7 +39,7 @@ Timeout::~Timeout()
 #ifdef _WIN32
     if( m_identifer != 0 ){
         std::lock_guard< std::mutex > lock( s_lock );
-        KillTimer( NULL, m_identifer );
+        KillTimer( nullptr, m_identifer );
         s_timeouts.erase( m_identifer );
         m_identifer = 0;
     }
@@ -55,7 +55,7 @@ Timeout* Timeout::connect( const sigc::slot< bool > slot_timeout, unsigned int i
 #ifdef _WIN32
     std::lock_guard< std::mutex > lock( s_lock );
     // use global windows timer
-    UINT_PTR ident = SetTimer( NULL, 0, interval, slot_timeout_win32 );
+    UINT_PTR ident = SetTimer( nullptr, 0, interval, slot_timeout_win32 );
     if( ident != 0 ) {
         // register object into static domain
         s_timeouts.insert( std::map< UINT_PTR, Timeout* >::value_type( ident, timeout ));
@@ -83,7 +83,7 @@ void Timeout::slot_timeout_callback()
 VOID CALLBACK Timeout::slot_timeout_win32( HWND hwnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime )
 {
     Timeout* timeout = s_timeouts[ idEvent ];
-    if( timeout != NULL ){
+    if( timeout != nullptr ){
         timeout->slot_timeout_callback();
     }
 }

--- a/src/linkfiltermanager.cpp
+++ b/src/linkfiltermanager.cpp
@@ -17,7 +17,7 @@
 
 #define ROOT_NODE_NAME_LINKFILTER "linkfilterlist"
 
-CORE::Linkfilter_Manager* instance_linkfilter_manager = NULL;
+CORE::Linkfilter_Manager* instance_linkfilter_manager = nullptr;
 
 CORE::Linkfilter_Manager* CORE::get_linkfilter_manager()
 {
@@ -31,7 +31,7 @@ CORE::Linkfilter_Manager* CORE::get_linkfilter_manager()
 void CORE::delete_linkfilter_manager()
 {
     if( instance_linkfilter_manager ) delete instance_linkfilter_manager;
-    instance_linkfilter_manager = NULL;
+    instance_linkfilter_manager = nullptr;
 }
 
 ///////////////////////////////////////////////

--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -324,7 +324,7 @@ void LinkFilterPref::slot_delete()
     Gtk::TreeModel::iterator row = get_selected_row();
     if( ! row ) return;
 
-    SKELETON::MsgDiag mdiag( NULL, "削除しますか？", false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
+    SKELETON::MsgDiag mdiag( nullptr, "削除しますか？", false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
     if( mdiag.run() != Gtk::RESPONSE_YES ) return;
 
     Gtk::TreePath path_next( row );

--- a/src/login2ch.cpp
+++ b/src/login2ch.cpp
@@ -23,7 +23,7 @@ enum
     SIZE_OF_RAWDATA = 64 * 1024
 };
 
-CORE::Login2ch* instance_login2ch = NULL;
+CORE::Login2ch* instance_login2ch = nullptr;
 
 CORE::Login2ch* CORE::get_login2ch()
 {
@@ -40,7 +40,7 @@ void CORE::delete_login2ch()
         instance_login2ch->terminate_load();
         delete instance_login2ch;
     }
-    instance_login2ch = NULL;
+    instance_login2ch = nullptr;
 }
 
 
@@ -49,7 +49,7 @@ using namespace CORE;
 
 Login2ch::Login2ch()
     : SKELETON::Login( URL_LOGIN2CH )
-    , m_rawdata( 0 ), m_lng_rawdata( 0 )
+    , m_rawdata( nullptr ), m_lng_rawdata( 0 )
 {
 #ifdef _DEBUG
     std::cout << "Login2ch::Login2ch\n";
@@ -196,21 +196,21 @@ void Login2ch::receive_finish()
 
     // エラー表示
     if( ! SESSION::is_online() ){
-        SKELETON::MsgDiag mdiag( NULL, "オフラインです" );
+        SKELETON::MsgDiag mdiag( nullptr, "オフラインです" );
         mdiag.run();
     }
     else if( get_username().empty() || get_passwd().empty() ){
-        SKELETON::MsgDiag mdiag( NULL, "IDまたはパスワードが設定されていません\n\n設定→ネットワーク→パスワードで設定してください" );
+        SKELETON::MsgDiag mdiag( nullptr, "IDまたはパスワードが設定されていません\n\n設定→ネットワーク→パスワードで設定してください" );
         mdiag.run();
     }
     else if( CONFIG::get_url_login2ch().empty() ){
-        SKELETON::MsgDiag mdiag( NULL, "2chの認証サーバのURLが指定されていません。" );
+        SKELETON::MsgDiag mdiag( nullptr, "2chの認証サーバのURLが指定されていません。" );
         mdiag.run();
     }
     else if( show_err ){
         std::string str_err = "ログインに失敗しました。\n";
         str_err += get_str_code();
-        SKELETON::MsgDiag mdiag( NULL, str_err );
+        SKELETON::MsgDiag mdiag( nullptr, str_err );
         mdiag.run();  
     }
 

--- a/src/loginbe.cpp
+++ b/src/loginbe.cpp
@@ -22,7 +22,7 @@ enum
     SIZE_OF_RAWDATA = 64 * 1024
 };
 
-CORE::LoginBe* instance_loginbe = NULL;
+CORE::LoginBe* instance_loginbe = nullptr;
 
 CORE::LoginBe* CORE::get_loginbe()
 {
@@ -39,7 +39,7 @@ void CORE::delete_loginbe()
         instance_loginbe->terminate_load();
         delete instance_loginbe;
     }
-    instance_loginbe = NULL;
+    instance_loginbe = nullptr;
 }
 
 
@@ -48,7 +48,7 @@ using namespace CORE;
 
 LoginBe::LoginBe()
     : SKELETON::Login( URL_LOGINBE ),
-      m_rawdata( NULL ),
+      m_rawdata( nullptr ),
       m_lng_rawdata( 0 )
 {
 #ifdef _DEBUG
@@ -97,19 +97,19 @@ void LoginBe::start_login()
     set_str_code( "" );
 
     if( ! SESSION::is_online() ){
-        SKELETON::MsgDiag mdiag( NULL, "オフラインです" );
+        SKELETON::MsgDiag mdiag( nullptr, "オフラインです" );
         mdiag.run();
         return;
     }
 
     if( get_username().empty() || get_passwd().empty() ){
-        SKELETON::MsgDiag mdiag( NULL, "メールアドレスまたはパスワードが設定されていません\n\n設定→ネットワーク→パスワードで設定してください" );
+        SKELETON::MsgDiag mdiag( nullptr, "メールアドレスまたはパスワードが設定されていません\n\n設定→ネットワーク→パスワードで設定してください" );
         mdiag.run();
         return;
     }
 
     if( CONFIG::get_url_loginbe().empty() ){
-        SKELETON::MsgDiag mdiag( NULL, "BEの認証サーバのアドレスが指定されていません。" );
+        SKELETON::MsgDiag mdiag( nullptr, "BEの認証サーバのアドレスが指定されていません。" );
         mdiag.run();
         return;
     }
@@ -208,7 +208,7 @@ void LoginBe::receive_finish()
 
         std::string str_err = "ログインに失敗しました。\n\nBEの認証サーバのアドレスやメールアドレス、パスワード等を確認して下さい。\n\n";
         str_err += get_str_code();
-        SKELETON::MsgDiag mdiag( NULL, str_err );
+        SKELETON::MsgDiag mdiag( nullptr, str_err );
         mdiag.run();  
     }
 }

--- a/src/loginp2.cpp
+++ b/src/loginp2.cpp
@@ -24,7 +24,7 @@ enum
     SIZE_OF_RAWDATA = 64 * 1024
 };
 
-CORE::Loginp2* instance_loginp2 = NULL;
+CORE::Loginp2* instance_loginp2 = nullptr;
 
 CORE::Loginp2* CORE::get_loginp2()
 {
@@ -41,7 +41,7 @@ void CORE::delete_loginp2()
         instance_loginp2->terminate_load();
         delete instance_loginp2;
     }
-    instance_loginp2 = NULL;
+    instance_loginp2 = nullptr;
 }
 
 
@@ -50,7 +50,7 @@ using namespace CORE;
 
 Loginp2::Loginp2()
     : SKELETON::Login( URL_LOGINP2 )
-    , m_rawdata( 0 ), m_lng_rawdata( 0 )
+    , m_rawdata( nullptr ), m_lng_rawdata( 0 )
 {
 #ifdef _DEBUG
     std::cout << "Loginp2::Loginp2\n";
@@ -103,19 +103,19 @@ void Loginp2::start_login()
     set_str_code( "" );
 
     if( ! SESSION::is_online() ){
-        SKELETON::MsgDiag mdiag( NULL, "オフラインです" );
+        SKELETON::MsgDiag mdiag( nullptr, "オフラインです" );
         mdiag.run();
         return;
     }
 
     if( get_username().empty() || get_passwd().empty() ){
-        SKELETON::MsgDiag mdiag( NULL, "IDまたはパスワードが設定されていません\n\n設定→ネットワーク→パスワードで設定してください" );
+        SKELETON::MsgDiag mdiag( nullptr, "IDまたはパスワードが設定されていません\n\n設定→ネットワーク→パスワードで設定してください" );
         mdiag.run();
         return;
     }
 
     if( CONFIG::get_url_loginp2().empty() ){
-        SKELETON::MsgDiag mdiag( NULL, "p2の認証サーバのアドレスが指定されていません。" );
+        SKELETON::MsgDiag mdiag( nullptr, "p2の認証サーバのアドレスが指定されていません。" );
         mdiag.run();
         return;
     }
@@ -208,7 +208,7 @@ void Loginp2::receive_finish()
         }
         else{
 
-            SKELETON::MsgDiag mdiag( NULL, "csrfid の取得に失敗しました。p2のサーバが落ちていないか確認して下さい。" );
+            SKELETON::MsgDiag mdiag( nullptr, "csrfid の取得に失敗しました。p2のサーバが落ちていないか確認して下さい。" );
             mdiag.run();
         }
 
@@ -238,7 +238,7 @@ void Loginp2::receive_finish()
                 if( CONFIG::get_url_loginp2() != regex.str( 1 ) ){
                     std::string str_err = "p2のリダイレクト要求がされました。ログイン先を変更してよろしいですか？\n\n";
                     str_err += regex.str( 1 );
-                    SKELETON::MsgDiag mdiag( NULL, str_err, false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
+                    SKELETON::MsgDiag mdiag( nullptr, str_err, false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
                     if( mdiag.run() != Gtk::RESPONSE_YES ) {
                         return;
                     }
@@ -341,7 +341,7 @@ void Loginp2::receive_finish()
 
             std::string str_err = "ログインに失敗しました。\n\np2の認証サーバのアドレスやID、パスワード等を確認して下さい。\n\n";
             str_err += get_str_code();
-            SKELETON::MsgDiag mdiag( NULL, str_err );
+            SKELETON::MsgDiag mdiag( nullptr, str_err );
             mdiag.run();  
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,7 @@ enum
     MAX_SAFE_ARGV = 1024 // 各引数の文字列の制限値
 };
 
-JDWinMain* Win_Main = NULL;
+JDWinMain* Win_Main = nullptr;
 
 
 // バックアップ復元
@@ -195,7 +195,7 @@ gboolean ice_process_message( GIOChannel *channel,
 {
     if( ! xsmpdata->ice_connect ) return FALSE;
 
-    IceProcessMessagesStatus status = IceProcessMessages( xsmpdata->ice_connect, NULL, NULL );
+    IceProcessMessagesStatus status = IceProcessMessages( xsmpdata->ice_connect, nullptr, nullptr );
 
 #ifdef _DEBUG
     std::cout << "ice_process_message status = " << status << std::endl;
@@ -208,7 +208,7 @@ gboolean ice_process_message( GIOChannel *channel,
 #endif
             
         IceCloseConnection( xsmpdata->ice_connect );
-        xsmpdata->ice_connect = NULL;
+        xsmpdata->ice_connect = nullptr;
         return FALSE;
     }
 
@@ -249,7 +249,7 @@ void ice_watch_proc( IceConn ice_connect,
                                                                 ( GIOCondition )( G_IO_IN | G_IO_PRI | G_IO_ERR | G_IO_HUP ),
                                                                 ( GIOFunc ) ice_process_message,
                                                                 xsmpdata,
-                                                                NULL );
+                                                                nullptr );
             g_io_channel_unref( channel );
         }
     }
@@ -261,7 +261,7 @@ void ice_watch_proc( IceConn ice_connect,
 void xsmp_session_init( XSMPDATA* xsmpdata )
 {
     if( xsmpdata->smc_connect ) return;
-    if( g_getenv("SESSION_MANAGER") == NULL ) return;
+    if( g_getenv("SESSION_MANAGER") == nullptr ) return;
 
 #ifdef _DEBUG
     std::cout << "SESSION_MANAGER = " << g_getenv("SESSION_MANAGER") << std::endl;
@@ -276,13 +276,13 @@ void xsmp_session_init( XSMPDATA* xsmpdata )
     smc_callbacks.save_complete.callback       = xsmp_session_save_complete;
     smc_callbacks.shutdown_cancelled.callback  = xsmp_session_shutdown_cancelled;
 
-    gchar *id = NULL;
+    gchar *id = nullptr;
     gchar errstr[ 1024 ];
     xsmpdata->smc_connect
-    = SmcOpenConnection( NULL, NULL, SmProtoMajor, SmProtoMinor,
+    = SmcOpenConnection( nullptr, nullptr, SmProtoMajor, SmProtoMinor,
                          SmcSaveYourselfProcMask | SmcDieProcMask | SmcSaveCompleteProcMask | SmcShutdownCancelledProcMask,
                          &smc_callbacks,
-                         NULL,
+                         nullptr,
                          &id,
                          1024, errstr );
     if( ! xsmpdata->smc_connect ){
@@ -295,8 +295,8 @@ void xsmp_session_init( XSMPDATA* xsmpdata )
 // XSMP終了関数
 void xsmp_session_end( XSMPDATA* xsmpdata )
 {
-    if( xsmpdata->smc_connect ) SmcCloseConnection( xsmpdata->smc_connect, 0, NULL );
-    xsmpdata->smc_connect = NULL;
+    if( xsmpdata->smc_connect ) SmcCloseConnection( xsmpdata->smc_connect, 0, nullptr );
+    xsmpdata->smc_connect = nullptr;
 }
 
 #endif
@@ -360,15 +360,15 @@ int main( int argc, char **argv )
     // --help, --tab=<url>, --multi, --norestore, --logfile --version
     const struct option options[] =
     {
-        { "help", 0, 0, 'h' },
-        //{ "tab", 1, 0, 't' },
-        { "multi", 0, 0, 'm' },
-        { "norestore", 0, 0, 'n' },
-        { "skip-setup", 0, 0, 's' },
-        { "logfile", 0, 0, 'l' },
-        { "geometry", required_argument, NULL, 'g' },
-        { "version", 0, 0, 'V' },
-        { 0, 0, 0, 0 }
+        { "help", 0, nullptr, 'h' },
+        //{ "tab", 1, nullptr, 't' },
+        { "multi", 0, nullptr, 'm' },
+        { "norestore", 0, nullptr, 'n' },
+        { "skip-setup", 0, nullptr, 's' },
+        { "logfile", 0, nullptr, 'l' },
+        { "geometry", required_argument, nullptr, 'g' },
+        { "version", 0, nullptr, 'V' },
+        { nullptr, 0, nullptr, 0 }
     };
 
     std::string url;
@@ -391,7 +391,7 @@ int main( int argc, char **argv )
 
     // -h, -t <url>, -m, -n, -s, -l, -g WxH+X+Y, -V
     int opt = 0;
-    while( ( opt = getopt_long( argc, argv, "ht:mnslg:V", options, NULL ) ) != -1 )
+    while( ( opt = getopt_long( argc, argv, "ht:mnslg:V", options, nullptr ) ) != -1 )
     {
         switch( opt )
         {
@@ -479,9 +479,9 @@ int main( int argc, char **argv )
     sigact.sa_flags = SA_RESETHAND;
 
     // シグナルハンドラ設定
-    if( sigaction( SIGHUP, &sigact, NULL ) != 0
-        || sigaction( SIGINT, &sigact, NULL ) != 0
-        || sigaction( SIGQUIT, &sigact, NULL ) != 0 ){
+    if( sigaction( SIGHUP, &sigact, nullptr ) != 0
+        || sigaction( SIGINT, &sigact, nullptr ) != 0
+        || sigaction( SIGQUIT, &sigact, nullptr ) != 0 ){
         fprintf( stderr, "sigaction failed\n" );
         exit( 1 );
     }
@@ -528,7 +528,7 @@ int main( int argc, char **argv )
     // gnomeセッションマネージャとつないでログアウト時に"save_yourself"シグナルをもらう
     gnome_init( "jdim", "1.0", argc, argv );
     GnomeClient *client_gnome = gnome_master_client();
-    if( client_gnome ) gtk_signal_connect( GTK_OBJECT( client_gnome ), "save_yourself", GTK_SIGNAL_FUNC( save_yourself_gnome ), NULL );
+    if( client_gnome ) gtk_signal_connect( GTK_OBJECT( client_gnome ), "save_yourself", GTK_SIGNAL_FUNC( save_yourself_gnome ), nullptr );
     else MISC::ERRMSG( "failed to connect to gnome session manager" );
 #endif
 
@@ -561,9 +561,9 @@ int main( int argc, char **argv )
         FILE *tmp; // warning 消し
         const char *logfile = to_locale_cstr( CACHE::path_msglog() );
         tmp = freopen( logfile, "ab", stdout );
-        setbuf( tmp, NULL );
+        setbuf( tmp, nullptr );
         tmp = freopen( logfile, "ab", stderr );
-        setbuf( tmp, NULL );
+        setbuf( tmp, nullptr );
     }
 
     /*--- IOMonitor -------------------------------------------------*/
@@ -631,7 +631,7 @@ int main( int argc, char **argv )
         m.run( *Win_Main );
 
         delete Win_Main;
-        Win_Main = NULL;
+        Win_Main = nullptr;
     }
 
 #ifdef USE_XSMP

--- a/src/maintoolbar.cpp
+++ b/src/maintoolbar.cpp
@@ -19,7 +19,7 @@ using namespace CORE;
 
 
 MainToolBar::MainToolBar() :
-    SKELETON::ToolBar( NULL ),
+    SKELETON::ToolBar( nullptr ),
     m_button_go( ICON::GO ),
 
       m_button_bbslist( ICON::BBSLISTVIEW ),

--- a/src/menuslots.cpp
+++ b/src/menuslots.cpp
@@ -66,7 +66,7 @@ using FontSelectionDialog = Gtk::FontSelectionDialog;
 //
 void Core::slot_openurl()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_OPENURL, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_OPENURL, "" );
     pref->run();
     delete pref;
 }
@@ -159,7 +159,7 @@ void Core::slot_toggle_loginp2()
 void Core::slot_reload_list()
 {
     if( ! SESSION::is_online() ){
-        SKELETON::MsgDiag mdiag( NULL, "オフラインです" );
+        SKELETON::MsgDiag mdiag( nullptr, "オフラインです" );
         mdiag.run();
         return;
     }
@@ -501,7 +501,7 @@ void Core::slot_toggle_show_ssspicon()
 //
 void Core::slot_setup_boarditem_column()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_BOARDITEM_COLUM, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BOARDITEM_COLUM, "" );
     pref->run();
     delete pref;
 }
@@ -512,7 +512,7 @@ void Core::slot_setup_boarditem_column()
 //
 void Core::slot_setup_mainitem()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_MAINITEM, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_MAINITEM, "" );
     pref->run();
     delete pref;
 }
@@ -523,7 +523,7 @@ void Core::slot_setup_mainitem()
 //
 void Core::slot_setup_sidebaritem()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_SIDEBARITEM, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_SIDEBARITEM, "" );
     pref->run();
     delete pref;
 }
@@ -534,7 +534,7 @@ void Core::slot_setup_sidebaritem()
 //
 void Core::slot_setup_boarditem()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_BOARDITEM, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BOARDITEM, "" );
     pref->run();
     delete pref;
 }
@@ -545,7 +545,7 @@ void Core::slot_setup_boarditem()
 //
 void Core::slot_setup_articleitem()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_ARTICLEITEM, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_ARTICLEITEM, "" );
     pref->run();
     delete pref;
 }
@@ -556,7 +556,7 @@ void Core::slot_setup_articleitem()
 //
 void Core::slot_setup_searchitem()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_SEARCHITEM, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_SEARCHITEM, "" );
     pref->run();
     delete pref;
 }
@@ -567,7 +567,7 @@ void Core::slot_setup_searchitem()
 //
 void Core::slot_setup_msgitem()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_MSGITEM, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_MSGITEM, "" );
     pref->run();
     delete pref;
 }
@@ -579,7 +579,7 @@ void Core::slot_setup_msgitem()
 //
 void Core::slot_setup_boarditem_menu()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_BOARDITEM_MENU, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BOARDITEM_MENU, "" );
     pref->run();
     delete pref;
 }
@@ -589,7 +589,7 @@ void Core::slot_setup_boarditem_menu()
 //
 void Core::slot_setup_articleitem_menu()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_ARTICLEITEM_MENU, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_ARTICLEITEM_MENU, "" );
     pref->run();
     delete pref;
 }
@@ -650,7 +650,7 @@ void Core::slot_toggle_fold_message()
 {
     CONFIG::set_fold_message( ! CONFIG::get_fold_message() );
 
-    SKELETON::MsgDiag mdiag( NULL, "次に書き込みビューを開いた時から有効になります" );
+    SKELETON::MsgDiag mdiag( nullptr, "次に書き込みビューを開いた時から有効になります" );
     mdiag.run();
 }
 
@@ -692,7 +692,7 @@ void Core::slot_toggle_use_mosaic()
 {
     CONFIG::set_use_mosaic( ! CONFIG::get_use_mosaic() );
 
-    SKELETON::MsgDiag mdiag( NULL, "次に開いた画像から有効になります" );
+    SKELETON::MsgDiag mdiag( nullptr, "次に開いた画像から有効になります" );
     mdiag.run();
 }
 
@@ -760,7 +760,7 @@ void Core::slot_toggle_emacsmode()
 //
 void Core::slot_setup_mouse()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_MOUSE, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_MOUSE, "" );
     pref->run();
     delete pref;
 }
@@ -771,7 +771,7 @@ void Core::slot_setup_mouse()
 //
 void Core::slot_setup_key()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_KEY, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_KEY, "" );
     pref->run();
     delete pref;
 }
@@ -782,7 +782,7 @@ void Core::slot_setup_key()
 //
 void Core::slot_setup_button()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_BUTTON, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BUTTON, "" );
     pref->run();
     delete pref;
 }
@@ -918,7 +918,7 @@ void Core::slot_changecolor_back_tree()
 //
 void Core::slot_setup_fontcolor()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_FONTCOLOR, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_FONTCOLOR, "" );
     pref->run();
     delete pref;
 }
@@ -929,7 +929,7 @@ void Core::slot_setup_fontcolor()
 //
 void Core::slot_setup_proxy()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_PROXY, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_PROXY, "" );
     pref->run();
     delete pref;
 }
@@ -940,7 +940,7 @@ void Core::slot_setup_proxy()
 //
 void Core::slot_setup_browser()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_BROWSER, URL_BROWSER );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BROWSER, URL_BROWSER );
     pref->run();
     delete pref;
 }
@@ -951,7 +951,7 @@ void Core::slot_setup_browser()
 //
 void Core::slot_setup_passwd()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_PASSWD, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_PASSWD, "" );
     pref->run();
     delete pref;
 }
@@ -971,7 +971,7 @@ void Core::slot_toggle_ipv6()
 //
 void Core::slot_setup_abone()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_GLOBALABONE, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_GLOBALABONE, "" );
     pref->run();
     delete pref;
 }
@@ -982,7 +982,7 @@ void Core::slot_setup_abone()
 //
 void Core::slot_setup_abone_thread()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_GLOBALABONETHREAD, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_GLOBALABONETHREAD, "" );
     pref->run();
     delete pref;
 }
@@ -1025,7 +1025,7 @@ void Core::slot_toggle_abone_icase_wchar()
 // 実況設定
 void Core::slot_setup_live()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_LIVE, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_LIVE, "" );
     pref->run();
     delete pref;
 }
@@ -1036,7 +1036,7 @@ void Core::slot_setup_live()
 //
 void Core::slot_usrcmd_pref()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_USRCMD, URL_USRCMD );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_USRCMD, URL_USRCMD );
     pref->run();
     delete pref;
 }
@@ -1047,7 +1047,7 @@ void Core::slot_usrcmd_pref()
 //
 void Core::slot_filter_pref()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_LINKFILTER, URL_LINKFILTER );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_LINKFILTER, URL_LINKFILTER );
     pref->run();
     delete pref;
 }
@@ -1058,7 +1058,7 @@ void Core::slot_filter_pref()
 //
 void Core::slot_aboutconfig()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_ABOUTCONFIG, URL_ABOUTCONFIG );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_ABOUTCONFIG, URL_ABOUTCONFIG );
     pref->run();
     delete pref;
 }
@@ -1068,7 +1068,7 @@ void Core::slot_aboutconfig()
 // プライバシー情報のクリア
 void Core::slot_clear_privacy()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_PRIVACY, URL_PRIVACY );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_PRIVACY, URL_PRIVACY );
     pref->run();
     delete pref;
 }
@@ -1079,7 +1079,7 @@ void Core::slot_clear_privacy()
 //
 void Core::slot_clear_post_log()
 {
-    SKELETON::MsgDiag mdiag( NULL, "書き込みログを削除しますか？",
+    SKELETON::MsgDiag mdiag( nullptr, "書き込みログを削除しますか？",
                              false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
     if( mdiag.run() != Gtk::RESPONSE_YES ) return;
 
@@ -1095,7 +1095,7 @@ void Core::slot_clear_post_log()
 //
 void Core::slot_clear_post_history()
 {
-    SKELETON::MsgDiag mdiag( NULL, "全スレの書き込み履歴を削除します。\n\nある板、または特定のスレの履歴を削除するには板またはスレのプロパティから行って下さい。\n\nまた全スレの書き込み履歴の削除には時間がかかります。\n\n全スレの書き込み履歴の削除を実行しますか？",
+    SKELETON::MsgDiag mdiag( nullptr, "全スレの書き込み履歴を削除します。\n\nある板、または特定のスレの履歴を削除するには板またはスレのプロパティから行って下さい。\n\nまた全スレの書き込み履歴の削除には時間がかかります。\n\n全スレの書き込み履歴の削除を実行しますか？",
                              false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
     if( mdiag.run() != Gtk::RESPONSE_YES ) return;
 

--- a/src/message/logmanager.cpp
+++ b/src/message/logmanager.cpp
@@ -29,7 +29,7 @@ enum
 };
 
 
-MESSAGE::Log_Manager* instance_log_manager = NULL;
+MESSAGE::Log_Manager* instance_log_manager = nullptr;
 
 MESSAGE::Log_Manager* MESSAGE::get_log_manager()
 {
@@ -43,7 +43,7 @@ MESSAGE::Log_Manager* MESSAGE::get_log_manager()
 void MESSAGE::delete_log_manager()
 {
     if( instance_log_manager ) delete instance_log_manager;
-    instance_log_manager = NULL;
+    instance_log_manager = nullptr;
 }
 
 

--- a/src/message/messageadmin.cpp
+++ b/src/message/messageadmin.cpp
@@ -21,7 +21,7 @@
 #include "global.h"
 #include "session.h"
 
-MESSAGE::MessageAdmin* instance_messageadmin = NULL;
+MESSAGE::MessageAdmin* instance_messageadmin = nullptr;
 
 MESSAGE::MessageAdmin* MESSAGE::get_admin()
 {
@@ -33,14 +33,14 @@ MESSAGE::MessageAdmin* MESSAGE::get_admin()
 void MESSAGE::delete_admin()
 {
     if( instance_messageadmin ) delete instance_messageadmin;
-    instance_messageadmin = NULL;
+    instance_messageadmin = nullptr;
 }
 
 using namespace MESSAGE;
 
 
 MessageAdmin::MessageAdmin( const std::string& url )
-    : SKELETON::Admin( url ), m_toolbar( NULL ), m_toolbar_preview( NULL ), m_text_message( NULL )
+    : SKELETON::Admin( url ), m_toolbar( nullptr ), m_toolbar_preview( nullptr ), m_text_message( nullptr )
 {
     get_notebook()->set_show_tabs( false );
 }

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -63,11 +63,11 @@ enum
 
 MessageViewBase::MessageViewBase( const std::string& url )
     : SKELETON::View( url ),
-      m_post( 0 ),
-      m_preview( 0 ),
+      m_post( nullptr ),
+      m_preview( nullptr ),
       m_entry_name( CORE::COMP_NAME ),
       m_entry_mail( CORE::COMP_MAIL ),
-      m_text_message( NULL ),
+      m_text_message( nullptr ),
       m_enable_focus( true ),
       m_lng_str_enc( 0 ),
       m_counter( 0 ),
@@ -110,16 +110,16 @@ MessageViewBase::~MessageViewBase()
     CORE::get_completion_manager()->set_query( CORE::COMP_MAIL, mail );
 
     if( m_preview ) delete m_preview;
-    m_preview = NULL;
+    m_preview = nullptr;
 
     if( m_post ){
         m_post->terminate_load();
         delete m_post;
     }
-    m_post = NULL;
+    m_post = nullptr;
 
     if( m_iconv ) delete m_iconv;
-    m_iconv = NULL;
+    m_iconv = nullptr;
 
     SESSION::set_close_mes( ! is_locked() );
 }
@@ -161,7 +161,7 @@ void MessageViewBase::clock_in()
         m_counter = 0;
 
         // 書き込みから時間があまり経っていなければステータス表示を更新
-        if( time( NULL ) - DBTREE::article_write_time( get_url() ) < 60 * 60 ) show_status();
+        if( time( nullptr ) - DBTREE::article_write_time( get_url() ) < 60 * 60 ) show_status();
 
         // 書き込み規制経過時刻表示
         time_t left = DBTREE::board_write_leftsec( get_url() );

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -36,12 +36,12 @@ Post::Post( Gtk::Widget* parent, const std::string& url, const std::string& msg,
       m_parent( parent ),
       m_url( url ),
       m_msg( msg ),
-      m_rawdata( 0 ),
+      m_rawdata( nullptr ),
       m_lng_rawdata( 0 ),
       m_count( 0 ),
       m_subbbs( 0 ),
       m_new_article( new_article ),
-      m_writingdiag( 0 )
+      m_writingdiag( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "Post::Post " << m_url << std::endl;
@@ -61,7 +61,7 @@ Post::~Post()
     clear();
 
     if( m_writingdiag ) delete m_writingdiag;
-    m_writingdiag = NULL;
+    m_writingdiag = nullptr;
 }
 
 
@@ -72,7 +72,7 @@ void Post::clear()
 #endif
 
     if( m_rawdata ) free( m_rawdata );
-    m_rawdata = NULL;
+    m_rawdata = nullptr;
 
     if( m_writingdiag ) m_writingdiag->hide();
 }
@@ -89,7 +89,7 @@ void Post::emit_sigfin()
     clear();
 
     if( m_writingdiag ) delete m_writingdiag;
-    m_writingdiag = NULL;
+    m_writingdiag = nullptr;
 }
 
 

--- a/src/message/toolbar.cpp
+++ b/src/message/toolbar.cpp
@@ -24,7 +24,7 @@ using namespace MESSAGE;
 MessageToolBarBase::MessageToolBarBase() :
     SKELETON::ToolBar( MESSAGE::get_admin() ),
     m_enable_slot( true ),
-    m_button_preview( NULL )
+    m_button_preview( nullptr )
 {}
 
 
@@ -74,11 +74,11 @@ void MessageToolBarBase::set_active_previewbutton( const bool active )
 
 MessageToolBar::MessageToolBar() :
     MessageToolBarBase(),
-    m_button_insert_draft( NULL ),
-    m_button_undo( NULL ),
+    m_button_insert_draft( nullptr ),
+    m_button_undo( nullptr ),
     m_show_entry_new_subject( false ),
-    m_tool_new_subject( NULL ),
-    m_entry_new_subject( NULL )
+    m_tool_new_subject( nullptr ),
+    m_entry_new_subject( nullptr )
 {
     pack_buttons();
 }

--- a/src/openurldiag.cpp
+++ b/src/openurldiag.cpp
@@ -9,7 +9,7 @@
 using namespace CORE;
 
 OpenURLDialog::OpenURLDialog( const std::string& url )
-    : SKELETON::PrefDiag( NULL, url, true, false, true ),
+    : SKELETON::PrefDiag( nullptr, url, true, false, true ),
       m_label_url( true, "URL ：" )
 {
     m_label_url.set_text( url );

--- a/src/prefdiagfactory.cpp
+++ b/src/prefdiagfactory.cpp
@@ -124,6 +124,6 @@ SKELETON::PrefDiag* CORE::PrefDiagFactory( Gtk::Window* parent, const int type, 
             return new CORE::OpenURLDialog( url );
 
         default:
-            return NULL;
+            return nullptr;
     }
 }

--- a/src/searchmanager.cpp
+++ b/src/searchmanager.cpp
@@ -15,7 +15,7 @@
 
 #include "config/globalconf.h"
 
-CORE::Search_Manager* instance_search_manager = NULL;
+CORE::Search_Manager* instance_search_manager = nullptr;
 
 CORE::Search_Manager* CORE::get_search_manager()
 {
@@ -29,7 +29,7 @@ CORE::Search_Manager* CORE::get_search_manager()
 void CORE::delete_search_manager()
 {
     if( instance_search_manager ) delete instance_search_manager;
-    instance_search_manager = NULL;
+    instance_search_manager = nullptr;
 }
 
 ///////////////////////////////////////////////
@@ -38,7 +38,7 @@ using namespace CORE;
 
 Search_Manager::Search_Manager()
     : m_searching( false ),
-      m_searchloader( NULL )
+      m_searchloader( nullptr )
 {}
 
 
@@ -110,7 +110,7 @@ void* Search_Manager::launcher( void* dat )
 {
     Search_Manager* sm = ( Search_Manager * ) dat;
     sm->thread_search();
-    return 0;
+    return nullptr;
 }
 
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -1189,12 +1189,12 @@ void SESSION::set_col_diff( const int width ){ board_col_diff = width; }
 // 現在開いているarticle の ARTICLE::DrawAreaBase
 ARTICLE::DrawAreaBase* SESSION::get_base_drawarea()
 {
-    ARTICLE::ArticleViewBase* base_view = NULL;
+    ARTICLE::ArticleViewBase* base_view = nullptr;
     base_view = dynamic_cast< ARTICLE::ArticleViewBase* >( ARTICLE::get_admin()->get_current_view() );
 
-    if( base_view == NULL ) return NULL;
+    if( base_view == nullptr ) return nullptr;
 
-    ARTICLE::DrawAreaBase* base_drawarea = NULL;
+    ARTICLE::DrawAreaBase* base_drawarea = nullptr;
     base_drawarea = base_view->drawarea();
 
     return base_drawarea;

--- a/src/setupwizard.cpp
+++ b/src/setupwizard.cpp
@@ -81,7 +81,7 @@ PageNet::PageNet() : Gtk::VBox(),
 //
 void PageNet::slot_setup_proxy()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_PROXY, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_PROXY, "" );
     pref->run();
     delete pref;
 }
@@ -92,7 +92,7 @@ void PageNet::slot_setup_proxy()
 //
 void PageNet::slot_setup_browser()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( NULL, CORE::PREFDIAG_BROWSER, "" );
+    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BROWSER, "" );
     pref->run();
     delete pref;
 

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -52,11 +52,11 @@ using namespace SKELETON;
 
 Admin::Admin( const std::string& url )
     : m_url( url ),
-      m_win( NULL ),
-      m_notebook( NULL ),
+      m_win( nullptr ),
+      m_notebook( nullptr ),
       m_focus( false ),
-      m_move_menu( NULL ),
-      m_tabswitchmenu( NULL ),
+      m_move_menu( nullptr ),
+      m_tabswitchmenu( nullptr ),
       m_use_viewhistory( false ),
       m_use_switchhistory( false )
 {
@@ -290,7 +290,7 @@ void Admin::delete_jdwin()
 {
     if( m_win ){
         delete m_win;
-        m_win = NULL;
+        m_win = nullptr;
     }
 }
 
@@ -549,7 +549,7 @@ void Admin::exec_command()
                 // 現在開いているタブへの switch 処理
                 const bool focus_tmp = m_focus;
                 m_focus = true;
-                slot_switch_page( NULL,  m_notebook->get_current_page() );
+                slot_switch_page( nullptr,  m_notebook->get_current_page() );
                 m_focus = focus_tmp;
             }
         }
@@ -1336,7 +1336,7 @@ void Admin::tab_num( const std::string& str_num )
 {
     if( str_num.empty() ) return;
 
-    const int num = strtol( str_num.c_str(), NULL, 10 );
+    const int num = strtol( str_num.c_str(), nullptr, 10 );
 
     // Firefoxの動作に合わせた
     // 0 → 無視
@@ -1957,7 +1957,7 @@ View* Admin::get_view( const std::string& url )
         }
     }
     
-    return NULL;
+    return nullptr;
 }
 
 
@@ -2014,7 +2014,7 @@ std::list< View* > Admin::get_list_view()
 View* Admin::get_current_view()
 {
     int page = m_notebook->get_current_page();
-    if( page == -1 ) return NULL;
+    if( page == -1 ) return nullptr;
     SKELETON::View* view =  dynamic_cast< View* >( m_notebook->get_nth_page( page ) );
 
     return view;

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -237,7 +237,7 @@ namespace SKELETON
 
         void open_list( const COMMAND_ARGS& command_list );
         virtual COMMAND_ARGS get_open_list_args( const std::string& url, const COMMAND_ARGS& command_list ){ return COMMAND_ARGS(); }
-        virtual View* create_view( const COMMAND_ARGS& command ){ return NULL; };
+        virtual View* create_view( const COMMAND_ARGS& command ){ return nullptr; };
         virtual View* get_view( const std::string& url );
 
         // url を含むビュークラスをリストで取得 ( url と一致するビューでは無い )

--- a/src/skeleton/detaildiag.cpp
+++ b/src/skeleton/detaildiag.cpp
@@ -17,7 +17,7 @@ DetailDiag::DetailDiag( Gtk::Window* parent, const std::string& url,
                         const std::string& detail_html, const std::string& tab_detail )
     : SKELETON::PrefDiag( parent, url, add_cancel ),
       m_message( message ),
-      m_detail( NULL )
+      m_detail( nullptr )
 {
 #if GTKMM_CHECK_VERSION(2,6,0)
     m_message.set_width_chars( 60 );

--- a/src/skeleton/dragnote.cpp
+++ b/src/skeleton/dragnote.cpp
@@ -29,7 +29,7 @@ DragableNoteBook::DragableNoteBook()
     , m_page( -1 )
     , m_dragging_tab( false )
     , m_dragable( false )
-    , m_down_arrow( NULL )
+    , m_down_arrow( nullptr )
 {
     set_spacing( 0 );
 

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -43,7 +43,7 @@ DragTreeView::DragTreeView( const std::string& url, const std::string& dndtarget
       m_dndtarget( dndtarget ),
       m_dragging( false ),
       m_use_bg_even( false ),
-      m_popup_win( NULL ),
+      m_popup_win( nullptr ),
       m_popup_shown( false )
 {
 #ifdef _DEBUG
@@ -284,7 +284,7 @@ void DragTreeView::delete_popup()
 #endif
 
         delete m_popup_win;
-        m_popup_win = NULL;
+        m_popup_win = nullptr;
 
         m_pre_popup_url = std::string();
         m_popup_shown = false;

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -192,12 +192,12 @@ void EditTreeView::setup()
     std::cout << "EditTreeView::Setup url = " << m_url << std::endl;
 #endif
 
-    m_parent_win = NULL;
+    m_parent_win = nullptr;
 
     m_updated = false;
     m_dragging_on_tree = false;
     m_editable = false;
-    m_undo_buffer = NULL;
+    m_undo_buffer = nullptr;
     m_dnd_counter = 0;
     m_row_dest = Gtk::TreeRow();
 
@@ -1535,7 +1535,7 @@ void EditTreeView::path2info( CORE::DATA_INFO& info, const Gtk::TreePath& path )
 
     info.type = row[ m_columns.m_type ];
 
-    info.parent = NULL;
+    info.parent = nullptr;
 
     tmp_str = row[ m_columns.m_url ];
     info.url = tmp_str.raw();

--- a/src/skeleton/editview.cpp
+++ b/src/skeleton/editview.cpp
@@ -35,8 +35,8 @@ EditTextView::EditTextView() :
     Gtk::TextView(),
     m_cancel_change( false ),
     m_line_offset( -1 ),
-    m_context_menu( NULL ),
-    m_aapopupmenu( NULL )
+    m_context_menu( nullptr ),
+    m_aapopupmenu( nullptr )
 {
     // コントロールモード設定
     m_control.add_mode( CONTROL::MODE_EDIT );
@@ -49,7 +49,7 @@ EditTextView::EditTextView() :
 EditTextView::~EditTextView()
 {
     if( m_aapopupmenu ) delete m_aapopupmenu;
-    m_aapopupmenu = NULL;
+    m_aapopupmenu = nullptr;
 }
 
 
@@ -617,7 +617,7 @@ void EditTextView::slot_hide_popupmenu()
     std::cout << "EditTextView::slot_hide_popupmenu\n";
 #endif
 
-    m_context_menu = NULL;
+    m_context_menu = nullptr;
     SESSION::set_popupmenu_shown( false );
 }
 

--- a/src/skeleton/filediag.h
+++ b/src/skeleton/filediag.h
@@ -35,7 +35,7 @@ namespace SKELETON
             add_buttons();
         }
 
-        // parent がポインタの時は  NULL かどうかで場合分け
+        // parent がポインタの時は  nullptr かどうかで場合分け
         FileDiag( Gtk::Window* parent, const Glib::ustring& title, Gtk::FileChooserAction action = Gtk::FILE_CHOOSER_ACTION_OPEN )
         : Gtk::FileChooserDialog( title, action ), m_action( action )
         {

--- a/src/skeleton/jdtoolbar.cpp
+++ b/src/skeleton/jdtoolbar.cpp
@@ -102,7 +102,7 @@ customized_toolbar_content_expose (ToolbarContent *content,
                         GdkEventExpose *expose)
 {
     GtkToolbarChild *child;
-    GtkWidget *widget = NULL; /* quiet gcc */
+    GtkWidget *widget = nullptr; /* quiet gcc */
  
     switch (content->type)
     {
@@ -161,7 +161,7 @@ customized_gtk_toolbar_expose (GtkWidget      *widget,
     }
 */
 
-    for (list = priv->content; list != NULL; list = list->next)
+    for (list = priv->content; list != nullptr; list = list->next)
     {
         ToolbarContent *content = (ToolbarContent*)list->data;
 

--- a/src/skeleton/loadable.cpp
+++ b/src/skeleton/loadable.cpp
@@ -13,7 +13,7 @@
 using namespace SKELETON;
 
 Loadable::Loadable()
-    : m_loader( NULL ),
+    : m_loader( nullptr ),
       m_low_priority( false )
 {
     clear_load_data();
@@ -61,7 +61,7 @@ bool Loadable::is_loading() const
 {
     if( ! m_loader ) return false;
 
-    // m_loader != NULL ならローダ起動中ってこと
+    // m_loader != nullptr ならローダ起動中ってこと
     return true;
 }
 
@@ -73,7 +73,7 @@ time_t Loadable::get_time_modified()
 {
     time_t time_out;
     time_out = MISC::datetotime( m_date_modified );
-    if( time_out == 0 ) time_out = time( NULL ) - 600;
+    if( time_out == 0 ) time_out = time( nullptr ) - 600;
 
 #ifdef _DEBUG
     std::cout << "Loadable::get_time_modified " << m_date_modified << std::endl
@@ -89,7 +89,7 @@ time_t Loadable::get_time_modified()
 void Loadable::delete_loader()
 {
     if( m_loader ) delete m_loader;
-    m_loader = NULL;
+    m_loader = nullptr;
 }
 
 
@@ -106,7 +106,7 @@ bool Loadable::start_load( const JDLIB::LOADERDATA& data )
     std::cout << "Loadable::start_load url = " << data.url << std::endl;
 #endif
 
-    assert( m_loader == NULL );
+    assert( m_loader == nullptr );
     m_loader = new JDLIB::Loader( m_low_priority );
 
     // 情報初期化

--- a/src/skeleton/menubutton.cpp
+++ b/src/skeleton/menubutton.cpp
@@ -21,14 +21,14 @@ enum
 
 
 MenuButton::MenuButton( const bool show_arrow, Gtk::Widget& label )
-    : m_label( NULL ), m_arrow( NULL )
+    : m_label( nullptr ), m_arrow( nullptr )
 {
     setup( show_arrow, &label );
 }
 
 
 MenuButton::MenuButton( const bool show_arrow, const int id )
-    : m_label( NULL ), m_arrow( NULL )
+    : m_label( nullptr ), m_arrow( nullptr )
 {
     setup( show_arrow, Gtk::manage( new Gtk::Image( ICON::get_icon( id ) ) ), Gtk::PACK_SHRINK );
 }
@@ -39,7 +39,7 @@ void MenuButton::setup( const bool show_arrow, Gtk::Widget* label, Gtk::PackOpti
     const int space = 4;
 
     m_label = label;
-    m_popupmenu =  NULL;
+    m_popupmenu =  nullptr;
     m_on_arrow = false;
     m_enable_sig_clicked = true;
 
@@ -106,7 +106,7 @@ void MenuButton::append_menu( std::vector< std::string >& items )
         for( int i = 0; i < menusize; ++i ) m_popupmenu->remove( *m_menuitems[ i ] );
         delete m_popupmenu;
     }
-    m_popupmenu = NULL;
+    m_popupmenu = nullptr;
 
     if( ! items.size() ) return;
 
@@ -115,7 +115,7 @@ void MenuButton::append_menu( std::vector< std::string >& items )
     const size_t size = MIN( items.size(), MAX_MENU_SIZE );
     for( size_t i = 0 ; i < size; ++i ){
 
-        Gtk::MenuItem* item = NULL;
+        Gtk::MenuItem* item = nullptr;
 
         if( items[ i ] == "separator" ){
             item = Gtk::manage( new Gtk::SeparatorMenuItem() );

--- a/src/skeleton/msgdiag.cpp
+++ b/src/skeleton/msgdiag.cpp
@@ -27,7 +27,7 @@ MsgDiag::MsgDiag( Gtk::Window& parent,
     : Gtk::MessageDialog( parent, message, use_markup, type, buttons, modal )
 {}
 
-// parent がポインタの時は  NULL かどうかで場合分け
+// parent がポインタの時は  nullptr かどうかで場合分け
 MsgDiag::MsgDiag( Gtk::Window* parent,
                   const Glib::ustring& message,
                   bool use_markup,
@@ -171,7 +171,7 @@ MsgCheckDiag::MsgCheckDiag( Gtk::Window* parent,
     hbox->pack_start( m_chkbutton, Gtk::PACK_EXPAND_WIDGET, mrg );
     get_vbox()->pack_start( *hbox, Gtk::PACK_SHRINK );
 
-    Gtk::Button* button = NULL;
+    Gtk::Button* button = nullptr;
 
     if( buttons == Gtk::BUTTONS_OK ){
 

--- a/src/skeleton/msgdiag.h
+++ b/src/skeleton/msgdiag.h
@@ -25,7 +25,7 @@ namespace SKELETON
                  Gtk::ButtonsType buttons = Gtk::BUTTONS_OK,
                  bool modal = false);
 
-        // parent がポインタの時は  NULL かどうかで場合分け
+        // parent がポインタの時は  nullptr かどうかで場合分け
         MsgDiag( Gtk::Window* parent,
                  const Glib::ustring& message,
                  bool use_markup = false,

--- a/src/skeleton/prefdiag.cpp
+++ b/src/skeleton/prefdiag.cpp
@@ -14,7 +14,7 @@
 using namespace SKELETON;
 
 PrefDiag::PrefDiag( Gtk::Window* parent, const std::string& url, const bool add_cancel, const bool add_apply, const bool add_open )
-    : Gtk::Dialog(), m_url( url ), m_bt_ok( NULL ), m_bt_apply( Gtk::Stock::APPLY )
+    : Gtk::Dialog(), m_url( url ), m_bt_ok( nullptr ), m_bt_apply( Gtk::Stock::APPLY )
 {
     if( add_apply ){
         m_bt_apply.signal_clicked().connect( sigc::mem_fun(*this, &PrefDiag::slot_apply_clicked ) );
@@ -39,7 +39,7 @@ PrefDiag::PrefDiag( Gtk::Window* parent, const std::string& url, const bool add_
 
 PrefDiag::~PrefDiag()
 {
-    if( m_conn_timer != NULL )
+    if( m_conn_timer != nullptr )
     {
         delete m_conn_timer;
     }

--- a/src/skeleton/prefdiag.h
+++ b/src/skeleton/prefdiag.h
@@ -26,7 +26,7 @@ namespace SKELETON
 
       public:
 
-        // parent == NULL のときはメインウィンドウをparentにする
+        // parent == nullptr のときはメインウィンドウをparentにする
         PrefDiag( Gtk::Window* parent, const std::string& url, const bool add_cancel = true, const bool add_apply = false, const bool add_open = false );
 
         ~PrefDiag();

--- a/src/skeleton/tablabel.cpp
+++ b/src/skeleton/tablabel.cpp
@@ -20,7 +20,7 @@ enum
 
 
 TabLabel::TabLabel( const std::string& url )
-    : m_url( url ), m_id_icon( ICON::NUM_ICONS ), m_image( NULL )
+    : m_url( url ), m_id_icon( ICON::NUM_ICONS ), m_image( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "TabLabel::TabLabel " << m_url << std::endl;

--- a/src/skeleton/tabnote.cpp
+++ b/src/skeleton/tabnote.cpp
@@ -122,7 +122,7 @@ bool TabNotebook::paint( GdkEventExpose* event )
 
     if( ! notebook->first_tab ) notebook->first_tab = notebook->children;
 
-    GtkNotebookPage* page = NULL;
+    GtkNotebookPage* page = nullptr;
     if( ! GTK_WIDGET_MAPPED( notebook->cur_page->tab_label ) ) page = GTK_NOTEBOOK_PAGE( notebook->first_tab );
     else page = notebook->cur_page;
 
@@ -288,7 +288,7 @@ void TabNotebook::get_arrow_rect( GtkWidget *widget, const GtkNotebook *notebook
         gtk_widget_style_get( widget,
                               "scroll-arrow-hlength", &rectangle->width,
                               "scroll-arrow-vlength", &rectangle->height,
-                              NULL );
+                              nullptr );
 #else
         // gtk+-2.9.1より前は 12 で固定
         rectangle->width = rectangle->height = 12;
@@ -307,7 +307,7 @@ void TabNotebook::get_arrow_rect( GtkWidget *widget, const GtkNotebook *notebook
 #if !GTKMM_CHECK_VERSION(3,0,0)
 gboolean TabNotebook::get_event_window_position( const GtkWidget *widget, const GtkNotebook *notebook, GdkRectangle *rectangle )
 {
-    GtkNotebookPage* visible_page = NULL;
+    GtkNotebookPage* visible_page = nullptr;
     GList* children = notebook->children;
     while( children ){
 

--- a/src/skeleton/textloader.cpp
+++ b/src/skeleton/textloader.cpp
@@ -26,7 +26,7 @@ using namespace SKELETON;
 TextLoader::TextLoader()
     : SKELETON::Loadable(),
       m_loaded( false ),
-      m_rawdata( NULL ),
+      m_rawdata( nullptr ),
       m_lng_rawdata( 0 )
 {
 #ifdef _DEBUG
@@ -54,7 +54,7 @@ void TextLoader::init()
 void TextLoader::clear()
 {
     if( m_rawdata ) free( m_rawdata );
-    m_rawdata = NULL;
+    m_rawdata = nullptr;
     m_lng_rawdata = 0;
 }
 

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -46,37 +46,37 @@ ToolBar::ToolBar( Admin* admin )
       m_buttonbar_shown( false ),
       m_buttonbar_packed( false ),
 
-      m_tool_label( NULL ),
-      m_ebox_label( NULL ),
-      m_label( NULL ),
+      m_tool_label( nullptr ),
+      m_ebox_label( nullptr ),
+      m_label( nullptr ),
 
-      m_searchbar( NULL ),
+      m_searchbar( nullptr ),
       m_searchbar_shown( false ),
       m_searchbar_packed( false ),
-      m_button_open_searchbar( NULL ),
-      m_button_close_searchbar( NULL ),
-      m_button_up_search( NULL ),
-      m_button_down_search( NULL ),
-      m_button_clear_highlight( NULL ),
+      m_button_open_searchbar( nullptr ),
+      m_button_close_searchbar( nullptr ),
+      m_button_up_search( nullptr ),
+      m_button_down_search( nullptr ),
+      m_button_clear_highlight( nullptr ),
 
-      m_tool_search( NULL ),
-      m_entry_search( NULL ),
+      m_tool_search( nullptr ),
+      m_entry_search( nullptr ),
 
-      m_label_board( NULL ),
-      m_button_board( NULL ),
+      m_label_board( nullptr ),
+      m_button_board( nullptr ),
 
-      m_button_write( NULL ),
-      m_button_reload( NULL ),
-      m_button_stop( NULL ),
-      m_button_close( NULL ),
-      m_button_delete( NULL ),
-      m_button_favorite( NULL ),
-      m_button_undo( NULL ),
-      m_button_redo( NULL ),
-      m_button_lock( NULL ),
+      m_button_write( nullptr ),
+      m_button_reload( nullptr ),
+      m_button_stop( nullptr ),
+      m_button_close( nullptr ),
+      m_button_delete( nullptr ),
+      m_button_favorite( nullptr ),
+      m_button_undo( nullptr ),
+      m_button_redo( nullptr ),
+      m_button_lock( nullptr ),
 
-      m_button_back( NULL ),
-      m_button_forward( NULL )
+      m_button_back( nullptr ),
+      m_button_forward( nullptr )
 {
     m_buttonbar.set_border_width( 0 );
 #if GTKMM_CHECK_VERSION(2,12,0)
@@ -256,7 +256,7 @@ void ToolBar::set_relief()
         std::vector< Gtk::Widget* >::iterator it = lists.begin();
         for( ; it != lists.end(); ++it ){
 
-            Gtk::Button* button = NULL;
+            Gtk::Button* button = nullptr;
             Gtk::ToolButton* toolbutton = dynamic_cast< Gtk::ToolButton* >( *it );
             if( toolbutton ) button = dynamic_cast< Gtk::Button* >( toolbutton->get_child() );
             if( ! button ){
@@ -702,7 +702,7 @@ void ToolBar::slot_menu_board( int i )
 {
     if( ! m_enable_slot ) return;
 
-    SKELETON::PrefDiag* pref = NULL;
+    SKELETON::PrefDiag* pref = nullptr;
 
     // ToolBar::get_button_board()で作成したメニューの順番に内容を合わせる
     if( i == 0 ) slot_open_board();

--- a/src/skeleton/toolmenubutton.cpp
+++ b/src/skeleton/toolmenubutton.cpp
@@ -35,10 +35,10 @@ ToolMenuButton::~ToolMenuButton() noexcept = default;
 void ToolMenuButton::setup( SKELETON::MenuButton* button, const std::string& label, const bool expand )
 {
     m_button = button;
-    assert( m_button != NULL );
-    assert( m_button->get_label_widget() != NULL );
+    assert( m_button != nullptr );
+    assert( m_button->get_label_widget() != nullptr );
 
-    Gtk::MenuItem* item = NULL;
+    Gtk::MenuItem* item = nullptr;
 
     // アイコンの場合はアイコン表示
     Gtk::Image* image = dynamic_cast< Gtk::Image* >( m_button->get_label_widget() );

--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -23,7 +23,7 @@ using namespace SKELETON;
 
 View::View( const std::string& url, const std::string& arg1 ,const std::string& arg2 )
     : m_url( url ),
-      m_parent_win( NULL ),
+      m_parent_win( nullptr ),
       m_status( std::string() ),
       m_enable_mg( false ),
       m_enable_autoreload( false ),

--- a/src/skeleton/view.h
+++ b/src/skeleton/view.h
@@ -156,7 +156,7 @@ namespace SKELETON
         virtual void activate_act_before_popupmenu( const std::string& url ){}
 
         //  ポップアップメニュー取得
-        virtual Gtk::Menu* get_popupmenu( const std::string& url ){ return NULL; }
+        virtual Gtk::Menu* get_popupmenu( const std::string& url ){ return nullptr; }
 
     public:
 

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -53,9 +53,9 @@ constexpr const char* JDWindow::s_css_stat_label;
 // メッセージウィンドウでは m_mginfo が不要なので need_mginfo = false になる
 JDWindow::JDWindow( const bool fold_when_focusout, const bool need_mginfo )
     : Gtk::Window( Gtk::WINDOW_TOPLEVEL ),
-      m_gtkwidget( NULL ),
-      m_gtkwindow( NULL ),
-      m_grand_parent_class( NULL ),
+      m_gtkwidget( nullptr ),
+      m_gtkwindow( nullptr ),
+      m_grand_parent_class( nullptr ),
       m_win_moved( false ),
       m_fold_when_focusout( fold_when_focusout ),
       m_boot( true ),
@@ -63,9 +63,9 @@ JDWindow::JDWindow( const bool fold_when_focusout, const bool need_mginfo )
       m_transient( false ),
       m_mode( JDWIN_INIT ),
       m_count_focusout( 0 ),
-      m_dummywin( NULL ),
-      m_scrwin( NULL ),
-      m_vbox_view( NULL )
+      m_dummywin( nullptr ),
+      m_scrwin( nullptr ),
+      m_vbox_view( nullptr )
 {
     // ステータスバー
 #if GTKMM_CHECK_VERSION(2,5,0)

--- a/src/sound/playsound.cpp
+++ b/src/sound/playsound.cpp
@@ -87,7 +87,7 @@ void* Play_Sound::launcher( void* dat )
 {
     Play_Sound* ps = ( Play_Sound * ) dat;
     ps->play_wavfile();
-    return 0;
+    return nullptr;
 }
 
 
@@ -102,9 +102,9 @@ void Play_Sound::play_wavfile()
     std::cout << "Play_Sound::play_wavfile file = " << m_wavfile << std::endl;
 #endif
 
-    char *buffer = NULL;
-    FILE* fin = NULL;
-    snd_pcm_t *handle = NULL;
+    char *buffer = nullptr;
+    FILE* fin = nullptr;
+    snd_pcm_t *handle = nullptr;
 
     try{
 

--- a/src/sound/soundmanager.cpp
+++ b/src/sound/soundmanager.cpp
@@ -7,7 +7,7 @@
 
 #include "cache.h"
 
-SOUND::SOUND_Manager* instance_sound_manager = NULL;
+SOUND::SOUND_Manager* instance_sound_manager = nullptr;
 
 SOUND::SOUND_Manager* SOUND::get_sound_manager()
 {
@@ -24,7 +24,7 @@ void SOUND::delete_sound_manager()
 {
 #ifdef USE_ALSA
     if( instance_sound_manager ) delete instance_sound_manager;
-    instance_sound_manager = NULL;
+    instance_sound_manager = nullptr;
 #endif
 }
 

--- a/src/updatemanager.cpp
+++ b/src/updatemanager.cpp
@@ -12,7 +12,7 @@
 
 #include <algorithm>
 
-CORE::CheckUpdate_Manager* instance_checkupdate_manager = NULL;
+CORE::CheckUpdate_Manager* instance_checkupdate_manager = nullptr;
 
 
 CORE::CheckUpdate_Manager* CORE::get_checkupdate_manager()
@@ -27,7 +27,7 @@ CORE::CheckUpdate_Manager* CORE::get_checkupdate_manager()
 void CORE::delete_checkupdate_manager()
 {
     if( instance_checkupdate_manager ) delete instance_checkupdate_manager;
-    instance_checkupdate_manager = NULL;
+    instance_checkupdate_manager = nullptr;
 }
 
 

--- a/src/urlreplacemanager.cpp
+++ b/src/urlreplacemanager.cpp
@@ -10,7 +10,7 @@
 #include "jdlib/miscutil.h"
 #include "jdlib/miscmsg.h"
 
-CORE::Urlreplace_Manager* instance_urlreplace_manager = NULL;
+CORE::Urlreplace_Manager* instance_urlreplace_manager = nullptr;
 
 CORE::Urlreplace_Manager* CORE::get_urlreplace_manager()
 {
@@ -24,7 +24,7 @@ CORE::Urlreplace_Manager* CORE::get_urlreplace_manager()
 void CORE::delete_urlreplace_manager()
 {
     if( instance_urlreplace_manager ) delete instance_urlreplace_manager;
-    instance_urlreplace_manager = NULL;
+    instance_urlreplace_manager = nullptr;
 }
 
 ///////////////////////////////////////////////

--- a/src/usrcmdmanager.cpp
+++ b/src/usrcmdmanager.cpp
@@ -23,7 +23,7 @@
 
 #include "config/globalconf.h"
 
-CORE::Usrcmd_Manager* instance_usrcmd_manager = NULL;
+CORE::Usrcmd_Manager* instance_usrcmd_manager = nullptr;
 
 CORE::Usrcmd_Manager* CORE::get_usrcmd_manager()
 {
@@ -37,7 +37,7 @@ CORE::Usrcmd_Manager* CORE::get_usrcmd_manager()
 void CORE::delete_usrcmd_manager()
 {
     if( instance_usrcmd_manager ) delete instance_usrcmd_manager;
-    instance_usrcmd_manager = NULL;
+    instance_usrcmd_manager = nullptr;
 }
 
 ///////////////////////////////////////////////
@@ -215,7 +215,7 @@ void Usrcmd_Manager::exec( const std::string command, // コマンド
 
     if( use_browser ) CORE::core_set_command( "open_url_browser", cmd );
     else if( show_dialog ){
-        SKELETON::MsgDiag mdiag( NULL, cmd );
+        SKELETON::MsgDiag mdiag( nullptr, cmd );
         mdiag.run();
     }
     else Glib::spawn_command_line_async( cmd );
@@ -229,7 +229,7 @@ bool Usrcmd_Manager::show_replacetextdiag( std::string& texti, const std::string
 {
     if( ! texti.empty() ) return true;
 
-    ReplaceTextDiag textdiag( NULL, title );
+    ReplaceTextDiag textdiag( nullptr, title );
     if( textdiag.run() != Gtk::RESPONSE_OK ) return false;
     texti = textdiag.get_text();
     return true;

--- a/src/usrcmdpref.cpp
+++ b/src/usrcmdpref.cpp
@@ -248,7 +248,7 @@ bool UsrCmdPref::slot_key_release( GdkEventKey* event )
 // ポップアップメニュー表示
 void UsrCmdPref::show_popupmenu()
 {
-    Gtk::Menu* menu = NULL;
+    Gtk::Menu* menu = nullptr;
     std::list< Gtk::TreeModel::iterator > list_it = m_treeview.get_selected_iterators();
     if( list_it.size() <= 1 ) menu = dynamic_cast< Gtk::Menu* >( m_ui_manager->get_widget( "/popup_menu" ) );
     else menu = dynamic_cast< Gtk::Menu* >( m_ui_manager->get_widget( "/popup_menu_mul" ) );
@@ -290,7 +290,7 @@ void UsrCmdPref::slot_newcmd()
         CORE::DATA_INFO_LIST list_info;
         CORE::DATA_INFO info;
         info.type = TYPE_USRCMD;
-        info.parent = NULL;
+        info.parent = nullptr;
         info.url = std::string();
         info.name = diag.get_name();
         info.data = diag.get_cmd();
@@ -322,7 +322,7 @@ void UsrCmdPref::slot_newsepa()
     CORE::DATA_INFO_LIST list_info;
     CORE::DATA_INFO info;
     info.type = TYPE_SEPARATOR;
-    info.parent = NULL;
+    info.parent = nullptr;
     info.url = std::string();
     info.name = "--- 区切り ---";
     info.data = std::string();
@@ -345,7 +345,7 @@ void UsrCmdPref::slot_newsepa()
 //
 void UsrCmdPref::delete_row()
 {
-    SKELETON::MsgDiag mdiag( NULL, "削除しますか？", false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
+    SKELETON::MsgDiag mdiag( nullptr, "削除しますか？", false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
     if( mdiag.run() != Gtk::RESPONSE_YES ) return;
 
     slot_delete();

--- a/src/viewfactory.cpp
+++ b/src/viewfactory.cpp
@@ -158,7 +158,7 @@ SKELETON::View* CORE::ViewFactory( int type, const std::string& url, VIEWFACTORY
             return new MESSAGE::MessageViewNew( url, view_args.arg1 );
 
         default:
-            return NULL;
+            return nullptr;
     }
 }
 

--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -28,7 +28,7 @@
 JDWinMain::JDWinMain( const bool init, const bool skip_setupdiag,
                       const int init_w, const int init_h, const int init_x, const int init_y )
     : SKELETON::JDWindow( false ),
-      m_core( NULL ),
+      m_core( nullptr ),
       m_cancel_state_event( false )
 {
 #ifdef _DEBUG
@@ -116,7 +116,7 @@ JDWinMain::~JDWinMain()
     if( m_core ){
 
         delete m_core;
-        m_core = NULL;
+        m_core = nullptr;
 
         JDLIB::check_loader_alive();
     }
@@ -346,5 +346,5 @@ bool JDWinMain::on_motion_notify_event( GdkEventMotion* event )
 
 bool JDWinMain::operate_win( const int control )
 {
-    return CONTROL::operate_common( control, std::string(), NULL );
+    return CONTROL::operate_common( control, std::string(), nullptr );
 }

--- a/src/xml/document.cpp
+++ b/src/xml/document.cpp
@@ -115,7 +115,7 @@ void Document::set_treestore( Glib::RefPtr< Gtk::TreeStore >& treestore, SKELETO
 //
 Dom* Document::get_root_element( const std::string& node_name )
 {
-    Dom* node = 0;
+    Dom* node = nullptr;
 
     DomList children = childNodes();
     std::list< Dom* >::iterator it = children.begin();

--- a/src/xml/dom.cpp
+++ b/src/xml/dom.cpp
@@ -30,7 +30,7 @@ Dom::Dom( const int type, const std::string& name, const bool html )
     : m_html( html ),
       m_nodeType( type ),
       m_nodeName( name ),
-      m_parentNode( 0 )
+      m_parentNode( nullptr )
 {
     // HTMLの場合に空要素として扱う物の内で、使われていそうな物( 小文字で統一 )
     if( html && m_static_html_elements.empty() )
@@ -61,7 +61,7 @@ Dom::Dom( const Dom& dom )
       m_nodeType( dom.m_nodeType ),
       m_nodeName( dom.m_nodeName ),
       m_nodeValue( dom.m_nodeValue ),
-      m_parentNode( 0 ),
+      m_parentNode( nullptr ),
       m_attributes( dom.m_attributes )
 {
     copy_childNodes( dom );
@@ -556,7 +556,7 @@ void Dom::nodeValue( const std::string& value )
 //
 Dom* Dom::getElementById( const std::string& id ) const
 {
-    Dom* node = 0;
+    Dom* node = nullptr;
 
     std::list< Dom* >::const_iterator it = m_childNodes.cbegin();
     while( it != m_childNodes.cend() )
@@ -689,7 +689,7 @@ void Dom::copy_childNodes( const Dom& dom )
 //
 Dom* Dom::firstChild() const
 {
-    if( m_childNodes.empty() ) return 0;
+    if( m_childNodes.empty() ) return nullptr;
 
     return m_childNodes.front();
 }
@@ -700,7 +700,7 @@ Dom* Dom::firstChild() const
 //
 Dom* Dom::lastChild() const
 {
-    if( m_childNodes.empty() ) return 0;
+    if( m_childNodes.empty() ) return nullptr;
 
     return m_childNodes.back();
 }
@@ -711,7 +711,7 @@ Dom* Dom::lastChild() const
 //
 Dom* Dom::appendChild( const int node_type, const std::string& node_name )
 {
-    Dom* node = 0;
+    Dom* node = nullptr;
     
     {
         node = new Dom( node_type, node_name, m_html );
@@ -745,7 +745,7 @@ bool Dom::removeChild( Dom* node )
 //
 Dom* Dom::replaceChild( const int node_type, const std::string& node_name, Dom* oldNode )
 {
-    Dom* newNode = 0;
+    Dom* newNode = nullptr;
 
     newNode = new Dom( node_type, node_name );
 
@@ -773,7 +773,7 @@ Dom* Dom::replaceChild( const int node_type, const std::string& node_name, Dom* 
 //
 Dom* Dom::insertBefore( const int node_type, const std::string& node_name, Dom* insNode )
 {
-    Dom* newNode = 0;
+    Dom* newNode = nullptr;
 
     newNode = new Dom( node_type, node_name );
 
@@ -798,7 +798,7 @@ Dom* Dom::insertBefore( const int node_type, const std::string& node_name, Dom* 
 //
 Dom* Dom::previousSibling() const
 {
-    Dom* previous = 0;
+    Dom* previous = nullptr;
 
     DomList brothers = m_parentNode->childNodes();
 
@@ -822,7 +822,7 @@ Dom* Dom::previousSibling() const
 //
 Dom* Dom::nextSibling() const
 {
-    Dom* next = 0;
+    Dom* next = nullptr;
 
     DomList brothers = m_parentNode->childNodes();
 

--- a/src/xml/domlist.cpp
+++ b/src/xml/domlist.cpp
@@ -20,7 +20,7 @@ DomList& DomList::operator =( const std::list< Dom* >& list )
 // 添字によるアクセス
 Dom* DomList::operator []( const unsigned int n )
 {
-    if( m_list.empty() || n > m_list.size() ) return 0;
+    if( m_list.empty() || n > m_list.size() ) return nullptr;
 
     size_t count = 0;
     std::list< Dom* >::iterator it = m_list.begin();
@@ -31,7 +31,7 @@ Dom* DomList::operator []( const unsigned int n )
         ++it;
     }
 
-    return 0;
+    return nullptr;
 }
 
 
@@ -75,7 +75,7 @@ bool DomList::empty() const
 // 参照ではなくポインタを返す
 Dom* DomList::front()
 {
-    if( m_list.empty() ) return 0;
+    if( m_list.empty() ) return nullptr;
 
     return *m_list.begin();
 }
@@ -83,7 +83,7 @@ Dom* DomList::front()
 // 参照ではなくポインタを返す
 Dom* DomList::back()
 {
-    if( m_list.empty() ) return 0;
+    if( m_list.empty() ) return nullptr;
 
     return *m_list.end();
 }


### PR DESCRIPTION
コンパイラーの `-Wzero-as-null-pointer-constant` オプションを利用しポインター変数に代入される `NULL` マクロや数値リテラルの `0` を `nullptr` に置き換えます。ただし、[zlibのマニュアル][zlib]に従い `Z_NULL` はそのままにします。

[zlib]: https://www.zlib.net/manual.html#Constants
