### PR TITLE
Fix thread view font configuration for GTK2

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -415,7 +415,11 @@ void DrawAreaBase::init_font()
     // layoutにフォントをセット
     m_font = &m_defaultfont;
     m_pango_layout->set_font_description( m_font->pfd );
+#if GTKMM_CHECK_VERSION(3,0,0)
     m_context->set_font_description( m_font->pfd );
+#else
+    modify_font( m_font->pfd );
+#endif
 }
 
 
@@ -2779,7 +2783,11 @@ void DrawAreaBase::set_node_font( LAYOUT* layout )
 
         // layoutにフォントをセット
         m_pango_layout->set_font_description( m_font->pfd );
+#if GTKMM_CHECK_VERSION(3,0,0)
         m_context->set_font_description( m_font->pfd );
+#else
+        modify_font( m_font->pfd );
+#endif
     }
 }
 


### PR DESCRIPTION
ecbc982d03ba5be6d4ef735f0bd3c45dd841b71f のマージ後GTK2版スレビューでフォント変更が反映されなくなった環境があったためGTK2の部分を元に戻します。

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1551889442/986-996