### PR TITLE
Change button config name "ブックマーク" with "しおりの設定/解除"

### DIFF
--- a/src/control/controllabel.h
+++ b/src/control/controllabel.h
@@ -214,7 +214,7 @@ namespace CONTROL
 
         { "PopupWarpButton", "クリックで多重ポップアップモードに移行" },
         { "ReferResButton", "参照レスポップアップ表示" },
-        { "BmResButton", "ブックマーク" },
+        { "BmResButton", "しおりの設定/解除" },
         { "PostedMarkButton", "書き込みマークの設定/解除" },
         { "PopupmenuResButton", "レス番号メニュー表示" },
 


### PR DESCRIPTION
[以前の変更][prev]で「ブックマーク」から「しおり」に改名がありましたがマウスボタン設定の項目がブックマークのままになっていたため修正します。
ソースコードのコメントで使われている「ブックマーク」は変更していません。

[変更履歴(2008年)][2008]から

> お気に入りと混同すると指摘があったのでスレやレスの「ブックマーク」を「しおり」に改名

[prev]: https://github.com/JDimproved/JDim/commit/c996b54fa438acbc31cb696d268015bf34eb60d1
[2008]: https://jdimproved.github.io/JDim/2008/#2.0.0-beta080418
