### PR TITLE
ImageAreaIcon: Fix member initialization

### DIFF
--- a/src/image/imageareaicon.cpp
+++ b/src/image/imageareaicon.cpp
@@ -21,7 +21,6 @@ using namespace IMAGE;
 
 ImageAreaIcon::ImageAreaIcon( const std::string& url )
     : ImageAreaBase( url, 0 ) // アイコンは常に Gdk::INTERP_NEAREST
-    , m_shown( false )
 {
 #ifdef _DEBUG    
     std::cout << "ImageAreaIcon::ImageAreaIcon url = " << url << std::endl;

--- a/src/image/imageareaicon.h
+++ b/src/image/imageareaicon.h
@@ -21,8 +21,8 @@ namespace IMAGE
 
     class ImageAreaIcon : public ImageAreaBase
     {
-        bool m_shown;
-        int m_imagetype; // dispatch()前に表示する画像を入れる
+        bool m_shown{};
+        int m_imagetype{}; // dispatch()前に表示する画像を入れる
 
         Glib::RefPtr< Gdk::Pixbuf > m_pixbuf;
         Glib::RefPtr< Gdk::Pixbuf > m_pixbuf_loading;


### PR DESCRIPTION

メンバ変数の初期化を変更してcppcheckの警告 `(warning) Member variable 'ImageAreaIcon::m_imagetype' is not initialized in the constructor.` を修正します。

```
[src/image/imageareaicon.cpp:22]: (warning) Member variable 'ImageAreaIcon::m_imagetype' is not initialized in the constructor.
```

関連のpull request: #208