### PR TITLE
ViewHistory: Fix ArticleBase::get_current_url() to const member

### DIFF
--- a/src/history/viewhistory.cpp
+++ b/src/history/viewhistory.cpp
@@ -79,7 +79,7 @@ void ViewHistory::set_end( const int end )
 }
 
 
-const std::string& ViewHistory::get_current_url()
+const std::string& ViewHistory::get_current_url() const
 {
 #ifdef _DEBUG
     std::cout << "ViewHistory::get_current_url" << std::endl
@@ -94,7 +94,7 @@ const std::string& ViewHistory::get_current_url()
 }
 
 
-const std::string& ViewHistory::get_current_title()
+const std::string& ViewHistory::get_current_title() const
 {
     return m_items[ m_history_current ]->title;
 }
@@ -162,7 +162,7 @@ void ViewHistory::replace_current_title( const std::string& title )
 
 
 // item の取得
-std::vector< ViewHistoryItem* >& ViewHistory::get_items_back( const int count )
+std::vector< ViewHistoryItem* >& ViewHistory::get_items_back( const int count ) const
 {
     static std::vector< ViewHistoryItem* > items;
     items.clear();
@@ -181,7 +181,7 @@ std::vector< ViewHistoryItem* >& ViewHistory::get_items_back( const int count )
 }
 
 
-std::vector< ViewHistoryItem* >& ViewHistory::get_items_forward( const int count )
+std::vector< ViewHistoryItem* >& ViewHistory::get_items_forward( const int count ) const
 {
     static std::vector< ViewHistoryItem* > items;
     items.clear();
@@ -203,7 +203,7 @@ std::vector< ViewHistoryItem* >& ViewHistory::get_items_forward( const int count
 //
 // 「戻る」可能
 //
-bool ViewHistory::can_back( const int count )
+bool ViewHistory::can_back( const int count ) const noexcept
 {
     if( count <= 0 ) return false;
 
@@ -221,7 +221,7 @@ bool ViewHistory::can_back( const int count )
 //
 // 「進む」可能
 //
-bool ViewHistory::can_forward( const int count )
+bool ViewHistory::can_forward( const int count ) const noexcept
 {
     if( count <= 0 ) return false;
 

--- a/src/history/viewhistory.h
+++ b/src/history/viewhistory.h
@@ -26,19 +26,19 @@ namespace HISTORY
         ViewHistory();
         virtual ~ViewHistory();
 
-        int get_size() const { return m_items.size(); }
-        const ViewHistoryItem* get_item( const int pos ){ return m_items[ pos ]; }
+        int get_size() const noexcept { return m_items.size(); }
+        const ViewHistoryItem* get_item( const int pos ) const { return m_items[ pos ]; }
 
-        int get_top() const { return m_history_top; }
-        int get_cur() const { return m_history_current; }
-        int get_end() const { return m_history_end; }
+        int get_top() const noexcept { return m_history_top; }
+        int get_cur() const noexcept { return m_history_current; }
+        int get_end() const noexcept { return m_history_end; }
 
         void set_top( const int top );
         void set_cur( const int cur );
         void set_end( const int end );
 
-        const std::string& get_current_url();
-        const std::string& get_current_title();
+        const std::string& get_current_url() const;
+        const std::string& get_current_title() const;
 
         // URL更新
         void replace_current_url( const std::string& url ); // 現在のアドレス
@@ -48,12 +48,12 @@ namespace HISTORY
         void replace_current_title( const std::string& title );
 
         // item の取得
-        std::vector< ViewHistoryItem* >& get_items_back( const int count );
-        std::vector< ViewHistoryItem* >& get_items_forward( const int count );
+        std::vector< ViewHistoryItem* >& get_items_back( const int count ) const;
+        std::vector< ViewHistoryItem* >& get_items_forward( const int count ) const;
 
         // 戻る / 進む 可能かの判定
-        bool can_back( const int count );
-        bool can_forward( const int count );
+        bool can_back( const int count ) const noexcept;
+        bool can_forward( const int count ) const noexcept;
 
         // 追加
         void append( const std::string& url );


### PR DESCRIPTION
メンバ関数empty()がassertマクロの中で呼ばれていますがcppcheckがconstメンバ関数でなく副作用がある可能性を警告していたため修正します。

さらにViewHistoryのメンバ関数のうちconstやnoexcept指定可能なものを修正します。

cppcheckのレポート
```
src/history/viewhistory.cpp:325:13: warning: Assert statement calls a function which may have desired side effects: 'get_current_url'. [assertWithSideEffect]
    assert( get_current_url() == url );
            ^
```