### PR TITLE
Add GitHub Actions configuration for CI

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,155 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+
+  build-default:
+
+    runs-on: ${{ matrix.sets.os }}
+    env:
+      CC: ${{ matrix.sets.cc }}
+      CXX: ${{ matrix.sets.cxx }}
+      CXXFLAGS: ${{ matrix.sets.debug }}
+    strategy:
+      matrix:
+        sets:
+          - os: ubuntu-16.04
+            cc: gcc-5
+            cxx: g++-5
+            package: g++-5
+            debug: -Og -D_DEBUG
+          - os: ubuntu-18.04
+            cc: gcc-6
+            cxx: g++-6
+            package: g++-6
+            debug: -Og -D_DEBUG
+          - os: ubuntu-18.04
+            cc: gcc-7
+            cxx: g++-7
+            package: g++-7
+            debug: -Og -D_DEBUG
+          - os: ubuntu-18.04
+            cc: gcc-8
+            cxx: g++-8
+            package: g++-8
+            debug: -Og -D_DEBUG
+
+          - os: ubuntu-16.04
+            cc: clang-4.0
+            cxx: clang++-4.0
+            package: clang-4.0
+            debug: -Og -D_DEBUG
+          - os: ubuntu-18.04
+            cc: clang-5.0
+            cxx: clang++-5.0
+            package: clang-5.0
+            debug: -Og -D_DEBUG
+          - os: ubuntu-18.04
+            cc: clang-6.0
+            cxx: clang++-6.0
+            package: clang-6.0
+            debug: -Og -D_DEBUG
+          - os: ubuntu-18.04
+            cc: clang-7
+            cxx: clang++-7
+            package: clang-7
+            debug: -Og -D_DEBUG
+          - os: ubuntu-18.04
+            cc: clang-8
+            cxx: clang++-8
+            package: clang-8
+            debug: -Og -D_DEBUG
+
+          - os: ubuntu-18.04
+            cc: gcc-7
+            cxx: g++-7
+            package: g++-7
+            debug:
+          - os: ubuntu-18.04
+            cc: clang-6.0
+            cxx: clang++-6.0
+            package: clang-6.0
+            debug:
+    steps:
+    - uses: actions/checkout@v2
+    - name: dependencies installation
+      run: |
+        sudo apt update
+        sudo apt install autoconf-archive libgnutls28-dev libgtkmm-3.0-dev libltdl-dev libtool zlib1g-dev ${{ matrix.sets.package }}
+      # 16.04's libgtest-dev is not same directory hierarchy for google/googletest.
+    - name: fetch googletest 1.10.0
+      run: git clone --branch=release-1.10.0 --depth 1 https://github.com/google/googletest.git test/googletest
+    - name: autoreconf -i
+      run: autoreconf -i
+    - name: ./configure --with-gtkmm3=yes
+      run: ./configure --with-gtkmm3=yes
+    - name: make -j$(nproc)
+      run: make -j$(nproc)
+    - name: make check -j$(nproc)
+      run: make check -j$(nproc)
+    - name: ./src/jdim -V
+      run: ./src/jdim -V
+
+  build-libs:
+
+    runs-on: ubuntu-18.04
+    env:
+      CC: ${{ matrix.compiler.cc }}
+      CXX: ${{ matrix.compiler.cxx }}
+      CXXFLAGS: -Og -D_DEBUG
+      GTEST_SRCDIR: /usr/src/googletest
+    strategy:
+      matrix:
+        compiler:
+          - cc: gcc-7
+            cxx: g++-7
+            package: g++-7
+          - cc: clang-6.0
+            cxx: clang++-6.0
+            package: clang-6.0
+        deps:
+          - config_args: --with-gtkmm3 --with-thread=posix --with-tls=gnutls --with-regex=posix --with-sessionlib=no --disable-compat-cache-dir
+            packages: libgtkmm-3.0-dev libgnutls28-dev
+          - config_args: --with-gtkmm3 --with-thread=posix --with-tls=openssl --with-regex=oniguruma --with-migemo --with-pangolayout
+            packages: libgtkmm-3.0-dev libssl-dev libonig-dev libmigemo-dev
+          - config_args: --with-gtkmm3 --with-thread=std --with-tls=gnutls --with-regex=pcre --with-alsa
+            packages: libgtkmm-3.0-dev libgnutls28-dev libpcre3-dev libasound2-dev
+          - config_args: --with-gtkmm3 --with-thread=std --with-tls=openssl --with-regex=posix --with-xdgopen
+            packages: libgtkmm-3.0-dev libssl-dev
+    steps:
+    - uses: actions/checkout@v2
+    - name: dependencies installation (${{ matrix.deps.packages }})
+      run: |
+        sudo apt update
+        sudo apt install autoconf-archive libgtest-dev libtool libltdl-dev ${{ matrix.deps.packages }} ${{ matrix.compiler.package }}
+    - name: autoreconf -i
+      run: autoreconf -i
+    - name: ./configure ${{ matrix.deps.config_args }}
+      run: ./configure ${{ matrix.deps.config_args }}
+    - name: make -j$(nproc)
+      run: make -j$(nproc)
+    - name: make check -j$(nproc)
+      run: make check -j$(nproc)
+    - name: ./src/jdim -V
+      run: ./src/jdim -V
+
+  manual:
+
+    runs-on: ubuntu-18.04
+    env:
+      NOKOGIRI_USE_SYSTEM_LIBRARIES: true
+    steps:
+    - uses: actions/checkout@v2
+    - name: dependencies installation
+      run: |
+        sudo apt update
+        sudo apt install ruby-dev ruby-bundler libcurl4-openssl-dev libxslt1-dev
+    - name: make -j$(nproc) -C docs build
+      run: make -j$(nproc) -C docs build

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ cache:
 
 matrix:
   include:
-    - name: "COMPILER=gcc CONFIG_ARG=\"--with-migemo --with-alsa --with-pangolayout\" CXXFLAGS=\"-D_DEBUG\""
+    - name: "CONFIG_ARG=\"--with-thread=std --with-tls=gnutls --with-regex=posix --with-migemo --with-xdgopen\""
       os: linux
       compiler: gcc
-      env: CONFIG_ARG="--with-migemo --with-alsa --with-pangolayout" CXXFLAGS="-D_DEBUG"
+      env: CONFIG_ARG="--with-thread=std --with-tls=gnutls --with-regex=posix --with-migemo --with-xdgopen"
       addons:
         apt:
           update: true
@@ -23,12 +23,11 @@ matrix:
             - zlib1g-dev
             - libgnutls28-dev
             - libmigemo-dev
-            - libasound2-dev
 
-    - name: "COMPILER=clang CONFIG_ARG=\"--with-sessionlib=gnomeui --with-regex=pcre --with-tls=openssl\""
+    - name: "CONFIG_ARG=\"--with-thread=posix --with-tls=openssl --with-regex=pcre --with-alsa --with-compat-cache-dir\""
       os: linux
-      compiler: clang
-      env: CONFIG_ARG="--with-sessionlib=gnomeui --with-regex=pcre --with-tls=openssl"
+      compiler: gcc
+      env: CONFIG_ARG="--with-thread=posix --with-tls=openssl --with-regex=pcre --with-alsa --with-compat-cache-dir"
       addons:
         apt:
           update: true
@@ -36,56 +35,30 @@ matrix:
             - autoconf-archive
             - libgtkmm-2.4-dev
             - zlib1g-dev
-            - libgnomeui-dev
             - libssl-dev
             - libpcre3-dev
+            - libasound2-dev
 
-    - name: "COMPILER=gcc CONFIG_ARG=\"--with-gtkmm3 --with-regex=oniguruma --with-thread=std\""
+    - name: "CONFIG_ARG=\"--with-thread=std --with-tls=gnutls --with-regex=oniguruma --with-sessionlib=no --with-pangolayout\""
       os: linux
       compiler: gcc
-      env: CONFIG_ARG="--with-gtkmm3 --with-regex=oniguruma --with-thread=std"
+      env: CONFIG_ARG="--with-thread=std --with-tls=gnutls --with-regex=oniguruma --with-sessionlib=no --with-pangolayout"
       addons:
         apt:
           update: true
           packages:
             - autoconf-archive
-            - libgtkmm-3.0-dev
+            - libgtkmm-2.4-dev
             - zlib1g-dev
             - libgnutls28-dev
             - libonig-dev
-
-    - name: "COMPILER=clang CONFIG_ARG=\"--with-gtkmm3 --with-xdgopen --disable-compat-cache-dir\" CXXFLAGS=\"-D_DEBUG\""
-      os: linux
-      compiler: clang
-      env: CONFIG_ARG="--with-gtkmm3 --with-xdgopen --disable-compat-cache-dir" CXXFLAGS="-D_DEBUG"
-      addons:
-        apt:
-          update: true
-          packages:
-            - autoconf-archive
-            - libgtkmm-3.0-dev
-            - zlib1g-dev
-            - libgnutls28-dev
-
-    - name: "manual build"
-      os: linux
-      language: ruby
-      rvm: 2.4.5
-      cache: bundler
-      sudo: false
-      env: NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-      addons:
-        apt:
-          packages:
-            - libcurl4-openssl-dev
-      script: make -j3 -C docs build
 
 install:
   - travis_retry git clone --depth 1 --branch master https://github.com/google/googletest.git test/googletest
 
 script:
   - autoreconf -i
-  - ./configure $CONFIG_ARG
-  - make -j3
-  - make test -j3
+  - ./configure --with-gtkmm3=no $CONFIG_ARG
+  - make -j$(nproc)
+  - make test -j$(nproc)
   - ./src/jdim -V

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # JDim - 2ch browser for linux
 
 [![Build Status](https://travis-ci.com/JDimproved/JDim.svg?branch=master)](https://travis-ci.com/JDimproved/JDim)
+[![GitHub Actions CI](https://github.com/JDimproved/JDim/workflows/CI/badge.svg)][actions-ci]
 
 ここに書かれていない詳細については[オンラインマニュアル][manual]や[リポジトリ][repository]を参照してください。
 
+[actions-ci]: https://github.com/JDimproved/JDim/actions?query=workflow%3ACI
 [manual]: https://jdimproved.github.io/JDim/
 [repository]: https://github.com/JDimproved/JDim
 

--- a/docs/manual/2019.md
+++ b/docs/manual/2019.md
@@ -10,6 +10,12 @@ layout: default
 
 <a name="0.3.0-unreleased"></a>
 ### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/362b797d53f...master) (unreleased)
+- Add GitHub Actions configuration for CI
+  ([#160](https://github.com/JDimproved/JDim/pull/160))
+- Replace char buffer with `std::string`
+  ([#159](https://github.com/JDimproved/JDim/pull/159))
+- Implement MessageView word/line selection by mouse click for gtk3.16+
+  ([#158](https://github.com/JDimproved/JDim/pull/158))
 - Fix logo color for "im"
   ([#156](https://github.com/JDimproved/JDim/pull/156))
 - Remove legacy gtk2 codes for less than version 2.18


### PR DESCRIPTION
Fixes #157.

GitHub Actionsを使って継続的インテグレーションを設定します。
travis-ciとジョブを振り分けてジョブの分散を行い実行時間の短縮とテストの種類を増やします。

#### travis-ci
- ubuntu 16.04 & GTK2 でオプションのライブラリや機能のビルド

#### GitHub Actions
- ubuntu 16.04 or 18.04 でコンパイラーを選択してビルド
  - gcc-5 (16.04)
  - gcc-6
  - gcc-7
  - gcc-8
  - clang-4.0 (16.04)
  - clang-5.0
  - clang-6.0
  - clang-7
  - clang-8
- ubuntu 18.04 & GTK3 でオプションのライブラリや機能のビルド
- ubuntu 18.04 でオンラインマニュアルのビルド
