### PR TITLE
Reduce memory usage for font width caches

### DIFF
--- a/src/article/font.cpp
+++ b/src/article/font.cpp
@@ -79,11 +79,11 @@ bool ARTICLE::get_width_of_char( const char* utfstr, int& byte, const char pre_c
         width_of_char[ mode ] = new WIDTH_DATA[ kMaxCacheCodePoint ]{} ;
     }
 
-    const int ucs2 = MISC::utf8toucs2( utfstr, byte );
-    if( byte && ucs2 < kMaxCacheCodePoint ){
+    const int c32 = MISC::utf8toucs2( utfstr, byte );
+    if( byte && c32 < kMaxCacheCodePoint ){
 
         // 全角モードの幅
-        width_wide = width_of_char[ mode ][ ucs2 ].width_wide;
+        width_wide = width_of_char[ mode ][ c32 ].width_wide;
 
         // 半角モードの幅
         width = width_wide;
@@ -91,18 +91,18 @@ bool ARTICLE::get_width_of_char( const char* utfstr, int& byte, const char pre_c
         // 厳密に求める場合
         if( byte == 1 && strict_of_char ){
 
-            if( ! width_of_char[ mode ][ ucs2 ].width ){
-                width_of_char[ mode ][ ucs2 ].width = new unsigned int[ 128 ]{} ;
+            if( ! width_of_char[ mode ][ c32 ].width ){
+                width_of_char[ mode ][ c32 ].width = new unsigned int[ 128 ]{} ;
             }
 
             const int pre_char_num = ( int ) pre_char;
-            if( pre_char_num < 128 ) width = width_of_char[ mode ][ ucs2 ].width[ pre_char_num ];
+            if( pre_char_num < 128 ) width = width_of_char[ mode ][ c32 ].width[ pre_char_num ];
         }
     }
     // Plane 14 追加特殊用途面(SSP)
     // 制御コードが追加されたら条件を追加する
-    else if( 0xE0001 == ucs2 || ( 0xE0020 <= ucs2 && ucs2 <= 0xE007F ) // タグ文字
-             || ( 0xE0100 <= ucs2 && ucs2 <= 0xE01EF )                 // 異字体セレクタ
+    else if( 0xE0001 == c32 || ( 0xE0020 <= c32 && c32 <= 0xE007F ) // タグ文字
+             || ( 0xE0100 <= c32 && c32 <= 0xE01EF )                // 異字体セレクタ
     ) {
         width = width_wide = 0;
         return true;
@@ -126,17 +126,17 @@ bool ARTICLE::get_width_of_char( const char* utfstr, int& byte, const char pre_c
 //
 void ARTICLE::set_width_of_char( const char* utfstr, int& byte, const char pre_char, const int width, const int width_wide, const int mode )
 {    
-    const int ucs2 = MISC::utf8toucs2( utfstr, byte );
+    const int c32 = MISC::utf8toucs2( utfstr, byte );
     if( ! byte ) return;
-    if( ucs2 >= kMaxCacheCodePoint ) return;
+    if( c32 >= kMaxCacheCodePoint ) return;
 
     // 半角モードの幅を厳密に求める場合
     if( byte == 1 && strict_of_char ){
 
         const int pre_char_num = ( int ) pre_char;
-        if( pre_char_num < 128 ) width_of_char[ mode ][ ucs2 ].width[ pre_char_num ] = width;
+        if( pre_char_num < 128 ) width_of_char[ mode ][ c32 ].width[ pre_char_num ] = width;
     }
 
     // 全角モードの幅
-    width_of_char[ mode ][ ucs2 ].width_wide = width_wide;
+    width_of_char[ mode ][ c32 ].width_wide = width_wide;
 }

--- a/src/article/font.cpp
+++ b/src/article/font.cpp
@@ -27,10 +27,10 @@ struct WIDTH_DATA
 static WIDTH_DATA* width_of_char[ FONT_NUM ];
 static bool strict_of_char = false;
 
-enum
-{
-    UCS2_MAX = 1114111
-};
+
+// UnicodeのPlane 0 基本多言語面(BMP)からPlane 3 第三漢字面(TIP)までキャッシュを持つ。
+// 現状のメモリ消費を抑えるためPlane 4からPlane 13は将来割り当てられたときにキャッシュ対応する。
+constexpr int kMaxCacheCodePoint{ 0x40000 };
 
 
 //
@@ -45,8 +45,8 @@ void ARTICLE::init_font()
 
         if( width_of_char[ i ]  ){
 
-            for( int j = 0; j < UCS2_MAX; ++j ){
-                
+            for( int j = 0; j < kMaxCacheCodePoint; ++j ){
+
                 if( width_of_char[ i ][ j ].width ) delete[] width_of_char[ i ][ j ].width;
             }
             delete[] width_of_char[ i ];
@@ -76,11 +76,11 @@ bool ARTICLE::get_width_of_char( const char* utfstr, int& byte, const char pre_c
     width_wide = 0;
 
     if( ! width_of_char[ mode ] ){
-        width_of_char[ mode ] = new WIDTH_DATA[ UCS2_MAX ]{} ;
+        width_of_char[ mode ] = new WIDTH_DATA[ kMaxCacheCodePoint ]{} ;
     }
 
     const int ucs2 = MISC::utf8toucs2( utfstr, byte );
-    if( byte && ucs2 < UCS2_MAX ){
+    if( byte && ucs2 < kMaxCacheCodePoint ){
 
         // 全角モードの幅
         width_wide = width_of_char[ mode ][ ucs2 ].width_wide;
@@ -98,6 +98,14 @@ bool ARTICLE::get_width_of_char( const char* utfstr, int& byte, const char pre_c
             const int pre_char_num = ( int ) pre_char;
             if( pre_char_num < 128 ) width = width_of_char[ mode ][ ucs2 ].width[ pre_char_num ];
         }
+    }
+    // Plane 14 追加特殊用途面(SSP)
+    // 制御コードが追加されたら条件を追加する
+    else if( 0xE0001 == ucs2 || ( 0xE0020 <= ucs2 && ucs2 <= 0xE007F ) // タグ文字
+             || ( 0xE0100 <= ucs2 && ucs2 <= 0xE01EF )                 // 異字体セレクタ
+    ) {
+        width = width_wide = 0;
+        return true;
     }
 
     if( width && width_wide ) return true;
@@ -120,7 +128,7 @@ void ARTICLE::set_width_of_char( const char* utfstr, int& byte, const char pre_c
 {    
     const int ucs2 = MISC::utf8toucs2( utfstr, byte );
     if( ! byte ) return;
-    if( ucs2 >= UCS2_MAX ) return;
+    if( ucs2 >= kMaxCacheCodePoint ) return;
 
     // 半角モードの幅を厳密に求める場合
     if( byte == 1 && strict_of_char ){


### PR DESCRIPTION
フォント幅をキャッシュするUnicode符号範囲を縮小しメモリ使用量を減らします。
Unicode第三漢字面(TIP, U+30000 - U+3FFFF)は2020年3月時点では文字が割り当てられていませんが追加予定の漢字があるためキャッシュの範囲にします。

#### メモリ使用量の目安
キャッシュする文字を0x10FFFF個から0x40000個に変更するためフォント設定毎に17,408 KiBから4,096 KiBになります。(x86\_64は1文字辺り16バイト消費する、0x10FFFF \* 16, 0x40000 \* 16)
ただしOSや実行環境のメモリ管理があるので実際にどれくらい減少するか不明です。
