### PR TITLE
Deprecate --with-xdgopen

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -95,6 +95,7 @@
     --with-xdgopen
 
        デフォルトブラウザとしてxdg-openを使用する。
+       xdg-openは将来のリリースでデフォルトブラウザになりこのオプションは廃止される予定です。
 
     --enable-gprof
 

--- a/configure.ac
+++ b/configure.ac
@@ -342,7 +342,8 @@ AC_MSG_RESULT($with_xdgopen)
 
 AS_IF(
   [test "x$with_xdgopen" = xyes],
-  [AC_DEFINE(XDGOPEN, , [use xdg-open])]
+  [AC_DEFINE(XDGOPEN, , [use xdg-open])
+   AC_MSG_WARN([--with-xdgopen will be removed and as default in the future release.])]
 )
 
 

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -98,7 +98,10 @@ OSやディストリビューション別の解説は[OS/ディストリビュ�
   <dd>ALSA による効果音再生機能を有効にする。
   詳しくは<a href="{{ site.baseurl }}/sound/">効果音の再生</a>の項を参照すること。</dd>
   <dt>--with-xdgopen</dt>
-  <dd>デフォルトブラウザとしてxdg-openを使用する。</dd>
+  <dd>
+    デフォルトブラウザとしてxdg-openを使用する。<br>
+    xdg-openは将来のリリースでデフォルトブラウザになりこのオプションは廃止される予定です。
+  </dd>
   <dt>--enable-gprof</dt>
   <dd>
     gprof によるプロファイリングを行う。


### PR DESCRIPTION
#253 の第一段階目のPRです。

将来のリリースで xdg-open を初期設定のブラウザに変更するためconfigureオプション `--with-xdgopen` を廃止予定にします。
