### PR TITLE
Search_Manager: Fix member initialization

### DIFF
--- a/src/searchmanager.cpp
+++ b/src/searchmanager.cpp
@@ -36,10 +36,7 @@ void CORE::delete_search_manager()
 
 using namespace CORE;
 
-Search_Manager::Search_Manager()
-    : m_searching( false ),
-      m_searchloader( nullptr )
-{}
+Search_Manager::Search_Manager() = default;
 
 
 Search_Manager::~Search_Manager()

--- a/src/searchmanager.h
+++ b/src/searchmanager.h
@@ -51,24 +51,24 @@ namespace CORE
 
         JDLIB::Thread m_thread;
 
-        int m_searchmode;
+        int m_searchmode{};
         std::string m_id;
         std::string m_url;
         std::string m_query;
-        bool m_mode_or;
-        bool m_bm;
-        bool m_calc_data;
+        bool m_mode_or{};
+        bool m_bm{};
+        bool m_calc_data{};
 
         std::vector< DBTREE::ArticleBase* > m_list_article;
         std::list< SEARCHDATA > m_list_data;
 
         // 検索実行中
-        bool m_searching;
+        bool m_searching{};
 
-        bool m_stop;
+        bool m_stop{};
 
         // スレタイ検索ローダ
-        SearchLoader* m_searchloader;
+        SearchLoader* m_searchloader{};
 
       public:
 


### PR DESCRIPTION
メンバ変数の初期化を変更してcppcheckの警告 `(warning) Member variable 'Search_Manager::XXX' is not initialized in the constructor.` を修正します。

```
[src/searchmanager.cpp:39]: (warning) Member variable 'Search_Manager::m_searchmode' is not initialized in the constructor.
[src/searchmanager.cpp:39]: (warning) Member variable 'Search_Manager::m_mode_or' is not initialized in the constructor.
[src/searchmanager.cpp:39]: (warning) Member variable 'Search_Manager::m_bm' is not initialized in the constructor.
[src/searchmanager.cpp:39]: (warning) Member variable 'Search_Manager::m_calc_data' is not initialized in the constructor.
[src/searchmanager.cpp:39]: (warning) Member variable 'Search_Manager::m_stop' is not initialized in the constructor.
```

関連のpull request: #208 
