### PR TITLE
Fix compiler warning for MISC::recover_path()

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1723,7 +1723,7 @@ std::string MISC::recover_path( const std::string& str )
 #endif
 }
 
-std::vector< std::string > MISC::recover_path( std::vector< std::string >&& list_str )
+std::vector< std::string > MISC::recover_path( std::vector< std::string > list_str )
 {
 #ifdef _WIN32
     std::vector< std::string > list_ret;

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -252,7 +252,7 @@ namespace MISC
 
     // pathセパレータを / に置き換える
     std::string recover_path( const std::string& str );
-    std::vector< std::string > recover_path( std::vector< std::string >&& list_str );
+    std::vector< std::string > recover_path( std::vector< std::string > list_str );
 
     // 文字列(utf-8)に全角英数字が含まれるか判定する
     bool has_widechar( const char* str );


### PR DESCRIPTION
clangのコンパイル時警告を修正します。

clang 9.0.0 warns:

```
miscutil.cpp:1735:12: warning: local variable 'list_str' will be copied despite being returned by name [-Wreturn-std-move]
return list_str;
       ^~~~~~~~
miscutil.cpp:1735:12: note: call 'std::move' explicitly to avoid copying
return list_str;
       ^~~~~~~~
       std::move(list_str)
```
