### PR TITLE
Replace char buffer with std::string part2

### DIFF
--- a/docs/manual/2019.md
+++ b/docs/manual/2019.md
@@ -10,6 +10,10 @@ layout: default
 
 <a name="0.3.0-unreleased"></a>
 ### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/362b797d53f...master) (unreleased)
+- Replace char buffer with std::string part2
+  ([#162](https://github.com/JDimproved/JDim/pull/162))
+- Unset 404 link on the GitHub Actions CI badge
+  ([#161](https://github.com/JDimproved/JDim/pull/161))
 - Add GitHub Actions configuration for CI
   ([#160](https://github.com/JDimproved/JDim/pull/160))
 - Replace char buffer with `std::string`

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -56,8 +56,7 @@ namespace DBTREE
         std::list< MOVETABLE > m_movetable;
 
         XML::Document m_xml_document;
-        char* m_rawdata;
-        size_t m_lng_rawdata;
+        std::string m_rawdata;
         std::list< DBTREE::ETCBOARDINFO > m_etcboards; // 外部板情報
 
         // 移転処理用変数

--- a/src/message/post.h
+++ b/src/message/post.h
@@ -33,8 +33,7 @@ namespace MESSAGE
         std::string m_msg;
         std::string m_return_html;
         std::string m_errmsg;
-        char* m_rawdata;
-        size_t m_lng_rawdata;
+        std::string m_rawdata;
 
         int m_count; // 書き込み確認時の永久ループ防止用
         bool m_subbbs; // true なら subbbs.cgiにpostする


### PR DESCRIPTION
malloc/freeによるバッファ確保をstd::stringで置き換えます。
std::stringでメモリは自動的に確保されますが挙動の変化を抑えるため修正前と同じ量を予約しておきます。

修正ではstd::stringのイテレーターからデーターへのポインター(`&*str.begin()`)を取得していますがC++11の規格で保証されています。
http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2011/n3242.pdf#subsection.21.4.1

> The char-like objects in a basic_string object shall be stored contiguously. That is, for any basic_string objects, the identity &*(s.begin() + n) == &*s.begin() + n shall hold for all values of n such that 0 <= n < s.size().
