### PR TITLE
Remove deprecated g_mem_set_vtable()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -460,23 +460,6 @@ int main( int argc, char **argv )
     }
 #endif
 
-#if !GLIB_CHECK_VERSION(2,45,5)
-#ifdef _DEBUG_MEM_PROFILE
-    g_mem_set_vtable( glib_mem_profiler_table );
-    atexit( g_mem_profile );
-#else
-    GMemVTable vtable;
-    vtable = *glib_mem_profiler_table;
-    vtable.malloc = malloc;
-    vtable.realloc = realloc;
-    vtable.free = free;
-    vtable.calloc = calloc;
-    vtable.try_malloc = malloc;
-    vtable.try_realloc = realloc;
-    g_mem_set_vtable( &vtable );
-#endif
-#endif
-
     Gtk::Main m( &argc, &argv );
 
     // XSMPによるセッション管理


### PR DESCRIPTION
[RFC 0006][rfc6] と #244 で動作環境を2016年以降のディストロに更新したため
glib 2.46 から [廃止予定] になっている `g_mem_set_vtable()` を呼び出すコードを削除します。

[rfc6]: https://github.com/JDimproved/rfcs/blob/d6469b2/docs/0006-platform-support.md "プラットフォームのサポート"
[廃止予定]: https://developer.gnome.org/glib/2.46/glib-Memory-Allocation.html#g-mem-set-vtable
