### PR TITLE
ArticleBase: Fix calling virtual function from the destructor

### DIFF
--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -117,7 +117,7 @@ ArticleBase::~ArticleBase()
     assert( get_lock() == 0 );
 
     // nodetreeのクリアと情報保存
-    unlock_impl();
+    ArticleBase::unlock_impl();
 }
 
 


### PR DESCRIPTION
ArticleBaseはデストラクタ内で仮想関数unlock_impl()を呼び出していますが、仮想関数はデストラクタ内で派生クラスの関数として呼び出しできないためcppcheckに警告されます。
そのためスコープ解決演算子を使ってクラスを明示します。

cppehckのレポート
```
src/dbtree/articlebase.h:420:14: warning: Virtual function 'unlock_impl' is called from destructor '~ArticleBase()' at line 120. Dynamic binding is not used. [virtualCallInConstructor]
        void unlock_impl() override;
             ^
src/dbtree/articlebase.cpp:120:5: note: Calling unlock_impl
    unlock_impl();
    ^
src/dbtree/articlebase.h:420:14: note: unlock_impl is a virtual function
        void unlock_impl() override;
             ^
```