### PR TITLE
ImgLoader: Fix member initialization

### DIFF
--- a/src/jdlib/imgloader.cpp
+++ b/src/jdlib/imgloader.cpp
@@ -16,12 +16,8 @@ using namespace JDLIB;
 /* constructions ******************************************/
 
 ImgLoader::ImgLoader( const std::string& file )
-    : m_file( file ),
-      m_width( 0 ),
-      m_height( 0 ),
-      m_stop( false ),
-      m_y( 0 ),
-      m_loadedlevel( LOADLEVEL_INIT )
+    : m_file( file )
+    , m_loadedlevel( LOADLEVEL_INIT )
 {
 #ifdef _DEBUG
     std::cout << "ImgLoader::ImgLoader file = " << m_file << std::endl;

--- a/src/jdlib/imgloader.h
+++ b/src/jdlib/imgloader.h
@@ -30,12 +30,12 @@ namespace JDLIB
         
         std::string m_file;
         std::string m_errmsg;
-        int m_width;
-        int m_height;
-        
-        bool m_stop;
-        int m_y;
-        int m_loadlevel;
+        int m_width{};
+        int m_height{};
+
+        bool m_stop{};
+        int m_y{};
+        int m_loadlevel{};
         int m_loadedlevel;
         
     public:


### PR DESCRIPTION
メンバ変数の初期化を変更してcppcheckの警告 `(warning) Member variable 'ImgLoader::m_loadlevel' is not initialized in the constructor.` を修正します。

```
[src/jdlib/imgloader.cpp:18]: (warning) Member variable 'ImgLoader::m_loadlevel' is not initialized in the constructor.
```