### PR TITLE
Deprecate thread configure options except for std

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -128,18 +128,11 @@
     --with-thread=[posix|glib|std]
 
        使用するスレッドライブラリを設定する。デフォルトでは std::thread を使用する。(v0.3.0以降)
-
-    --with-thread=posix
-
-       std::thread のかわりに pthread を使用する。
-
-    --with-thread=glib
-
-       非推奨: かわりに --with-thread=std を使用してください。
+       非推奨: スレッドライブラリを設定するオプションは将来のリリースで削除される予定です。
 
     --with-[gthread|stdthread]
 
-       非推奨: かわりに --with-thread=[glib|std] を使用してください。
+       非推奨: スレッドライブラリを設定するオプションは将来のリリースで削除される予定です。
 
     --with-gtkmm3=no
 

--- a/configure.ac
+++ b/configure.ac
@@ -373,15 +373,14 @@ dnl checking gthread (deprecated option)
 dnl
 AC_ARG_WITH(gthread,
 AS_HELP_STRING([--with-gthread], [DEPRECATED. use --with-thread=glib]),
-[AC_MSG_WARN([--with-gthread is deprecated. Use --with-thread=glib instead.])
- with_thread=glib])
+[with_thread=glib])
 
 dnl
 dnl checking std::thread (deprecated option)
 dnl
 AC_ARG_WITH(stdthread,
 AS_HELP_STRING([--with-stdthread], [DEPRECATED. use --with-thread=std]),
-[AC_MSG_WARN([--with-stdthread is deprecated. Use --with-thread=std instead.])
+[AC_MSG_WARN([Thread options will be removed in the future release.])
  with_thread=std])
 
 dnl
@@ -396,10 +395,10 @@ AC_MSG_RESULT($with_thread)
 
 AS_IF(
   [test "x$with_thread" = xposix],
-  [],
+  [AC_MSG_WARN([Thread options will be removed in the future release.])],
 
   [test "x$with_thread" = xglib],
-  [AC_MSG_WARN([--with-thread=glib is deprecated. Use --with-thread=std instead.])
+  [AC_MSG_WARN([Thread options will be removed in the future release.])
    AC_DEFINE(USE_GTHREAD, , [Use gthread instead of pthread])],
 
   [test "x$with_thread" = xstd],

--- a/docs/manual/2020.md
+++ b/docs/manual/2020.md
@@ -10,6 +10,18 @@ layout: default
 
 <a name="0.4.0-unreleased"></a>
 ### [0.4.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.3.0...master) (unreleased)
+- Deprecate thread configure options except for std
+  ([#236](https://github.com/JDimproved/JDim/pull/236))
+- Fix checking sssp scheme
+  ([#235](https://github.com/JDimproved/JDim/pull/235))
+- Add const qualifier to `XML::Dom*` variables
+  ([#234](https://github.com/JDimproved/JDim/pull/234))
+- `ImageViewBase`: Fix member initialization
+  ([#233](https://github.com/JDimproved/JDim/pull/233))
+- Change button config name "ブックマーク" with "しおりの設定/解除"
+  ([#232](https://github.com/JDimproved/JDim/pull/232))
+- Add the toggle command for posted mark to mouse button config
+  ([#231](https://github.com/JDimproved/JDim/pull/231))
 - `ImageViewMain`: Fix member initialization
   ([#227](https://github.com/JDimproved/JDim/pull/227))
 - Replace char buffer with `std::string` for `SKELETON::TextLoader`

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -126,13 +126,12 @@ OSやディストリビューション別の解説は[OS/ディストリビュ�
   <dd><strong>非推奨</strong>: かわりに <code>--with-regex=pcre</code> を使用してください。</dd>
 
   <dt>--with-thread=[posix|glib|std]</dt>
-  <dd>使用するスレッドライブラリを設定する。デフォルトでは std::thread を使用する。(v0.3.0以降)</dd>
-  <dt>--with-thread=posix</dt>
-  <dd>std::thread のかわりに pthread を使用する。</dd>
-  <dt>--with-thread=glib</dt>
-  <dd><strong>非推奨</strong>: かわりに <code>--with-thread=std</code> を使用してください。</dd>
+  <dd>
+    使用するスレッドライブラリを設定する。デフォルトでは std::thread を使用する。(v0.3.0以降)<br>
+    <strong>非推奨</strong>: スレッドライブラリを設定するオプションは将来のリリースで削除される予定です。
+  </dd>
   <dt>--with-[gthread|stdthread]</dt>
-  <dd><strong>非推奨</strong>: かわりに <code>--with-thread=[glib|std]</code> を使用してください。</dd>
+  <dd><strong>非推奨</strong>: スレッドライブラリを設定するオプションは将来のリリースで削除される予定です。</dd>
 
   <dt>--with-gtkmm3=no</dt>
   <dd>gtkmm3のかわりにgtkmm2を使用する。</dd>


### PR DESCRIPTION
スレッドライブラリを`std::thread`にまとめる(#228)のステップ1です。

configureスクリプトを修正してスレッドライブラリのオプションが将来のバージョンで削除されることを通知します。(`--with-thread=std`を除く)
また、ドキュメントを更新してスレッドライブラリのオプションが将来削除されることを載せます。
