### PR TITLE
RuleLoader: Fix calling virtual function from the ctor and dtor

### DIFF
--- a/src/dbtree/ruleloader.cpp
+++ b/src/dbtree/ruleloader.cpp
@@ -22,7 +22,7 @@ RuleLoader::RuleLoader( const std::string& url_boadbase )
       m_url_boadbase( url_boadbase )
 {
 #ifdef _DEBUG
-    std::cout << "RuleLoader::RuleLoader : " << get_url() << std::endl;
+    std::cout << "RuleLoader::RuleLoader : " << RuleLoader::get_url() << std::endl;
 #endif
 
     set_date_modified( DBTREE::board_get_modified_localrule( m_url_boadbase ) );
@@ -32,7 +32,7 @@ RuleLoader::RuleLoader( const std::string& url_boadbase )
 RuleLoader::~RuleLoader()
 {
 #ifdef _DEBUG
-    std::cout << "RuleLoader::~RuleLoader : " << get_url() << std::endl;
+    std::cout << "RuleLoader::~RuleLoader : " << RuleLoader::get_url() << std::endl;
 #endif
 }
 


### PR DESCRIPTION
RuleLoaderはコンストラクタ・デストラクタ内で仮想関数get_url()を呼び出していますが、仮想関数はコンストラクタ・デストラクタ内で派生クラスの関数として呼び出しできないためcppcheckに警告されます。
そのためスコープ解決演算子を使ってクラスを明示します。

cppcheckのレポート
```
src/dbtree/ruleloader.h:31:21: warning: Virtual function 'get_url' is called from constructor 'RuleLoader(const std::string&url_boardbase)' at line 25. Dynamic binding is not used. [virtualCallInConstructor]
        std::string get_url() override;
                    ^
src/dbtree/ruleloader.cpp:25:49: note: Calling get_url
    std::cout << "RuleLoader::RuleLoader : " << get_url() << std::endl;
                                                ^
src/dbtree/ruleloader.h:31:21: note: get_url is a virtual function
        std::string get_url() override;
                    ^
src/dbtree/ruleloader.h:31:21: warning: Virtual function 'get_url' is called from destructor '~RuleLoader()' at line 35. Dynamic binding is not used. [virtualCallInConstructor]
        std::string get_url() override;
                    ^
src/dbtree/ruleloader.cpp:35:50: note: Calling get_url
    std::cout << "RuleLoader::~RuleLoader : " << get_url() << std::endl;
                                                 ^
src/dbtree/ruleloader.h:31:21: note: get_url is a virtual function
        std::string get_url() override;
                    ^
```