### PR TITLE
ArticleHash: Fix member initialization

### DIFF
--- a/src/dbtree/articlehash.cpp
+++ b/src/dbtree/articlehash.cpp
@@ -18,8 +18,7 @@ enum
 
 
 ArticleHash::ArticleHash()
-    : m_size( 0 ),
-      m_min_hash( HASH_TBLSIZE + 1 )
+    : m_min_hash( HASH_TBLSIZE + 1 )
 {
     m_iterator = new ArticleHashIterator( this );
 }

--- a/src/dbtree/articlehash.h
+++ b/src/dbtree/articlehash.h
@@ -20,15 +20,15 @@ namespace DBTREE
     {
         friend class ArticleHashIterator;
 
-        size_t m_size;
+        size_t m_size{};
         size_t m_min_hash;
         ArticleHashIterator* m_iterator;
         std::vector< std::vector< ArticleBase* > > m_table;
 
         // iterator 用変数
-        size_t m_it_hash;
-        size_t m_it_pos;
-        size_t m_it_size;
+        size_t m_it_hash{};
+        size_t m_it_pos{};
+        size_t m_it_size{};
 
       public:
 


### PR DESCRIPTION
メンバ変数の初期化を変更してcppcheckの警告 `(warning) Member variable 'ArticleHash::XXX' is not initialized in the constructor.` を修正します。

```
[src/dbtree/articlehash.cpp:20]: (warning) Member variable 'ArticleHash::m_it_hash' is not initialized in the constructor.
[src/dbtree/articlehash.cpp:20]: (warning) Member variable 'ArticleHash::m_it_pos' is not initialized in the constructor.
[src/dbtree/articlehash.cpp:20]: (warning) Member variable 'ArticleHash::m_it_size' is not initialized in the constructor.
```
