### PR TITLE
ArticleViewMain: Fix member initialization

### DIFF
--- a/src/article/articleview.cpp
+++ b/src/article/articleview.cpp
@@ -47,13 +47,7 @@ enum
 // メインビュー
 
 ArticleViewMain::ArticleViewMain( const std::string& url )
-    : ArticleViewBase( url, url ),
-      m_gotonum_reserve_to( 0 ),
-      m_gotonum_reserve_from( 0 ),
-      m_gotonum_seen( 0 ),
-      m_playsound( false ),
-      m_reload_reserve( false ),
-      m_cancel_reload_counter( 0 )
+    : ArticleViewBase( url, url )
 {
 #ifdef _DEBUG
     std::cout << "ArticleViewMain::ArticleViewMain " << get_url() << " url_article = " << url_article() << std::endl;

--- a/src/article/articleview.h
+++ b/src/article/articleview.h
@@ -14,23 +14,23 @@ namespace ARTICLE
     class ArticleViewMain : public ArticleViewBase
     {
         // ジャンプ予約, goto_num() のコメント参照
-        int m_gotonum_reserve_to; 
-        int m_gotonum_reserve_from; 
+        int m_gotonum_reserve_to{};
+        int m_gotonum_reserve_from{};
 
-        int m_gotonum_seen; // 前回見ていた場所へのジャンプ用
+        int m_gotonum_seen{}; // 前回見ていた場所へのジャンプ用
 
-        bool m_set_history; // update_finish() で履歴を登録する
+        bool m_set_history{}; // update_finish() で履歴を登録する
 
-        bool m_show_instdialog;
+        bool m_show_instdialog{};
 
-        bool m_playsound;
+        bool m_playsound{};
 
-        bool m_show_closedialog;
+        bool m_show_closedialog{};
 
-        bool m_reload_reserve;
+        bool m_reload_reserve{};
 
         // 連続リロード防止用
-        int m_cancel_reload_counter;
+        int m_cancel_reload_counter{};
 
       public:
         ArticleViewMain( const std::string& url );


### PR DESCRIPTION
メンバ変数の初期化を変更してcppcheckの警告 `(warning) Member variable 'ArticleViewMain::XXX' is not initialized in the constructor.` を修正します。
