### PR TITLE
View: Fix calling virtual function from the destructor

### DIFF
--- a/src/article/articleview.cpp
+++ b/src/article/articleview.cpp
@@ -75,7 +75,7 @@ ArticleViewMain::~ArticleViewMain()
     std::cout << "ArticleViewMain::~ArticleViewMain : " << get_url() << " url_article = " << url_article() << std::endl;
 #endif
 
-    save_session();
+    ArticleViewMain::save_session();
 
     // 閉じたタブ履歴更新
     HISTORY::append_history( URL_HISTCLOSEVIEW,

--- a/src/board/boardview.cpp
+++ b/src/board/boardview.cpp
@@ -51,7 +51,7 @@ BoardView::~BoardView()
                              DBTREE::board_name( get_url() ), TYPE_BOARD );
 
 
-    if( ! SESSION::is_quitting() ) save_session();
+    if( ! SESSION::is_quitting() ) BoardView::save_session();
 }
 
 


### PR DESCRIPTION
ArticleViewMain、BoardViewはコンストラクタ内で仮想関数save_session()を呼び出していますが、仮想関数はコントラクタ内で派生クラスの関数として呼び出しできないためcppcheckに警告されます。
そのためスコープ解決演算子を使ってクラスを明示します。

cppcheckのレポート
```
src/article/articleview.h:46:14: warning: Virtual function 'save_session' is called from destructor '~ArticleViewMain()' at line 78. Dynamic binding is not used. [virtualCallInConstructor]
        void save_session() override;
             ^
src/article/articleview.cpp:78:5: note: Calling save_session
    save_session();
    ^
src/article/articleview.h:46:14: note: save_session is a virtual function
        void save_session() override;
             ^
src/board/boardview.h:21:14: warning: Virtual function 'save_session' is called from destructor '~BoardView()' at line 54. Dynamic binding is not used. [virtualCallInConstructor]
        void save_session() override;
             ^
src/board/boardview.cpp:54:36: note: Calling save_session
    if( ! SESSION::is_quitting() ) save_session();
                                   ^
src/board/boardview.h:21:14: note: save_session is a virtual function
        void save_session() override;
             ^
```