### PR TITLE
Replace char buffer with std::string for DBTREE::NodeTreeJBBS

### DIFF
--- a/src/dbtree/nodetreejbbs.h
+++ b/src/dbtree/nodetreejbbs.h
@@ -9,6 +9,8 @@
 
 #include "nodetreebase.h"
 
+#include <string>
+
 namespace JDLIB
 {
     class Iconv;
@@ -20,8 +22,8 @@ namespace DBTREE
     class NodeTreeJBBS : public NodeTreeBase
     {
         JDLIB::Iconv* m_iconv;
-        char* m_decoded_lines;
-        
+        std::string m_decoded_lines;
+
       public:
 
         NodeTreeJBBS( const std::string& url, const std::string& date_modified );


### PR DESCRIPTION
`malloc/free`で確保しているバッファを`std::string`で置き換えます。
メモリは自動的に確保されますが挙動の変化を抑えるため修正前と同じ量を予約しておきます。
