### PR TITLE
Set std::thread as default for configure script

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -126,15 +126,15 @@
 
     --with-thread=[posix|glib|std]
 
-       使用するスレッドライブラリを設定する。デフォルトでは pthread を使用する。
+       使用するスレッドライブラリを設定する。デフォルトでは std::thread を使用する。(v0.3.0以降)
+
+    --with-thread=posix
+
+       std::thread のかわりに pthread を使用する。
 
     --with-thread=glib
 
        非推奨: かわりに --with-thread=std を使用してください。
-
-    --with-thread=std
-
-       pthread のかわりに std::thread を使用する。
 
     --with-[gthread|stdthread]
 

--- a/configure.ac
+++ b/configure.ac
@@ -405,8 +405,8 @@ dnl
 AC_MSG_CHECKING(for --with-thread)
 AC_ARG_WITH(thread,
 AC_HELP_STRING([--with-thread=@<:@posix|glib|std@:>@],
-               [use thread library @<:@default=posix@:>@]),
-[with_thread="$withval"], [with_thread=posix])
+               [use thread library @<:@default=std@:>@]),
+[with_thread="$withval"], [with_thread=std])
 AC_MSG_RESULT($with_thread)
 
 AS_IF(

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -127,11 +127,11 @@ OSやディストリビューション別の解説は[OS/ディストリビュ�
   <dd><strong>非推奨</strong>: かわりに <code>--with-regex=pcre</code> を使用してください。</dd>
 
   <dt>--with-thread=[posix|glib|std]</dt>
-  <dd>使用するスレッドライブラリを設定する。デフォルトでは pthread を使用する。</dd>
+  <dd>使用するスレッドライブラリを設定する。デフォルトでは std::thread を使用する。(v0.3.0以降)</dd>
+  <dt>--with-thread=posix</dt>
+  <dd>std::thread のかわりに pthread を使用する。</dd>
   <dt>--with-thread=glib</dt>
   <dd><strong>非推奨</strong>: かわりに <code>--with-thread=std</code> を使用してください。</dd>
-  <dt>--with-thread=std</dt>
-  <dd>pthread のかわりに std::thread を使用する。</dd>
   <dt>--with-[gthread|stdthread]</dt>
   <dd><strong>非推奨</strong>: かわりに <code>--with-thread=[glib|std]</code> を使用してください。</dd>
 


### PR DESCRIPTION
Fixes #171.

configureスクリプトのオプション `--with-thread` のデフォルト値を **std** に変更して `std::thread` をメインにします。
POSIX Threadsを使う場合は `--with-thread=posix` を指定して ./configure を実行してください。
