### PR TITLE
Replace char buffer with std::string for SKELETON::TextLoader

### DIFF
--- a/src/skeleton/textloader.h
+++ b/src/skeleton/textloader.h
@@ -22,10 +22,9 @@ namespace SKELETON
 {
     class TextLoader : public SKELETON::Loadable
     {
-        bool m_loaded; // 読み込み済みか
+        bool m_loaded{}; // 読み込み済みか
 
-        char* m_rawdata;
-        int m_lng_rawdata;
+        std::string m_rawdata;
         std::string m_data;
 
       public:


### PR DESCRIPTION
malloc/freeで確保しているバッファをstd::stringで置き換えます。
メモリは自動的に確保されますが挙動の変化を抑えるため修正前と同じ量を予約しておきます。

関連のpull request: #159
