### PR TITLE
Fix memory leak for JDLIB::Timeout::connect()

### DIFF
--- a/src/article/articleadmin.cpp
+++ b/src/article/articleadmin.cpp
@@ -70,7 +70,7 @@ ArticleAdmin::ArticleAdmin( const std::string& url )
     // オートスクロール時など、スムースにスクロールをするため描画用タイマーを
     // メインタイマと別にする。DrawAreaBase::clock_in_smooth_scroll() も参照すること
     sigc::slot< bool > slot_timeout = sigc::bind( sigc::mem_fun(*this, &ArticleAdmin::clock_in_smooth_scroll ), 0 );
-    JDLIB::Timeout::connect( slot_timeout, TIMER_TIMEOUT_SMOOTH_SCROLL );
+    m_conn_timer = JDLIB::Timeout::connect( slot_timeout, TIMER_TIMEOUT_SMOOTH_SCROLL );
 }
 
 

--- a/src/article/articleadmin.h
+++ b/src/article/articleadmin.h
@@ -10,8 +10,16 @@
 
 #include "sign.h"
 
-#include <string>
+#include <memory>
 #include <set>
+#include <string>
+
+
+namespace JDLIB
+{
+    class Timeout;
+}
+
 
 namespace ARTICLE
 {
@@ -31,6 +39,8 @@ namespace ARTICLE
         ArticleToolBar* m_toolbar;
         ArticleToolBarSimple* m_toolbarsimple;
         SearchToolBar* m_search_toolbar;
+
+        std::unique_ptr<JDLIB::Timeout> m_conn_timer;
 
       public:
         ArticleAdmin( const std::string& url );

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -3347,7 +3347,7 @@ void Core::exec_command_after_boot()
 
     // タイマーセット
     sigc::slot< bool > slot_timeout = sigc::bind( sigc::mem_fun(*this, &Core::slot_timeout), 0 );
-    JDLIB::Timeout::connect( slot_timeout, TIMER_TIMEOUT );
+    m_conn_timer = JDLIB::Timeout::connect( slot_timeout, TIMER_TIMEOUT );
 
     // 2chログイン
     if( SESSION::login2ch() ) slot_toggle_login2ch();

--- a/src/core.h
+++ b/src/core.h
@@ -11,6 +11,7 @@
 
 #include <gtkmm.h>
 #include <list>
+#include <memory>
 #include <string>
 
 #include "skeleton/dispatchable.h"
@@ -49,6 +50,11 @@ namespace ARTICLE
 namespace IMAGE
 {
     class ImageAdmin;
+}
+
+namespace JDLIB
+{
+    class Timeout;
 }
 
 
@@ -114,6 +120,8 @@ namespace CORE
 
         // セッション保存までのカウンタ
         int m_count_savesession;
+
+        std::unique_ptr<JDLIB::Timeout> m_conn_timer;
 
     public:
 

--- a/src/jdlib/timeout.cpp
+++ b/src/jdlib/timeout.cpp
@@ -49,7 +49,7 @@ Timeout::~Timeout()
 }
 
 // static
-Timeout* Timeout::connect( const sigc::slot< bool > slot_timeout, unsigned int interval )
+std::unique_ptr<Timeout> Timeout::connect( const sigc::slot< bool > slot_timeout, unsigned int interval )
 {
     Timeout* timeout = new Timeout( slot_timeout );
 #ifdef _WIN32
@@ -68,7 +68,7 @@ Timeout* Timeout::connect( const sigc::slot< bool > slot_timeout, unsigned int i
 #else
     timeout->m_connection = Glib::signal_timeout().connect( slot_timeout, interval );
 #endif
-    return timeout;
+    return std::unique_ptr<Timeout>( timeout );
 }
 
 #ifdef _WIN32

--- a/src/jdlib/timeout.h
+++ b/src/jdlib/timeout.h
@@ -10,6 +10,9 @@
 #include <mutex>
 #endif
 
+#include <memory>
+
+
 namespace JDLIB
 {
     class Timeout
@@ -28,7 +31,7 @@ namespace JDLIB
     public:
         ~Timeout();
         
-        static Timeout* connect( const sigc::slot< bool > slot_timeout, unsigned int interval );
+        static std::unique_ptr<Timeout> connect( const sigc::slot< bool > slot_timeout, unsigned int interval );
 
     private:
         Timeout( const sigc::slot< bool > slot_timeout );

--- a/src/skeleton/msgdiag.h
+++ b/src/skeleton/msgdiag.h
@@ -14,7 +14,7 @@ namespace SKELETON
     class MsgDiag : public Gtk::MessageDialog
     {
 
-        JDLIB::Timeout* m_conn_timer{};
+        std::unique_ptr<JDLIB::Timeout> m_conn_timer;
 
       public:
 

--- a/src/skeleton/prefdiag.cpp
+++ b/src/skeleton/prefdiag.cpp
@@ -37,13 +37,7 @@ PrefDiag::PrefDiag( Gtk::Window* parent, const std::string& url, const bool add_
 }
 
 
-PrefDiag::~PrefDiag()
-{
-    if( m_conn_timer != nullptr )
-    {
-        delete m_conn_timer;
-    }
-}
+PrefDiag::~PrefDiag() = default;
 
 
 //

--- a/src/skeleton/prefdiag.h
+++ b/src/skeleton/prefdiag.h
@@ -22,7 +22,7 @@ namespace SKELETON
         Gtk::Button* m_bt_ok;
         Gtk::Button m_bt_apply;
 
-        JDLIB::Timeout* m_conn_timer;
+        std::unique_ptr<JDLIB::Timeout> m_conn_timer;
 
       public:
 


### PR DESCRIPTION
Fixes #276 

タイマーを使うコードで寿命管理が徹底されていなかったためメモリリークが発生していました。
スマートポインターを返すように変更してリークを修正します。

gcc-9のログ
```
Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f18a17e03d1 in operator new(unsigned long) (/lib/x86_64-linux-gnu/liblsan.so.0+0x103d1)
    #1 0x55ff4e8a91f5 in JDLIB::Timeout::connect(sigc::slot<bool, sigc::nil, sigc::nil, sigc::nil, sigc::nil, sigc::nil, sigc::nil, sigc::nil>, unsigned int) src/jdlib/timeout.cpp:54
    #2 0x55ff4df0f034 in ARTICLE::ArticleViewMain::show_instruct_diag() src/article/articleview.cpp:654
    #3 0x55ff4df15888 in ARTICLE::ArticleViewMain::update_finish() src/article/articleview.cpp:593
    #4 0x55ff4e3ed537 in SKELETON::Admin::update_finish(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) src/skeleton/admin.cpp:1645
```
