### PR TITLE
TabLabel: Fix member initialization

### DIFF
--- a/src/skeleton/tablabel.cpp
+++ b/src/skeleton/tablabel.cpp
@@ -20,7 +20,8 @@ enum
 
 
 TabLabel::TabLabel( const std::string& url )
-    : m_url( url ), m_id_icon( ICON::NUM_ICONS ), m_image( nullptr )
+    : m_url( url )
+    , m_id_icon( ICON::NUM_ICONS )
 {
 #ifdef _DEBUG
     std::cout << "TabLabel::TabLabel " << m_url << std::endl;

--- a/src/skeleton/tablabel.h
+++ b/src/skeleton/tablabel.h
@@ -26,10 +26,10 @@ namespace SKELETON
         SIG_TAB_DRAG_DATA_GET m_sig_tab_drag_data_get;
         SIG_TAB_DRAG_END m_sig_tab_drag_end;
 
-        int m_x;
-        int m_y;
-        int m_width;
-        int m_height;
+        int m_x{};
+        int m_y{};
+        int m_width{};
+        int m_height{};
 
         std::string m_url;
         Gtk::HBox m_hbox;
@@ -38,7 +38,7 @@ namespace SKELETON
         Gtk::Label m_label;
 
         // アイコン画像
-        Gtk::Image* m_image;
+        Gtk::Image* m_image{};
 
         // ラベルに表示する文字列の全体
         std::string m_fulltext;


### PR DESCRIPTION
メンバ変数の初期化を変更してcppcheckの警告 `(warning) Member variable 'TabLabel::XXX' is not initialized in the constructor.` を修正します。

```
[src/skeleton/tablabel.cpp:22]: (warning) Member variable 'TabLabel::m_x' is not initialized in the constructor.
[src/skeleton/tablabel.cpp:22]: (warning) Member variable 'TabLabel::m_y' is not initialized in the constructor.
[src/skeleton/tablabel.cpp:22]: (warning) Member variable 'TabLabel::m_width' is not initialized in the constructor.
[src/skeleton/tablabel.cpp:22]: (warning) Member variable 'TabLabel::m_height' is not initialized in the constructor.
```

関連のpull request: #208