### PR TITLE
ToolBar: Fix calling virtual function from the constructor

### DIFF
--- a/src/article/toolbar.cpp
+++ b/src/article/toolbar.cpp
@@ -44,7 +44,7 @@ ArticleToolBar::ArticleToolBar() :
     m_button_drawout_or.signal_clicked().connect( sigc::mem_fun(*this, &ArticleToolBar::slot_drawout_or ) );
     m_button_drawout_and.signal_clicked().connect( sigc::mem_fun(*this, &ArticleToolBar::slot_drawout_and ) );
 
-    pack_buttons();
+    ArticleToolBar::pack_buttons();
 }
         
 

--- a/src/article/toolbarsearch.cpp
+++ b/src/article/toolbarsearch.cpp
@@ -33,7 +33,7 @@ SearchToolBar::SearchToolBar() :
     get_searchbar()->append( m_tool_bm );
     get_searchbar()->append( *get_button_close_searchbar() );
 
-    pack_buttons();
+    SearchToolBar::pack_buttons();
 }
 
 

--- a/src/article/toolbarsimple.cpp
+++ b/src/article/toolbarsimple.cpp
@@ -20,7 +20,7 @@ ArticleToolBarSimple::ArticleToolBarSimple() :
     get_searchbar()->append( *get_button_up_search() );
     get_searchbar()->append( *get_button_close_searchbar() );
 
-    pack_buttons();
+    ArticleToolBarSimple::pack_buttons();
 }
 
 

--- a/src/bbslist/toolbar.cpp
+++ b/src/bbslist/toolbar.cpp
@@ -56,7 +56,7 @@ BBSListToolBar::BBSListToolBar() :
     m_tool_label.append( *get_button_close() );
     pack_start( m_tool_label, Gtk::PACK_SHRINK );
 
-    pack_buttons();
+    BBSListToolBar::pack_buttons();
     add_search_control_mode( CONTROL::MODE_BBSLIST );
 }
 
@@ -232,7 +232,7 @@ void BBSListToolBar::slot_check_update_open_root()
 EditListToolBar::EditListToolBar() :
     SKELETON::ToolBar( nullptr )
 {
-    pack_buttons();
+    EditListToolBar::pack_buttons();
 }
 
 

--- a/src/board/toolbar.cpp
+++ b/src/board/toolbar.cpp
@@ -19,7 +19,7 @@ using namespace BOARD;
 BoardToolBar::BoardToolBar() :
     SKELETON::ToolBar( BOARD::get_admin() )
 {
-    pack_buttons();
+    BoardToolBar::pack_buttons();
 
     // JDEntry::on_key_release_event()で
     // CONTROL::SearchCache を有効にする

--- a/src/maintoolbar.cpp
+++ b/src/maintoolbar.cpp
@@ -61,8 +61,8 @@ MainToolBar::MainToolBar()
     set_tooltip( m_button_image, std::string( ITEM_NAME_IMAGEVIEW )
                  + "\n\nスレビューに切替 "
                  + CONTROL::get_str_motions( CONTROL::ToggleArticle ) + " , " + CONTROL::get_str_motions( CONTROL::Left ) );
-        
-    pack_buttons();
+
+    MainToolBar::pack_buttons();
 }
 
 

--- a/src/message/toolbar.cpp
+++ b/src/message/toolbar.cpp
@@ -79,7 +79,7 @@ MessageToolBar::MessageToolBar() :
     m_tool_new_subject( nullptr ),
     m_entry_new_subject( nullptr )
 {
-    pack_buttons();
+    MessageToolBar::pack_buttons();
 }
 
 
@@ -239,7 +239,7 @@ void MessageToolBar::slot_insert_draft_clicked()
 MessageToolBarPreview::MessageToolBarPreview() :
     MessageToolBarBase()
 {
-    pack_buttons();
+    MessageToolBarPreview::pack_buttons();
 }
 
 


### PR DESCRIPTION
XXXToolBarはコンストラクタ内で仮想関数pack_buttons()を呼び出していますが、仮想関数はコントラクタ内で派生クラスの関数として呼び出しできないためcppcheckに警告されます。
そのためスコープ解決演算子を使ってクラスを明示します。

<details>
<summary>cppcheckのレポート</summary>

```
src/article/toolbarsearch.h:36:14: warning: Virtual function 'pack_buttons' is called from constructor 'SearchToolBar()' at line 36. Dynamic binding is not used. [virtualCallInConstructor]
        void pack_buttons() override;
             ^
src/article/toolbarsearch.cpp:36:5: note: Calling pack_buttons
    pack_buttons();
    ^
src/article/toolbarsearch.h:36:14: note: pack_buttons is a virtual function
        void pack_buttons() override;
             ^
src/article/toolbar.h:39:14: warning: Virtual function 'pack_buttons' is called from constructor 'ArticleToolBar()' at line 47. Dynamic binding is not used. [virtualCallInConstructor]
        void pack_buttons() override;
             ^
src/article/toolbar.cpp:47:5: note: Calling pack_buttons
    pack_buttons();
    ^
src/article/toolbar.h:39:14: note: pack_buttons is a virtual function
        void pack_buttons() override;
             ^
src/article/toolbarsimple.h:21:14: warning: Virtual function 'pack_buttons' is called from constructor 'ArticleToolBarSimple()' at line 23. Dynamic binding is not used. [virtualCallInConstructor]
        void pack_buttons() override;
             ^
src/article/toolbarsimple.cpp:23:5: note: Calling pack_buttons
    pack_buttons();
    ^
src/article/toolbarsimple.h:21:14: note: pack_buttons is a virtual function
        void pack_buttons() override;
             ^
src/bbslist/toolbar.h:38:14: warning: Virtual function 'pack_buttons' is called from constructor 'BBSListToolBar()' at line 59. Dynamic binding is not used. [virtualCallInConstructor]
        void pack_buttons() override;
             ^
src/bbslist/toolbar.cpp:59:5: note: Calling pack_buttons
    pack_buttons();
    ^
src/bbslist/toolbar.h:38:14: note: pack_buttons is a virtual function
        void pack_buttons() override;
             ^
src/bbslist/toolbar.h:64:14: warning: Virtual function 'pack_buttons' is called from constructor 'EditListToolBar()' at line 235. Dynamic binding is not used. [virtualCallInConstructor]
        void pack_buttons() override;
             ^
src/bbslist/toolbar.cpp:235:5: note: Calling pack_buttons
    pack_buttons();
    ^
src/bbslist/toolbar.h:64:14: note: pack_buttons is a virtual function
        void pack_buttons() override;
             ^
src/board/toolbar.h:26:14: warning: Virtual function 'pack_buttons' is called from constructor 'BoardToolBar()' at line 22. Dynamic binding is not used. [virtualCallInConstructor]
        void pack_buttons() override;
             ^
src/board/toolbar.cpp:22:5: note: Calling pack_buttons
    pack_buttons();
    ^
src/board/toolbar.h:26:14: note: pack_buttons is a virtual function
        void pack_buttons() override;
             ^
src/maintoolbar.h:48:14: warning: Virtual function 'pack_buttons' is called from constructor 'MainToolBar()' at line 65. Dynamic binding is not used. [virtualCallInConstructor]
        void pack_buttons() override;
             ^
src/maintoolbar.cpp:65:5: note: Calling pack_buttons
    pack_buttons();
    ^
src/maintoolbar.h:48:14: note: pack_buttons is a virtual function
        void pack_buttons() override;
             ^
src/message/toolbar.h:64:14: warning: Virtual function 'pack_buttons' is called from constructor 'MessageToolBar()' at line 82. Dynamic binding is not used. [virtualCallInConstructor]
        void pack_buttons() override;
             ^
src/message/toolbar.cpp:82:5: note: Calling pack_buttons
    pack_buttons();
    ^
src/message/toolbar.h:64:14: note: pack_buttons is a virtual function
        void pack_buttons() override;
             ^
src/message/toolbar.h:84:14: warning: Virtual function 'pack_buttons' is called from constructor 'MessageToolBarPreview()' at line 242. Dynamic binding is not used. [virtualCallInConstructor]
        void pack_buttons() override;
             ^
src/message/toolbar.cpp:242:5: note: Calling pack_buttons
    pack_buttons();
    ^
src/message/toolbar.h:84:14: note: pack_buttons is a virtual function
        void pack_buttons() override;
             ^
```

</details>
