### PR TITLE
Fix number of bytes for strncpy argument of Css_Manager::create_textnode()

### DIFF
--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -662,7 +662,7 @@ DOM* Css_Manager::create_textnode( const char* text )
 
     DOM* tmpdom = create_domnode( DOMNODE_TEXT );
     tmpdom->chardat = ( char* ) m_heap.heap_alloc_char( lng + 1 );
-    strncpy( tmpdom->chardat, text, lng );
+    strncpy( tmpdom->chardat, text, lng + 1 );
 
     return tmpdom;
 }


### PR DESCRIPTION
Fixes #182 

Compiler warns:
```
In file included from /usr/include/string.h:494,
                 from /usr/include/c++/9/cstring:42,
                 from jdlib/miscutil.h:9,
                 from cssmanager.cpp:8:
In function 'char* strncpy(char*, const char*, size_t)',
    inlined from 'CORE::DOM* CORE::Css_Manager::create_textnode(const char*)' at cssmanager.cpp:665:12:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:34: warning: 'char* __builtin_strncpy(char*, const char*, long unsigned int)' output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cssmanager.cpp: In member function 'CORE::DOM* CORE::Css_Manager::create_textnode(const char*)':
cssmanager.cpp:656:21: note: length computed here
  656 |     int lng = strlen( text );
      |               ~~~~~~^~~~~~~~
```

Fortunately it does not cause bugs, but compiler warning indicates improper use of the function.