### PR TITLE
Set gtkmm3 as default for configure script

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -49,6 +49,8 @@
 
 * make 方法( configure + make の場合 )
 
+    デフォルトの設定ではGTK3版をビルドする。(バージョン0.3.0以降)
+
     1. autoreconf -i ( 又は ./autogen.sh )
     2. ./configure
     3. make
@@ -140,9 +142,9 @@
 
        非推奨: かわりに --with-thread=[glib|std] を使用してください。
 
-    --with-gtkmm3
+    --with-gtkmm3=no
 
-       gtkmm2のかわりにgtkmm3を使用する。
+       gtkmm3のかわりにgtkmm2を使用する。
 
     --disable-compat-cache-dir
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ CentOS 7(2014年)より前にリリースされたディストリビューショ
 
 ## 導入方法
 
-ソースコードからJDimをビルドします。**デフォルトの設定ではGTK2版がビルド**されますのでご注意ください。
+ソースコードからJDimをビルドします。**デフォルトの設定ではGTK3版がビルド**されますのでご注意ください。
 詳細は [INSTALL](./INSTALL) にも書いてあります。
 
 
@@ -60,14 +60,14 @@ CentOS 7(2014年)より前にリリースされたディストリビューショ
 ツールチェーンとライブラリをインストールします。一度インストールすれば次回から事前準備はいりません。
 
 #### Redhat系
-*GTK2版*
-```sh
-dnf install gtkmm24-devel gnutls-devel libSM-devel libtool automake autoconf-archive git
-```
-
-*GTK3版* - `gtkmm24-devel` のかわりに `gtkmm30-devel` をインストールします。
+*GTK3版*
 ```sh
 dnf install gtkmm30-devel gnutls-devel libSM-devel libtool automake autoconf-archive git
+```
+
+*GTK2版* - `gtkmm30-devel` のかわりに `gtkmm24-devel` をインストールします。
+```sh
+dnf install gtkmm24-devel gnutls-devel libSM-devel libtool automake autoconf-archive git
 ```
 
 #### Debian (stretch-backportsあるいはbuster以降)
@@ -88,20 +88,20 @@ sudo apt install build-essential automake autoconf-archive git libtool
 
 必要なライブラリを入れます。(抜けがあるかも)
 
-*GTK2版*
-```sh
-sudo apt install libgtkmm-2.4-dev libmigemo1 libasound2-data libltdl-dev libasound2-dev libgnutls28-dev
-```
-
-*GTK3版* - `libgtkmm-2.4-dev` のかわりに `libgtkmm-3.0-dev` をインストールします。
+*GTK3版*
 ```sh
 sudo apt install libgtkmm-3.0-dev libmigemo1 libasound2-data libltdl-dev libasound2-dev libgnutls28-dev
+```
+
+*GTK2版* - `libgtkmm-3.0-dev` のかわりに `libgtkmm-2.4-dev` をインストールします。
+```sh
+sudo apt install libgtkmm-2.4-dev libmigemo1 libasound2-data libltdl-dev libasound2-dev libgnutls28-dev
 ```
 
 
 ### ビルド
 
-*GTK2版 (デフォルト)*
+*GTK3版 (デフォルト)*
 ```sh
 git clone -b master --depth 1 https://github.com/JDimproved/JDim.git jdim
 cd jdim
@@ -110,12 +110,12 @@ autoreconf -i
 make
 ```
 
-*GTK3版* - ./configure にオプション `--with-gtkmm3` を追加します。
+*GTK2版* - ./configure にオプション `--with-gtkmm3=no` を追加します。
 ```sh
 git clone -b master --depth 1 https://github.com/JDimproved/JDim.git jdim
 cd jdim
 autoreconf -i
-./configure --with-gtkmm3
+./configure --with-gtkmm3=no
 make
 ```
 

--- a/configure.ac
+++ b/configure.ac
@@ -84,9 +84,9 @@ dnl checking gtkmm
 dnl
 AC_MSG_CHECKING(for --with-gtkmm3)
 AC_ARG_WITH(gtkmm3,
-  [AS_HELP_STRING([--with-gtkmm3], [use gtkmm-3.0 instead of gtkmm-2.4 [default=no]])],
+  [AS_HELP_STRING([--with-gtkmm3], [use gtkmm-3.0 instead of gtkmm-2.4 @<:@default=yes@:>@])],
   [with_gtkmm3="$withval"],
-  [with_gtkmm3=no])
+  [with_gtkmm3=yes])
 AC_MSG_RESULT($with_gtkmm3)
 
 AS_IF([test "x$with_gtkmm3" = xno],

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -64,6 +64,8 @@ OSやディストリビューション別の解説は[OS/ディストリビュ�
 
 <a name="make-configure"></a>
 ### make 方法( configure + make の場合 )
+デフォルトの設定では**GTK3版をビルド**する。(バージョン0.3.0以降)
+
 1. `autoreconf -i` ( 又は `./autogen.sh` )
 2. `./configure`
 3. `make`
@@ -135,8 +137,8 @@ OSやディストリビューション別の解説は[OS/ディストリビュ�
   <dt>--with-[gthread|stdthread]</dt>
   <dd><strong>非推奨</strong>: かわりに <code>--with-thread=[glib|std]</code> を使用してください。</dd>
 
-  <dt>--with-gtkmm3</dt>
-  <dd>gtkmm2のかわりにgtkmm3を使用する。</dd>
+  <dt>--with-gtkmm3=no</dt>
+  <dd>gtkmm3のかわりにgtkmm2を使用する。</dd>
 
   <dt>--disable-compat-cache-dir</dt>
   <dd>JDのキャッシュディレクトリ <code>~/.jd</code> を読み込む互換機能を無効化する。</dd>


### PR DESCRIPTION
Fixes #170.

configureスクリプトのオプション `--with-gtkmm3` のデフォルト値を **yes** に 変更してGTK3版をメインにします。
GTK2版をビルドするには `--with-gtkmm3=no` を指定して ./configure を実行してください。
