### PR TITLE
layout_one_text_node: reset br_size after writing characters

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -1523,10 +1523,8 @@ void DrawAreaBase::layout_one_text_node( LAYOUT* layout, int& x, int& y, int& br
 //                  << " w = " << layout->rect->width << " h = " << layout->rect->height << std::endl;
 #endif
 
-        // 改行位置を、フォントよりも大きく設定しておく
-        if( br_size < m_font->br_size ){
-            br_size = m_font->br_size;
-        }
+        // 一文字でも書いたので、改行位置をフォントにあわせて更新
+        br_size = m_font->br_size;
 
         x += rect->width;
         if( pos_to >= byte_to ) break;
@@ -1534,7 +1532,6 @@ void DrawAreaBase::layout_one_text_node( LAYOUT* layout, int& x, int& y, int& br
         // wrap 処理
         x = div ? div->rect->x + div->css->padding_left : 0;
         y += br_size;
-        br_size = m_font->br_size; // 次の行の改行位置をリセット
 
         pos_start = pos_to;
     }


### PR DESCRIPTION
よく見てみて分かったのですが、メールのフォントを極端に大きくした時に、下のスクリーンショットのように、スレビューで、本文の1行目と2行目との間に余計な隙間が出来てしまうので、これを修正します。 

https://mtasaka.fedorapeople.org/Bugfix/jdim/jd-screenshot-89c12d7816.png

現状だと、1行目と2行目は、（メールのフォントの高さ）と（スレビューのフォントの高さ）のおおきい方分隙間が空いてしまうので、本文を書いた時には常に改行高さを更新するようにします。

----------------------------------------------------------------------------------------------------------------------
テキストノードで一文字でも文字を書いた後は、改行の高さを、現在の行のフォントの高さに更新する。