### PR TITLE
Update snapcraft grade to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.com/JDimproved/JDim.svg?branch=master)](https://travis-ci.com/JDimproved/JDim)
 ![GitHub Actions CI](https://github.com/JDimproved/JDim/workflows/CI/badge.svg)
+[![Snap Status](https://build.snapcraft.io/badge/JDimproved/JDim.svg)](https://build.snapcraft.io/user/JDimproved/JDim)
+[![jdim](https://snapcraft.io//jdim/badge.svg)](https://snapcraft.io/jdim)
 
 ここに書かれていない詳細については[オンラインマニュアル][manual]や[リポジトリ][repository]を参照してください。
 
@@ -14,6 +16,7 @@
   * [事前準備](#事前準備)
   * [ビルド](#ビルド)
   * [GTK3版について](#GTK3版について)
+  * [Snapパッケージ](#Snapパッケージ)
 * [通常の起動](#通常の起動)
   * [コマンドライン オプション](#コマンドライン-オプション)
 * [多重起動について](#多重起動について)
@@ -208,6 +211,14 @@ GDK_CORE_DEVICE_EVENTS=1 ./src/jdim
 * ~~ダイアログウインドウの幅が項目の長さに合わせて大きくなり縮小できない。~~
 * ~~スレビューのスクロールバーがスクロール操作や検索したレスへの移動に反応せず、その後も1操作遅れて反応する。~~<br>
   **上記の３件は0.2.0-20191019以降のバージョンで修正されています。**
+
+
+### Snapパッケージ
+JDim GTK3版はSnapパッケージとして[Snap Storeで公開][snapcraft]されています。
+詳細は[マニュアル][manual-snap]を参照してください。
+
+[snapcraft]: https://snapcraft.io/jdim
+[manual-snap]: https://jdimproved.github.io/JDim/start#snap
 
 
 ## 通常の起動

--- a/docs/manual/2020.md
+++ b/docs/manual/2020.md
@@ -10,7 +10,15 @@ layout: default
 
 <a name="0.3.0-unreleased"></a>
 ### [0.3.0-unreleased](https://github.com/JDimproved/JDim/compare/362b797d53f...master) (unreleased)
-- Replace char buffer with std::string part2
+- Update snapcraft grade to stable
+  ([#165](https://github.com/JDimproved/JDim/pull/165))
+- Replace char buffer with `std::string` for `MISC::Iconv()`
+  ([#166](https://github.com/JDimproved/JDim/pull/166))
+- Update year to 2020
+  ([#164](https://github.com/JDimproved/JDim/pull/164))
+- Add a description for undocumented operation to the manual
+  ([#163](https://github.com/JDimproved/JDim/pull/163))
+- Replace char buffer with `std::string` part2
   ([#162](https://github.com/JDimproved/JDim/pull/162))
 - Unset 404 link on the GitHub Actions CI badge
   ([#161](https://github.com/JDimproved/JDim/pull/161))

--- a/docs/manual/start.md
+++ b/docs/manual/start.md
@@ -11,6 +11,7 @@ layout: default
 - [多重起動について](#multiple)
 - [JDとの互換性](#compatibility)
 - [GTK3版について](#gtk3)
+- [Snapパッケージ](#snap)
 
 
 <a name="run"></a>
@@ -157,6 +158,28 @@ GDK_CORE_DEVICE_EVENTS=1 ./src/jdim
   **上記の３件は0.2.0-20191019以降のバージョンで修正された。**
 
 
+<a name="snap"></a>
+### Snapパッケージ
+JDim GTK3版はSnapパッケージとして[Snap Storeで公開][snapcraft]されている。
+`snap`コマンドやwebページからインストールすることでコマンドやデスクトップ環境のメニューから起動できる。
+
+```sh
+sudo snap install jdim --edge
+```
+
+Snapパッケージ版はアクセス制限が導入されているため通常のパッケージやビルドと異なる点がある。
+
+- デフォルトのキャッシュディレクトリが異なる (`~/snap/jdim/common/.cache/jdim/`)
+- **デフォルトのキャッシュディレクトリはパッケージを削除すると消去される**
+- JDのキャッシュディレクトリ (`~/.jd`) は使えない
+- 隠しファイル（ドットファイル）のキャッシュディレクトリは使えない
+- 外部コマンドの呼び出しは制限される
+- 環境によってはGTKテーマ、アイコン、マウスカーソルがうまく表示されない場合がある<br>
+  環境変数 (`GTK_THEME`) やGTKの設定ファイル (`$XDG_CONFIG_HOME/gtk-3.0/settings.ini`)
+  を調整することで改善できるかもしれない
+
+
 [pr-merged]: https://github.com/JDimproved/JDim/pulls?q=is%3Apr+is%3Amerged
+[snapcraft]: https://snapcraft.io/jdim
 
 [操作方法について]: {{ site.baseurl }}/operation/#threadview_touch "操作方法について \| JDim"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ license: "GPL-2.0"
 
 confinement: strict
 base: core18
-grade: devel
+grade: stable
 icon: jdim.png
 
 plugs:
@@ -72,7 +72,7 @@ parts:
     override-build: |
       set -eu
       snapcraftctl build
-      VER="$(./src/jdim -V | sed -n -e '1s%^[^0-9]*\([^-]\+\)-\([^(]\+\).*$%\1-\2%p')"
+      VER="$(./src/jdim -V | sed -n -e '1s%^[^0-9]*\([^-]\+\)-\([^(]\+\)(git:\([0-9a-f]\+\).*$%\1-\2-\3%p')"
       echo "version ${VER}"
       snapcraftctl set-version "${VER}"
     override-prime: |

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -31,7 +31,7 @@ clean:
 distclean: clean
 	$(RM) Makefile
 
-test: $(BUILD_DIR) $(BUILD_DIR)/$(TEST_TARGET)
+test: $(BUILD_DIR)/$(TEST_TARGET)
 	$(BUILD_DIR)/$(TEST_TARGET)
 
 # NOTE: A link error might occur due to ordering for libraries.
@@ -64,7 +64,7 @@ TEST_OBJS = $(addprefix $(BUILD_DIR)/,$(TEST_SRCS:.cpp=.o))
 $(BUILD_DIR):
 	@$(MKDIR_P) $(BUILD_DIR)
 
-$(BUILD_DIR)/%.o: %.cpp
+$(BUILD_DIR)/%.o: %.cpp $(BUILD_DIR)
 	$(CXX) $(CPPFLAGS) $(AM_CXXFLAGS) -c -o $@ $<
 
 
@@ -78,7 +78,7 @@ GTEST_SRCS = $(GTEST_DIR)/src/*.cc $(GTEST_DIR)/src/*.h $(GTEST_HEADERS)
 # conservative and not optimized.  This is fine as Google Test
 # compiles fast and for ordinary users its source rarely changes.
 
-$(BUILD_DIR)/%.o: $(GTEST_DIR)/src/%.cc $(GTEST_SRCS)
+$(BUILD_DIR)/%.o: $(GTEST_DIR)/src/%.cc $(GTEST_SRCS) $(BUILD_DIR)
 	$(CXX) $(CPPFLAGS) -I$(GTEST_DIR) $(CXXFLAGS) -c -o $@ $<
 
 $(BUILD_DIR)/gtest_main.a: $(BUILD_DIR)/gtest-all.o $(BUILD_DIR)/gtest_main.o


### PR DESCRIPTION
Snapパッケージのgrade設定をstableに変更し安定版として公開できるようにします。

- Snapパッケージのバージョン番号にコミットハッシュを追加
- マニュアルにSnapパッケージの説明を追加
- READMEにマニュアルへのリンクとバッジを追加
