### PR TITLE
Replace char buffer with std::string for DBTREE::BoardBase

### DIFF
--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -61,7 +61,6 @@ BoardBase::BoardBase( const std::string& root, const std::string& path_board, co
     , m_last_access_time( 0 )
     , m_number_max_res( 0 )
     , m_iconv( nullptr )
-    , m_rawdata( nullptr )
     , m_rawdata_left( nullptr )
     , m_read_info( 0 )
     , m_append_articles( false )
@@ -340,13 +339,12 @@ void BoardBase::set_list_cookies_for_write( const std::list< std::string >& list
 
 void BoardBase::clear()
 {
-    if( m_rawdata ) free( m_rawdata );
-    m_rawdata = nullptr;
+    m_rawdata.clear();
+    m_rawdata.shrink_to_fit();
 
     if( m_rawdata_left ) free( m_rawdata_left );
     m_rawdata_left = nullptr;
 
-    m_lng_rawdata = 0;
     m_lng_rawdata_left = 0;
 
     m_get_article_url = std::string();
@@ -1077,11 +1075,10 @@ void BoardBase::receive_data( const char* data, size_t size )
 {
     if( ! size ) return;
 
-    if( ! m_rawdata ) m_rawdata = ( char* )malloc( SIZE_OF_RAWDATA );
-
-    memcpy( m_rawdata + m_lng_rawdata , data, size );
-    m_lng_rawdata += size;
-    m_rawdata[ m_lng_rawdata ] = '\0';
+    if( m_rawdata.capacity() < SIZE_OF_RAWDATA ) {
+        m_rawdata.reserve( SIZE_OF_RAWDATA );
+    }
+    m_rawdata.append( data, size );
 
     if( m_read_url_boardbase ) return; // url_boardbase をロードして移転が起きたかチェック中
 
@@ -1110,7 +1107,7 @@ void BoardBase::receive_data( const char* data, size_t size )
         memmove( m_rawdata_left, m_rawdata_left + byte_in, m_lng_rawdata_left );
 
 #ifdef _DEBUG
-        std::cout << "BoardBase::receive_data lng_rawdata = " << m_lng_rawdata << " size = " << size
+        std::cout << "BoardBase::receive_data rawdata.size = " << m_rawdata.size() << " size = " << size
                   << " byte_in = " << byte_in << " byte_out = " << byte_out << " lng_rawdata_left = " << m_lng_rawdata_left << std::endl;
 #endif
     }
@@ -1135,7 +1132,7 @@ void BoardBase::receive_finish()
 
 #ifdef _DEBUG
     std::cout << "----------------------------------\nBoardBase::receive_finish code = " << get_str_code() << std::endl;
-    std::cout << "lng_rawdata = " << m_lng_rawdata << std::endl;
+    std::cout << "rawdata.size = " << m_rawdata.size() << std::endl;
 #endif
 
     ///////////////////////////////////////////////////////
@@ -1149,7 +1146,8 @@ void BoardBase::receive_finish()
         set_date_modified( std::string() );
         send_update_board();
 
-        if( m_lng_rawdata && get_code() == HTTP_OK && strstr( m_rawdata, "window.location.href" ) != nullptr ){
+        if( !m_rawdata.empty() && get_code() == HTTP_OK
+                && m_rawdata.find( "window.location.href" ) != std::string::npos ) {
 
 #ifdef _DEBUG
             std::cout << m_rawdata << std::endl;
@@ -1249,7 +1247,7 @@ void BoardBase::receive_finish()
 #ifdef _DEBUG
         std::cout << "read from cache " << path_subject << std::endl;
 #endif
-        m_lng_rawdata = 0;
+        m_rawdata.clear();
         m_lng_rawdata_left = 0;
 
         char* rawdata = ( char* )malloc( SIZE_OF_RAWDATA );
@@ -1259,7 +1257,8 @@ void BoardBase::receive_finish()
     }
 
 #ifdef _DEBUG
-    std::cout << "size = " << m_list_artinfo.size() << " lng_rawdata = " << m_lng_rawdata << " left = " << m_lng_rawdata_left << std::endl;
+    std::cout << "size = " << m_list_artinfo.size() << " rawdata.size = " << m_rawdata.size()
+              << " left = " << m_lng_rawdata_left << std::endl;
 #endif
 
     // データが無い
@@ -1394,7 +1393,7 @@ void BoardBase::receive_finish()
                 }
 
                 // subject.txt セーブ
-                CACHE::save_rawdata( path_subject, m_rawdata, m_lng_rawdata );
+                CACHE::save_rawdata( path_subject, m_rawdata );
             }
         }
 
@@ -1434,7 +1433,7 @@ bool BoardBase::start_checkking_if_board_moved()
     std::cout << "BoardBase::start_checkking_if_board_moved " << url_boardbase() << std::endl;
 #endif
 
-    m_lng_rawdata = 0;
+    m_rawdata.clear();
 
     JDLIB::LOADERDATA data;
     data.init_for_data();

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1248,10 +1248,9 @@ void BoardBase::receive_finish()
         m_rawdata.clear();
         m_rawdata_left.clear();
 
-        char* rawdata = ( char* )malloc( SIZE_OF_RAWDATA );
-        size_t lng = CACHE::load_rawdata( path_subject, rawdata, SIZE_OF_RAWDATA );
-        receive_data( rawdata, lng );
-        free( rawdata );
+        std::vector<char> rawdata( SIZE_OF_RAWDATA );
+        const std::size_t lng = CACHE::load_rawdata( path_subject, rawdata.data(), SIZE_OF_RAWDATA );
+        receive_data( rawdata.data(), lng );
     }
 
 #ifdef _DEBUG

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -177,8 +177,7 @@ namespace DBTREE
         std::list< std::string > m_url_update_views; // CORE::core_set_command( "update_board" ) を送信するビューのアドレス
         JDLIB::Iconv* m_iconv;
         std::string m_rawdata;
-        char* m_rawdata_left;
-        size_t m_lng_rawdata_left;
+        std::string m_rawdata_left;
 
         // 情報ファイルを読みこんだらtrueにして2度読みしないようにする
         bool m_read_info;

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -176,9 +176,8 @@ namespace DBTREE
         // ダウンロード用変数
         std::list< std::string > m_url_update_views; // CORE::core_set_command( "update_board" ) を送信するビューのアドレス
         JDLIB::Iconv* m_iconv;
-        char* m_rawdata;
+        std::string m_rawdata;
         char* m_rawdata_left;
-        size_t m_lng_rawdata;
         size_t m_lng_rawdata_left;
 
         // 情報ファイルを読みこんだらtrueにして2度読みしないようにする


### PR DESCRIPTION
malloc/freeで確保しているバッファをstd::stringで置き換えます。
メモリは自動的に確保されますが挙動の変化を抑えるため修正前と同じ量を予約しておきます。

