### PR TITLE
Unset 404 link on the GitHub Actions CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # JDim - 2ch browser for linux
 
 [![Build Status](https://travis-ci.com/JDimproved/JDim.svg?branch=master)](https://travis-ci.com/JDimproved/JDim)
-[![GitHub Actions CI](https://github.com/JDimproved/JDim/workflows/CI/badge.svg)][actions-ci]
+![GitHub Actions CI](https://github.com/JDimproved/JDim/workflows/CI/badge.svg)
 
 ここに書かれていない詳細については[オンラインマニュアル][manual]や[リポジトリ][repository]を参照してください。
 
-[actions-ci]: https://github.com/JDimproved/JDim/actions?query=workflow%3ACI
 [manual]: https://jdimproved.github.io/JDim/
 [repository]: https://github.com/JDimproved/JDim
 


### PR DESCRIPTION
GitHub Actionsのページはアクセス権限がないと404 Not Foundが返されるためCIバッジのリンクを解除します。
