### PR TITLE
Root: Fix parsing bbsmenu for 2ch.sc and next2ch.net

### DIFF
--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -412,7 +412,15 @@ void Root::bbsmenu2xml( const std::string& menu )
     bool enabled = true;
 
     // 現在の仕様では HTML > BODY > font[size="2"] の子要素が対象
-    XML::DomList targets = html.getElementsByTagName( "font" )[0]->childNodes();
+    // 特定のサイト(2ch.sc、next2ch.net)のbbsmenu.htmlにはfontタグがないため別のタグを使う
+    XML::DomList targets = html.getElementsByTagName( "font" );
+    if( targets.empty() ) targets = html.getElementsByTagName( "small" );
+    if( targets.empty() ) targets = html.getElementsByTagName( "body" );
+    if( targets.empty() ) {
+        MISC::ERRMSG( "parse error for bbsmenu" );
+        return;
+    }
+    targets = targets.front()->childNodes();
     std::list< XML::Dom* >::iterator it = targets.begin();
     while( it != targets.end() )
     {


### PR DESCRIPTION
https://github.com/JDimproved/JDim/pull/195#issuecomment-592562856 より

> 話がちょっとそれますが
> 
> > ```
> > 2. `next2ch.net`はサイトの`http://next2ch.net/bbsmenu.html`を読み込むとクラッシュするため別サイトを使った
> > 3. `2ch.sc`はサイトの`https://menu.2ch.sc/bbsmenu.html`を読み込むとクラッシュするため外部板として登録した
> > ```
> 
中略
> 
> https://github.com/JDimproved/JDim/blob/df78f8145a4ef4cfa539f10334bc7ffdeb371982/src/dbtree/root.cpp#L414
> この辺で死んでます。クラッシュするサイトのソースを見ると、他のにはある`<font size=2>` というのがこれらのサイトに無い為、`html.getElementsByTagName( "font" )[0]`というのがnullptrになって死んでいるようです。



2ch.scとnext2ch.netのbbsmenu.htmlではfontタグが使われていないためfontタグが見つからない場合は別のタグ（small, body）を取得して解析するようにします。
それでも見つからないときはエラーメッセージを出して解析処理を中止します。