### PR TITLE
Initialize some bool members for search mode

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -72,6 +72,7 @@ ArticleViewBase::ArticleViewBase( const std::string& url, const std::string& url
       m_popup_win( nullptr ),
       m_popup_shown( false ),
       m_hidepopup_counter( 0 ),
+      m_search_invert( false ),
       m_enable_menuslot( true ),
       m_current_bm( 0 ),
       m_current_post( 0 ),

--- a/src/jdlib/jdregex.cpp
+++ b/src/jdlib/jdregex.cpp
@@ -21,7 +21,9 @@ enum
 using namespace JDLIB;
 
 Regex::Regex()
-    : m_compiled(false)
+    : m_compiled(false),
+      m_newline(false),
+      m_wchar(false)
 {
     m_results.clear();
     m_pos.clear();


### PR DESCRIPTION
詳細は後で書きます。

スレビューで検索をする時、幾つかのクラスのbool memberが未初期化と怒られるので、
明示的に初期化する。