### PR TITLE
Refactor XML::Dom

### DIFF
--- a/docs/manual/2020.md
+++ b/docs/manual/2020.md
@@ -10,6 +10,20 @@ layout: default
 
 <a name="0.4.0-unreleased"></a>
 ### [0.4.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.3.0...master) (unreleased)
+- Refactor `XML::Dom`
+  ([#221](https://github.com/JDimproved/JDim/pull/221))
+- Replace char buffer with `std::string` for `DBTREE::NodeTreeBase` [2/2]
+  ([#220](https://github.com/JDimproved/JDim/pull/220))
+- `ArticleViewMain`: Fix member initialization
+  ([#219](https://github.com/JDimproved/JDim/pull/219))
+- Fix thread view font configuration for GTK2
+  ([#218](https://github.com/JDimproved/JDim/pull/218))
+- snap: Remove dbus slot from snapcraft.yaml
+  ([#217](https://github.com/JDimproved/JDim/pull/217))
+- `Iconv::convert`: handle emoji subdivision flags sequence
+  ([#216](https://github.com/JDimproved/JDim/pull/216))
+- Implement high reference extraction
+  ([#215](https://github.com/JDimproved/JDim/pull/215))
 - Replace char buffer with `std::string` for `DBTREE::NodeTreeBase` [1/2]
   ([#212](https://github.com/JDimproved/JDim/pull/212))
 - Fix compiler warning -Wformat-truncation= for `MISC::timettostr()`

--- a/src/xml/dom.cpp
+++ b/src/xml/dom.cpp
@@ -46,7 +46,7 @@ Dom::Dom( const int type, const std::string& name, const bool html )
 }
 
 // デストラクタ
-Dom::~Dom()
+Dom::~Dom() noexcept
 {
 #ifdef _DEBUG
     std::cout << "~Dom() : " << m_nodeName << ", " << m_childNodes.size() << std::endl;
@@ -71,7 +71,7 @@ Dom::Dom( const Dom& dom )
 //
 // 子ノードのクリア
 //
-void Dom::clear()
+void Dom::clear() noexcept
 {
     std::list< Dom* >::iterator it = m_childNodes.begin();
     while( it != m_childNodes.end() )
@@ -244,7 +244,7 @@ void Dom::parse( const std::string& str )
 //
 // 属性ペアのリストを作成
 //
-std::map< std::string, std::string > Dom::create_attribute( const std::string& str )
+std::map< std::string, std::string > Dom::create_attribute( const std::string& str ) const
 {
     std::map< std::string, std::string > attributes_pair;
 
@@ -485,10 +485,10 @@ void Dom::parse( const Gtk::TreeModel::Children& children, SKELETON::EditColumns
 void Dom::append_treestore( Glib::RefPtr< Gtk::TreeStore >& treestore,
                             SKELETON::EditColumns& columns,
                              std::list< Gtk::TreePath >& list_path_expand,
-                             const Gtk::TreeModel::Row& parent )
+                             const Gtk::TreeModel::Row& parent ) const
 {
     // ノードの子要素を走査
-    std::list< Dom* >::iterator it = m_childNodes.begin();
+    std::list< Dom* >::const_iterator it = m_childNodes.begin();
     while( it != m_childNodes.end() )
     {
         const int node_type = (*it)->nodeType();
@@ -530,17 +530,17 @@ void Dom::append_treestore( Glib::RefPtr< Gtk::TreeStore >& treestore,
 //
 // プロパティを扱うアクセッサ
 //
-int Dom::nodeType()
+int Dom::nodeType() const noexcept
 {
     return m_nodeType;
 }
 
-std::string Dom::nodeName()
+std::string Dom::nodeName() const
 {
     return m_nodeName;
 }
 
-std::string Dom::nodeValue()
+std::string Dom::nodeValue() const
 {
     return m_nodeValue;
 }
@@ -604,7 +604,7 @@ std::list<Dom*> Dom::getElementsByTagName( const std::string& name ) const
 //
 // ノード：ownerDocument
 //
-Dom* Dom::ownerDocument() const
+Dom* Dom::ownerDocument() const noexcept
 {
     Dom* parent = m_parentNode;
 
@@ -621,7 +621,7 @@ Dom* Dom::ownerDocument() const
 //
 // ノード：parentNode
 //
-Dom* Dom::parentNode()
+Dom* Dom::parentNode() const noexcept
 {
     return m_parentNode;
 }
@@ -635,7 +635,7 @@ void Dom::parentNode( Dom* parent )
 //
 // ノード：hasChildNodes
 //
-bool Dom::hasChildNodes()
+bool Dom::hasChildNodes() const noexcept
 {
     return ! m_childNodes.empty();
 }
@@ -839,7 +839,7 @@ Dom* Dom::nextSibling() const
 //
 // 属性：attributes
 //
-std::map< std::string, std::string > Dom::attributes()
+std::map< std::string, std::string > Dom::attributes() const
 {
     return m_attributes;
 }
@@ -853,7 +853,7 @@ void Dom::attributes( const std::map< std::string, std::string > attributes )
 //
 // 属性：hasAttributes()
 //
-bool Dom::hasAttributes()
+bool Dom::hasAttributes() const noexcept
 {
     return ! m_attributes.empty();
 }

--- a/src/xml/dom.cpp
+++ b/src/xml/dom.cpp
@@ -526,31 +526,6 @@ void Dom::append_treestore( Glib::RefPtr< Gtk::TreeStore >& treestore,
 }
 
 
-
-//
-// プロパティを扱うアクセッサ
-//
-int Dom::nodeType() const noexcept
-{
-    return m_nodeType;
-}
-
-std::string Dom::nodeName() const
-{
-    return m_nodeName;
-}
-
-std::string Dom::nodeValue() const
-{
-    return m_nodeValue;
-}
-
-void Dom::nodeValue( const std::string& value )
-{
-    m_nodeValue = value;
-}
-
-
 //
 // getElementById()
 //
@@ -602,34 +577,11 @@ std::list<Dom*> Dom::getElementsByTagName( const std::string& name ) const
 
 
 //
-// ノード：parentNode
-//
-Dom* Dom::parentNode() const noexcept
-{
-    return m_parentNode;
-}
-
-void Dom::parentNode( Dom* parent )
-{
-    m_parentNode = parent;
-}
-
-
-//
 // ノード：hasChildNodes
 //
 bool Dom::hasChildNodes() const noexcept
 {
     return ! m_childNodes.empty();
-}
-
-
-//
-// ノード：childNodes
-//
-std::list<Dom*> Dom::childNodes() const
-{
-    return m_childNodes;
 }
 
 

--- a/src/xml/dom.cpp
+++ b/src/xml/dom.cpp
@@ -602,23 +602,6 @@ std::list<Dom*> Dom::getElementsByTagName( const std::string& name ) const
 
 
 //
-// ノード：ownerDocument
-//
-Dom* Dom::ownerDocument() const noexcept
-{
-    Dom* parent = m_parentNode;
-
-    while( parent )
-    {
-        if( parent->nodeType() == NODE_TYPE_DOCUMENT ) break;
-        else parent = parent->parentNode();
-    }
-
-    return parent;    
-}
-
-
-//
 // ノード：parentNode
 //
 Dom* Dom::parentNode() const noexcept
@@ -690,17 +673,6 @@ Dom* Dom::firstChild() const
 
 
 //
-// ノード：lastChild
-//
-Dom* Dom::lastChild() const
-{
-    if( m_childNodes.empty() ) return nullptr;
-
-    return m_childNodes.back();
-}
-
-
-//
 // ノード：appendChild()
 //
 Dom* Dom::appendChild( const int node_type, const std::string& node_name )
@@ -735,34 +707,6 @@ bool Dom::removeChild( Dom* node )
 
 
 //
-// ノード：replaceChild()
-//
-Dom* Dom::replaceChild( const int node_type, const std::string& node_name, Dom* oldNode )
-{
-    Dom* newNode = nullptr;
-
-    newNode = new Dom( node_type, node_name );
-
-    std::list< Dom* >::iterator it = m_childNodes.begin();
-    while( it != m_childNodes.end() )
-    {
-        if( *it == oldNode )
-        {
-            newNode->parentNode( oldNode->parentNode() );
-            m_childNodes.erase( it );
-            m_childNodes.insert( it, newNode );
-            break;
-        }
-        ++it;
-    }
-
-    if( oldNode ) delete oldNode;
-
-    return newNode;
-}
-
-
-//
 // ノード：insertBefore()
 //
 Dom* Dom::insertBefore( const int node_type, const std::string& node_name, Dom* insNode )
@@ -784,89 +728,6 @@ Dom* Dom::insertBefore( const int node_type, const std::string& node_name, Dom* 
     }
 
     return newNode;
-}
-
-
-//
-// ノード：previousSibling
-//
-Dom* Dom::previousSibling() const
-{
-    Dom* previous = nullptr;
-
-    std::list<Dom*> brothers = m_parentNode->childNodes();
-
-    std::list< Dom* >::iterator it = brothers.begin();
-    while( it != brothers.end() )
-    {
-        if( it != brothers.begin() && *it == this )
-        {
-            previous = *( --it );
-            break;
-        }
-        ++it;
-    }
-
-    return previous;
-}
-
-
-//
-// ノード：nextSibling
-//
-Dom* Dom::nextSibling() const
-{
-    Dom* next = nullptr;
-
-    std::list<Dom*> brothers = m_parentNode->childNodes();
-
-    std::list< Dom* >::iterator it = brothers.begin();
-    while( it != brothers.end() )
-    {
-        if( *it == this )
-        {
-            ++it;
-            if( it != brothers.end() ) next = *it;
-            break;
-        }
-        ++it;
-    }
-
-    return next;
-}
-
-
-//
-// 属性：attributes
-//
-std::map< std::string, std::string > Dom::attributes() const
-{
-    return m_attributes;
-}
-
-void Dom::attributes( const std::map< std::string, std::string > attributes )
-{
-    if( ! attributes.empty() ) m_attributes = attributes;
-}
-
-
-//
-// 属性：hasAttributes()
-//
-bool Dom::hasAttributes() const noexcept
-{
-    return ! m_attributes.empty();
-}
-
-
-//
-// 属性：hasAttribute()
-//
-bool Dom::hasAttribute( const std::string& name ) const
-{
-    if( name.empty() ) return false;
-
-    return m_attributes.find( name ) != m_attributes.end();
 }
 
 
@@ -920,25 +781,3 @@ bool Dom::setAttribute( const std::string& name, const int value )
 
     return true;
 }
-
-
-//
-// 属性：removeAttribute()
-//
-bool Dom::removeAttribute( const std::string& name )
-{
-    bool result = false;
-
-    if( name.empty() ) return result;
-
-    std::map< std::string, std::string >::iterator it = m_attributes.find( name );
-
-    if( it != m_attributes.end() )
-    {
-        m_attributes.erase( it );
-        result = true;
-    }
-
-    return result;
-}
-

--- a/src/xml/dom.cpp
+++ b/src/xml/dom.cpp
@@ -232,8 +232,8 @@ void Dom::parse( const std::string& str )
 
         // ノードを追加
         Dom* node = appendChild( type, name );
-        node->attributes( attributes_pair );
-        node->nodeValue( value );
+        node->m_attributes = std::move( attributes_pair );
+        node->m_nodeValue = std::move( value );
 
         // 再帰
         if( ! next_source.empty() ) node->parse( next_source );
@@ -600,9 +600,9 @@ void Dom::copy_childNodes( const Dom& dom )
         while( it != children.end() )
         {
             Dom* node = new Dom( (*it)->nodeType(), (*it)->nodeName() );
-            node->nodeValue( (*it)->nodeValue() );
-            node->parentNode( this );
-            node->attributes( (*it)->attributes() );
+            node->m_nodeValue = (*it)->nodeValue();
+            node->m_parentNode = this;
+            node->m_attributes = (*it)->m_attributes;
             node->copy_childNodes( *(*it) );
 
             m_childNodes.push_back( node );
@@ -634,7 +634,7 @@ Dom* Dom::appendChild( const int node_type, const std::string& node_name )
     {
         node = new Dom( node_type, node_name, m_html );
 
-        node->parentNode( this );
+        node->m_parentNode = this;
 
         m_childNodes.push_back( node );
     }
@@ -672,7 +672,7 @@ Dom* Dom::insertBefore( const int node_type, const std::string& node_name, Dom* 
     {
         if( *it == insNode )
         {
-            newNode->parentNode( insNode->parentNode() );
+            newNode->m_parentNode = insNode->m_parentNode;
             m_childNodes.insert( it, newNode );
             break;
         }

--- a/src/xml/dom.h
+++ b/src/xml/dom.h
@@ -70,7 +70,7 @@ namespace XML
         void parse( const Gtk::TreeModel::Children& children, SKELETON::EditColumns& columns );
 
         // プロパティをセットするアクセッサ
-        void parentNode( Dom* parent );
+        void parentNode( Dom* parent ) { m_parentNode = parent; }
         void copy_childNodes( const Dom& dom ); // dom の子ノードをコピーする
 
         // ノードを分解して Gtk::TreeStore へ Gtk::TreeModel::Row を追加
@@ -97,10 +97,10 @@ namespace XML
         std::list<Dom*> getElementsByTagName( const std::string& name ) const;
 
         // プロパティを扱うアクセッサ
-        int nodeType() const noexcept;
-        std::string nodeName() const;
-        std::string nodeValue() const;
-        void nodeValue( const std::string& value );
+        int nodeType() const noexcept { return m_nodeType; }
+        std::string nodeName() const { return m_nodeName; }
+        std::string nodeValue() const { return m_nodeValue; }
+        void nodeValue( const std::string& value ) { m_nodeValue = value; }
 
         // ノード
         // 注意：appendChild(), replaceChild(), insertBefore() は
@@ -113,9 +113,9 @@ namespace XML
         // クラス外で使用していないメンバ関数は削除してあります。
 
         Dom* ownerDocument() const noexcept = delete;
-        Dom* parentNode() const noexcept;
+        Dom* parentNode() const noexcept { return m_parentNode; }
         bool hasChildNodes() const noexcept;
-        std::list<Dom*> childNodes() const;
+        std::list<Dom*> childNodes() const { return m_childNodes; }
         Dom* firstChild() const;
         Dom* lastChild() const = delete;
         Dom* appendChild( const int node_type, const std::string& node_name );

--- a/src/xml/dom.h
+++ b/src/xml/dom.h
@@ -52,7 +52,7 @@ namespace XML
       private:
 
         // このクラスの代入演算子は使わない
-        Dom& operator=( const Dom& );
+        Dom& operator=( const Dom& ) = delete;
 
         // 属性ペアのリストを作成
         std::map< std::string, std::string > create_attribute( const std::string& str ) const;
@@ -109,29 +109,31 @@ namespace XML
         // delete忘れを防ぐために外部でnewしない方が良いだろうという
         // 事で、メンバ関数の内部でnewして追加されたノードのポインタ
         // を返すようにしてあります。
+        //
+        // クラス外で使用していないメンバ関数は削除してあります。
 
-        Dom* ownerDocument() const noexcept;
+        Dom* ownerDocument() const noexcept = delete;
         Dom* parentNode() const noexcept;
         bool hasChildNodes() const noexcept;
         std::list<Dom*> childNodes() const;
         Dom* firstChild() const;
-        Dom* lastChild() const;
+        Dom* lastChild() const = delete;
         Dom* appendChild( const int node_type, const std::string& node_name );
         bool removeChild( Dom* node );
-        Dom* replaceChild( const int node_type, const std::string& node_name, Dom* oldNode );
+        Dom* replaceChild( const int node_type, const std::string& node_name, Dom* oldNode ) = delete;
         Dom* insertBefore( const int node_type, const std::string& node_name, Dom* insNode );
-        Dom* previousSibling() const;
-        Dom* nextSibling() const;
+        Dom* previousSibling() const = delete;
+        Dom* nextSibling() const = delete;
 
         // 属性
-        bool hasAttributes() const noexcept;
-        std::map< std::string, std::string > attributes() const;
-        void attributes( const std::map< std::string, std::string > attributes );
-        bool hasAttribute( const std::string& name ) const;
+        bool hasAttributes() const noexcept = delete;
+        std::map< std::string, std::string > attributes() const = delete;
+        void attributes( std::map< std::string, std::string > attributes ) = delete;
+        bool hasAttribute( const std::string& name ) const = delete;
         std::string getAttribute( const std::string& name ) const;
         bool setAttribute( const std::string& name, const std::string& value );
         bool setAttribute( const std::string& name, const int value );
-        bool removeAttribute( const std::string& name );
+        bool removeAttribute( const std::string& name ) = delete;
     };
 }
 

--- a/src/xml/dom.h
+++ b/src/xml/dom.h
@@ -55,7 +55,7 @@ namespace XML
         Dom& operator=( const Dom& );
 
         // 属性ペアのリストを作成
-        std::map< std::string, std::string > create_attribute( const std::string& str );
+        std::map< std::string, std::string > create_attribute( const std::string& str ) const;
 
       protected:
 
@@ -78,16 +78,16 @@ namespace XML
         void append_treestore( Glib::RefPtr< Gtk::TreeStore >& treestore,
                                SKELETON::EditColumns& columns,
                                 std::list< Gtk::TreePath >& list_path_expand,
-                                const Gtk::TreeModel::Row& parnet = Gtk::TreeModel::Row() );
+                                const Gtk::TreeModel::Row& parnet = Gtk::TreeModel::Row() ) const;
 
       public:
 
         // コンストラクタ、デストラクタ
         Dom( const int type, const std::string& name, const bool html = false );
-        virtual ~Dom();
+        virtual ~Dom() noexcept;
 
         // クリア
-        void clear();
+        void clear() noexcept;
 
         // XMLタグ構造の文字列を生成
         std::string get_xml( const int n = 0 ) const;
@@ -97,9 +97,9 @@ namespace XML
         std::list<Dom*> getElementsByTagName( const std::string& name ) const;
 
         // プロパティを扱うアクセッサ
-        int nodeType();
-        std::string nodeName();
-        std::string nodeValue();
+        int nodeType() const noexcept;
+        std::string nodeName() const;
+        std::string nodeValue() const;
         void nodeValue( const std::string& value );
 
         // ノード
@@ -110,9 +110,9 @@ namespace XML
         // 事で、メンバ関数の内部でnewして追加されたノードのポインタ
         // を返すようにしてあります。
 
-        Dom* ownerDocument() const;
-        Dom* parentNode();
-        bool hasChildNodes();
+        Dom* ownerDocument() const noexcept;
+        Dom* parentNode() const noexcept;
+        bool hasChildNodes() const noexcept;
         std::list<Dom*> childNodes() const;
         Dom* firstChild() const;
         Dom* lastChild() const;
@@ -124,8 +124,8 @@ namespace XML
         Dom* nextSibling() const;
 
         // 属性
-        bool hasAttributes();
-        std::map< std::string, std::string > attributes();
+        bool hasAttributes() const noexcept;
+        std::map< std::string, std::string > attributes() const;
         void attributes( const std::map< std::string, std::string > attributes );
         bool hasAttribute( const std::string& name ) const;
         std::string getAttribute( const std::string& name ) const;

--- a/src/xml/dom.h
+++ b/src/xml/dom.h
@@ -100,7 +100,7 @@ namespace XML
         int nodeType() const noexcept { return m_nodeType; }
         std::string nodeName() const { return m_nodeName; }
         std::string nodeValue() const { return m_nodeValue; }
-        void nodeValue( const std::string& value ) = delete;
+        void nodeValue( const std::string& value ) { m_nodeValue = value; }
 
         // ノード
         // 注意：appendChild(), replaceChild(), insertBefore() は

--- a/src/xml/dom.h
+++ b/src/xml/dom.h
@@ -70,7 +70,7 @@ namespace XML
         void parse( const Gtk::TreeModel::Children& children, SKELETON::EditColumns& columns );
 
         // プロパティをセットするアクセッサ
-        void parentNode( Dom* parent ) { m_parentNode = parent; }
+        void parentNode( Dom* parent ) = delete;
         void copy_childNodes( const Dom& dom ); // dom の子ノードをコピーする
 
         // ノードを分解して Gtk::TreeStore へ Gtk::TreeModel::Row を追加
@@ -100,7 +100,7 @@ namespace XML
         int nodeType() const noexcept { return m_nodeType; }
         std::string nodeName() const { return m_nodeName; }
         std::string nodeValue() const { return m_nodeValue; }
-        void nodeValue( const std::string& value ) { m_nodeValue = value; }
+        void nodeValue( const std::string& value ) = delete;
 
         // ノード
         // 注意：appendChild(), replaceChild(), insertBefore() は
@@ -113,7 +113,7 @@ namespace XML
         // クラス外で使用していないメンバ関数は削除してあります。
 
         Dom* ownerDocument() const noexcept = delete;
-        Dom* parentNode() const noexcept { return m_parentNode; }
+        Dom* parentNode() const noexcept = delete;
         bool hasChildNodes() const noexcept;
         std::list<Dom*> childNodes() const { return m_childNodes; }
         Dom* firstChild() const;

--- a/test/gtest_xml_dom.cpp
+++ b/test/gtest_xml_dom.cpp
@@ -7,6 +7,38 @@
 
 namespace {
 
+class XML_DomProperty : public ::testing::Test {};
+
+TEST_F(XML_DomProperty, node_type)
+{
+    const auto types = {
+        XML::NODE_TYPE_UNKNOWN,
+        XML::NODE_TYPE_ELEMENT,
+        XML::NODE_TYPE_TEXT,
+        XML::NODE_TYPE_DOCUMENT,
+    };
+    for( const auto t : types ) {
+        XML::Dom dom{ t, "test" };
+        int result = dom.nodeType();
+        EXPECT_EQ( t, result );
+    }
+}
+
+TEST_F(XML_DomProperty, node_name)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
+    std::string name = dom.nodeName();
+    EXPECT_EQ( "test", name );
+}
+
+TEST_F(XML_DomProperty, node_value)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
+    std::string value = dom.nodeValue();
+    EXPECT_EQ( "", value );
+}
+
+
 class XML_DomAttribute : public ::testing::Test {};
 
 TEST_F(XML_DomAttribute, set_not_element_type)

--- a/test/gtest_xml_dom.cpp
+++ b/test/gtest_xml_dom.cpp
@@ -39,6 +39,69 @@ TEST_F(XML_DomProperty, node_value)
 }
 
 
+class XML_DomGetElement : public ::testing::Test {};
+
+TEST_F(XML_DomGetElement, empty_id)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
+    XML::Dom* result = dom.getElementById( "" );
+    EXPECT_EQ( nullptr, result );
+}
+
+TEST_F(XML_DomGetElement, not_found_id)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
+    XML::Dom* child = dom.appendChild( XML::NODE_TYPE_UNKNOWN, "unknown" );
+    child->setAttribute( "id", "the-id" );
+    child = dom.appendChild( XML::NODE_TYPE_TEXT, "text" );
+    child->setAttribute( "id", "the-id" );
+    child = dom.appendChild( XML::NODE_TYPE_DOCUMENT, "document" );
+    child->setAttribute( "id", "the-id" );
+    XML::Dom* result = dom.getElementById( "the-id" );
+    EXPECT_EQ( nullptr, result );
+}
+
+TEST_F(XML_DomGetElement, found_first_id)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
+    XML::Dom* child = dom.appendChild( XML::NODE_TYPE_ELEMENT, "first" );
+    child->setAttribute( "id", "the-id" );
+    XML::Dom* expect = child;
+    child = dom.appendChild( XML::NODE_TYPE_ELEMENT, "second" );
+    child->setAttribute( "id", "the-id" );
+    XML::Dom* result = dom.getElementById( "the-id" );
+    EXPECT_EQ( expect, result );
+}
+
+TEST_F(XML_DomGetElement, empty_tag_name)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
+    const std::list<XML::Dom*> result = dom.getElementsByTagName( "" );
+    EXPECT_TRUE( result.empty() );
+}
+
+TEST_F(XML_DomGetElement, not_found_tag_name)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
+    dom.appendChild( XML::NODE_TYPE_UNKNOWN, "the-tag" );
+    dom.appendChild( XML::NODE_TYPE_TEXT, "the-tag" );
+    dom.appendChild( XML::NODE_TYPE_DOCUMENT, "the-tag" );
+    const std::list<XML::Dom*> result = dom.getElementsByTagName( "" );
+    EXPECT_TRUE( result.empty() );
+}
+
+TEST_F(XML_DomGetElement, found_tag_name)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
+    XML::Dom* first = dom.appendChild( XML::NODE_TYPE_ELEMENT, "the-tag" );
+    dom.appendChild( XML::NODE_TYPE_ELEMENT, "another-tag" );
+    XML::Dom* second = dom.appendChild( XML::NODE_TYPE_ELEMENT, "the-tag" );
+    const std::list<XML::Dom*> expect = { first, second };
+    const std::list<XML::Dom*> result = dom.getElementsByTagName( "the-tag" );
+    EXPECT_EQ( expect, result );
+}
+
+
 class XML_DomChildren : public ::testing::Test {};
 
 TEST_F(XML_DomChildren, has_child_nodes)

--- a/test/gtest_xml_dom.cpp
+++ b/test/gtest_xml_dom.cpp
@@ -39,6 +39,89 @@ TEST_F(XML_DomProperty, node_value)
 }
 
 
+class XML_DomChildren : public ::testing::Test {};
+
+TEST_F(XML_DomChildren, has_child_nodes)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
+    bool result = dom.hasChildNodes();
+    EXPECT_FALSE( result );
+
+    dom.appendChild( XML::NODE_TYPE_ELEMENT, "child" );
+    result = dom.hasChildNodes();
+    EXPECT_TRUE( result );
+}
+
+TEST_F(XML_DomChildren, child_nodes)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "unknown" };
+    XML::Dom* first = dom.appendChild( XML::NODE_TYPE_ELEMENT, "element" );
+    XML::Dom* second = dom.appendChild( XML::NODE_TYPE_TEXT, "text" );
+    XML::Dom* third = dom.appendChild( XML::NODE_TYPE_DOCUMENT, "document" );
+    const std::list<XML::Dom*> expect = { first, second, third };
+    const std::list<XML::Dom*> result = dom.childNodes();
+    EXPECT_EQ( expect, result );
+}
+
+TEST_F(XML_DomChildren, append_child)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
+    XML::Dom* child = dom.appendChild( XML::NODE_TYPE_ELEMENT, "child" );
+    EXPECT_NE( nullptr, child );
+    EXPECT_EQ( XML::NODE_TYPE_ELEMENT, child->nodeType() );
+    EXPECT_EQ( "child", child->nodeName() );
+}
+
+
+TEST_F(XML_DomChildren, first_child)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
+    XML::Dom* child = dom.firstChild();
+    EXPECT_EQ( nullptr, child );
+
+    dom.appendChild( XML::NODE_TYPE_ELEMENT, "child" );
+    child = dom.firstChild();
+    EXPECT_NE( nullptr, child );
+    EXPECT_EQ( XML::NODE_TYPE_ELEMENT, child->nodeType() );
+    EXPECT_EQ( "child", child->nodeName() );
+}
+
+TEST_F(XML_DomChildren, remove_child)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
+    bool result = dom.removeChild( nullptr );
+    EXPECT_FALSE( result );
+
+    XML::Dom* child = dom.appendChild( XML::NODE_TYPE_ELEMENT, "child" );
+    result = dom.removeChild( child );
+    EXPECT_TRUE( result );
+    EXPECT_FALSE( dom.hasChildNodes() );
+}
+
+TEST_F(XML_DomChildren, insert_before)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
+    XML::Dom* leak_child = dom.insertBefore( XML::NODE_TYPE_ELEMENT, "null", nullptr );
+    EXPECT_NE( nullptr, leak_child );
+    EXPECT_FALSE( dom.hasChildNodes() );
+    delete leak_child;
+
+    XML::Dom* first_child = dom.appendChild( XML::NODE_TYPE_ELEMENT, "child1" );
+    XML::Dom* second_child = dom.insertBefore( XML::NODE_TYPE_ELEMENT, "child2", first_child );
+    XML::Dom* result = dom.firstChild();
+    EXPECT_EQ( second_child, result );
+}
+
+TEST_F(XML_DomChildren, children_clear)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
+    dom.appendChild( XML::NODE_TYPE_ELEMENT, "child1" );
+    dom.appendChild( XML::NODE_TYPE_ELEMENT, "child2" );
+    dom.clear();
+    EXPECT_FALSE( dom.hasChildNodes() );
+}
+
+
 class XML_DomAttribute : public ::testing::Test {};
 
 TEST_F(XML_DomAttribute, set_not_element_type)

--- a/test/gtest_xml_dom.cpp
+++ b/test/gtest_xml_dom.cpp
@@ -1,0 +1,129 @@
+// License: GPL-2.0
+
+#include "xml/dom.h"
+
+#include "gtest/gtest.h"
+
+
+namespace {
+
+class XML_DomAttribute : public ::testing::Test {};
+
+TEST_F(XML_DomAttribute, set_not_element_type)
+{
+    XML::Dom dom_unknown{ XML::NODE_TYPE_UNKNOWN, "unknown" };
+    bool result = dom_unknown.setAttribute( "name", "value" );
+    EXPECT_FALSE( result );
+    XML::Dom dom_text{ XML::NODE_TYPE_TEXT, "text" };
+    result = dom_text.setAttribute( "name", "value" );
+    EXPECT_FALSE( result );
+    XML::Dom dom_doc{ XML::NODE_TYPE_DOCUMENT, "document" };
+    result = dom_doc.setAttribute( "name", "value" );
+    EXPECT_FALSE( result );
+}
+
+TEST_F(XML_DomAttribute, set_empty_name_with_string_value)
+{
+    XML::Dom dom{ XML::NODE_TYPE_ELEMENT, "test" };
+    bool result = dom.setAttribute( "", "value" );
+    EXPECT_FALSE( result );
+}
+
+TEST_F(XML_DomAttribute, set_empty_name_with_integer_value)
+{
+    XML::Dom dom{ XML::NODE_TYPE_ELEMENT, "test" };
+    bool result = dom.setAttribute( "", 123 );
+    EXPECT_FALSE( result );
+}
+
+TEST_F(XML_DomAttribute, set_empty_string_value)
+{
+    XML::Dom dom{ XML::NODE_TYPE_ELEMENT, "test" };
+    bool result = dom.setAttribute( "name", "" );
+    EXPECT_FALSE( result );
+}
+
+TEST_F(XML_DomAttribute, get_empty)
+{
+    XML::Dom dom{ XML::NODE_TYPE_ELEMENT, "test" };
+    std::string value = dom.getAttribute( "" );
+    EXPECT_EQ( "", value );
+}
+
+TEST_F(XML_DomAttribute, get_not_found)
+{
+    XML::Dom dom{ XML::NODE_TYPE_ELEMENT, "test" };
+    std::string value = dom.getAttribute( "not-found" );
+    EXPECT_EQ( "", value );
+}
+
+TEST_F(XML_DomAttribute, set_string_value)
+{
+    XML::Dom dom{ XML::NODE_TYPE_ELEMENT, "test" };
+    bool result = dom.setAttribute( "hello", "world" );
+    std::string value = dom.getAttribute( "hello" );
+    EXPECT_TRUE( result );
+    EXPECT_EQ( "world", value );
+}
+
+TEST_F(XML_DomAttribute, set_string_value_twice)
+{
+    XML::Dom dom{ XML::NODE_TYPE_ELEMENT, "test" };
+    dom.setAttribute( "hello", "world" );
+    bool result = dom.setAttribute( "hello", "jdim" );
+    std::string value = dom.getAttribute( "hello" );
+    EXPECT_TRUE( result );
+    EXPECT_EQ( "world", value );
+}
+
+TEST_F(XML_DomAttribute, set_positive_integer_value)
+{
+    XML::Dom dom{ XML::NODE_TYPE_ELEMENT, "test" };
+    bool result = dom.setAttribute( "width", 32767 );
+    std::string value = dom.getAttribute( "width" );
+    EXPECT_TRUE( result );
+    EXPECT_EQ( "32767", value );
+}
+
+TEST_F(XML_DomAttribute, set_negative_integer_value)
+{
+    XML::Dom dom{ XML::NODE_TYPE_ELEMENT, "test" };
+    bool result = dom.setAttribute( "width", -32768 );
+    std::string value = dom.getAttribute( "width" );
+    EXPECT_TRUE( result );
+    EXPECT_EQ( "-32768", value );
+}
+
+TEST_F(XML_DomAttribute, set_integer_value_twice)
+{
+    XML::Dom dom{ XML::NODE_TYPE_ELEMENT, "test" };
+    dom.setAttribute( "width", 12321 );
+    bool result = dom.setAttribute( "width", 0 );
+    std::string value = dom.getAttribute( "width" );
+    EXPECT_TRUE( result );
+    EXPECT_EQ( "12321", value );
+}
+
+TEST_F(XML_DomAttribute, set_uppercase_name_with_string_value)
+{
+    XML::Dom dom{ XML::NODE_TYPE_ELEMENT, "test" };
+    bool result = dom.setAttribute( "UPPER", "hello world" );
+    EXPECT_TRUE( result );
+    std::string value = dom.getAttribute( "UPPER" );
+    EXPECT_EQ( "", value );
+    value = dom.getAttribute( "upper" );
+    EXPECT_EQ( "hello world", value );
+}
+
+TEST_F(XML_DomAttribute, set_uppercase_name_with_integer_value)
+{
+    XML::Dom dom{ XML::NODE_TYPE_ELEMENT, "test" };
+    bool result = dom.setAttribute( "UPPER", 256 );
+    EXPECT_TRUE( result );
+    std::string value = dom.getAttribute( "UPPER" );
+    EXPECT_EQ( "", value );
+    value = dom.getAttribute( "upper" );
+    EXPECT_EQ( "256", value );
+}
+
+} // namespace

--- a/test/gtest_xml_dom.cpp
+++ b/test/gtest_xml_dom.cpp
@@ -7,6 +7,68 @@
 
 namespace {
 
+class XML_DomGetXml : public ::testing::Test {};
+
+TEST_F(XML_DomGetXml, xml_empty)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
+    std::string xml = dom.get_xml();
+    EXPECT_EQ( "", xml );
+}
+
+TEST_F(XML_DomGetXml, xml_empty_document)
+{
+    XML::Dom dom{ XML::NODE_TYPE_DOCUMENT, "document" };
+    std::string xml = dom.get_xml();
+    EXPECT_EQ( "", xml );
+}
+
+TEST_F(XML_DomGetXml, xml_single_element)
+{
+    XML::Dom dom{ XML::NODE_TYPE_DOCUMENT, "document" };
+    XML::Dom* root = dom.appendChild( XML::NODE_TYPE_ELEMENT, "root" );
+    root->setAttribute( "name", "value" );
+    std::string xml = dom.get_xml();
+    EXPECT_EQ( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root name=\"value\" />\n", xml );
+}
+
+TEST_F(XML_DomGetXml, xml_single_child_element)
+{
+    XML::Dom dom{ XML::NODE_TYPE_DOCUMENT, "document" };
+    XML::Dom* root = dom.appendChild( XML::NODE_TYPE_ELEMENT, "root" );
+    root->appendChild( XML::NODE_TYPE_ELEMENT, "child" );
+    std::string xml = dom.get_xml();
+    EXPECT_EQ( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root>\n  <child />\n</root>\n", xml );
+}
+
+TEST_F(XML_DomGetXml, xml_single_child_text)
+{
+    XML::Dom dom{ XML::NODE_TYPE_DOCUMENT, "document" };
+    XML::Dom* root = dom.appendChild( XML::NODE_TYPE_ELEMENT, "root" );
+    XML::Dom* child = root->appendChild( XML::NODE_TYPE_TEXT, "child" );
+    child->nodeValue( "hello world" );
+    std::string xml = dom.get_xml();
+    EXPECT_EQ( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root>\n  hello world\n</root>\n", xml );
+}
+
+TEST_F(XML_DomGetXml, xml_nesting_child_element)
+{
+    XML::Dom dom{ XML::NODE_TYPE_DOCUMENT, "document" };
+    XML::Dom* root = dom.appendChild( XML::NODE_TYPE_ELEMENT, "root" );
+    XML::Dom* child = root->appendChild( XML::NODE_TYPE_ELEMENT, "first" );
+    child->appendChild( XML::NODE_TYPE_ELEMENT, "second" );
+    std::string xml = dom.get_xml();
+    std::string expect = R"=(<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <first>
+    <second />
+  </first>
+</root>
+)=";
+    EXPECT_EQ( expect, xml );
+}
+
+
 class XML_DomProperty : public ::testing::Test {};
 
 TEST_F(XML_DomProperty, node_type)


### PR DESCRIPTION
[`XML::Dom`](https://github.com/JDimproved/JDim/blob/7a0f87c29256db2bf772cb8c2a1c0441e9e55115/src/xml/dom.h) のコードを整理してテストケースを追加します。

- メンバ関数にconstやnoexceptを指定する
- 未使用のメンバ関数やクラス外で使用していないgetter/setter関数を削除する
- 単純なgetter/setterはヘッダーに実装を移動してインライン展開を図る

関連のpull request: #210 