### PR TITLE
CheckUpdate_Manager: Fix member initialization

### DIFF
--- a/src/updatemanager.cpp
+++ b/src/updatemanager.cpp
@@ -35,11 +35,7 @@ void CORE::delete_checkupdate_manager()
 
 using namespace CORE;
 
-CheckUpdate_Manager::CheckUpdate_Manager()
-    : m_running( false )
-{
-    m_list_open.clear();
-}
+CheckUpdate_Manager::CheckUpdate_Manager() = default;
 
 
 CheckUpdate_Manager::~CheckUpdate_Manager() noexcept

--- a/src/updatemanager.h
+++ b/src/updatemanager.h
@@ -30,8 +30,8 @@ namespace CORE
         std::list< CheckItem > m_list_item;
         std::list< std::string > m_list_open;
 
-        bool m_running;
-        int m_total;
+        bool m_running{};
+        int m_total{};
         std::string m_url_checking;
 
       public:


### PR DESCRIPTION
メンバ変数の初期化を変更してcppcheckの警告`(warning) Member variable 'CheckUpdate_Manager::m_total' is not initialized in the constructor.` を修正します。

```
[src/updatemanager.cpp:38]: (warning) Member variable 'CheckUpdate_Manager::m_total' is not initialized in the constructor.
```

関連のpull request: #208 
