### PR TITLE
Fix buffer overrun for NodeTreeBase::parse_html()

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -2232,8 +2232,10 @@ void NodeTreeBase::parse_html( const char* str, const int lng, const int color_t
             pos += n_in; 
 
             // , や = や +が続くとき
+            // MAX_ANCINFOを超えた部分はリンクに含めない
             mode = 1;
-            while( check_anchor( mode, pos, n_in, tmpstr + lng_str, tmplink + lng_link ,
+            while( lng_anc < static_cast<int>( MAX_ANCINFO ) &&
+                   check_anchor( mode, pos, n_in, tmpstr + lng_str, tmplink + lng_link ,
                                  LNG_LINK - lng_link, ancinfo + lng_anc ) ){
 
                 lng_str += strlen( tmpstr ) - lng_str;


### PR DESCRIPTION
アンカーのチェック部分でANCINFOの配列サイズ(MAX_ANCINFO)を超えてデータを追加しないようにループ処理に条件を追加します。
つまり一連のアンカーのうちMAX_ANCINFO個を超えた部分はリンクに含まれなくなります。

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1584619744/69