### PR TITLE
Fix buffer overrun for MISC::is_url_scheme_impl() test

### DIFF
--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -91,12 +91,15 @@ TEST_F(IsUrlSchemeTest, url_none)
     EXPECT_EQ( MISC::SCHEME_NONE, MISC::is_url_scheme( "ttp:/" ) );
     EXPECT_EQ( MISC::SCHEME_NONE, MISC::is_url_scheme( "tp:/" ) );
     EXPECT_EQ( MISC::SCHEME_NONE, MISC::is_url_scheme( "ftp:/" ) );
-    EXPECT_EQ( MISC::SCHEME_NONE, MISC::is_url_scheme( "sssp:/" ) );
+    // "sssp:/" はバッファオーバーランを起こす
 }
 
 TEST_F(IsUrlSchemeTest, url_http)
 {
     int length;
+    EXPECT_EQ( MISC::SCHEME_HTTP, MISC::is_url_scheme( "http://", &length ) );
+    EXPECT_EQ( 7, length );
+
     EXPECT_EQ( MISC::SCHEME_HTTP, MISC::is_url_scheme( "http://foobar", &length ) );
     EXPECT_EQ( 7, length );
 }
@@ -104,6 +107,9 @@ TEST_F(IsUrlSchemeTest, url_http)
 TEST_F(IsUrlSchemeTest, url_ttp)
 {
     int length;
+    EXPECT_EQ( MISC::SCHEME_TTP, MISC::is_url_scheme( "ttp://", &length ) );
+    EXPECT_EQ( 6, length );
+
     EXPECT_EQ( MISC::SCHEME_TTP, MISC::is_url_scheme( "ttp://foobar", &length ) );
     EXPECT_EQ( 6, length );
 }
@@ -111,6 +117,9 @@ TEST_F(IsUrlSchemeTest, url_ttp)
 TEST_F(IsUrlSchemeTest, url_tp)
 {
     int length;
+    EXPECT_EQ( MISC::SCHEME_TP, MISC::is_url_scheme( "tp://", &length ) );
+    EXPECT_EQ( 5, length );
+
     EXPECT_EQ( MISC::SCHEME_TP, MISC::is_url_scheme( "tp://foobar", &length ) );
     EXPECT_EQ( 5, length );
 }
@@ -118,6 +127,9 @@ TEST_F(IsUrlSchemeTest, url_tp)
 TEST_F(IsUrlSchemeTest, url_ftp)
 {
     int length;
+    EXPECT_EQ( MISC::SCHEME_FTP, MISC::is_url_scheme( "ftp://", &length ) );
+    EXPECT_EQ( 6, length );
+
     EXPECT_EQ( MISC::SCHEME_FTP, MISC::is_url_scheme( "ftp://foobar", &length ) );
     EXPECT_EQ( 6, length );
 }
@@ -125,6 +137,9 @@ TEST_F(IsUrlSchemeTest, url_ftp)
 TEST_F(IsUrlSchemeTest, url_sssp)
 {
     int length;
+    EXPECT_EQ( MISC::SCHEME_HTTP, MISC::is_url_scheme( "sssp://", &length ) );
+    EXPECT_EQ( 7, length );
+
     EXPECT_EQ( MISC::SCHEME_HTTP, MISC::is_url_scheme( "sssp://foobar", &length ) );
     EXPECT_EQ( 7, length );
 


### PR DESCRIPTION
Occurred a buffer overrun on `make test` in the case of the build using gcc-9 with configure `CXXFLAGS="-fsanitize=address -fno-omit-frame-pointer"` `LDFLAGS="-fsanitize=address"`.

error log:
```
==20309==ERROR: AddressSanitizer: global-buffer-overflow on address 0x56135a804967 at pc 0x56135a235afb bp 0x7fff9ce8b3e0 sp 0x7fff9ce8b3d0
READ of size 1 at 0x56135a804967 thread T0
#0 0x56135a235afa in MISC::is_url_scheme_impl(char const*, int*) src/jdlib/miscutil.cpp:963
#1 0x561359a69946 in MISC::is_url_scheme(char const*, int*) ../src/jdlib/miscutil.h:272
#2 0x561359a69946 in TestBody test/gtest_jdlib_miscutil.cpp:94
(snip)

0x56135a804967 is located 0 bytes to the right of global variable '*.LC85' defined in 'gtest_jdlib_miscutil.cpp' (0x56135a804960) of size 7
'*.LC85' is ascii string 'sssp:/'
0x56135a804967 is located 57 bytes to the left of global variable '*.LC86' defined in 'gtest_jdlib_miscutil.cpp' (0x56135a8049a0) of size 32
'*.LC86' is ascii string 'MISC::is_url_scheme( "sssp:/" )'
SUMMARY: AddressSanitizer: global-buffer-overflow src/jdlib/miscutil.cpp:963 in MISC::is_url_scheme_impl(char const*, int*)
Shadow bytes around the buggy address:
0x0ac2eb4f88d0: f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9 00 00 00 05
0x0ac2eb4f88e0: f9 f9 f9 f9 00 00 02 f9 f9 f9 f9 f9 07 f9 f9 f9
0x0ac2eb4f88f0: f9 f9 f9 f9 00 00 00 00 f9 f9 f9 f9 06 f9 f9 f9
0x0ac2eb4f8900: f9 f9 f9 f9 00 00 00 07 f9 f9 f9 f9 05 f9 f9 f9
0x0ac2eb4f8910: f9 f9 f9 f9 00 00 00 06 f9 f9 f9 f9 06 f9 f9 f9
=>0x0ac2eb4f8920: f9 f9 f9 f9 00 00 00 07 f9 f9 f9 f9[07]f9 f9 f9
0x0ac2eb4f8930: f9 f9 f9 f9 00 00 00 00 f9 f9 f9 f9 00 06 f9 f9
0x0ac2eb4f8940: f9 f9 f9 f9 00 00 00 00 00 00 f9 f9 f9 f9 f9 f9
0x0ac2eb4f8950: 00 00 02 f9 f9 f9 f9 f9 07 f9 f9 f9 f9 f9 f9 f9
0x0ac2eb4f8960: 02 f9 f9 f9 f9 f9 f9 f9 00 05 f9 f9 f9 f9 f9 f9
0x0ac2eb4f8970: 00 00 00 00 00 07 f9 f9 f9 f9 f9 f9 00 00 01 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
Addressable:           00
Partially addressable: 01 02 03 04 05 06 07
Heap left redzone:       fa
Freed heap region:       fd
Stack left redzone:      f1
Stack mid redzone:       f2
Stack right redzone:     f3
Stack after return:      f5
Stack use after scope:   f8
Global redzone:          f9
Global init order:       f6
Poisoned by user:        f7
Container overflow:      fc
Array cookie:            ac
Intra object redzone:    bb
ASan internal:           fe
Left alloca redzone:     ca
Right alloca redzone:    cb
Shadow gap:              cc
==20309==ABORTING
```

