### PR TITLE
MsgDiag: Fix member initialization

### DIFF
--- a/src/skeleton/msgdiag.h
+++ b/src/skeleton/msgdiag.h
@@ -14,7 +14,7 @@ namespace SKELETON
     class MsgDiag : public Gtk::MessageDialog
     {
 
-        JDLIB::Timeout* m_conn_timer;
+        JDLIB::Timeout* m_conn_timer{};
 
       public:
 


### PR DESCRIPTION
メンバ変数の初期化を変更してcppcheckの警告 `(warning) Member variable 'MsgDiag::m_conn_timer' is not initialized in the constructor.` を修正します。

```
[src/skeleton/msgdiag.cpp:17]: (warning) Member variable 'MsgDiag::m_conn_timer' is not initialized in the constructor.
[src/skeleton/msgdiag.cpp:27]: (warning) Member variable 'MsgDiag::m_conn_timer' is not initialized in the constructor.
```

関連のpull request: #208