### PR TITLE
Replace char buffer with std::string for DBTREE::NodeTreeBase [2/2]

### DIFF
--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -111,7 +111,7 @@ namespace DBTREE
 
         // ロード用変数
         std::string m_buffer_lines;
-        char* m_parsed_text;
+        std::string m_parsed_text; // HTMLパーサに使うバッファ
         std::string m_buffer_write; // 書き込みチェック用バッファ
         bool m_check_update; // HEADによる更新チェックのみ
         bool m_check_write; // 自分の書き込みかチェックする


### PR DESCRIPTION
malloc/freeで確保しているバッファを`std::string`で置き換えます。
メモリは自動的に確保されますが挙動の変化を抑えるため修正前と同じ量を予約しておきます。