### PR TITLE
Improve JDLIB::HEAP to return pointer aligned by specified type

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -23,7 +23,7 @@
 
   ・autoconf
   ・automake
-  ・g++ (C++11 mode)
+  ・g++ 5 以上、または clang++ 3.3 以上
   ・gnutls
   ・gtkmm
   ・libtool

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -37,7 +37,7 @@ layout: default
 #### 必須
 - autoconf
 - automake
-- g++ 4.8.1 以上、または clang++ 3.3 以上
+- g++ 5 以上、または clang++ 3.3 以上
 - gnutls
 - gtkmm
 - libtool

--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -110,7 +110,7 @@ void LayoutTree::clear()
 // RECTANGLE型のメモリ確保
 RECTANGLE* LayoutTree::create_rect()
 {
-    RECTANGLE* rect = ( RECTANGLE* ) m_heap.heap_alloc( sizeof( RECTANGLE ) );
+    RECTANGLE* rect = m_heap.heap_alloc<RECTANGLE>();
     rect->end = true;
 
     return rect;
@@ -122,7 +122,7 @@ RECTANGLE* LayoutTree::create_rect()
 //
 LAYOUT* LayoutTree::create_layout( const int type )
 {
-    LAYOUT* tmplayout = ( LAYOUT* ) m_heap.heap_alloc( sizeof( LAYOUT ) );
+    LAYOUT* tmplayout = m_heap.heap_alloc<LAYOUT>();
     tmplayout->type = type;
     tmplayout->id_header = m_id_header; 
     tmplayout->id = m_id_layout++;
@@ -250,7 +250,7 @@ LAYOUT* LayoutTree::create_layout_div( const int id )
 
     m_last_div = div;
 
-    div->css = ( CORE::CSS_PROPERTY* ) m_heap.heap_alloc( sizeof( CORE::CSS_PROPERTY ) );
+    div->css = m_heap.heap_alloc<CORE::CSS_PROPERTY>();
     *div->css = CORE::get_css_manager()->get_property( id );
 
     return div;
@@ -575,7 +575,7 @@ LAYOUT* LayoutTree::create_separator()
     LAYOUT* header = create_layout_div( classid );
     header->type = DBTREE::NODE_HEADER;
 
-    DBTREE::NODE* node = ( DBTREE::NODE* ) m_heap.heap_alloc( sizeof( DBTREE::NODE ) );
+    DBTREE::NODE* node = m_heap.heap_alloc<DBTREE::NODE>();
     node->fontid = FONT_DEFAULT; // デフォルトフォントを設定
     header->node = node;
 

--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -610,7 +610,7 @@ void Css_Manager::set_size( CSS_PROPERTY* css, double height ) const
 //
 DOM* Css_Manager::create_domnode( int type )
 {
-    DOM* tmpdom = ( DOM* ) m_heap.heap_alloc( sizeof( DOM ) );
+    DOM* tmpdom = m_heap.heap_alloc<DOM>();
     tmpdom->nodetype = type;
     tmpdom->attr = 0;
 
@@ -661,7 +661,7 @@ DOM* Css_Manager::create_textnode( const char* text )
 #endif
 
     DOM* tmpdom = create_domnode( DOMNODE_TEXT );
-    tmpdom->chardat = ( char* ) m_heap.heap_alloc_char( lng + 1 );
+    tmpdom->chardat = m_heap.heap_alloc<char>( lng + 1 );
     strncpy( tmpdom->chardat, text, lng + 1 );
 
     return tmpdom;

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -800,7 +800,7 @@ std::string NodeTreeBase::get_id_name( int number )
 //
 NODE* NodeTreeBase::create_node()
 {
-    NODE* tmpnode = ( NODE* ) m_heap.heap_alloc( sizeof( NODE ) );
+    NODE* tmpnode = m_heap.heap_alloc<NODE>();
 
     tmpnode->id_header = m_id_header;
     tmpnode->fontid = FONT_EMPTY; // フォントID未設定
@@ -828,7 +828,7 @@ NODE* NodeTreeBase::create_node_header()
     tmpnode->type =  NODE_HEADER;
 
     // ヘッダ情報
-    tmpnode->headinfo = ( HEADERINFO* )m_heap.heap_alloc( sizeof( HEADERINFO ) );
+    tmpnode->headinfo = m_heap.heap_alloc<HEADERINFO>();
     if( m_id_header >= 2 ) m_vec_header[ m_id_header -1 ]->headinfo->next_header = tmpnode;
     
     return tmpnode;
@@ -933,12 +933,12 @@ NODE* NodeTreeBase::create_node_link( const char* text, const int n, const char*
         tmpnode->type = NODE_LINK;
 
         // リンク情報作成
-        char *tmplink = ( char* )m_heap.heap_alloc_char( n_link + 1 );
+        char *tmplink = m_heap.heap_alloc<char>( n_link + 1 );
         memcpy( tmplink, link, n_link );
         tmplink[ n_link ] = '\0';
 
         // リンク情報セット
-        tmpnode->linkinfo = ( LINKINFO* )m_heap.heap_alloc( sizeof( LINKINFO ) );
+        tmpnode->linkinfo = m_heap.heap_alloc<LINKINFO>();
         tmpnode->linkinfo->link = tmplink;
     }
     
@@ -956,7 +956,7 @@ NODE* NodeTreeBase::create_node_anc( const char* text, const int n, const char* 
     NODE* tmpnode = create_node_link( text, n, link, n_link, color_text, bold );
     if( tmpnode ){
 
-        tmpnode->linkinfo->ancinfo = ( ANCINFO* )m_heap.heap_alloc( sizeof( ANCINFO ) * ( lng_ancinfo + 1 ) );
+        tmpnode->linkinfo->ancinfo = m_heap.heap_alloc<ANCINFO>( lng_ancinfo + 1 );
         memcpy( tmpnode->linkinfo->ancinfo, ancinfo, sizeof( ANCINFO ) * lng_ancinfo );
     }
     
@@ -973,12 +973,12 @@ NODE* NodeTreeBase::create_node_sssp( const char* link, const int n_link )
     tmpnode->type = NODE_SSSP;
 
     // リンク情報作成
-    char *tmplink = ( char* )m_heap.heap_alloc_char( n_link + 1 );
+    char *tmplink = m_heap.heap_alloc<char>( n_link + 1 );
     memcpy( tmplink, link, n_link );
     tmplink[ n_link ] = '\0';
 
     // リンク情報セット
-    tmpnode->linkinfo = ( LINKINFO* )m_heap.heap_alloc( sizeof( LINKINFO ) );
+    tmpnode->linkinfo = m_heap.heap_alloc<LINKINFO>();
     tmpnode->linkinfo->link = tmplink;
     tmpnode->linkinfo->image = true;
     tmpnode->linkinfo->imglink = tmpnode->linkinfo->link;
@@ -1011,7 +1011,7 @@ NODE* NodeTreeBase::create_node_thumbnail( const char* text, const int n, const 
 
     if( tmpnode ){
         // サムネイル画像のURLをセット
-        char *tmpthumb = ( char* )m_heap.heap_alloc_char( n_thumb + 1 );
+        char *tmpthumb = m_heap.heap_alloc<char>( n_thumb + 1 );
         memcpy( tmpthumb, thumb, n_thumb );
         tmpthumb[ n_thumb ] = '\0';
 
@@ -1045,7 +1045,7 @@ NODE* NodeTreeBase::create_node_ntext( const char* text, const int n, const int 
     if( tmpnode ){
         tmpnode->type = NODE_TEXT;
 
-        tmpnode->text = ( char* )m_heap.heap_alloc_char( n + MAX_RES_DIGIT + 4 );
+        tmpnode->text = m_heap.heap_alloc<char>( n + MAX_RES_DIGIT + 4 );
         memcpy( tmpnode->text, text, n ); tmpnode->text[ n ] = '\0';
         tmpnode->color_text = color_text;
         tmpnode->bold = bold;
@@ -1755,7 +1755,7 @@ void NodeTreeBase::parse_name( NODE* header, const char* str, const int lng, con
     // plainな名前取得
     // 名前あぼーんや名前抽出などで使用する
     if( defaultname ){
-        header->headinfo->name = ( char* )m_heap.heap_alloc_char( lng +2 );
+        header->headinfo->name = m_heap.heap_alloc<char>( lng +2 );
         memcpy( header->headinfo->name, str, lng );
     }
     else{
@@ -1765,7 +1765,7 @@ void NodeTreeBase::parse_name( NODE* header, const char* str, const int lng, con
             if( node->text ) str_tmp += node->text;
             node = node->next_node;
         }
-        header->headinfo->name = ( char* )m_heap.heap_alloc_char( str_tmp.length() +2 );
+        header->headinfo->name = m_heap.heap_alloc<char>( str_tmp.length() +2 );
         memcpy( header->headinfo->name, str_tmp.c_str(), str_tmp.length() );
     }
 }

--- a/src/jdlib/heap.h
+++ b/src/jdlib/heap.h
@@ -2,29 +2,41 @@
 
 // ヒープクラス
 
-#ifndef _HEAP_H
-#define _HEAP_H
+#ifndef HEAP_H
+#define HEAP_H
 
-#include <string>
 #include <list>
+#include <memory>
+
 
 namespace JDLIB
 {
     class HEAP
     {
-        std::list< unsigned char* >m_heap_list;
-        long m_max;  // ブロックサイズ
-        long m_used; // ブロック内の使用量
-        long m_total_size; // トータルサイズ
-        
+        std::list< std::unique_ptr<unsigned char[]> > m_heap_list;
+        std::size_t m_blocksize; // ブロックサイズ
+        std::size_t m_space_avail; // ブロックの未使用サイズ
+        void* m_ptr_head; // 検索開始位置
+
       public:
-        HEAP( long blocksize );
+        HEAP( std::size_t blocksize ) noexcept;
         ~HEAP();
+
+        HEAP( const HEAP& ) = delete;
+        HEAP& operator=( const HEAP& ) = delete;
+        HEAP( HEAP&& ) noexcept = default;
+        HEAP& operator=( HEAP&& ) = default;
 
         void clear();
 
-        unsigned char* heap_alloc( long n, long alignment = 8 );
-        unsigned char* heap_alloc_char( long n ) { return heap_alloc(n, 1); };
+        // 戻り値はunsigned char*のエイリアス
+        void* heap_alloc( std::size_t size_bytes, std::size_t alignment );
+
+        template<typename T>
+        T* heap_alloc( std::size_t length = 1 )
+        {
+            return reinterpret_cast<T*>( heap_alloc( sizeof(T) * length, alignof(T) ) );
+        }
     };
 }
 


### PR DESCRIPTION
Fixes #183
ヒープクラスによるメモリ確保を型に合わせてアライメント調整されるように修正します。
この修正でメモリ使用量が若干減ります。

##### 互換性に関する注意
パッチで使用する[`std::align()`][align]はgcc 5以上が必要になります。

[align]: https://cpprefjp.github.io/reference/memory/align.html
