### PR TITLE
Iconv: Fix member initialization

### DIFF
--- a/src/jdlib/jdiconv.cpp
+++ b/src/jdlib/jdiconv.cpp
@@ -34,7 +34,7 @@ struct iconv_cast
 using namespace JDLIB;
 
 Iconv::Iconv( const std::string& coding_from, const std::string& coding_to )
-    : m_buf_in( nullptr ), m_buf_out( nullptr ), m_coding_from( coding_from )
+    : m_coding_from( coding_from )
 {
 #ifdef _DEBUG
     std::cout << "Iconv::Iconv coding = " << m_coding_from << " to " << coding_to << std::endl;
@@ -68,7 +68,6 @@ Iconv::Iconv( const std::string& coding_from, const std::string& coding_to )
     if( m_cd == ( iconv_t ) -1 ){
         MISC::ERRMSG( "can't open iconv coding = " + m_coding_from + " to " + coding_to );
     }
-    m_byte_left_in = 0;
 }
 
 Iconv::~Iconv()

--- a/src/jdlib/jdiconv.h
+++ b/src/jdlib/jdiconv.h
@@ -20,11 +20,11 @@ namespace JDLIB
     {
         iconv_t m_cd;
 
-        size_t m_byte_left_in;
-        char* m_buf_in;
-        char* m_buf_in_tmp;
+        size_t m_byte_left_in{};
+        char* m_buf_in{};
+        char* m_buf_in_tmp{};
 
-        char* m_buf_out;
+        char* m_buf_out{};
 
         std::string m_coding_from;
 


### PR DESCRIPTION
メンバ変数の初期化を変更してcppcheckの警告 `(warning) Member variable
'Iconv::m_buf_in_tmp' is not initialized in the constructor.` を修正します。

```
[src/jdlib/jdiconv.cpp:36]: (warning) Member variable 'Iconv::m_buf_in_tmp' is not initialized in the constructor.
```

関連のpull request: #208
