### PR TITLE
Admin: Fix calling virtual function from the destructor

### DIFF
--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -90,7 +90,7 @@ ImageAdmin::~ImageAdmin()
     std::cout << "ImageAdmin::~ImageAdmin\n";
 #endif 
 
-    close_window();
+    ImageAdmin::close_window();
 }
 
 

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -107,7 +107,7 @@ Admin::~Admin()
     }
     m_list_command.clear();
 
-    close_window();
+    Admin::close_window();
     delete_jdwin();
 
     if( m_notebook ) delete m_notebook;


### PR DESCRIPTION
Admin、ImageAdminはデストラクタ内で仮想関数close_window()を呼び出していますが、仮想関数はデストラクタ内で派生クラスの関数として呼び出しできないためcppcheckに警告されます。
そのためスコープ解決演算子を使ってクラスを明示します。

cppehckのレポート
```
src/image/imageadmin.h:83:14: warning: Virtual function 'close_window' is called from destructor '~ImageAdmin()' at line 93. Dynamic binding is not used. [virtualCallInConstructor]
        void close_window() override;
             ^
src/image/imageadmin.cpp:93:5: note: Calling close_window
    close_window();
    ^
src/image/imageadmin.h:83:14: note: close_window is a virtual function
        void close_window() override;
             ^
src/skeleton/admin.h:225:22: warning: Virtual function 'close_window' is called from destructor '~Admin()' at line 110. Dynamic binding is not used. [virtualCallInConstructor]
        virtual void close_window(){}
                     ^
src/skeleton/admin.cpp:110:5: note: Calling close_window
    close_window();
    ^
src/skeleton/admin.h:225:22: note: close_window is a virtual function
        virtual void close_window(){}
                     ^
```