### PR TITLE
Fix deprecated warning for including <asoundlib.h>

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -375,6 +375,7 @@ case "${host_os}" in
     [test "x$with_alsa" = xyes],
     [PKG_CHECK_MODULES(ALSA, [alsa >= 1.0])
      AC_DEFINE(USE_ALSA, , [use alsa])
+     AC_CHECK_HEADERS([alsa/asoundlib.h])
      AC_SUBST(ALSA_CFLAGS)
      AC_SUBST(ALSA_LIBS)]
   )

--- a/src/sound/playsound.cpp
+++ b/src/sound/playsound.cpp
@@ -10,7 +10,11 @@
 #include "jdlib/miscmsg.h"
 
 #include <string>
+#ifdef HAVE_ALSA_ASOUNDLIB_H
+#include <alsa/asoundlib.h>
+#else
 #include <asoundlib.h>
+#endif
 
 using namespace SOUND;
 


### PR DESCRIPTION
`asoundlib.h`をincludeしたときに発生する`This header is deprecated, use <alsa/asoundlib.h> instead.` の警告に対処するため `alsa/asoundlib.h` が存在するかチェックしてヘッダーのincludeを変更する条件を追加します。
