### PR TITLE
XML::Dom: Change behavior for insertBefore()

### DIFF
--- a/src/xml/dom.cpp
+++ b/src/xml/dom.cpp
@@ -625,13 +625,14 @@ bool Dom::removeChild( Dom* node )
 //
 Dom* Dom::insertBefore( const int node_type, const std::string& node_name, Dom* insNode )
 {
-    Dom* newNode = nullptr;
+    if( ! insNode ) return appendChild( node_type, node_name );
 
-    newNode = new Dom( node_type, node_name );
+    Dom* newNode = nullptr;
 
     const auto it = std::find( m_childNodes.begin(), m_childNodes.end(), insNode );
     if( it != m_childNodes.end() )
     {
+        newNode = new Dom( node_type, node_name );
         newNode->m_parentNode = insNode->m_parentNode;
         m_childNodes.insert( it, newNode );
     }

--- a/test/gtest_xml_dom.cpp
+++ b/test/gtest_xml_dom.cpp
@@ -226,15 +226,17 @@ TEST_F(XML_DomChildren, remove_child)
 TEST_F(XML_DomChildren, insert_before)
 {
     XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
-    XML::Dom* leak_child = dom.insertBefore( XML::NODE_TYPE_ELEMENT, "null", nullptr );
-    EXPECT_NE( nullptr, leak_child );
-    EXPECT_FALSE( dom.hasChildNodes() );
-    delete leak_child;
 
     XML::Dom* first_child = dom.appendChild( XML::NODE_TYPE_ELEMENT, "child1" );
     XML::Dom* second_child = dom.insertBefore( XML::NODE_TYPE_ELEMENT, "child2", first_child );
-    XML::Dom* result = dom.firstChild();
-    EXPECT_EQ( second_child, result );
+    EXPECT_EQ( dom.firstChild(), second_child );
+
+    XML::Dom* third_child = dom.insertBefore( XML::NODE_TYPE_ELEMENT, "child2", nullptr );
+    EXPECT_EQ( dom.childNodes().back(), third_child );
+
+    XML::Dom not_child{ XML::NODE_TYPE_UNKNOWN, "test" };
+    XML::Dom* null_child = dom.insertBefore( XML::NODE_TYPE_ELEMENT, "null", &not_child );
+    EXPECT_EQ( nullptr, null_child );
 }
 
 TEST_F(XML_DomChildren, children_clear)


### PR DESCRIPTION
[MDNのリファレンス][mdn]を参考に `Dom::insertBefore()` の挙動を変更します。
変更後もJavaScriptの挙動と異なるので注意してください。

https://github.com/JDimproved/JDim/blob/9c2098d69ada53fea4b4670fd95575eb12c015eb/src/xml/dom.h#L124
- 引数 `insNode` が `nullptr` の場合はノードを子の末尾に挿入する。
- 引数 `insNode` が子の中に無い場合はノードを挿入せず `nullptr` を返す。

関連のissue: #209

[mdn]: https://developer.mozilla.org/ja/docs/Web/API/Node/insertBefore
