### PR TITLE
Remove the option to fetch kako logs using offlaw2

### DIFF
--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -140,7 +140,6 @@ void AboutConfig::append_rows()
     append_row( "2chのクッキー:HAPを保存する", get_confitem()->use_cookie_hap, CONF_USE_COOKIE_HAP );
     append_row( "2chのクッキー:HAP", get_confitem()->cookie_hap, CONF_COOKIE_HAP );
     append_row( "BBSPINKのクッキー:HAP", get_confitem()->cookie_hap_bbspink, CONF_COOKIE_HAP_BBSPINK );
-    append_row( "2chの過去ログ取得時にofflaw2を使用する", get_confitem()->use_offlaw2_2ch, CONF_USE_OFFLAW2_2CH );
 
     // ツリービュー
     append_row( "" );

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -159,9 +159,6 @@ bool ConfigItems::load( const bool restore )
     cookie_hap = cf.get_option_str( "cookie_hap", CONF_COOKIE_HAP );
     cookie_hap_bbspink = cf.get_option_str( "cookie_hap_bbspink", CONF_COOKIE_HAP_BBSPINK );
 
-    // 2chの過去ログ取得時にofflaw2を使用する
-    use_offlaw2_2ch = cf.get_option_bool( "use_offlaw2_2ch", CONF_USE_OFFLAW2_2CH );
-
     // ブラウザ設定ダイアログのコンボボックスの番号
     browsercombo_id = cf.get_option_int( "browsercombo_id", CONF_BROWSER_NO, 0, CORE::get_browser_number() -1 );
 
@@ -718,8 +715,6 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "use_cookie_hap", use_cookie_hap );
     cf.update( "cookie_hap", cookie_hap );
     cf.update( "cookie_hap_bbspink", cookie_hap_bbspink );
-
-    cf.update( "use_offlaw2_2ch", use_offlaw2_2ch );
 
     cf.update( "command_openurl", command_openurl );
     cf.update( "browsercombo_id", browsercombo_id );

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -97,8 +97,7 @@ namespace CONFIG
         std::string cookie_hap;
         std::string cookie_hap_bbspink;
 
-        // 2chの過去ログ取得時にofflaw2を使用する
-        bool use_offlaw2_2ch;
+        enum { use_offlaw2_2ch }; // Removed in v0.3.0 (2020-04)
 
         // リンクをクリックしたときに実行するコマンド
         std::string command_openurl;

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -37,7 +37,6 @@ namespace CONFIG
         CONF_USE_IPV6 = 1,          // ipv6使用
         CONF_CONNECTION_NUM = 2,    // 同一ホストに対する最大コネクション数( 1 または 2 )
         CONF_USE_COOKIE_HAP = 0,    // 2chのクッキー:HAPを保存する
-        CONF_USE_OFFLAW2_2CH = 0,   // 2chの過去ログ取得時にofflaw2を使用する
         CONF_REFPOPUP_BY_MO = 0,    // レス番号の上にマウスオーバーしたときに参照ポップアップ表示する
         CONF_NAMEPOPUP_BY_MO = 0,   // 名前の上にマウスオーバーしたときにポップアップ表示する
         CONF_IDPOPUP_BY_MO = 0,     // IDの上にマウスオーバーしたときにIDをポップアップ表示する

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -239,9 +239,6 @@ const std::string& CONFIG::get_cookie_hap_bbspink(){ return get_confitem()->cook
 void CONFIG::set_cookie_hap( const std::string& cookie_hap ){ get_confitem()->cookie_hap = cookie_hap; }
 void CONFIG::set_cookie_hap_bbspink( const std::string& cookie_hap ){ get_confitem()->cookie_hap_bbspink = cookie_hap; }
 
-// 2chの過去ログ取得時にofflaw2を使用する
-bool CONFIG::get_use_offlaw2_2ch(){ return get_confitem()->use_offlaw2_2ch; }
-
 const std::string& CONFIG::get_command_openurl() { return get_confitem()->command_openurl; }
 void CONFIG::set_command_openurl( const std::string& command ){ get_confitem()->command_openurl = command; }
 

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -200,8 +200,7 @@ namespace CONFIG
     void set_cookie_hap( const std::string& cookie_hap );
     void set_cookie_hap_bbspink( const std::string& cookie_hap );
 
-    // 2chの過去ログ取得時にofflaw2を使用する
-    bool get_use_offlaw2_2ch();
+    bool get_use_offlaw2_2ch() = delete; // Removed in v0.3.0 (2020-04)
 
     // リンクをクリックしたときに実行するコマンド
     const std::string& get_command_openurl();

--- a/src/dbtree/article2ch.cpp
+++ b/src/dbtree/article2ch.cpp
@@ -116,7 +116,5 @@ NodeTreeBase* Article2ch::create_nodetree()
 bool Article2ch::is_load_olddat()
 {
     // 2chにログインしている場合
-    // または、offlaw2を使う設定の場合 ( bbspinkを除く )
-    return CORE::get_login2ch()->login_now()
-            || ( CONFIG::get_use_offlaw2_2ch() && get_url().find( ".bbspink.com" ) == std::string::npos );
+    return CORE::get_login2ch()->login_now();
 }


### PR DESCRIPTION
Fixes #242

2chの過去ログ取得時にofflaw2を使用するオプションを削除します。
offlaw2.soは[2015-03-17][]に廃止されています。

機能削除後も設定ファイルのオプション項目`use_offlaw2_2ch`は残ります。
そのため互換性を考慮しソースコード上でも`use_offlaw2_2ch`を無名のenumで予約しておきます。

[2015-03-17]: https://maguro.5ch.net/test/read.cgi/mango/1426045212/538
