### PR TITLE
Add const qualifier to XML::Dom* variables

### DIFF
--- a/src/aamanager.cpp
+++ b/src/aamanager.cpp
@@ -152,11 +152,11 @@ void AAManager::load_history()
 #endif
 
     XML::Document document( xml );
-    XML::Dom* root = document.get_root_element( std::string( ROOT_NODE_NAME ) );
+    const XML::Dom* root = document.get_root_element( std::string( ROOT_NODE_NAME ) );
     if( ! root ) return;
 
     std::list< std::string > tmp_history;
-    for( XML::Dom* child : root->childNodes() ){
+    for( const XML::Dom* child : root->childNodes() ){
         if( static_cast<int>( tmp_history.size() ) >= CONFIG::get_aahistory_size() ) break;
 
         if( child->nodeType() == XML::NODE_TYPE_ELEMENT ){

--- a/src/aamanager.cpp
+++ b/src/aamanager.cpp
@@ -151,7 +151,7 @@ void AAManager::load_history()
     std::cout << xml << std::endl;
 #endif
 
-    XML::Document document( xml );
+    const XML::Document document( xml );
     const XML::Dom* root = document.get_root_element( std::string( ROOT_NODE_NAME ) );
     if( ! root ) return;
 

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -2278,7 +2278,7 @@ void BBSListViewBase::xml2tree( const std::string& root_name, const std::string&
     m_treeview.xml2tree( m_document, m_treestore, root_name );
 
     // ルート要素を取り出す
-    XML::Dom* root = m_document.get_root_element( root_name );
+    const XML::Dom* root = m_document.get_root_element( root_name );
     if( root ){
 
 	// ルート要素から属性( date_modified, path, y )の値を取得

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -421,7 +421,7 @@ void Root::bbsmenu2xml( const std::string& menu )
         return;
     }
     targets = targets.front()->childNodes();
-    for( XML::Dom* child : targets )
+    for( const XML::Dom* child : targets )
     {
         // 要素b( カテゴリ名 )
         if( child->nodeName() == "b" )
@@ -483,7 +483,7 @@ void Root::analyze_board_xml()
 
     const std::list<XML::Dom*> boards = m_xml_document.getElementsByTagName( "board" );
 
-    for( XML::Dom* child : boards )
+    for( const XML::Dom* child : boards )
     {
         const std::string name = child->getAttribute( "name" );
         const std::string url = child->getAttribute( "url" );
@@ -509,7 +509,7 @@ void Root::analyze_board_xml()
         }
     }
 
-    XML::Dom* root = m_xml_document.get_root_element( std::string( ROOT_NODE_NAME ) );
+    const XML::Dom* root = m_xml_document.get_root_element( std::string( ROOT_NODE_NAME ) );
     if( root ) set_date_modified( root->getAttribute( "date_modified" ) );
 
     m_analyzing_board_xml = false;

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -399,7 +399,7 @@ void Root::bbsmenu2xml( const std::string& menu )
     const bool wchar = false;
 
     // menu のノードツリーを取得( menu がHTMLなので第二引数は true )
-    XML::Document html( menu, true );
+    const XML::Document html( menu, true );
 
     // XML用のノードツリーにルートノードを追加
     m_xml_document.clear();

--- a/src/history/historymanager.cpp
+++ b/src/history/historymanager.cpp
@@ -222,11 +222,11 @@ void History_Manager::xml2viewhistory()
 
     XML::Document document( xml );
 
-    XML::Dom* root = document.get_root_element( std::string( ROOT_NODE_NAME ) );
+    const XML::Dom* root = document.get_root_element( std::string( ROOT_NODE_NAME ) );
 
     const std::list<XML::Dom*> domlist = root->childNodes();
 
-    for( XML::Dom* subdir : domlist ){
+    for( const XML::Dom* subdir : domlist ){
 
         if( subdir->nodeType() != XML::NODE_TYPE_ELEMENT ) continue;
 
@@ -251,7 +251,7 @@ void History_Manager::xml2viewhistory()
 
         // viewhistory に item を append
         const std::list<XML::Dom*> domlist_hist = subdir->childNodes();
-        for( XML::Dom* histitem : domlist_hist ){
+        for( const XML::Dom* histitem : domlist_hist ){
 
             if( histitem->nodeType() != XML::NODE_TYPE_ELEMENT ) continue;
 

--- a/src/history/historymanager.cpp
+++ b/src/history/historymanager.cpp
@@ -220,7 +220,7 @@ void History_Manager::xml2viewhistory()
 #endif
     if( xml.empty() ) return;
 
-    XML::Document document( xml );
+    const XML::Document document( xml );
 
     const XML::Dom* root = document.get_root_element( std::string( ROOT_NODE_NAME ) );
 

--- a/src/linkfiltermanager.cpp
+++ b/src/linkfiltermanager.cpp
@@ -53,7 +53,7 @@ void Linkfilter_Manager::xml2list( const std::string& xml )
     m_list_cmd.clear();
     if( xml.empty() ) return;
 
-    XML::Document document( xml );
+    const XML::Document document( xml );
 
     const XML::Dom* root = document.get_root_element( std::string( ROOT_NODE_NAME_LINKFILTER ) );
     if( ! root ) return;

--- a/src/linkfiltermanager.cpp
+++ b/src/linkfiltermanager.cpp
@@ -55,7 +55,7 @@ void Linkfilter_Manager::xml2list( const std::string& xml )
 
     XML::Document document( xml );
 
-    XML::Dom* root = document.get_root_element( std::string( ROOT_NODE_NAME_LINKFILTER ) );
+    const XML::Dom* root = document.get_root_element( std::string( ROOT_NODE_NAME_LINKFILTER ) );
     if( ! root ) return;
     const std::list<XML::Dom*> domlist = root->childNodes();
 
@@ -64,7 +64,7 @@ void Linkfilter_Manager::xml2list( const std::string& xml )
     std::cout << " children =" << document.childNodes().size() << std::endl;
 #endif
 
-    for( XML::Dom* child : domlist ){
+    for( const XML::Dom* child : domlist ){
 
         if( child->nodeType() == XML::NODE_TYPE_ELEMENT ){
 

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -333,7 +333,7 @@ void EditTreeView::set_treestore( const Glib::RefPtr< Gtk::TreeStore >& treestor
 //
 // xml -> tree 展開して treestore をセットする
 //
-void EditTreeView::xml2tree( XML::Document& document, Glib::RefPtr< Gtk::TreeStore >& treestore, const std::string& root_name )
+void EditTreeView::xml2tree( const XML::Document& document, Glib::RefPtr< Gtk::TreeStore >& treestore, const std::string& root_name )
 {
 #ifdef _DEBUG
     std::cout << "EditTreeView::xml2tree ";

--- a/src/skeleton/edittreeview.h
+++ b/src/skeleton/edittreeview.h
@@ -104,7 +104,7 @@ namespace SKELETON
         void set_treestore( const Glib::RefPtr< Gtk::TreeStore >& treestore );
 
         // xml -> tree 展開して treestore をセットする
-        void xml2tree( XML::Document& document, Glib::RefPtr< Gtk::TreeStore >& treestore, const std::string& root_name );
+        void xml2tree( const XML::Document& document, Glib::RefPtr< Gtk::TreeStore >& treestore, const std::string& root_name );
 
         // tree -> XML 変換
         void tree2xml( XML::Document& document, const std::string& root_name );

--- a/src/usrcmdmanager.cpp
+++ b/src/usrcmdmanager.cpp
@@ -94,7 +94,7 @@ void Usrcmd_Manager::analyze_xml()
 
     const std::list<XML::Dom*> usrcmds = m_document.getElementsByTagName( XML::get_name( TYPE_USRCMD ) );
 
-    for( XML::Dom* usrcmd : usrcmds )
+    for( const XML::Dom* usrcmd : usrcmds )
     {
         const std::string cmd = usrcmd->getAttribute( "data" );
 
@@ -444,13 +444,13 @@ std::string Usrcmd_Manager::create_usrcmd_menu( Glib::RefPtr< Gtk::ActionGroup >
 
 // ユーザコマンドの登録とメニュー作成(再帰用)
 std::string Usrcmd_Manager::create_usrcmd_menu( Glib::RefPtr< Gtk::ActionGroup >& action_group,
-                                                XML::Dom* dom, int& dirno, int& cmdno )
+                                                const XML::Dom* dom, int& dirno, int& cmdno )
 {
     std::string menu;
     if( ! dom ) return menu;
 
     const std::list<XML::Dom*> domlist = dom->childNodes();
-    for( XML::Dom* child : domlist )
+    for( const XML::Dom* child : domlist )
     {
         if( child->nodeType() == XML::NODE_TYPE_ELEMENT )
         {

--- a/src/usrcmdmanager.h
+++ b/src/usrcmdmanager.h
@@ -63,7 +63,7 @@ namespace CORE
         // ユーザコマンドメニューの作成
         std::string create_usrcmd_menu( Glib::RefPtr< Gtk::ActionGroup >& action_group );
         std::string create_usrcmd_menu( Glib::RefPtr< Gtk::ActionGroup >& action_group,
-                                        XML::Dom* dom, int& dirno, int& cmdno );
+                                        const XML::Dom* dom, int& dirno, int& cmdno );
 
         Glib::RefPtr< Gtk::Action > get_action( Glib::RefPtr< Gtk::ActionGroup >& action_group, const int num );
 

--- a/src/xml/document.cpp
+++ b/src/xml/document.cpp
@@ -94,7 +94,7 @@ std::string Document::remove_comments( const std::string& str )
 // list_path_expand = 後で Gtk::TreeView::expand_row() をするためのリスト
 //
 void Document::set_treestore( Glib::RefPtr< Gtk::TreeStore >& treestore, SKELETON::EditColumns& columns,
-                              const std::string& root_name, std::list< Gtk::TreePath >& list_path_expand )
+                              const std::string& root_name, std::list< Gtk::TreePath >& list_path_expand ) const
 {
     treestore->clear();
 
@@ -113,7 +113,7 @@ void Document::set_treestore( Glib::RefPtr< Gtk::TreeStore >& treestore, SKELETO
 //
 // ルート要素を取得
 //
-Dom* Document::get_root_element( const std::string& node_name )
+Dom* Document::get_root_element( const std::string& node_name ) const
 {
     Dom* node = nullptr;
 

--- a/src/xml/document.cpp
+++ b/src/xml/document.cpp
@@ -101,7 +101,7 @@ void Document::set_treestore( Glib::RefPtr< Gtk::TreeStore >& treestore, SKELETO
     if( childNodes().size() )
     {
         // ルートの子要素以下が対象
-        Dom* root = get_root_element( root_name );
+        const Dom* root = get_root_element( root_name );
 
         // ルート要素の有無で処理を分ける( 旧様式=無, 新様式=有 )
         if( root ) root->append_treestore( treestore, columns, list_path_expand );

--- a/src/xml/document.h
+++ b/src/xml/document.h
@@ -44,10 +44,10 @@ namespace XML
         // Gtk::TreeStore をセットする
         // ただし列は SKELETON::EditColumns を継承したものであること
         void set_treestore( Glib::RefPtr< Gtk::TreeStore >& treestore, SKELETON::EditColumns& columns,
-                            const std::string& root_name, std::list< Gtk::TreePath >& list_path_expand );
+                            const std::string& root_name, std::list< Gtk::TreePath >& list_path_expand ) const;
 
         // ルート要素を取得する
-        Dom* get_root_element( const std::string& node_name = std::string() );
+        Dom* get_root_element( const std::string& node_name = std::string() ) const;
     };
 }
 


### PR DESCRIPTION
`XML::Dom*`や`XML::Document`の変数にconst修飾子を付けて保守性を高めます。

関連のissue: #209
