### PR TITLE
PaneControl: Fix member initialization

### DIFF
--- a/src/skeleton/panecontrol.cpp
+++ b/src/skeleton/panecontrol.cpp
@@ -13,16 +13,12 @@ enum
 };
 
 PaneControl::PaneControl( Gtk::Paned& paned, int fixmode )
-    : m_paned( paned ),
-      m_click_fold( PANE_CLICK_NORMAL ),
-      m_clicked( false ),
-      m_drag( false ),
-      m_on_paned( false ),
-      m_fixmode( fixmode ),
-      m_mode( PANE_NORMAL )
-{
-    m_pre_size = -1;
-}
+    : m_paned( paned )
+    , m_click_fold( PANE_CLICK_NORMAL )
+    , m_fixmode( fixmode )
+    , m_mode( PANE_NORMAL )
+    , m_pre_size{ -1 }
+{}
 
 
 PaneControl::~PaneControl() noexcept = default;

--- a/src/skeleton/panecontrol.h
+++ b/src/skeleton/panecontrol.h
@@ -43,13 +43,13 @@ namespace SKELETON
 
         int m_click_fold;
 
-        bool m_clicked;
-        bool m_drag;
-        bool m_on_paned;
+        bool m_clicked{};
+        bool m_drag{};
+        bool m_on_paned{};
 
         int m_fixmode;
         int m_mode;
-        int m_pos;
+        int m_pos{};
 
         int m_pre_size;
 


### PR DESCRIPTION
メンバ変数の初期化を変更してcppcheckの警告 `(warning) Member variable 'PaneControl::m_pos' is not initialized in the constructor.` を修正します。

```
[src/skeleton/panecontrol.cpp:15]: (warning) Member variable 'PaneControl::m_pos' is not initialized in the constructor.
```

関連のpull request: #208
