### PR TITLE
JDWindow: Fix calling virtual function from the ctor and dtor

### DIFF
--- a/src/image/imagewin.cpp
+++ b/src/image/imagewin.cpp
@@ -22,8 +22,8 @@ ImageWin::ImageWin()
 {
 #ifdef _DEBUG
     std::cout << "ImageWin::ImageWin x y w h = "
-              << get_x_win() << " " << get_y_win()
-              << " " << get_width_win() << " " << get_height_win() << std::endl;
+              << ImageWin::get_x_win() << " " << ImageWin::get_y_win()
+              << " " << ImageWin::get_width_win() << " " << ImageWin::get_height_win() << std::endl;
 #endif
 
     init_win();
@@ -38,8 +38,9 @@ ImageWin::ImageWin()
 ImageWin::~ImageWin()
 {
 #ifdef _DEBUG
-    std::cout << "ImageWin::~ImageWin window size : x = " << get_x_win() << " y = " << get_y_win()
-              << " w = " << get_width_win() << " h = " << get_height_win() << " max = " << is_maximized_win() << std::endl;
+    std::cout << "ImageWin::~ImageWin window size : x = " << ImageWin::get_x_win() << " y = " << ImageWin::get_y_win()
+              << " w = " << ImageWin::get_width_win() << " h = " << ImageWin::get_height_win()
+              << " max = " << ImageWin::is_maximized_win() << std::endl;
 #endif
 
     set_shown_win( false );

--- a/src/message/messagewin.cpp
+++ b/src/message/messagewin.cpp
@@ -22,8 +22,8 @@ MessageWin::MessageWin()
 {
 #ifdef _DEBUG
     std::cout << "MessageWin::MessageWin x y w h = "
-              << get_x_win() << " " << get_y_win()
-              << " " << get_width_win() << " " << get_height_win() << std::endl;
+              << MessageWin::get_x_win() << " " << MessageWin::get_y_win()
+              << " " << MessageWin::get_width_win() << " " << MessageWin::get_height_win() << std::endl;
 #endif
 
     get_vbox().pack_remove_end( false, get_statbar(), Gtk::PACK_SHRINK );
@@ -38,8 +38,9 @@ MessageWin::MessageWin()
 MessageWin::~MessageWin()
 {
 #ifdef _DEBUG
-    std::cout << "MessageWin::~MessageWin window size : x = " << get_x_win() << " y = " << get_y_win()
-              << " w = " << get_width_win() << " h = " << get_height_win() << " max = " << is_maximized_win() << std::endl;
+    std::cout << "MessageWin::~MessageWin window size : x = " << MessageWin::get_x_win()
+              << " y = " << MessageWin::get_y_win() << " w = " << MessageWin::get_width_win()
+              << " h = " << MessageWin::get_height_win() << " max = " << MessageWin::is_maximized_win() << std::endl;
 #endif
 
     set_shown_win( false );


### PR DESCRIPTION
ImageWin、MessageWinはコンストラクタ・デストラクタ内のprintデバッグで仮想関数get_xxx()を呼び出していますが、仮想関数はコンストラクタ・デストラクタ内で派生クラスの関数として呼び出しできないためcppcheckに警告されます。
そのためスコープ解決演算子を使ってクラスを明示します。

<details>
<summary>cppcheckのレポート</summary>

```
src/image/imagewin.h:31:13: warning: Virtual function 'get_x_win' is called from constructor 'ImageWin()' at line 25. Dynamic binding is not used. [virtualCallInConstructor]
        int get_x_win() override;
            ^
src/image/imagewin.cpp:25:18: note: Calling get_x_win
              << get_x_win() << " " << get_y_win()
                 ^
src/image/imagewin.h:31:13: note: get_x_win is a virtual function
        int get_x_win() override;
            ^
src/image/imagewin.h:32:13: warning: Virtual function 'get_y_win' is called from constructor 'ImageWin()' at line 25. Dynamic binding is not used. [virtualCallInConstructor]
        int get_y_win() override;
            ^
src/image/imagewin.cpp:25:40: note: Calling get_y_win
              << get_x_win() << " " << get_y_win()
                                       ^
src/image/imagewin.h:32:13: note: get_y_win is a virtual function
        int get_y_win() override;
            ^
src/image/imagewin.h:36:13: warning: Virtual function 'get_width_win' is called from constructor 'ImageWin()' at line 26. Dynamic binding is not used. [virtualCallInConstructor]
        int get_width_win() override;
            ^
src/image/imagewin.cpp:26:25: note: Calling get_width_win
              << " " << get_width_win() << " " << get_height_win() << std::endl;
                        ^
src/image/imagewin.h:36:13: note: get_width_win is a virtual function
        int get_width_win() override;
            ^
src/image/imagewin.h:37:13: warning: Virtual function 'get_height_win' is called from constructor 'ImageWin()' at line 26. Dynamic binding is not used. [virtualCallInConstructor]
        int get_height_win() override;
            ^
src/image/imagewin.cpp:26:51: note: Calling get_height_win
              << " " << get_width_win() << " " << get_height_win() << std::endl;
                                                  ^
src/image/imagewin.h:37:13: note: get_height_win is a virtual function
        int get_height_win() override;
            ^
src/image/imagewin.h:31:13: warning: Virtual function 'get_x_win' is called from destructor '~ImageWin()' at line 41. Dynamic binding is not used. [virtualCallInConstructor]
        int get_x_win() override;
            ^
src/image/imagewin.cpp:41:62: note: Calling get_x_win
    std::cout << "ImageWin::~ImageWin window size : x = " << get_x_win() << " y = " << get_y_win()
                                                             ^
src/image/imagewin.h:31:13: note: get_x_win is a virtual function
        int get_x_win() override;
            ^
src/image/imagewin.h:32:13: warning: Virtual function 'get_y_win' is called from destructor '~ImageWin()' at line 41. Dynamic binding is not used. [virtualCallInConstructor]
        int get_y_win() override;
            ^
src/image/imagewin.cpp:41:88: note: Calling get_y_win
    std::cout << "ImageWin::~ImageWin window size : x = " << get_x_win() << " y = " << get_y_win()
                                                                                       ^
src/image/imagewin.h:32:13: note: get_y_win is a virtual function
        int get_y_win() override;
            ^
src/image/imagewin.h:36:13: warning: Virtual function 'get_width_win' is called from destructor '~ImageWin()' at line 42. Dynamic binding is not used. [virtualCallInConstructor]
        int get_width_win() override;
            ^
src/image/imagewin.cpp:42:29: note: Calling get_width_win
              << " w = " << get_width_win() << " h = " << get_height_win() << " max = " << is_maximized_win() << std::endl;
                            ^
src/image/imagewin.h:36:13: note: get_width_win is a virtual function
        int get_width_win() override;
            ^
src/image/imagewin.h:37:13: warning: Virtual function 'get_height_win' is called from destructor '~ImageWin()' at line 42. Dynamic binding is not used. [virtualCallInConstructor]
        int get_height_win() override;
            ^
src/image/imagewin.cpp:42:59: note: Calling get_height_win
              << " w = " << get_width_win() << " h = " << get_height_win() << " max = " << is_maximized_win() << std::endl;
                                                          ^
src/image/imagewin.h:37:13: note: get_height_win is a virtual function
        int get_height_win() override;
            ^
src/image/imagewin.h:44:14: warning: Virtual function 'is_maximized_win' is called from destructor '~ImageWin()' at line 42. Dynamic binding is not used. [virtualCallInConstructor]
        bool is_maximized_win() override;
             ^
src/image/imagewin.cpp:42:92: note: Calling is_maximized_win
              << " w = " << get_width_win() << " h = " << get_height_win() << " max = " << is_maximized_win() << std::endl;
                                                                                           ^
src/image/imagewin.h:44:14: note: is_maximized_win is a virtual function
        bool is_maximized_win() override;
             ^

src/message/messagewin.h:23:13: warning: Virtual function 'get_x_win' is called from constructor 'MessageWin()' at line 25. Dynamic binding is not used. [virtualCallInConstructor]
        int get_x_win() override;
            ^
src/message/messagewin.cpp:25:18: note: Calling get_x_win
              << get_x_win() << " " << get_y_win()
                 ^
src/message/messagewin.h:23:13: note: get_x_win is a virtual function
        int get_x_win() override;
            ^
src/message/messagewin.h:24:13: warning: Virtual function 'get_y_win' is called from constructor 'MessageWin()' at line 25. Dynamic binding is not used. [virtualCallInConstructor]
        int get_y_win() override;
            ^
src/message/messagewin.cpp:25:40: note: Calling get_y_win
              << get_x_win() << " " << get_y_win()
                                       ^
src/message/messagewin.h:24:13: note: get_y_win is a virtual function
        int get_y_win() override;
            ^
src/message/messagewin.h:28:13: warning: Virtual function 'get_width_win' is called from constructor 'MessageWin()' at line 26. Dynamic binding is not used. [virtualCallInConstructor]
        int get_width_win() override;
            ^
src/message/messagewin.cpp:26:25: note: Calling get_width_win
              << " " << get_width_win() << " " << get_height_win() << std::endl;
                        ^
src/message/messagewin.h:28:13: note: get_width_win is a virtual function
        int get_width_win() override;
            ^
src/message/messagewin.h:29:13: warning: Virtual function 'get_height_win' is called from constructor 'MessageWin()' at line 26. Dynamic binding is not used. [virtualCallInConstructor]
        int get_height_win() override;
            ^
src/message/messagewin.cpp:26:51: note: Calling get_height_win
              << " " << get_width_win() << " " << get_height_win() << std::endl;
                                                  ^
src/message/messagewin.h:29:13: note: get_height_win is a virtual function
        int get_height_win() override;
            ^
src/message/messagewin.h:23:13: warning: Virtual function 'get_x_win' is called from destructor '~MessageWin()' at line 41. Dynamic binding is not used. [virtualCallInConstructor]
        int get_x_win() override;
            ^
src/message/messagewin.cpp:41:66: note: Calling get_x_win
    std::cout << "MessageWin::~MessageWin window size : x = " << get_x_win() << " y = " << get_y_win()
                                                                 ^
src/message/messagewin.h:23:13: note: get_x_win is a virtual function
        int get_x_win() override;
            ^
src/message/messagewin.h:24:13: warning: Virtual function 'get_y_win' is called from destructor '~MessageWin()' at line 41. Dynamic binding is not used. [virtualCallInConstructor]
        int get_y_win() override;
            ^
src/message/messagewin.cpp:41:92: note: Calling get_y_win
    std::cout << "MessageWin::~MessageWin window size : x = " << get_x_win() << " y = " << get_y_win()
                                                                                           ^
src/message/messagewin.h:24:13: note: get_y_win is a virtual function
        int get_y_win() override;
            ^
src/message/messagewin.h:28:13: warning: Virtual function 'get_width_win' is called from destructor '~MessageWin()' at line 42. Dynamic binding is not used. [virtualCallInConstructor]
        int get_width_win() override;
            ^
src/message/messagewin.cpp:42:29: note: Calling get_width_win
              << " w = " << get_width_win() << " h = " << get_height_win() << " max = " << is_maximized_win() << std::endl;
                            ^
src/message/messagewin.h:28:13: note: get_width_win is a virtual function
        int get_width_win() override;
            ^
src/message/messagewin.h:29:13: warning: Virtual function 'get_height_win' is called from destructor '~MessageWin()' at line 42. Dynamic binding is not used. [virtualCallInConstructor]
        int get_height_win() override;
            ^
src/message/messagewin.cpp:42:59: note: Calling get_height_win
              << " w = " << get_width_win() << " h = " << get_height_win() << " max = " << is_maximized_win() << std::endl;
                                                          ^
src/message/messagewin.h:29:13: note: get_height_win is a virtual function
        int get_height_win() override;
            ^
src/message/messagewin.h:36:14: warning: Virtual function 'is_maximized_win' is called from destructor '~MessageWin()' at line 42. Dynamic binding is not used. [virtualCallInConstructor]
        bool is_maximized_win() override;
             ^
src/message/messagewin.cpp:42:92: note: Calling is_maximized_win
              << " w = " << get_width_win() << " h = " << get_height_win() << " max = " << is_maximized_win() << std::endl;
                                                                                           ^
src/message/messagewin.h:36:14: note: is_maximized_win is a virtual function
        bool is_maximized_win() override;
             ^
```

</details>
