### PR TITLE
HEAP::heap_alloc(): adjust alignment

### DIFF
--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -661,7 +661,7 @@ DOM* Css_Manager::create_textnode( const char* text )
 #endif
 
     DOM* tmpdom = create_domnode( DOMNODE_TEXT );
-    tmpdom->chardat = ( char* ) m_heap.heap_alloc( lng + 1 );
+    tmpdom->chardat = ( char* ) m_heap.heap_alloc_char( lng + 1 );
     strncpy( tmpdom->chardat, text, lng );
 
     return tmpdom;

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -933,7 +933,7 @@ NODE* NodeTreeBase::create_node_link( const char* text, const int n, const char*
         tmpnode->type = NODE_LINK;
 
         // リンク情報作成
-        char *tmplink = ( char* )m_heap.heap_alloc( n_link + 1 );
+        char *tmplink = ( char* )m_heap.heap_alloc_char( n_link + 1 );
         memcpy( tmplink, link, n_link );
         tmplink[ n_link ] = '\0';
 
@@ -973,7 +973,7 @@ NODE* NodeTreeBase::create_node_sssp( const char* link, const int n_link )
     tmpnode->type = NODE_SSSP;
 
     // リンク情報作成
-    char *tmplink = ( char* )m_heap.heap_alloc( n_link + 1 );
+    char *tmplink = ( char* )m_heap.heap_alloc_char( n_link + 1 );
     memcpy( tmplink, link, n_link );
     tmplink[ n_link ] = '\0';
 
@@ -1011,7 +1011,7 @@ NODE* NodeTreeBase::create_node_thumbnail( const char* text, const int n, const 
 
     if( tmpnode ){
         // サムネイル画像のURLをセット
-        char *tmpthumb = ( char* )m_heap.heap_alloc( n_thumb + 1 );
+        char *tmpthumb = ( char* )m_heap.heap_alloc_char( n_thumb + 1 );
         memcpy( tmpthumb, thumb, n_thumb );
         tmpthumb[ n_thumb ] = '\0';
 
@@ -1045,7 +1045,7 @@ NODE* NodeTreeBase::create_node_ntext( const char* text, const int n, const int 
     if( tmpnode ){
         tmpnode->type = NODE_TEXT;
 
-        tmpnode->text = ( char* )m_heap.heap_alloc( n + MAX_RES_DIGIT + 4 );
+        tmpnode->text = ( char* )m_heap.heap_alloc_char( n + MAX_RES_DIGIT + 4 );
         memcpy( tmpnode->text, text, n ); tmpnode->text[ n ] = '\0';
         tmpnode->color_text = color_text;
         tmpnode->bold = bold;
@@ -1755,7 +1755,7 @@ void NodeTreeBase::parse_name( NODE* header, const char* str, const int lng, con
     // plainな名前取得
     // 名前あぼーんや名前抽出などで使用する
     if( defaultname ){
-        header->headinfo->name = ( char* )m_heap.heap_alloc( lng +2 );
+        header->headinfo->name = ( char* )m_heap.heap_alloc_char( lng +2 );
         memcpy( header->headinfo->name, str, lng );
     }
     else{
@@ -1765,7 +1765,7 @@ void NodeTreeBase::parse_name( NODE* header, const char* str, const int lng, con
             if( node->text ) str_tmp += node->text;
             node = node->next_node;
         }
-        header->headinfo->name = ( char* )m_heap.heap_alloc( str_tmp.length() +2 );
+        header->headinfo->name = ( char* )m_heap.heap_alloc_char( str_tmp.length() +2 );
         memcpy( header->headinfo->name, str_tmp.c_str(), str_tmp.length() );
     }
 }

--- a/src/jdlib/heap.cpp
+++ b/src/jdlib/heap.cpp
@@ -48,11 +48,11 @@ void HEAP::clear()
 }
 
 
-unsigned char* HEAP::heap_alloc( long n )
+unsigned char* HEAP::heap_alloc( long n, long alignment )
 {
     assert( n > 0 && n <= m_max );
 
-    if( m_used == 0 || m_used + n > m_max ){
+    if( m_used == 0 || m_used + n + (alignment - 1) > m_max ){
 
         m_heap_list.push_back( ( unsigned char* )malloc( m_max ) );
         memset( m_heap_list.back(), 0, m_max );
@@ -64,6 +64,14 @@ unsigned char* HEAP::heap_alloc( long n )
     }
 
     unsigned char* heap = m_heap_list.back() + m_used;
+
+    // アライメント調整
+    uintptr_t i_heap = reinterpret_cast<uintptr_t>(heap);
+    int rem = (i_heap % alignment) ? alignment - (i_heap % alignment) : 0;
+    heap += rem;
+    m_used += rem;
+    m_total_size += rem;
+
     m_used += n + 4;
     m_total_size += n + 4;
     

--- a/src/jdlib/heap.h
+++ b/src/jdlib/heap.h
@@ -23,7 +23,8 @@ namespace JDLIB
 
         void clear();
 
-        unsigned char* heap_alloc( long n );
+        unsigned char* heap_alloc( long n, long alignment = 8 );
+        unsigned char* heap_alloc_char( long n ) { return heap_alloc(n, 1); };
     };
 }
 


### PR DESCRIPTION
一先ずpull requestを作りました。default alignmentは8で、char用にalignment 1の専用関数を作りました。ただ、本当は型を引数とするマクロを作った方がすっきりすると思います。

```
gcc10 -fsanitize=address detects alignment errors like:
=====================================================
cssmanager.cpp:614:22: runtime error: member access within misaligned address 0x6290002a3224 for type 'struct DOM', which requires 8 byte alignment
0x6290002a3224: note: pointer points here
  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
=====================================================

So adjust the return address of heap_alloc() for alignment.
Also, create heap_alloc_char() function, which sets alignment as 1.
```

Closes JDimproved/JDim#183 .