### PR TITLE
CONTROL::get_keyconfig use snprintf and set copying buffer size corre…

### DIFF
--- a/src/control/controlutil.cpp
+++ b/src/control/controlutil.cpp
@@ -47,8 +47,8 @@ CONTROL::KeyConfig* CONTROL::get_keyconfig()
         instance_keyconfig = new CONTROL::KeyConfig();
 
         // ラベルをセットしておく
-        strncpy( control_label[ CONTROL::SearchWeb ][ 1 ], CONFIG::get_menu_search_web().c_str(), MAX_CONTROL_LABEL );
-        strncpy( control_label[ CONTROL::SearchTitle ][ 1 ], CONFIG::get_menu_search_title().c_str(), MAX_CONTROL_LABEL );
+        snprintf( control_label[ CONTROL::SearchWeb ][ 1 ], MAX_CONTROL_LABEL, "%s", CONFIG::get_menu_search_web().c_str() );
+        snprintf( control_label[ CONTROL::SearchTitle ][ 1 ], MAX_CONTROL_LABEL, "%s", CONFIG::get_menu_search_title().c_str() );
     }
 
     return instance_keyconfig;


### PR DESCRIPTION
…ctly

gcc9 warns:
In function 'char* strncpy(char*, const char*, size_t)',
    inlined from 'CONTROL::KeyConfig* CONTROL::get_keyconfig()' at controlutil.cpp:50:16:
/usr/include/bits/string_fortified.h:106:34: warning: 'char* __builtin_strncpy(char*, const char*, long unsigned int)' specified bound 64 equals destination size [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'char* strncpy(char*, const char*, size_t)',
    inlined from 'CONTROL::KeyConfig* CONTROL::get_keyconfig()' at controlutil.cpp:51:16:
/usr/include/bits/string_fortified.h:106:34: warning: 'char* __builtin_strncpy(char*, const char*, long unsigned int)' specified bound 64 equals destination size [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Actually when setting some long text to CONFIG::get_menu_search_web or CONFIG::get_menu_search_title(), some unexpected behavior happen.
This patch uses snprintf to make sure the copy-ed buffer terminates with null character, and the copying buffer size are set correctly.

Closes JDimproved/JDim#180 .