### PR TITLE
ImageViewBase: Fix member initialization

### DIFF
--- a/src/image/imageviewbase.cpp
+++ b/src/image/imageviewbase.cpp
@@ -42,11 +42,8 @@ using namespace IMAGE;
 
 
 ImageViewBase::ImageViewBase( const std::string& url, const std::string& arg1, const std::string& arg2 )
-    : SKELETON::View( url ),
-      m_wait( false ),
-      m_loading( false ),
-      m_under_mouse( false ),
-      m_enable_menuslot( true )
+    : SKELETON::View( url )
+    , m_enable_menuslot( true )
 {
     // 高速化のためデータベースに直接アクセス
     m_img =  DBIMG::get_img( get_url() );

--- a/src/image/imageviewbase.h
+++ b/src/image/imageviewbase.h
@@ -40,11 +40,11 @@ namespace IMAGE
         // Gtk::manage で作っているのでdeleteしなくても良い
         JDLIB::ConstPtr< ImageAreaBase > m_imagearea;
 
-        bool m_wait;
-        bool m_loading;
+        bool m_wait{};
+        bool m_loading{};
         Gtk::EventBox m_event;
-        bool m_dblclick;
-        bool m_under_mouse;
+        bool m_dblclick{};
+        bool m_under_mouse{};
 
         bool m_enable_menuslot;
 


### PR DESCRIPTION
メンバ変数の初期化を変更してcppcheckの警告 `(warning) Member variable ImageViewBase::m_dblclick' is not initialized in the constructor.` を修正します。

```
[src/image/imageviewbase.cpp:44]: (warning) Member variable 'ImageViewBase::m_dblclick' is not initialized in the constructor.
```

関連のpull request: #208
