### PR TITLE
Fix thread view popup window scrolling for GTK3

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -437,11 +437,7 @@ void DrawAreaBase::init_font()
     // layoutにフォントをセット
     m_font = &m_defaultfont;
     m_pango_layout->set_font_description( m_font->pfd );
-#if GTKMM_CHECK_VERSION(3,0,0)
-    override_font( m_font->pfd );
-#else
-    modify_font( m_font->pfd );
-#endif
+    m_context->set_font_description( m_font->pfd );
 }
 
 
@@ -2808,12 +2804,7 @@ void DrawAreaBase::set_node_font( LAYOUT* layout )
 
         // layoutにフォントをセット
         m_pango_layout->set_font_description( m_font->pfd );
-#if GTKMM_CHECK_VERSION(3,0,0)
         m_context->set_font_description( m_font->pfd );
-        override_font( m_font->pfd );
-#else
-        modify_font( m_font->pfd );
-#endif
     }
 }
 


### PR DESCRIPTION
Fixes #200
GTK3版スレビューのポップアップウインドウでポップアップ内容をスクロールしたとき表示内容が一番上に戻ってしまう問題を修正します。
