### PR TITLE
JDWindow: Fix calling virtual function from the destructor

### DIFF
--- a/src/image/imagewin.cpp
+++ b/src/image/imagewin.cpp
@@ -42,7 +42,7 @@ ImageWin::~ImageWin()
               << " w = " << get_width_win() << " h = " << get_height_win() << " max = " << is_maximized_win() << std::endl;
 #endif
 
-    set_shown_win( false );
+    ImageWin::set_shown_win( false );
     CORE::core_set_command( "restore_focus" );
 }
 

--- a/src/message/messagewin.cpp
+++ b/src/message/messagewin.cpp
@@ -42,7 +42,7 @@ MessageWin::~MessageWin()
               << " w = " << get_width_win() << " h = " << get_height_win() << " max = " << is_maximized_win() << std::endl;
 #endif
 
-    set_shown_win( false );
+    MessageWin::set_shown_win( false );
     CORE::core_set_command( "restore_focus" );
 }
 


### PR DESCRIPTION
ImageWin、MessageWinはデストラクタ内で仮想関数set_shown_win()を呼び出していますが、仮想関数はデストラクタ内で派生クラスの関数として呼び出しできないためcppcheckに警告されます。
そのためスコープ解決演算子を使ってクラスを明示します。

cppehckのレポート
```
src/image/imagewin.h:54:14: warning: Virtual function 'set_shown_win' is called from destructor '~ImageWin()' at line 45. Dynamic binding is not used. [virtualCallInConstructor]
        void set_shown_win( const bool set ) override;
             ^
src/image/imagewin.cpp:45:5: note: Calling set_shown_win
    set_shown_win( false );
    ^
src/image/imagewin.h:54:14: note: set_shown_win is a virtual function
        void set_shown_win( const bool set ) override;
             ^
src/message/messagewin.h:46:14: warning: Virtual function 'set_shown_win' is called from destructor '~MessageWin()' at line 45. Dynamic binding is not used. [virtualCallInConstructor]
        void set_shown_win( const bool set ) override;
             ^
src/message/messagewin.cpp:45:5: note: Calling set_shown_win
    set_shown_win( false );
    ^
src/message/messagewin.h:46:14: note: set_shown_win is a virtual function
        void set_shown_win( const bool set ) override;
             ^
```