### PR TITLE
ArticleViewSearch: Fix calling virtual function from the destructor

### DIFF
--- a/src/article/articleviewsearch.cpp
+++ b/src/article/articleviewsearch.cpp
@@ -59,7 +59,7 @@ ArticleViewSearch::~ArticleViewSearch()
     std::cout << "ArticleViewSearch::~ArticleViewSearch : " << get_url() << std::endl;
 #endif
 
-    stop();
+    ArticleViewSearch::stop();
 }
 
 


### PR DESCRIPTION
ArticleViewSearchはデストラクタ内で仮想関数stop()を呼び出していますが、仮想関数はデストラクタ内で派生クラスの関数として呼び出しできないためcppcheckに警告されます。
そのためスコープ解決演算子を使ってクラスを明示します。

cppcheckのレポート
```
src/article/articleviewsearch.h:49:14: warning: Virtual function 'stop' is called from destructor '~ArticleViewSearch()' at line 62. Dynamic binding is not used. [virtualCallInConstructor]
        void stop() override;
             ^
src/article/articleviewsearch.cpp:62:5: note: Calling stop
    stop();
    ^
src/article/articleviewsearch.h:49:14: note: stop is a virtual function
        void stop() override;
             ^
```