### PR TITLE
Replace char buffer with std::string for DBTREE::NodeTreeBase [1/2]

### DIFF
--- a/docs/manual/2020.md
+++ b/docs/manual/2020.md
@@ -10,6 +10,18 @@ layout: default
 
 <a name="0.4.0-unreleased"></a>
 ### [0.4.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.3.0...master) (unreleased)
+- Replace char buffer with `std::string` for `DBTREE::NodeTreeBase` [1/2]
+  ([#212](https://github.com/JDimproved/JDim/pull/212))
+- Fix compiler warning -Wformat-truncation= for `MISC::timettostr()`
+  ([#211](https://github.com/JDimproved/JDim/pull/211))
+- Fix wordings for about:config favorite category to directory
+  ([#213](https://github.com/JDimproved/JDim/pull/213))
+- Replace `XMLDomList` with `std::list<XML::Dom*>`
+  ([#210](https://github.com/JDimproved/JDim/pull/210))
+- `DrawAreaBase`: Fix member initialization
+  ([#208](https://github.com/JDimproved/JDim/pull/208))
+- Initialize some `bool` members for search mode
+  ([#207](https://github.com/JDimproved/JDim/pull/207))
 - Update manual
   ([#205](https://github.com/JDimproved/JDim/pull/205))
 - `layout_one_text_node`: `reset br_size` after writing characters

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -55,6 +55,8 @@ constexpr size_t SIZE_OF_HEAP = MAXSISE_OF_LINES + 64;
 
 constexpr size_t INITIAL_RES_BUFSIZE = 128;  // レスの文字列を返すときの初期バッファサイズ
 
+constexpr std::size_t kMaxBytesOfUTF8Char = 4 + 1; // UTF-8文字の最大バイト数 + ヌル文字
+
 
 // レジュームのモード
 enum
@@ -85,7 +87,6 @@ NodeTreeBase::NodeTreeBase( const std::string& url, const std::string& modified 
       m_broken( false ),
       m_heap( SIZE_OF_HEAP ),
       m_parsed_text( nullptr ),
-      m_buffer_write( nullptr ),
       m_check_update( false ),
       m_check_write( false ),
       m_loading_newthread( false ),
@@ -179,9 +180,9 @@ void NodeTreeBase::clear()
     if( m_parsed_text ) free( m_parsed_text );
     m_parsed_text = nullptr;
 
-    if( m_buffer_write ) free( m_buffer_write );
-    m_buffer_write = nullptr;
-    
+    m_buffer_write.clear();
+    m_buffer_write.shrink_to_fit();
+
     if( m_fout ) fclose( m_fout );
     m_fout = nullptr;
 
@@ -1603,19 +1604,21 @@ const char* NodeTreeBase::add_one_dat_line( const char* datline )
     // 自分の書き込みかチェック
     if( m_check_write && MESSAGE::get_log_manager()->has_items( m_url, m_loading_newthread ) ){
 
-        if( ! m_buffer_write ) m_buffer_write = ( char* ) malloc( MAXSISE_OF_LINES ); 
+        if( m_buffer_write.capacity() < MAXSISE_OF_LINES ) {
+            m_buffer_write.reserve( MAXSISE_OF_LINES );
+        }
 
         // 簡易チェック
         // 最初の lng_check 文字だけ見る
         const bool newthread = ( header->id_header == 1 );
-        const int lng_check = MIN( section_lng[ 3 ], 32 );
+        const std::size_t lng_check = MIN( section_lng[ 3 ], 32 );
         parse_write( section[ 3 ], section_lng[ 3 ], lng_check );
-        if( MESSAGE::get_log_manager()->check_write( m_url, newthread, m_buffer_write, lng_check ) ){
+        if( MESSAGE::get_log_manager()->check_write( m_url, newthread, m_buffer_write.c_str(), lng_check ) ){
 
             // 全ての文字列で一致しているかチェック
             parse_write( section[ 3 ], section_lng[ 3 ], 0 );
 
-            const bool hit = MESSAGE::get_log_manager()->check_write( m_url, newthread, m_buffer_write, 0 );
+            const bool hit = MESSAGE::get_log_manager()->check_write( m_url, newthread, m_buffer_write.c_str(), 0 );
             if( hit ){
                 m_posts.insert( header->id_header );
             }
@@ -2373,10 +2376,8 @@ void NodeTreeBase::parse_html( const char* str, const int lng, const int color_t
 //
 // max_lng_write > 0 のときは m_buffer_write の文字数が max_lng_write 以上になったら停止
 //
-void NodeTreeBase::parse_write( const char* str, const int lng, const int max_lng_write )
+void NodeTreeBase::parse_write( const char* str, const int lng, const std::size_t max_lng_write )
 {
-    if( ! m_buffer_write ) return;
-
 #ifdef _DEBUG
     std::cout << "NodeTreeBase::parse_write lng = " << lng << " max = " << max_lng_write << std::endl;
 #endif
@@ -2388,13 +2389,13 @@ void NodeTreeBase::parse_write( const char* str, const int lng, const int max_ln
     int offset_num;
     int lng_num;
 
-    char* pos_write = m_buffer_write;
+    m_buffer_write.clear();
 
     // 行頭の空白は全て除く
     while( *pos == ' ' ) ++pos;
     
     for( ; pos < pos_end
-         && ( max_lng_write == 0 || (int)( pos_write - m_buffer_write ) < max_lng_write )
+         && ( max_lng_write == 0 || m_buffer_write.size() < max_lng_write )
          ; ++pos ){
 
         // タグ
@@ -2404,7 +2405,7 @@ void NodeTreeBase::parse_write( const char* str, const int lng, const int max_ln
             if( ( *( pos + 1 ) == 'b' || *( pos + 1 ) == 'B' )
                 && ( *( pos + 2 ) == 'r' || *( pos + 2 ) == 'R' )
                 ){
-                *(pos_write++) = '\n';
+                m_buffer_write.push_back( '\n' );
                 pos += 3;
             }
 
@@ -2417,7 +2418,7 @@ void NodeTreeBase::parse_write( const char* str, const int lng, const int max_ln
         // gt
         else if( *pos == '&' && ( *( pos + 1 ) == 'g' && *( pos + 2 ) == 't' && *( pos + 3 ) == ';' ) ){
 
-            *(pos_write++) = '>';
+            m_buffer_write.push_back( '>' );
             pos += 3;
 
             continue;
@@ -2426,7 +2427,7 @@ void NodeTreeBase::parse_write( const char* str, const int lng, const int max_ln
         // lt
         else if( *pos == '&' && ( *( pos + 1 ) == 'l' && *( pos + 2 ) == 't' && *( pos + 3 ) == ';' ) ){
 
-            *(pos_write++) = '<';
+            m_buffer_write.push_back( '<' );
             pos += 3;
 
             continue;
@@ -2435,7 +2436,7 @@ void NodeTreeBase::parse_write( const char* str, const int lng, const int max_ln
         // amp
         else if( *pos == '&' && ( *( pos + 1 ) == 'a' && *( pos + 2 ) == 'm' && *( pos + 3 ) == 'p' && *( pos + 4 ) == ';' ) ){
 
-            *(pos_write++) = '&';
+            m_buffer_write.push_back( '&' );
             pos += 4;
 
             continue;
@@ -2444,7 +2445,7 @@ void NodeTreeBase::parse_write( const char* str, const int lng, const int max_ln
         // quot
         else if( *pos == '&' && ( *( pos + 1 ) == 'q' && *( pos + 2 ) == 'u' && *( pos + 3 ) == 'o' && *( pos + 4 ) == 't' && *( pos + 5 ) == ';' ) ){
 
-            *(pos_write++) = '"';
+            m_buffer_write.push_back( '"' );
             pos += 5;
 
             continue;
@@ -2463,7 +2464,7 @@ void NodeTreeBase::parse_write( const char* str, const int lng, const int max_ln
         else if( *pos == '\t' ){
 
             // 空白に置き換える
-            *(pos_write++) = ' ';
+            m_buffer_write.push_back( ' ' );
 
             continue;
         }
@@ -2472,18 +2473,17 @@ void NodeTreeBase::parse_write( const char* str, const int lng, const int max_ln
         else if( *pos == '&' && *( pos + 1 ) == '#' && ( lng_num = MISC::spchar_number_ln( pos, offset_num ) ) != -1 ){
 
             const int num = MISC::decode_spchar_number( pos, offset_num, lng_num );
-            const int n_out = MISC::ucs2toutf8( num, pos_write );
-            pos_write += n_out;
+            char utf8[kMaxBytesOfUTF8Char]{};
+            const int n_out = MISC::ucs2toutf8( num, utf8 );
+            m_buffer_write.append( utf8, n_out );
             pos += offset_num + lng_num;
 
             continue;
         }
 
         head = false;
-        *(pos_write++) = *pos;
+        m_buffer_write.push_back( *pos );
     }
-
-    *pos_write = '\0';
 }
 
 

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -110,8 +110,7 @@ namespace DBTREE
         std::map< int, std::vector< int > > m_map_future_refer;
 
         // ロード用変数
-        char* m_buffer_lines;
-        size_t m_byte_buffer_lines_left;
+        std::string m_buffer_lines;
         char* m_parsed_text;
         char* m_buffer_write; // 書き込みチェック用バッファ
         bool m_check_update; // HEADによる更新チェックのみ

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -112,7 +112,7 @@ namespace DBTREE
         // ロード用変数
         std::string m_buffer_lines;
         char* m_parsed_text;
-        char* m_buffer_write; // 書き込みチェック用バッファ
+        std::string m_buffer_write; // 書き込みチェック用バッファ
         bool m_check_update; // HEADによる更新チェックのみ
         bool m_check_write; // 自分の書き込みかチェックする
         bool m_loading_newthread; // 新スレ読み込み中
@@ -322,7 +322,7 @@ namespace DBTREE
 
         // 書き込みログ比較用文字列作成
         // m_buffer_write に作成した文字列をセットする
-        void parse_write( const char* str, const int lng, const int max_lng_write );
+        void parse_write( const char* str, const int lng, const std::size_t max_lng_write );
 
         bool check_anchor( const int mode, const char* str_in, int& n, char* str_out, char* str_link, int lng_link, ANCINFO* ancinfo );
         int check_link( const char* str_in, const int lng_in, int& n_in, char* str_link, const int lng_link );


### PR DESCRIPTION
malloc/freeで確保しているバッファをstd::stringで置き換えます。
メモリは自動的に確保されますが挙動の変化を抑えるため修正前と同じ量を予約しておきます。
