### PR TITLE
ArticleViewMain: Fix calling virtual function from the destructor

### DIFF
--- a/src/article/articleview.cpp
+++ b/src/article/articleview.cpp
@@ -84,7 +84,7 @@ ArticleViewMain::~ArticleViewMain()
 
     CORE::core_set_command( "close_message" ,url_article() );
 
-    if( get_live() ) live_stop();
+    if( get_live() ) ArticleViewMain::live_stop();
 }
 
 


### PR DESCRIPTION
ArticleViewMainはデストラクタ内で仮想関数live_stop()を呼び出していますが、仮想関数はデストラクタ内で派生クラスの関数として呼び出しできないためcppcheckに警告されます。
そのためスコープ解決演算子を使ってクラスを明示します。

cppcheckのレポート
```
src/article/articleview.h:64:14: warning: Virtual function 'live_stop' is called from destructor '~ArticleViewMain()' at line 87. Dynamic binding is not used. [virtualCallInConstructor]
        void live_stop() override;
             ^
src/article/articleview.cpp:87:22: note: Calling live_stop
    if( get_live() ) live_stop();
                     ^
src/article/articleview.h:64:14: note: live_stop is a virtual function
        void live_stop() override;
             ^
```