### PR TITLE
ArticleHash: Fix the class to be compliant with rule of three

### DIFF
--- a/src/dbtree/articlehash.h
+++ b/src/dbtree/articlehash.h
@@ -33,7 +33,10 @@ namespace DBTREE
       public:
 
         ArticleHash();
+        ArticleHash( const ArticleHash& ) = delete;
         virtual ~ArticleHash();
+
+        ArticleHash& operator=( const ArticleHash& ) = delete;
 
         size_t size() const { return m_size; }
 


### PR DESCRIPTION
ArticleHashはコンストラクタ/デストラクタでメモリの確保/解放をしているためcppcheckからコピー対応するよう警告された。(Rule of three)
実際のコードではArticleHashのコピーはしていないのでメンバ関数のdelete宣言でコピーできないように修正する。

```
[src/dbtree/articlehash.cpp:23]: (warning) Class 'ArticleHash' does not have a copy constructor which is recommended since it has dynamic memory/resource allocation(s).
[src/dbtree/articlehash.cpp:23]: (warning) Class 'ArticleHash' does not have a operator= which is recommended since it has dynamic memory/resource allocation(s).
```
