### PR TITLE
DrawAreaBase: Fix redundant condition

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -4297,8 +4297,7 @@ LAYOUT* DrawAreaBase::set_caret( CARET_POSITION& caret_pos, int x, int y )
 
                 // 次のノードが画像ノード場合
                 // 現在のノードの右端にキャレットをセットして画像ノードを返す
-                if( layout_next
-                    && ( layout_next->type == DBTREE::NODE_IMG || layout_next->type == DBTREE::NODE_SSSP )
+                if( ( layout_next->type == DBTREE::NODE_IMG || layout_next->type == DBTREE::NODE_SSSP )
                     && ( layout_next->rect->x <= x && x <= layout_next->rect->x + layout_next->rect->width )
                     && ( layout_next->rect->y <= y && y <= layout_next->rect->y + layout_next->rect->height ) ){
 


### PR DESCRIPTION
冗長なnullチェックを削除してcppcheckの警告 `(warning) Either the condition 'layout_next' is redundant or there is possible null pointer dereference: layout_next.` を修正します。

```
[src/article/drawareabase.cpp:4300] -> [src/article/drawareabase.cpp:4309]: (warning) Either the condition 'layout_next' is redundant or there is possible null pointer dereference: layout_next.
```
