### PR TITLE
MISC::remove_space: handle the case str consists of just spaces

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -304,7 +304,7 @@ std::string MISC::remove_space( const std::string& str )
 
     // 前
     size_t i = 0;
-    while( 1 ){
+    while( i < lng ){
 
         // 半角
         if( str[ i ] == ' ' ) ++i;
@@ -315,6 +315,7 @@ std::string MISC::remove_space( const std::string& str )
                  str[ i +2 ] == str_space[ 2 ] ) i += lng_space;
         else break;
     }
+    if (i >= lng) return "";
 
     // 後
     size_t i2 = lng -1;


### PR DESCRIPTION
Fedoraでは（でrpmにパッケージする時には）defaultで ``-Wp,-D_GLIBCXX_ASSERTIONS``をつけてcompileすることになっていて、 https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_macros.html これをつけて test と master branchをcompileすると、JDimが起動しません。

```
[tasaka1@localhost JDim]$ gdb ./src/jdim 
GNU gdb (GDB) Fedora 8.3.50.20190824-27.fc31
(gdb) r
Starting program: /home/tasaka1/rpmbuild/fedora-specific/JDim/src/jdim 
Program received signal SIGABRT, Aborted.
0x00007ffff633b625 in raise () from /lib64/libc.so.6
Missing separate debuginfos, use: dnf debuginfo-install at-spi2-atk-2.34.1-1.fc31.x86_64 at-spi2-core-2.34.0-1.fc31.x86_64 atk-2.34.1-1.fc31.x86_64 atkmm-2.24.3-3.fc31.x86_64 bzip2-libs-1.0.8-1.fc31.x86_64 cairo-1.16.0-6.fc31.x86_64 cairo-gobject-1.16.0-6.fc31.x86_64 cairomm-1.12.0-11.fc31.x86_64 cmigemo-1.3-0.13.date20110227.fc31.2.x86_64 dbus-libs-1.12.16-3.fc31.x86_64 expat-2.2.8-1.fc31.x86_64 freetype-2.10.0-3.fc31.x86_64 fribidi-1.0.5-5.fc31.x86_64 glibmm24-2.62.0-1.fc31.x86_64 gmp-6.1.2-10.fc31.x86_64 gnutls-3.6.11-1.fc31.x86_64 gtkmm30-3.24.2-1.fc31.x86_64 harfbuzz-2.6.1-2.fc31.x86_64 libICE-1.0.10-2.fc31.x86_64 libSM-1.2.3-4.fc31.x86_64 libXau-1.0.9-2.fc31.x86_64 libXcursor-1.1.15-6.fc31.x86_64 libXdamage-1.1.4-17.fc31.x86_64 libXext-1.3.4-2.fc31.x86_64 libXfixes-5.0.3-10.fc31.x86_64 libXi-1.7.10-2.fc31.x86_64 libXinerama-1.1.4-4.fc31.x86_64 libXrandr-1.5.2-2.fc31.x86_64 libblkid-2.34-4.fc31.x86_64 libdatrie-0.2.9-10.fc31.x86_64 libepoxy-1.5.3-4.fc31.x86_64 libgcc-9.2.1-1.fc31.x86_64 libgcrypt-1.8.5-1.fc31.x86_64 libidn2-2.3.0-1.fc31.x86_64 libmount-2.34-4.fc31.x86_64 libpng-1.6.37-2.fc31.x86_64 libselinux-2.9-5.fc31.x86_64 libsigc++20-2.10.2-2.fc31.x86_64 libstdc++-9.2.1-1.fc31.x86_64 libtasn1-4.14-2.fc31.x86_64 libthai-0.1.28-3.fc31.x86_64 libuuid-2.34-4.fc31.x86_64 libwayland-client-1.17.0-2.fc31.x86_64 libwayland-cursor-1.17.0-2.fc31.x86_64 libwayland-egl-1.17.0-2.fc31.x86_64 libxcb-1.13.1-3.fc31.x86_64 libxcrypt-4.4.12-1.fc31.x86_64 libxkbcommon-0.9.1-3.fc31.x86_64 lz4-libs-1.9.1-1.fc31.x86_64 nettle-3.5.1-3.fc31.x86_64 p11-kit-0.23.20-1.fc31.x86_64 pangomm-2.40.2-3.fc31.x86_64 systemd-libs-243.5-1.fc31.x86_64 xz-libs-5.2.4-6.fc31.x86_64 zlib-1.2.11-20.fc31.x86_64
(gdb) bt
#0  0x00007ffff633b625 in raise () at /lib64/libc.so.6
#1  0x00007ffff63248d9 in abort () at /lib64/libc.so.6
#2  0x000055555595d0c8 in std::__replacement_assert(char const*, int, char const*, char const*)
    (__file=__file@entry=0x555555ba8fc0 "/usr/include/c++/9/bits/basic_string.h", __line=__line@entry=1048, __function=__function@entry=0x555555bb70c8 "std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::const_reference std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::operator[](std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type) con"..., __condition=__condition@entry=0x555555ba95b9 "__pos <= size()") at /usr/include/c++/9/x86_64-redhat-linux/bits/c++config.h:2533
#3  0x0000555555b5d49f in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::operator[](unsigned long) const (__pos=<optimized out>, this=0x7fffffffd1b0)
    at /usr/include/c++/9/bits/basic_string.h:936
#4  MISC::remove_space(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (str=" ") at miscutil.cpp:324
#5  0x0000555555b6b6e3 in JDLIB::ConfLoader::ConfLoader(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (this=0x7fffffffd7b0, file=..., str_conf=...) at /usr/include/c++/9/bits/basic_string.h:329
#6  0x0000555555b50b01 in CONFIG::ConfigItems::load(bool) (this=0x555555ef6540, restore=<optimized out>) at /usr/include/c++/9/bits/char_traits.h:300
#7  0x00005555558a2b3b in main(int, char**) (argc=<optimized out>, argv=<optimized out>) at main.cpp:538
(gdb) up
#1  0x00007ffff63248d9 in abort () from /lib64/libc.so.6
(gdb) 
#2  0x000055555595d0c8 in std::__replacement_assert (__file=__file@entry=0x555555ba8fc0 "/usr/include/c++/9/bits/basic_string.h", __line=__line@entry=1048, 
    __function=__function@entry=0x555555bb70c8 "std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::const_reference std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::operator[](std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type) con"..., __condition=__condition@entry=0x555555ba95b9 "__pos <= size()") at /usr/include/c++/9/x86_64-redhat-linux/bits/c++config.h:2533
2533	    __builtin_abort();
(gdb) 
#3  0x0000555555b5d49f in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::operator[] (__pos=<optimized out>, this=0x7fffffffd1b0)
    at /usr/include/c++/9/bits/basic_string.h:936
936	      length() const _GLIBCXX_NOEXCEPT
(gdb) 
#4  MISC::remove_space (str=" ") at miscutil.cpp:324
324	        if( str[ i2 ] == ' ' ) --i2;
(gdb) p lng
$1 = 1
(gdb) p str
$2 = " "
(gdb) p lng_space
$3 = 3
(gdb) p i2
$4 = <optimized out>
(gdb) p str[0]
$5 = (const __gnu_cxx::__alloc_traits<std::allocator<char>, char>::value_type &) @0x7fffffffd1c0: 32 ' '
(gdb) p str[1]
$6 = (const __gnu_cxx::__alloc_traits<std::allocator<char>, char>::value_type &) @0x7fffffffd1c1: 0 '\000'
```

現状だと、``MISC::remove_space`` で、strがspaceだけだった場合、i2が巨大な数値になってしまいます。