### PR TITLE
ArticleBase: Fix ArticleBase::empty() to const member

### DIFF
--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -121,12 +121,6 @@ ArticleBase::~ArticleBase()
 }
 
 
-bool ArticleBase::empty()
-{
-    return  m_url.empty();
-}
-
-
 // ID がこのスレのものかどうか
 bool ArticleBase::equal( const std::string& datbase, const std::string& id )
 {

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -122,7 +122,7 @@ namespace DBTREE
         ArticleBase( const std::string& datbase, const std::string& id, bool cached );
         ~ArticleBase();
 
-        bool empty();
+        bool empty() const noexcept { return m_url.empty(); }
 
         const std::string& get_url() const { return m_url; }
 


### PR DESCRIPTION
メンバ関数empty()をconstメンバーに修正して副作用がないことを明らかにします。
empty()はassertマクロで呼び出されるためcppcheckが望ましい副作用がある可能性を警告しました。

```
[src/dbtree/articlebase.cpp:1010]: (warning) Assert statement calls a function which may have desired side effects: 'empty'.
```
