### PR TITLE
Add RFC repository link to documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ Pull requestは`master`ブランチに対してお願いいたします。
 
 * 文書やソースコードのタイプミス修正、バグ修正、文書の改善、機能の改善などは直接PRを受け付けています。
 * ユーザーインタフェースの変更や互換性に影響が出る修正は最初にissueを開いて意見・要望をお伝えいただければ幸いです。
+* 影響が大きい変更は[RFCプロセス][rfcs]が必要になる場合があります。
 * オンラインマニュアルの編集については [docs/README.md][docs-readme] を参照してください。
 * テストケースを追加して動作をチェックすることもできます。詳細は [test/README.md][test-readme] を参照してください。
 
@@ -59,6 +60,7 @@ Pull requestは`master`ブランチに対してお願いいたします。
 [linux-5ch]: https://mao.5ch.net/linux/
 [new-issue]: https://github.com/JDimproved/JDim/issues/new
 [manual]: https://jdimproved.github.io/JDim/
+[rfcs]: https://github.com/JDimproved/rfcs
 [docs-readme]: https://github.com/JDimproved/JDim/tree/master/docs/README.md
 [test-readme]: https://github.com/JDimproved/JDim/tree/master/test/README.md
 [isocpp]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 [![Snap Status](https://build.snapcraft.io/badge/JDimproved/JDim.svg)](https://build.snapcraft.io/user/JDimproved/JDim)
 [![jdim](https://snapcraft.io//jdim/badge.svg)](https://snapcraft.io/jdim)
 
-ここに書かれていない詳細については[オンラインマニュアル][manual]や[リポジトリ][repository]を参照してください。
+ここに書かれていない詳細は [オンラインマニュアル][manual] を、
+開発に参加するための手順については [CONTRIBUTING][contrib] や [RFC][rfcs] を参照してください。
 
 [manual]: https://jdimproved.github.io/JDim/
 [repository]: https://github.com/JDimproved/JDim
+[rfcs]: https://github.com/JDimproved/rfcs "Request for Comments"
 
 * [概要](#概要)
 * [動作プラットフォーム](#動作プラットフォーム)

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ layout: default
 
 - [FAQ][wiki-faq] (JD wiki)
 - [Tips][wiki-tips] (JD wiki)
+- [開発ドキュメント][wiki-rfcs] (GitHub wiki)
 - [その他]({{ site.baseurl }}/info/)
 - [更新履歴]({{ site.baseurl }}/history/)
 
@@ -38,4 +39,5 @@ layout: default
 [wiki-install]: https://ja.osdn.net/projects/jd4linux/wiki/OS%2F%E3%83%87%E3%82%A3%E3%82%B9%E3%83%88%E3%83%AA%E3%83%93%E3%83%A5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E5%88%A5%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95
 [wiki-faq]: https://ja.osdn.net/projects/jd4linux/wiki/FAQ
 [wiki-tips]: https://ja.osdn.net/projects/jd4linux/wiki/Tips
+[wiki-rfcs]: https://github.com/JDimproved/rfcs/wiki/rfc-index "Request for Comments"
 [jd-289]: https://jd4linux.osdn.jp/manual/289/


### PR DESCRIPTION
RFCリポジトリのリンクをドキュメントに追加し開発ドキュメントを参照しやすくします。