### PR TITLE
Update year to 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ JDimで追加された不具合や機能の修正については[Pull requests][
 ## 著作権
 
 © 2017-2019 yama-natuki [https://github.com/yama-natuki/JD]  
-© 2019 JDimproved project [https://github.com/JDimproved/JDim]
+© 2019-2020 JDimproved project [https://github.com/JDimproved/JDim]
 
 パッチやファイルを取り込んだ場合、それらのコピーライトは「JDimproved project」に統一します。
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ layout: default
 - [JDim 0.1.0-20190122](./link-20190122)
 - [JD 2.8.9-150226][jd-289] (jd4linux)
 
-© 2019 JDimproved project
+© 2019-2020 JDimproved project
 
 [wiki-install]: https://ja.osdn.net/projects/jd4linux/wiki/OS%2F%E3%83%87%E3%82%A3%E3%82%B9%E3%83%88%E3%83%AA%E3%83%93%E3%83%A5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E5%88%A5%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95
 [wiki-faq]: https://ja.osdn.net/projects/jd4linux/wiki/FAQ

--- a/docs/manual/2019.md
+++ b/docs/manual/2019.md
@@ -8,46 +8,6 @@ layout: default
 ## {{ page.title }}
 
 
-<a name="0.3.0-unreleased"></a>
-### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/362b797d53f...master) (unreleased)
-- Replace char buffer with std::string part2
-  ([#162](https://github.com/JDimproved/JDim/pull/162))
-- Unset 404 link on the GitHub Actions CI badge
-  ([#161](https://github.com/JDimproved/JDim/pull/161))
-- Add GitHub Actions configuration for CI
-  ([#160](https://github.com/JDimproved/JDim/pull/160))
-- Replace char buffer with `std::string`
-  ([#159](https://github.com/JDimproved/JDim/pull/159))
-- Implement MessageView word/line selection by mouse click for gtk3.16+
-  ([#158](https://github.com/JDimproved/JDim/pull/158))
-- Fix logo color for "im"
-  ([#156](https://github.com/JDimproved/JDim/pull/156))
-- Remove legacy gtk2 codes for less than version 2.18
-  ([#155](https://github.com/JDimproved/JDim/pull/155))
-- Fix icon background to transparency
-  ([#154](https://github.com/JDimproved/JDim/pull/154))
-- Fix deprecated warning for including `<asoundlib.h>`
-  ([#153](https://github.com/JDimproved/JDim/pull/153))
-- Update logo
-  ([#152](https://github.com/JDimproved/JDim/pull/152))
-- Fix menu item labels for toolbar overflow menu
-  ([#151](https://github.com/JDimproved/JDim/pull/151))
-- Replace `NULL` and `0` for being assigned to pointer with `nullptr`
-  ([#150](https://github.com/JDimproved/JDim/pull/150))
-- Remove make rule which generates unused compiler info
-  ([#149](https://github.com/JDimproved/JDim/pull/149))
-- Use `std::to_string` instead of `MISC::itostr`
-  ([#148](https://github.com/JDimproved/JDim/pull/148))
-- Fix unable for initialization by `JDIM_CACHE` on compat mode
-  ([#147](https://github.com/JDimproved/JDim/pull/147))
-- Update history
-  ([#143](https://github.com/JDimproved/JDim/pull/143))
-- Deprecate `--with-sessionlib=gnomeui` option
-  ([#142](https://github.com/JDimproved/JDim/pull/142))
-- Deprecate gtkmm version less than 2.24
-  ([#141](https://github.com/JDimproved/JDim/pull/141))
-
-
 <a name="0.2.0-20191027"></a>
 ### [0.2.0-20191027](https://github.com/JDimproved/JDim/compare/JDim-v0.2.0...362b797d53f) (2019-10-27)
 - Remove deprecated cpu optimization options

--- a/docs/manual/2020.md
+++ b/docs/manual/2020.md
@@ -1,0 +1,48 @@
+---
+title: 更新履歴(2020年)
+layout: default
+---
+
+&gt; [Top](../) &gt; [更新履歴]({{ site.baseurl }}/history/) &gt; {{ page.title }}
+
+## {{ page.title }}
+
+
+<a name="0.3.0-unreleased"></a>
+### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/362b797d53f...master) (unreleased)
+- Replace char buffer with std::string part2
+  ([#162](https://github.com/JDimproved/JDim/pull/162))
+- Unset 404 link on the GitHub Actions CI badge
+  ([#161](https://github.com/JDimproved/JDim/pull/161))
+- Add GitHub Actions configuration for CI
+  ([#160](https://github.com/JDimproved/JDim/pull/160))
+- Replace char buffer with `std::string`
+  ([#159](https://github.com/JDimproved/JDim/pull/159))
+- Implement MessageView word/line selection by mouse click for gtk3.16+
+  ([#158](https://github.com/JDimproved/JDim/pull/158))
+- Fix logo color for "im"
+  ([#156](https://github.com/JDimproved/JDim/pull/156))
+- Remove legacy gtk2 codes for less than version 2.18
+  ([#155](https://github.com/JDimproved/JDim/pull/155))
+- Fix icon background to transparency
+  ([#154](https://github.com/JDimproved/JDim/pull/154))
+- Fix deprecated warning for including `<asoundlib.h>`
+  ([#153](https://github.com/JDimproved/JDim/pull/153))
+- Update logo
+  ([#152](https://github.com/JDimproved/JDim/pull/152))
+- Fix menu item labels for toolbar overflow menu
+  ([#151](https://github.com/JDimproved/JDim/pull/151))
+- Replace `NULL` and `0` for being assigned to pointer with `nullptr`
+  ([#150](https://github.com/JDimproved/JDim/pull/150))
+- Remove make rule which generates unused compiler info
+  ([#149](https://github.com/JDimproved/JDim/pull/149))
+- Use `std::to_string` instead of `MISC::itostr`
+  ([#148](https://github.com/JDimproved/JDim/pull/148))
+- Fix unable for initialization by `JDIM_CACHE` on compat mode
+  ([#147](https://github.com/JDimproved/JDim/pull/147))
+- Update history
+  ([#143](https://github.com/JDimproved/JDim/pull/143))
+- Deprecate `--with-sessionlib=gnomeui` option
+  ([#142](https://github.com/JDimproved/JDim/pull/142))
+- Deprecate gtkmm version less than 2.24
+  ([#141](https://github.com/JDimproved/JDim/pull/141))

--- a/docs/manual/about.md
+++ b/docs/manual/about.md
@@ -27,7 +27,7 @@ JDimはGPLv2の下で公開されている [JD][] からforkしたソフトウ�
 <a name="copyright"></a>
 ### 著作権
 © 2017-2019 [yama-natuki][]  
-© 2019 [JDimproved project][repository]
+© 2019-2020 [JDimproved project][repository]
 
 パッチやファイルを取り込んだ場合、それらのコピーライトは「JDimproved project」に統一します。
 

--- a/docs/manual/history.md
+++ b/docs/manual/history.md
@@ -7,6 +7,7 @@ layout: default
 
 ## {{ page.title }}
 
+- [2020年]({{ site.baseurl }}/2020/)
 - [2019年]({{ site.baseurl }}/2019/) ... JDimproved project
 - [2018年]({{ site.baseurl }}/2018/)
 - [2017年]({{ site.baseurl }}/2017/) ... yama-natuki/JD

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -25,7 +25,7 @@
 #define JDCOMMENT "JDim (JD improved) は gtkmm/GTK+ を用いた2chブラウザです。"
 #define JDCOPYRIGHT "(c) 2006-2015 JD project" "\n" \
                     "(c) 2017-2019 yama-natuki" "\n" \
-                    "(c) 2019 JDimproved project"
+                    "(c) 2019-2020 JDimproved project"
 #define JDBBS CONFIG::get_url_jdhp()+"cgi-bin/bbs/support/"
 #define JD2CHLOG CONFIG::get_url_jdhp()+"old2ch/"
 #define JDHELP "https://jdimproved.github.io/JDim/"


### PR DESCRIPTION
copyrightの表示を2020年に更新します。
オンラインマニュアルに更新履歴(2020年)を作成し未リリースの変更を移動します。
