### PR TITLE
Fix not setting result to the out parameter of NodeTreeMachi::raw2dat()

### DIFF
--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -336,6 +336,7 @@ const char* NodeTreeMachi::raw2dat( char* rawlines, int& byte )
     }
 
     m_decoded_lines = std::move( buffer );
+    byte = m_decoded_lines.size();
 
     return m_decoded_lines.c_str();
 }


### PR DESCRIPTION
修正で抜け落ちた出力パラメーター"byte"への代入を追加します。