### PR TITLE
ImageViewMain: Fix member initialization

### DIFF
--- a/docs/manual/2020.md
+++ b/docs/manual/2020.md
@@ -10,6 +10,12 @@ layout: default
 
 <a name="0.4.0-unreleased"></a>
 ### [0.4.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.3.0...master) (unreleased)
+- `ImageViewMain`: Fix member initialization
+  ([#227](https://github.com/JDimproved/JDim/pull/227))
+- Replace char buffer with `std::string` for `SKELETON::TextLoader`
+  ([#226](https://github.com/JDimproved/JDim/pull/226))
+- `XML::Dom`: Change behavior for `insertBefore()`
+  ([#225](https://github.com/JDimproved/JDim/pull/225))
 - Refactor `XML::Dom` part2
   ([#224](https://github.com/JDimproved/JDim/pull/224))
 - Replace char buffer with `std::string` for `CACHE::jdcopy()`

--- a/src/image/imageview.cpp
+++ b/src/image/imageview.cpp
@@ -44,14 +44,7 @@ using namespace IMAGE;
 
 
 ImageViewMain::ImageViewMain( const std::string& url )
-    : ImageViewBase( url ),
-      m_scrwin( nullptr ),
-      m_length_prev( 0 ),
-      m_show_status( false ),
-      m_update_status( false ),
-      m_show_label( false ),
-      m_do_resizing( false ),
-      m_scrolled( false )
+    : ImageViewBase( url )
 {
 #ifdef _DEBUG    
     std::cout << "ImageViewMain::ImageViewMain : " << get_url() << std::endl;

--- a/src/image/imageview.h
+++ b/src/image/imageview.h
@@ -13,23 +13,23 @@ namespace IMAGE
 {
     class ImageViewMain : public ImageViewBase
     {
-        Gtk::ScrolledWindow* m_scrwin;
+        Gtk::ScrolledWindow* m_scrwin{};
         Gtk::Label m_label;
-        gdouble m_x_motion;
-        gdouble m_y_motion;
-        size_t m_length_prev;
-        bool m_show_status;
-        bool m_update_status;
-        bool m_show_label;
+        gdouble m_x_motion{};
+        gdouble m_y_motion{};
+        size_t m_length_prev{};
+        bool m_show_status{};
+        bool m_update_status{};
+        bool m_show_label{};
 
         std::string m_status_local;
 
-        int m_pre_width;
-        int m_pre_height;
-        int m_redraw_count;
+        int m_pre_width{};
+        int m_pre_height{};
+        int m_redraw_count{};
 
-        bool m_do_resizing;
-        bool m_scrolled;
+        bool m_do_resizing{};
+        bool m_scrolled{};
 
       public:
         ImageViewMain( const std::string& url );


### PR DESCRIPTION
メンバ変数の初期化を変更してcppcheckの警告
`(warning) Member variable 'ImageViewMain::XXX' is not initialized in the constructor.` を修正します。

```
[src/image/imageview.cpp:46]: (warning) Member variable 'ImageViewMain::m_pre_width' is not initialized in the constructor.
[src/image/imageview.cpp:46]: (warning) Member variable 'ImageViewMain::m_pre_height' is not initialized in the constructor.
[src/image/imageview.cpp:46]: (warning) Member variable 'ImageViewMain::m_redraw_count' is not initialized in the constructor.
```

関連のpull request: #208
