### PR TITLE
Play_Sound: Fix member initialization

### DIFF
--- a/src/sound/playsound.cpp
+++ b/src/sound/playsound.cpp
@@ -20,7 +20,6 @@ using namespace SOUND;
 
 
 Play_Sound::Play_Sound()
-    : m_playing( false )
 {
 #ifdef _DEBUG
     std::cout << "Play_Sound::Play_Sound\n";

--- a/src/sound/playsound.h
+++ b/src/sound/playsound.h
@@ -50,8 +50,8 @@ namespace SOUND
     {
         JDLIB::Thread m_thread;
         std::string m_wavfile;
-        bool m_stop;
-        bool m_playing;
+        bool m_stop{};
+        bool m_playing{};
 
       public:
 


### PR DESCRIPTION
メンバ変数の初期化を変更してcppcheckの警告 `(warning) Member variable 'Play_Sound::m_stop' is not initialized in the constructor.` を修正します。

```
[src/sound/playsound.cpp:22]: (warning) Member variable 'Play_Sound::m_stop' is not initialized in the constructor.
```

関連のpull request: #208 
