### PR TITLE
Remove unused NodeTreeBase::get_raw_res_str()

### DIFF
--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -341,15 +341,6 @@ std::string ArticleBase::get_res_str( int number, bool ref )
 
 
 //
-// number　番のレスの生文字列を返す
-//
-std::string ArticleBase::get_raw_res_str( int number )
-{
-    return get_nodetree()->get_raw_res_str( number );
-}
-
-
-//
 // 更新時刻
 //
 time_t ArticleBase::get_time_modified()

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -213,9 +213,6 @@ namespace DBTREE
         // ref == true なら先頭に ">" を付ける
         std::string get_res_str( int number, bool ref = false );
 
-        // number　番のレスの生文字列を返す
-        std::string get_raw_res_str( int number );
-
         // 書き込み時の名前とメアド
         const std::string& get_write_name() const { return m_write_name; }
         void set_write_name( const std::string& str ){ m_save_info = true; m_write_name = str; }

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -663,53 +663,6 @@ std::string NodeTreeBase::get_res_str( int number, bool ref )
 
 
 //
-// number　番のレスの生文字列を返す
-//
-std::string NodeTreeBase::get_raw_res_str( int number )
-{
-#ifdef _DEBUG
-    std::cout << "NodeTreeBase::get_raw_res_str : num = " << number << std::endl;
-#endif
-    std::string retstr;
-
-    std::string str;
-    std::string path_cache = CACHE::path_dat( m_url );
-    if( ! CACHE::load_rawdata( path_cache, str ) ) return std::string();
-
-    char* rawlines = ( char* ) malloc( str.size() + 64 );
-    strcpy( rawlines, str.c_str() );
-
-    // dat形式に変換
-
-    int id_header = m_id_header;
-    m_id_header = 0;
-    init_loading();
-
-    int byte;
-    const char* datlines = raw2dat( rawlines, byte );
-    if( byte ){
-
-        std::list< std::string > lines = MISC::get_lines( datlines );
-        std::list< std::string >::iterator it = lines.begin();
-        for( int i = 1; it != lines.end() && i < number ; ++it, ++i );
-        if( it != lines.end() ) retstr = *it;
-    }
-
-#ifdef _DEBUG
-    std::cout << retstr << std::endl;
-#endif
-
-    clear();
-    m_id_header = id_header;
-    if( rawlines ) free( rawlines );
-
-    return retstr;
-}
-
-
-
-
-//
 // number番を書いた人の名前を取得
 //
 std::string NodeTreeBase::get_name( int number )

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -216,9 +216,6 @@ namespace DBTREE
         // ref == true なら先頭に ">" を付ける        
         std::string get_res_str( int number, bool ref = false );
 
-        // number　番のレスの生文字列を返す
-        std::string get_raw_res_str( int number );
-        
         // 明示的にhtml を加える
         // パースして追加したノードのポインタを返す
         // html は UTF-8　であること


### PR DESCRIPTION
bc4eb7e5ccf1a1540ad104eef15997883f8508b9 で実装されてから一度も使われていない`get_raw_res_str()`を削除します。
