### PR TITLE
snap: Remove dbus slot from snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,12 +80,6 @@ parts:
       - ./usr/lib/**/libpcre2-8.so*
       - ./usr/lib/**/libsigc-2.0.so*
 
-slots:
-  dbus-daemon:
-    interface: dbus
-    bus: session
-    name: com.github.jdimproved.JDim
-
 apps:
   jdim:
     command: bin/jdim
@@ -98,7 +92,5 @@ apps:
       - home
       - network
       - unity7
-    slots:
-      - dbus-daemon
     command-chain:
       - snap/command-chain/desktop-launch


### PR DESCRIPTION
dbusの利用にはSnap Storeのレビューが必要ですが今のところ使用していないためslotから外して自動レビューに戻します。