### PR TITLE
Remove legacy gtk2 codes for less than version 2.24

### DIFF
--- a/docs/manual/2020.md
+++ b/docs/manual/2020.md
@@ -10,6 +10,14 @@ layout: default
 
 <a name="0.4.0-unreleased"></a>
 ### [0.4.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.3.0...master) (unreleased)
+- Remove legacy gtk2 codes for less than version 2.24
+  ([#194](https://github.com/JDimproved/JDim/pull/194))
+- Remove unused `NodeTreeBase::get_raw_res_str()`
+  ([#193](https://github.com/JDimproved/JDim/pull/193))
+- Improve `JDLIB::HEAP` to return pointer aligned by specified type
+  ([#192](https://github.com/JDimproved/JDim/pull/192))
+- Fix not setting result to the out parameter of `NodeTreeMachi::raw2dat()`
+  ([#191](https://github.com/JDimproved/JDim/pull/191))
 - Replace char buffer with `std::string` for `DBTREE::NodeTreeMachi`
   ([#190](https://github.com/JDimproved/JDim/pull/190))
 - Remove zlib client codes for version < 1.2.0

--- a/src/control/keysyms.h
+++ b/src/control/keysyms.h
@@ -5,12 +5,6 @@
 #ifndef _KEYSYMS_H
 #define _KEYSYMS_H
 
-#include "gtkmmversion.h"
-
-#if GTKMM_CHECK_VERSION(3,0,0)
-#include <gdk/gdkkeysyms-compat.h>
-#endif
-
 enum
 {
     MAX_KEYNAME = 64
@@ -28,55 +22,55 @@ namespace CONTROL
 {
     KEYSYMS keysyms[] ={
 
-        { "Space", GDK_space },
-        { "Escape", GDK_Escape },
-        { "Delete", GDK_Delete },
-        { "Enter", GDK_Return },
+        { "Space", GDK_KEY_space },
+        { "Escape", GDK_KEY_Escape },
+        { "Delete", GDK_KEY_Delete },
+        { "Enter", GDK_KEY_Return },
 
-        { "Up", GDK_Up },
-        { "Down", GDK_Down },
-        { "Left", GDK_Left },
-        { "Right", GDK_Right },
-        { "Page_Up", GDK_Page_Up },
-        { "Page_Down", GDK_Page_Down },
-        { "Tab", GDK_Tab },
-        { "Left_Tab", GDK_ISO_Left_Tab },
-        { "Home", GDK_Home },
-        { "End", GDK_End },
-        { "BackSpace", GDK_BackSpace },
+        { "Up", GDK_KEY_Up },
+        { "Down", GDK_KEY_Down },
+        { "Left", GDK_KEY_Left },
+        { "Right", GDK_KEY_Right },
+        { "Page_Up", GDK_KEY_Page_Up },
+        { "Page_Down", GDK_KEY_Page_Down },
+        { "Tab", GDK_KEY_Tab },
+        { "Left_Tab", GDK_KEY_ISO_Left_Tab },
+        { "Home", GDK_KEY_Home },
+        { "End", GDK_KEY_End },
+        { "BackSpace", GDK_KEY_BackSpace },
 
-        { "F1", GDK_F1 },
-        { "F2", GDK_F2 },
-        { "F3", GDK_F3 },
-        { "F4", GDK_F4 },
-        { "F5", GDK_F5 },
-        { "F6", GDK_F6 },
-        { "F7", GDK_F7 },
-        { "F8", GDK_F8 },
-        { "F9", GDK_F9 },
-        { "F10", GDK_F10 },
-        { "F11", GDK_F11 },
-        { "F12", GDK_F12 },
+        { "F1", GDK_KEY_F1 },
+        { "F2", GDK_KEY_F2 },
+        { "F3", GDK_KEY_F3 },
+        { "F4", GDK_KEY_F4 },
+        { "F5", GDK_KEY_F5 },
+        { "F6", GDK_KEY_F6 },
+        { "F7", GDK_KEY_F7 },
+        { "F8", GDK_KEY_F8 },
+        { "F9", GDK_KEY_F9 },
+        { "F10", GDK_KEY_F10 },
+        { "F11", GDK_KEY_F11 },
+        { "F12", GDK_KEY_F12 },
 
-        { "Menu", GDK_Menu },
+        { "Menu", GDK_KEY_Menu },
 
         // テンキー
-        { "KP_Divide", GDK_KP_Divide },     // "/"
-        { "KP_Multiply", GDK_KP_Multiply }, // "*"
-        { "KP_Subtract", GDK_KP_Subtract }, // "-"
-        { "KP_Home", GDK_KP_Home },         // "Home(7)"
-        { "KP_Up", GDK_KP_Up },             // "↑(8)"
-        { "KP_Prior", GDK_KP_Prior },       // "Pg UP(9)"
-        { "KP_Add", GDK_KP_Add },           // "+"
-        { "KP_Left", GDK_KP_Left },         // "←(4)"
-        //{ "KP_Begin", GDK_KP_Begin },       // "(5)"
-        { "KP_Right", GDK_KP_Right },       // "→(6)"
-        { "KP_End", GDK_KP_End },           // "End(1)"
-        { "KP_Down", GDK_KP_Down },         // "↓(2)"
-        { "KP_Next", GDK_KP_Next },         // "Pg Dn(3)"
-        { "KP_Enter", GDK_KP_Enter },       // "Enter"
-        { "KP_Insert", GDK_KP_Insert },     // "Ins(0)"
-        { "KP_Delete", GDK_KP_Delete },     // "Del(.)"
+        { "KP_Divide", GDK_KEY_KP_Divide },     // "/"
+        { "KP_Multiply", GDK_KEY_KP_Multiply }, // "*"
+        { "KP_Subtract", GDK_KEY_KP_Subtract }, // "-"
+        { "KP_Home", GDK_KEY_KP_Home },         // "Home(7)"
+        { "KP_Up", GDK_KEY_KP_Up },             // "↑(8)"
+        { "KP_Prior", GDK_KEY_KP_Prior },       // "Pg UP(9)"
+        { "KP_Add", GDK_KEY_KP_Add },           // "+"
+        { "KP_Left", GDK_KEY_KP_Left },         // "←(4)"
+        //{ "KP_Begin", GDK_KEY_KP_Begin },       // "(5)"
+        { "KP_Right", GDK_KEY_KP_Right },       // "→(6)"
+        { "KP_End", GDK_KEY_KP_End },           // "End(1)"
+        { "KP_Down", GDK_KEY_KP_Down },         // "↓(2)"
+        { "KP_Next", GDK_KEY_KP_Next },         // "Pg Dn(3)"
+        { "KP_Enter", GDK_KEY_KP_Enter },       // "Enter"
+        { "KP_Insert", GDK_KEY_KP_Insert },     // "Ins(0)"
+        { "KP_Delete", GDK_KEY_KP_Delete },     // "Del(.)"
     };
 }
 

--- a/src/skeleton/aamenu.cpp
+++ b/src/skeleton/aamenu.cpp
@@ -13,10 +13,6 @@
 #include "aamanager.h"
 #include "cache.h"
 
-#if GTKMM_CHECK_VERSION(3,0,0)
-#include <gdk/gdkkeysyms-compat.h>
-#endif
-
 using namespace SKELETON;
 
 AAMenu::AAMenu( Gtk::Window& parent )
@@ -207,9 +203,9 @@ bool AAMenu::on_key_press_event( GdkEventKey* event )
 #endif
 
     // 下移動
-    if( event->keyval == GDK_j
-             || ( ( event->state & GDK_CONTROL_MASK ) && event->keyval == GDK_n )
-             || event->keyval == GDK_space
+    if( event->keyval == GDK_KEY_j
+             || ( ( event->state & GDK_CONTROL_MASK ) && event->keyval == GDK_KEY_n )
+             || event->keyval == GDK_KEY_space
         ){
 
         move_down();
@@ -217,8 +213,8 @@ bool AAMenu::on_key_press_event( GdkEventKey* event )
     }
 
     // 上移動
-    else if( event->keyval == GDK_k
-                  || ( ( event->state & GDK_CONTROL_MASK ) && event->keyval == GDK_p )
+    else if( event->keyval == GDK_KEY_k
+                  || ( ( event->state & GDK_CONTROL_MASK ) && event->keyval == GDK_KEY_p )
         ){
         move_up();
         return true;

--- a/src/skeleton/editview.cpp
+++ b/src/skeleton/editview.cpp
@@ -19,10 +19,6 @@
 
 #include "gtk/gtktextview.h"
 
-#if GTKMM_CHECK_VERSION(3,0,0)
-#include <gdk/gdkkeysyms-compat.h>
-#endif
-
 using namespace SKELETON;
 
 enum
@@ -352,7 +348,7 @@ bool EditTextView::on_key_press_event( GdkEventKey* event )
 
     bool cancel_event = false;
     m_delete_pushed = false;
-    if( event->keyval == GDK_Delete ) m_delete_pushed = true;
+    if( event->keyval == GDK_KEY_Delete ) m_delete_pushed = true;
 
     const int controlid = m_control.key_press( event );
 
@@ -425,7 +421,7 @@ bool EditTextView::on_key_press_event( GdkEventKey* event )
         case CONTROL::UndoEdit: undo(); return true;
 
         case CONTROL::EnterEdit:
-            event->keyval = GDK_Return;
+            event->keyval = GDK_KEY_Return;
             event->state &= ~GDK_CONTROL_MASK;
             event->state &= ~GDK_SHIFT_MASK;
             event->state &= ~GDK_MOD1_MASK;

--- a/src/skeleton/editview.cpp
+++ b/src/skeleton/editview.cpp
@@ -17,7 +17,6 @@
 #include "jdlib/miscutil.h"
 #include "config/globalconf.h"
 
-#include "gtk/gtktextview.h"
 
 using namespace SKELETON;
 
@@ -373,7 +372,6 @@ bool EditTextView::on_key_press_event( GdkEventKey* event )
         case CONTROL::UndoEdit:
         case CONTROL::InputAA:
         {
-#if GTKMM_CHECK_VERSION(3,0,0)
             if( im_context_filter_keypress( event ) ) {
 #ifdef _DEBUG
                 std::cout << "gtk_im_context_filter_keypress\n";
@@ -381,17 +379,6 @@ bool EditTextView::on_key_press_event( GdkEventKey* event )
                 reset_im_context();
                 return true;
             }
-#else
-            GtkTextView *textview = gobj();
-            if( gtk_im_context_filter_keypress( textview->im_context, event ) )
-            {
-#ifdef _DEBUG    
-                std::cout << "gtk_im_context_filter_keypress\n";
-#endif
-                textview->need_im_reset = TRUE;
-                return true;
-            }
-#endif // GTKMM_CHECK_VERSION(3,0,0)
         }
     }
 

--- a/src/skeleton/entry.cpp
+++ b/src/skeleton/entry.cpp
@@ -1,16 +1,12 @@
 // ライセンス: GPL2
 
 //#define _DEBUG
-#include "gtkmmversion.h"
 #include "jddebug.h"
 
 #include "entry.h"
 
 #include "control/controlid.h"
 
-#if GTKMM_CHECK_VERSION(3,0,0)
-#include <gdk/gdkkeysyms-compat.h>
-#endif
 #include <gtk/gtkentry.h>
 
 using namespace SKELETON;
@@ -43,9 +39,9 @@ bool JDEntry::on_key_press_event( GdkEventKey* event )
 
     const guint key = event->keyval;
     const bool ctrl = ( event->state ) & GDK_CONTROL_MASK;
-    const bool up = ( key == GDK_Up || ( ctrl && key == 'p' ) );
-    const bool down = ( key == GDK_Down || ( ctrl && key == 'n' ) );
-    const bool esc = ( key == GDK_Escape );
+    const bool up = ( key == GDK_KEY_Up || ( ctrl && key == 'p' ) );
+    const bool down = ( key == GDK_KEY_Down || ( ctrl && key == 'n' ) );
+    const bool esc = ( key == GDK_KEY_Escape );
 
     // 上下をキャンセル
     // gtkentry.cpp からのハック。環境やバージョンによっては問題が出るかもしれないので注意

--- a/src/skeleton/entry.cpp
+++ b/src/skeleton/entry.cpp
@@ -7,7 +7,6 @@
 
 #include "control/controlid.h"
 
-#include <gtk/gtkentry.h>
 
 using namespace SKELETON;
 
@@ -47,7 +46,6 @@ bool JDEntry::on_key_press_event( GdkEventKey* event )
     // gtkentry.cpp からのハック。環境やバージョンによっては問題が出るかもしれないので注意
     if( up || down || esc ){
 
-#if GTKMM_CHECK_VERSION(3,0,0)
         if( im_context_filter_keypress( event ) ) {
 #ifdef _DEBUG
             std::cout << "gtk_im_context_filter_keypress\n";
@@ -55,18 +53,6 @@ bool JDEntry::on_key_press_event( GdkEventKey* event )
             reset_im_context();
             return TRUE;
         }
-#else
-        GtkEntry *entry = gobj();
-        if( gtk_im_context_filter_keypress( entry->im_context, event ) )
-        {
-#ifdef _DEBUG    
-            std::cout << "gtk_im_context_filter_keypress\n";
-#endif
-            entry->need_im_reset = TRUE;
-
-            return TRUE;
-        }
-#endif // GTKMM_CHECK_VERSION(3,0,0)
         else if( up || down ){
 
             if( up ) m_sig_operate.emit( CONTROL::Up );

--- a/src/skeleton/msgdiag.cpp
+++ b/src/skeleton/msgdiag.cpp
@@ -10,10 +10,6 @@
 #include "dispatchmanager.h"
 #include "global.h"
 
-#if !GTKMM_CHECK_VERSION(2,22,0)
-#include <gtk/gtkmessagedialog.h>
-#include <gtk/gtklabel.h>
-#endif
 
 using namespace SKELETON;
 
@@ -39,20 +35,12 @@ MsgDiag::MsgDiag( Gtk::Window* parent,
     if( parent ) set_transient_for( *parent );
     else set_transient_for( *CORE::get_mainwindow() );
 
-#if GTKMM_CHECK_VERSION(2,22,0)
+    // tab でラベルにフォーカスが移らないようにする
     const std::vector< Gtk::Widget* > area = get_message_area()->get_children();
     Gtk::Label* const primary_label = dynamic_cast< Gtk::Label* >( area.front() );
     if( primary_label ) {
         primary_label->set_can_focus( false );
     }
-#else
-    // tab でラベルにフォーカスが移らないようにする ( messagedialog.ccg をハックした )
-    Gtk::Widget* wdt = Glib::wrap( gobj()->label );
-    if( wdt ){
-        Gtk::Label* label = dynamic_cast< Gtk::Label* >( wdt );
-        if( label ) label->property_can_focus() = false;
-    }
-#endif // GTKMM_CHECK_VERSION(2,22,0)
 }
 
 

--- a/src/skeleton/selectitempref.cpp
+++ b/src/skeleton/selectitempref.cpp
@@ -1,7 +1,6 @@
 // ライセンス: GPL2
 
 //#define _DEBUG
-#include "gtkmmversion.h"
 #include "jddebug.h"
 
 #include "selectitempref.h"
@@ -11,10 +10,6 @@
 
 #include "global.h"
 #include "session.h"
-
-#if GTKMM_CHECK_VERSION(3,0,0)
-#include <gdk/gdkkeysyms-compat.h>
-#endif
 
 using namespace SKELETON;
 
@@ -339,10 +334,10 @@ bool SelectItemPref::on_key_press_event( GdkEventKey* event )
     bool hook = false;
 
     // "Gtk::Dialog"は"Esc"を押すと閉じられてしまうので
-    // "GDK_Escape"をキャンセルする
+    // "GDK_KEY_Escape"をキャンセルする
     switch( event->keyval )
     {
-        case GDK_Escape :
+        case GDK_KEY_Escape :
             hook = true;
             break;
     }
@@ -363,17 +358,17 @@ bool SelectItemPref::on_key_release_event( GdkEventKey* event )
 
     switch( event->keyval )
     {
-        case GDK_Escape :
+        case GDK_KEY_Escape :
             hook = true;
             m_tree_shown.get_selection()->unselect_all();
             m_tree_hidden.get_selection()->unselect_all();
             break;
 
-        case GDK_Right :
+        case GDK_KEY_Right :
             slot_delete();
             break;
 
-        case GDK_Left :
+        case GDK_KEY_Left :
             slot_add();
             break;
     }

--- a/src/skeleton/tabnote.cpp
+++ b/src/skeleton/tabnote.cpp
@@ -653,12 +653,7 @@ void TabNotebook::calc_tabsize()
             int tab_w = -1;
             int tab_h = -1;
 
-#if GTKMM_CHECK_VERSION(2,20,0)
-            const bool mapped = tab->get_mapped();
-#else
-            const bool mapped = tab->is_mapped();
-#endif
-            if( mapped && page ) {
+            if( tab->get_mapped() && page ) {
 
                 tab_x = page->allocation.x;
                 tab_y = page->allocation.y;

--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -1,7 +1,6 @@
 // ライセンス: GPL2
 
 //#define _DEBUG
-#include "gtkmmversion.h"
 #include "jddebug.h"
 
 #include "admin.h"
@@ -14,10 +13,6 @@
 #include "global.h"
 #include "session.h"
 #include "command.h"
-
-#if GTKMM_CHECK_VERSION(3,0,0)
-#include <gdk/gdkkeysyms-compat.h>
-#endif
 
 using namespace SKELETON;
 
@@ -166,9 +161,9 @@ void View::reset_keyjump_counter()
 bool View::release_keyjump_key( int key )
 {
     // キーパッド対応
-    if( key >= GDK_KP_0 && key <= GDK_KP_9 ) key = key - GDK_KP_0 + GDK_0;
+    if( key >= GDK_KEY_KP_0 && key <= GDK_KEY_KP_9 ) key = key - GDK_KEY_KP_0 + GDK_KEY_0;
 
-    if( key >= GDK_0 && key <= GDK_9 ){
+    if( key >= GDK_KEY_0 && key <= GDK_KEY_9 ){
         m_keyjump_counter = 1;
         m_keyjump_num *= 10;
         m_keyjump_num += key - '0';

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -422,12 +422,7 @@ void JDWindow::restore_status()
 // マウスジェスチャ表示
 void JDWindow::set_mginfo( const std::string& mginfo )
 {
-#if GTKMM_CHECK_VERSION(2,20,0)
-    const bool realized = m_mginfo.get_realized();
-#else
-    const bool realized = m_mginfo.is_realized();
-#endif
-    if( realized ) {
+    if( m_mginfo.get_realized() ) {
         m_mginfo.set_text( mginfo );
     }
 }


### PR DESCRIPTION
Fixes #137
GTK2版のバージョン要件の変更(2.24以上)により使われなくなったコードを削除します。

- GTK3で廃止されたマクロを新しく導入されたマクロへ移行する
- GTK3からウィジェットのフィールドに直接アクセスできなくなるためメンバー関数を使う
- GTK3で廃止されたメンバー関数を削除してコードを統一する
