### PR TITLE
Fix thread title search for the initial setting

### DIFF
--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -219,7 +219,7 @@ namespace CONFIG
 #define CONF_URL_SEARCH_TITLE "https://ff5ch.syoboi.jp/?q=$TEXTU"
 
 // スレタイ検索用正規表現
-#define CONF_REGEX_SEARCH_TITLE R"=(<a href="(http[^"]+)">([^<]+)</a><span class="count"> \(([0-9]{1,4})\)</span>)="
+#define CONF_REGEX_SEARCH_TITLE R"=(<a class="thread" href="(http[^"]+)">([^<]+)</a><span\n +class="count"> \(([0-9]+)\))="
 
 // WEB検索用メニュータイトルアドレス
 #define CONF_MENU_SEARCH_WEB  "WEB検索 (google)"


### PR DESCRIPTION
Fixes #257 

初期設定のスレタイ検索サイト https://ff5ch.syoboi.jp の検索結果が0件になる不具合を修正します。合わせて ff5ch.syoboi.jp 対応の正規表現を更新します。

#### 実装の詳細
- HTMLソースを行で分けて行頭行末の空白を削除したり "\&amp;" を "&" に変換する処理を止めてソースをそのまま検索するように変更する。

- 複数行に分かれているデータに対応するため正規表現パターン中の "\n" は改行文字に変換して検索する。

#### マージ後の復旧
不具合のあるバージョンから更新した場合はabout:configの「スレタイ検索時にアドレスとスレタイを取得する正規表現」をデフォルトに戻してください。

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1584619744/191
