### PR TITLE
Implement mouse gesture wheel for GTK3

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -148,6 +148,10 @@ void ArticleViewBase::setup_view()
     assert( m_article );
     assert( m_drawarea );
 
+#if GTKMM_CHECK_VERSION(3,3,18)
+    m_drawarea->add_events( Gdk::SMOOTH_SCROLL_MASK );
+#endif
+
     m_drawarea->sig_button_press().connect(  sigc::mem_fun( *this, &ArticleViewBase::slot_button_press ));
     m_drawarea->sig_button_release().connect(  sigc::mem_fun( *this, &ArticleViewBase::slot_button_release ));
     m_drawarea->sig_motion_notify().connect(  sigc::mem_fun( *this, &ArticleViewBase::slot_motion_notify ) );

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -172,6 +172,10 @@ BBSListViewBase::BBSListViewBase( const std::string& url,const std::string& arg1
     m_treeview.set_show_expanders( CONFIG::get_tree_show_expanders() );
     m_treeview.set_level_indentation( CONFIG::get_tree_level_indent() );
 
+#if GTKMM_CHECK_VERSION(3,3,18)
+    m_treeview.add_events( Gdk::SMOOTH_SCROLL_MASK );
+#endif
+
     // treeviewのシグナルにコネクト
     m_treeview.signal_row_expanded().connect( sigc::mem_fun(*this, &BBSListViewBase::slot_row_exp ) );
     m_treeview.signal_row_collapsed().connect( sigc::mem_fun(*this, &BBSListViewBase::slot_row_col ) );

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -162,6 +162,10 @@ BoardViewBase::BoardViewBase( const std::string& url, const bool show_col_board 
     m_liststore->set_sort_func( COL_SPEED, sigc::mem_fun( *this, &BoardViewBase::slot_compare_row ) );
     m_liststore->set_sort_func( COL_DIFF, sigc::mem_fun( *this, &BoardViewBase::slot_compare_row ) );
 
+#if GTKMM_CHECK_VERSION(3,3,18)
+    m_treeview.add_events( Gdk::SMOOTH_SCROLL_MASK );
+#endif
+
     m_treeview.sig_button_press().connect( sigc::mem_fun(*this, &BoardViewBase::slot_button_press ) );
     m_treeview.sig_button_release().connect( sigc::mem_fun(*this, &BoardViewBase::slot_button_release ) );
     m_treeview.sig_motion_notify().connect( sigc::mem_fun(*this, &BoardViewBase::slot_motion_notify ) );

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -417,6 +417,17 @@ int Control::MG_wheel_scroll( const GdkEventScroll* event )
 
     else if( ( mask & button ) && direction == GDK_SCROLL_DOWN ) control = CONTROL::TabRight;
 
+#if GTKMM_CHECK_VERSION(3,3,18)
+    else if( ( mask & button ) && direction == GDK_SCROLL_SMOOTH ) {
+        if( event->delta_y < 0.0 ) {
+            control = CONTROL::TabLeft;
+        }
+        else if( event->delta_y > 0.0 ) {
+            control = CONTROL::TabRight;
+        }
+    }
+#endif
+
 #ifdef _DEBUG
     std::cout << "Control::MG_wheel_scroll control = " << control << std::endl;
 #endif

--- a/src/image/imageviewbase.cpp
+++ b/src/image/imageviewbase.cpp
@@ -95,6 +95,9 @@ void ImageViewBase::setup_common()
     // focus 可、モーションキャプチャ可
     m_event.set_can_focus( true );
     m_event.add_events( Gdk::POINTER_MOTION_MASK );
+#if GTKMM_CHECK_VERSION(3,3,18)
+    m_event.add_events( Gdk::SMOOTH_SCROLL_MASK );
+#endif
 
     m_event.signal_button_press_event().connect( sigc::mem_fun( *this, &ImageViewBase::slot_button_press ) );
     m_event.signal_button_release_event().connect( sigc::mem_fun( *this, &ImageViewBase::slot_button_release ) );


### PR DESCRIPTION
マウスジェスチャー（右クリック）中にマウスホイール操作をするとタブやページの切り替えを行う機能をGTK3版に実装します。
この機能は元々GTK2版にありましたがGTK3版を実装したときに抜け落ちていました。

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1551889442/950
