### PR TITLE
Fix a -Wstringop-overflow compiler warning in create_trip_newtype()

### DIFF
--- a/docs/manual/2020.md
+++ b/docs/manual/2020.md
@@ -10,7 +10,17 @@ layout: default
 
 <a name="0.4.0-unreleased"></a>
 ### [0.4.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.3.0...master) (unreleased)
-- Replace dynamic allocation with local variable for struct utsname
+- Fix a `-Wstringop-overflow` compiler warning in `create_trip_newtype()`
+  ([#187](https://github.com/JDimproved/JDim/pull/187))
+- Replace char buffer with `std::string` for `DBTREE::NodeTreeJBBS`
+  ([#186](https://github.com/JDimproved/JDim/pull/186))
+- Fix number of bytes for `strncpy` argument of `Css_Manager::create_textnode()`
+  ([#185](https://github.com/JDimproved/JDim/pull/185))
+- `HEAP::heap_alloc()`: adjust alignment
+  ([#184](https://github.com/JDimproved/JDim/pull/184))
+- `CONTROL::get_keyconfig` use `snprintf` and set copying buffer size correctly
+  ([#181](https://github.com/JDimproved/JDim/pull/181))
+- Replace dynamic allocation with local variable for `struct utsname`
   ([#179](https://github.com/JDimproved/JDim/pull/179))
 - Remove deprecated `--with-sessionlib=gnomeui` option
   ([#178](https://github.com/JDimproved/JDim/pull/178))

--- a/src/jdlib/misctrip.cpp
+++ b/src/jdlib/misctrip.cpp
@@ -119,7 +119,7 @@ std::string create_trip_newtype( const std::string& key )
             // 16進数文字列を全てバイナリに変換出来た [0-9A-Za-z]{16}
             if( MISC::chrtobin( hex_part.c_str(), key_binary ) == 16 )
             {
-                char salt[5] = { 0 };
+                std::string salt;
 
                 bool is_salt_suitable = true;
 
@@ -131,7 +131,7 @@ std::string create_trip_newtype( const std::string& key )
                     // [./0-9A-Za-z]
                     if( isalnum( key[n] ) != 0 || (unsigned char)( key[n] - 0x2e ) < 2 )
                     {
-                        strncat( salt, &key[n], 1 );
+                        salt.push_back( key[n] );
                     }
                     else
                     {
@@ -144,10 +144,10 @@ std::string create_trip_newtype( const std::string& key )
                 if( is_salt_suitable == true )
                 {
                     // salt に".."を足す
-                    strncat( salt, "..", 2 );
+                    salt.append( ".." );
 
                     // crypt (key は先頭8文字しか使われない)
-                    const char *crypted = crypt( key_binary, salt );
+                    const char *crypted = crypt( key_binary, salt.c_str() );
 
                     // 末尾から10文字(cryptの戻り値はnullptrでなければ必ず13文字)
                     if( crypted ) trip = std::string( crypted + 3 );


### PR DESCRIPTION
Compiler warns:

```
misctrip.cpp: In function 'std::string create_trip_newtype(const string&)':
misctrip.cpp:147:28: warning: 'char* strncat(char*, const char*, size_t)' specified bound 2 equals source length [-Wstringop-overflow=]
  147 |                     strncat( salt, "..", 2 );
      |                     ~~~~~~~^~~~~~~~~~~~~~~~~
```

The salt string is short and it probably does the std::string's small string optimization.