### PR TITLE
JDWindow: Fix member initialization

### DIFF
--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -52,20 +52,11 @@ constexpr const char* JDWindow::s_css_stat_label;
 
 // メッセージウィンドウでは m_mginfo が不要なので need_mginfo = false になる
 JDWindow::JDWindow( const bool fold_when_focusout, const bool need_mginfo )
-    : Gtk::Window( Gtk::WINDOW_TOPLEVEL ),
-      m_gtkwidget( nullptr ),
-      m_gtkwindow( nullptr ),
-      m_grand_parent_class( nullptr ),
-      m_win_moved( false ),
-      m_fold_when_focusout( fold_when_focusout ),
-      m_boot( true ),
-      m_enable_fold( m_fold_when_focusout ),
-      m_transient( false ),
-      m_mode( JDWIN_INIT ),
-      m_count_focusout( 0 ),
-      m_dummywin( nullptr ),
-      m_scrwin( nullptr ),
-      m_vbox_view( nullptr )
+    : Gtk::Window( Gtk::WINDOW_TOPLEVEL )
+    , m_fold_when_focusout( fold_when_focusout )
+    , m_boot( true )
+    , m_enable_fold( m_fold_when_focusout )
+    , m_mode( JDWIN_INIT )
 {
     // ステータスバー
     m_label_stat.set_size_request( 0, -1 );

--- a/src/skeleton/window.h
+++ b/src/skeleton/window.h
@@ -16,26 +16,26 @@ namespace SKELETON
 {
     class JDWindow : public Gtk::Window
     {
-        GtkWidget* m_gtkwidget;
-        GtkWindow *m_gtkwindow;
-        gpointer m_grand_parent_class;
+        GtkWidget* m_gtkwidget{};
+        GtkWindow* m_gtkwindow{};
+        gpointer m_grand_parent_class{};
 
-        bool m_win_moved;
+        bool m_win_moved{};
 
         // フォーカスアウト時の折りたたみ処理で用いるメンバ変数
         bool m_fold_when_focusout; // フォーカスアウトしたときにウィンドウを畳むか
         bool m_boot;
         bool m_enable_fold; // 「一時的に」折りたたみ可能かどうか切り替える
-        bool m_transient;
+        bool m_transient{};
         int m_mode;
-        int m_counter;
-        int m_count_focusout; // フォーカス制御用カウンタ
-        Gtk::Window* m_dummywin; // set_transient()で使うダミーwindow
+        int m_counter{};
+        int m_count_focusout{}; // フォーカス制御用カウンタ
+        Gtk::Window* m_dummywin{}; // set_transient()で使うダミーwindow
 
         SKELETON::JDVBox m_vbox;
 
-        Gtk::ScrolledWindow* m_scrwin;
-        SKELETON::JDVBox* m_vbox_view;
+        Gtk::ScrolledWindow* m_scrwin{};
+        SKELETON::JDVBox* m_vbox_view{};
 
         // ステータスバー
         std::string m_status;


### PR DESCRIPTION
メンバ変数の初期化を変更してcppcheckの警告 `(warning) Member variable 'JDWindow::m_counter' is not initialized in the constructor.` を修正します。

```
[src/skeleton/window.cpp:54]: (warning) Member variable 'JDWindow::m_counter' is not initialized in the constructor.
```

関連のpull request: #208 
