### PR TITLE
NodeTreeBase: Fix calling virtual function from the destructor

### DIFF
--- a/src/dbtree/nodetree2chcompati.cpp
+++ b/src/dbtree/nodetree2chcompati.cpp
@@ -33,7 +33,7 @@ NodeTree2chCompati::~NodeTree2chCompati()
     std::cout << "NodeTree2chCompati::~NodeTree2chCompati : " << get_url() << std::endl;
 #endif
 
-    clear();
+    NodeTree2chCompati::clear();
 }
 
 

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -93,8 +93,6 @@ NodeTreeBase::NodeTreeBase( const std::string& url, const std::string& modified 
 {
     set_date_modified( modified );
 
-    clear();
-
     // ルートヘッダ作成。中は空。
     m_id_header = -1; // ルートヘッダIDが 0 になるように -1
     NODE* tmpnode = create_node_header();
@@ -131,8 +129,8 @@ NodeTreeBase::~NodeTreeBase()
 #ifdef _DEBUG    
     std::cout << "NodeTreeBase::~NodeTreeBase : " << m_url << std::endl;
 #endif
-    
-    clear();
+
+    NodeTreeBase::clear();
 }
 
 

--- a/src/dbtree/nodetreejbbs.cpp
+++ b/src/dbtree/nodetreejbbs.cpp
@@ -42,7 +42,7 @@ NodeTreeJBBS::~NodeTreeJBBS()
     std::cout << "NodeTreeJBBS::~NodeTreeJBBS : " << get_url() << std::endl;
 #endif
 
-    clear();
+    NodeTreeJBBS::clear();
 }
 
 

--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -43,7 +43,7 @@ NodeTreeMachi::~NodeTreeMachi()
     std::cout << "NodeTreeMachi::~NodeTreeMachi : " << get_url() << std::endl;
 #endif
 
-    clear();
+    NodeTreeMachi::clear();
 }
 
 


### PR DESCRIPTION
NodeTreeXXXはデストラクタ内で仮想関数clear()を呼び出していますが、仮想関数はデストラクタ内で派生クラスの関数として呼び出しできないためcppcheckに警告されます。
そのためスコープ解決演算子を使ってクラスを明示します。

cppcheckのレポート
```
src/dbtree/nodetree2chcompati.h:30:14: warning: Virtual function 'clear' is called from destructor '~NodeTree2chCompati()' at line 36. Dynamic binding is not used. [virtualCallInConstructor]
        void clear() override;
             ^
src/dbtree/nodetree2chcompati.cpp:36:5: note: Calling clear
    clear();
    ^
src/dbtree/nodetree2chcompati.h:30:14: note: clear is a virtual function
        void clear() override;
             ^
src/dbtree/nodetreejbbs.h:34:14: warning: Virtual function 'clear' is called from destructor '~NodeTreeJBBS()' at line 45. Dynamic binding is not used. [virtualCallInConstructor]
        void clear() override;
             ^
src/dbtree/nodetreejbbs.cpp:45:5: note: Calling clear
    clear();
    ^
src/dbtree/nodetreejbbs.h:34:14: note: clear is a virtual function
        void clear() override;
             ^
src/dbtree/nodetreemachi.h:40:14: warning: Virtual function 'clear' is called from destructor '~NodeTreeMachi()' at line 46. Dynamic binding is not used. [virtualCallInConstructor]
        void clear() override;
             ^
src/dbtree/nodetreemachi.cpp:46:5: note: Calling clear
    clear();
    ^
src/dbtree/nodetreemachi.h:40:14: note: clear is a virtual function
        void clear() override;
             ^
src/dbtree/nodetreebase.h:267:22: warning: Virtual function 'clear' is called from constructor 'NodeTreeBase(const std::string&url,const std::string&date_modified)' at line 96. Dynamic binding is not used. [virtualCallInConstructor]
        virtual void clear();
                     ^
src/dbtree/nodetreebase.cpp:96:5: note: Calling clear
    clear();
    ^
src/dbtree/nodetreebase.h:267:22: note: clear is a virtual function
        virtual void clear();
                     ^
src/dbtree/nodetreebase.h:267:22: warning: Virtual function 'clear' is called from destructor '~NodeTreeBase()' at line 135. Dynamic binding is not used. [virtualCallInConstructor]
        virtual void clear();
                     ^
src/dbtree/nodetreebase.cpp:135:5: note: Calling clear
    clear();
    ^
src/dbtree/nodetreebase.h:267:22: note: clear is a virtual function
        virtual void clear();
                     ^
```
