### PR TITLE
Replace char buffer with std::string for DBTREE::NodeTreeMachi

### DIFF
--- a/docs/manual/2020.md
+++ b/docs/manual/2020.md
@@ -10,6 +10,12 @@ layout: default
 
 <a name="0.4.0-unreleased"></a>
 ### [0.4.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.3.0...master) (unreleased)
+- Replace char buffer with `std::string` for `DBTREE::NodeTreeMachi`
+  ([#190](https://github.com/JDimproved/JDim/pull/190))
+- Remove zlib client codes for version < 1.2.0
+  ([#189](https://github.com/JDimproved/JDim/pull/189))
+- Fix buffer overrun for `MISC::is_url_scheme_impl()` test
+  ([#188](https://github.com/JDimproved/JDim/pull/188))
 - Fix a `-Wstringop-overflow` compiler warning in `create_trip_newtype()`
   ([#187](https://github.com/JDimproved/JDim/pull/187))
 - Replace char buffer with `std::string` for `DBTREE::NodeTreeJBBS`

--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -30,7 +30,6 @@ NodeTreeMachi::NodeTreeMachi( const std::string& url, const std::string& date_mo
     : NodeTreeBase( url, date_modified )
     , m_regex( nullptr )
     , m_iconv( nullptr )
-    , m_buffer( nullptr )
     , m_buffer_for_200( nullptr )
 {
 #ifdef _DEBUG
@@ -70,8 +69,8 @@ void NodeTreeMachi::clear()
     m_decoded_lines.clear();
     m_decoded_lines.shrink_to_fit();
 
-    if( m_buffer ) free( m_buffer );
-    m_buffer = nullptr;
+    m_buffer.clear();
+    m_buffer.shrink_to_fit();
 
     if( m_buffer_for_200 ) free( m_buffer_for_200 );
     m_buffer_for_200 = nullptr;
@@ -96,8 +95,6 @@ void NodeTreeMachi::init_loading()
     // iconv 初期化
     std::string charset = DBTREE::board_charset( get_url() );
     if( ! m_iconv ) m_iconv = new JDLIB::Iconv( charset, "UTF-8" );
-
-    if( ! m_buffer ) m_buffer = ( char* )malloc( BUF_SIZE_ICONV_OUT + 64 );
 
     if( m_buffer_for_200 ) m_buffer_for_200[ 0 ] = '\0';
 
@@ -231,11 +228,9 @@ char* NodeTreeMachi::process_raw_lines( char* rawlines )
         buffer = std::string();
     }
 
-    int byte = buffer.length();
-    memcpy( m_buffer, buffer.c_str(), byte );
-    m_buffer[ byte ] = '\0';
+    m_buffer = std::move( buffer );
 
-    return m_buffer;
+    return &*m_buffer.begin();
 }
 
 

--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -30,7 +30,6 @@ NodeTreeMachi::NodeTreeMachi( const std::string& url, const std::string& date_mo
     : NodeTreeBase( url, date_modified )
     , m_regex( nullptr )
     , m_iconv( nullptr )
-    , m_decoded_lines( nullptr )
     , m_buffer( nullptr )
     , m_buffer_for_200( nullptr )
 {
@@ -68,8 +67,8 @@ void NodeTreeMachi::clear()
     if( m_iconv ) delete m_iconv;
     m_iconv = nullptr;
 
-    if( m_decoded_lines ) free( m_decoded_lines );
-    m_decoded_lines = nullptr;
+    m_decoded_lines.clear();
+    m_decoded_lines.shrink_to_fit();
 
     if( m_buffer ) free( m_buffer );
     m_buffer = nullptr;
@@ -98,7 +97,6 @@ void NodeTreeMachi::init_loading()
     std::string charset = DBTREE::board_charset( get_url() );
     if( ! m_iconv ) m_iconv = new JDLIB::Iconv( charset, "UTF-8" );
 
-    if( ! m_decoded_lines ) m_decoded_lines = ( char* )malloc( BUF_SIZE_ICONV_OUT );
     if( ! m_buffer ) m_buffer = ( char* )malloc( BUF_SIZE_ICONV_OUT + 64 );
 
     if( m_buffer_for_200 ) m_buffer_for_200[ 0 ] = '\0';
@@ -343,11 +341,9 @@ const char* NodeTreeMachi::raw2dat( char* rawlines, int& byte )
         buffer = std::string();
     }
 
-    byte = buffer.length();
-    memcpy( m_decoded_lines, buffer.c_str(), byte );
-    m_decoded_lines[ byte ] = '\0';
+    m_decoded_lines = std::move( buffer );
 
-    return m_decoded_lines;
+    return m_decoded_lines.c_str();
 }
 
 

--- a/src/dbtree/nodetreemachi.h
+++ b/src/dbtree/nodetreemachi.h
@@ -24,7 +24,7 @@ namespace DBTREE
         JDLIB::Iconv* m_iconv;
         std::string m_decoded_lines;
         std::string m_buffer;
-        char* m_buffer_for_200;  // HTTP200が来た時のdat落ち判定用
+        std::string m_buffer_for_200;  // HTTP200が来た時のdat落ち判定用
 
         std::string m_tmp_buffer;
 

--- a/src/dbtree/nodetreemachi.h
+++ b/src/dbtree/nodetreemachi.h
@@ -22,7 +22,7 @@ namespace DBTREE
     {
         JDLIB::Regex* m_regex;
         JDLIB::Iconv* m_iconv;
-        char* m_decoded_lines;
+        std::string m_decoded_lines;
         char* m_buffer;
         char* m_buffer_for_200;  // HTTP200が来た時のdat落ち判定用
 

--- a/src/dbtree/nodetreemachi.h
+++ b/src/dbtree/nodetreemachi.h
@@ -23,7 +23,7 @@ namespace DBTREE
         JDLIB::Regex* m_regex;
         JDLIB::Iconv* m_iconv;
         std::string m_decoded_lines;
-        char* m_buffer;
+        std::string m_buffer;
         char* m_buffer_for_200;  // HTTP200が来た時のdat落ち判定用
 
         std::string m_tmp_buffer;


### PR DESCRIPTION
malloc/freeで確保しているバッファをstd::stringで置き換えます。
