### PR TITLE
Replace char buffer with std::string for DBTREE::Board classes

### DIFF
--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -343,7 +343,6 @@ void Board2chCompati::parse_subject( const char* str_subject_txt )
         int lng_id_dat = 0;
         const char* str_subject;
         int lng_subject = 0;
-        char str_num[ 16 ];
 
         while( *pos == ' ' ) ++pos;
 
@@ -382,21 +381,20 @@ void Board2chCompati::parse_subject( const char* str_subject_txt )
             break;
         }
         lng_subject = ( int )( pos - str_subject );
-        
-        // レス数取得
+
+        // レス数取得 (符号付き32bit整数より大きいと未定義)
         ++pos;
-        int i = 0;
-        while( '0' <= *pos && *pos <= '9' && i < 16 ) str_num[ i++ ] = *( pos++ );
+        std::string str_num;
+        while( '0' <= *pos && *pos <= '9' ) str_num.push_back( *( pos++ ) );
 
         // 壊れてる
-        if( i == 0 ){
+        if( str_num.empty() ){
             MISC::ERRMSG( "subject.txt is broken (res)" );
             break;
         }
         if( *pos == '\0' ) break;
         if( *pos == '\n' ) { ++pos; continue; }
 
-        str_num[ i ] = '\0';
         ++pos;
 
         // id, subject, number 取得
@@ -414,7 +412,7 @@ void Board2chCompati::parse_subject( const char* str_subject_txt )
             artinfo.subject = MISC::replace_str( artinfo.subject, "&gt;", ">" );
         }
 
-        const auto num = std::atoi( str_num );
+        const auto num = std::atoi( str_num.c_str() );
         artinfo.number = ( num < CONFIG::get_max_resnumber() ) ? num : CONFIG::get_max_resnumber();
 
         get_list_artinfo().push_back( artinfo );

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -164,7 +164,6 @@ void BoardJBBS::parse_subject( const char* str_subject_txt )
         int lng_id_dat = 0;
         const char* str_subject;
         int lng_subject = 0;
-        char str_num[ 16 ];
 
         // datのID取得
         // ".cgi" は除く
@@ -188,21 +187,20 @@ void BoardJBBS::parse_subject( const char* str_subject_txt )
             break;
         }
         lng_subject = ( int )( pos - str_subject );
-        
-        // レス数取得
+
+        // レス数取得 (符号付き32bit整数より大きいと未定義)
         ++pos;
-        int i = 0;
-        while( '0' <= *pos && *pos <= '9' && i < 16 ) str_num[ i++ ] = *( pos++ );
+        std::string str_num;
+        while( '0' <= *pos && *pos <= '9' ) str_num.push_back( *( pos++ ) );
 
         // 壊れてる
-        if( i == 0 ){
+        if( str_num.empty() ){
             MISC::ERRMSG( "subject.txt is broken (res)" );
             break;
         }
         if( *pos == '\0' ) break;
         if( *pos == '\n' ) { ++pos; continue; }
 
-        str_num[ i ] = '\0';
         ++pos;
 
         // id, subject, number 取得
@@ -216,7 +214,7 @@ void BoardJBBS::parse_subject( const char* str_subject_txt )
         artinfo.subject = MISC::replace_str( artinfo.subject, "&lt;", "<" );
         artinfo.subject = MISC::replace_str( artinfo.subject, "&gt;", ">" );
 
-        const auto num = std::atoi( str_num );
+        const auto num = std::atoi( str_num.c_str() );
         artinfo.number = ( num < CONFIG::get_max_resnumber() ) ? num : CONFIG::get_max_resnumber();
 
         get_list_artinfo().push_back( artinfo );

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -224,7 +224,6 @@ void BoardMachi::parse_subject( const char* str_subject_txt )
         int lng_id_dat = 0;
         const char* str_subject;
         int lng_subject = 0;
-        char str_num[ 16 ];
 
         // datのID取得
         // ".cgi" は除く
@@ -248,21 +247,20 @@ void BoardMachi::parse_subject( const char* str_subject_txt )
             break;
         }
         lng_subject = ( int )( pos - str_subject );
-        
-        // レス数取得
+
+        // レス数取得 (符号付き32bit整数より大きいと未定義)
         ++pos;
-        int i = 0;
-        while( '0' <= *pos && *pos <= '9' && i < 16 ) str_num[ i++ ] = *( pos++ );
+        std::string str_num;
+        while( '0' <= *pos && *pos <= '9' ) str_num.push_back( *( pos++ ) );
 
         // 壊れてる
-        if( i == 0 ){
+        if( str_num.empty() ){
             MISC::ERRMSG( "subject.txt is broken (res)" );
             break;
         }
         if( *pos == '\0' ) break;
         if( *pos == '\n' ) { ++pos; continue; }
 
-        str_num[ i ] = '\0';
         ++pos;
 
         // id, subject, number 取得
@@ -276,7 +274,7 @@ void BoardMachi::parse_subject( const char* str_subject_txt )
         artinfo.subject = MISC::replace_str( artinfo.subject, "&lt;", "<" );
         artinfo.subject = MISC::replace_str( artinfo.subject, "&gt;", ">" );
 
-        const auto num = std::atoi( str_num );
+        const auto num = std::atoi( str_num.c_str() );
         artinfo.number = ( num < CONFIG::get_max_resnumber() ) ? num : CONFIG::get_max_resnumber();
 
         get_list_artinfo().push_back( artinfo );        


### PR DESCRIPTION
char配列について冗長または範囲外なアクセスの可能性をcppcheckに警告されました。
配列の長さは16でSmall String Optimizationが期待できるためstd::stringに置き換えます。

cppcheckのレポート
```
src/dbtree/board2chcompati.cpp:399:16: warning: Either the condition 'i<16' is redundant or the array 'str_num[16]' is accessed at index 16, which is out of bounds. [arrayIndexOutOfBoundsCond]
        str_num[ i ] = '\0';
               ^
src/dbtree/board2chcompati.cpp:389:48: note: Assuming that condition 'i<16' is not redundant
        while( '0' <= *pos && *pos <= '9' && i < 16 ) str_num[ i++ ] = *( pos++ );
                                               ^
src/dbtree/board2chcompati.cpp:399:16: note: Array index out of bounds
        str_num[ i ] = '\0';
               ^
src/dbtree/boardjbbs.cpp:205:16: warning: Either the condition 'i<16' is redundant or the array 'str_num[16]' is accessed at index 16, which is out of bounds. [arrayIndexOutOfBoundsCond]
        str_num[ i ] = '\0';
               ^
src/dbtree/boardjbbs.cpp:195:48: note: Assuming that condition 'i<16' is not redundant
        while( '0' <= *pos && *pos <= '9' && i < 16 ) str_num[ i++ ] = *( pos++ );
                                               ^
src/dbtree/boardjbbs.cpp:205:16: note: Array index out of bounds
        str_num[ i ] = '\0';
               ^
src/dbtree/boardmachi.cpp:265:16: warning: Either the condition 'i<16' is redundant or the array 'str_num[16]' is accessed at index 16, which is out of bounds. [arrayIndexOutOfBoundsCond]
        str_num[ i ] = '\0';
               ^
src/dbtree/boardmachi.cpp:255:48: note: Assuming that condition 'i<16' is not redundant
        while( '0' <= *pos && *pos <= '9' && i < 16 ) str_num[ i++ ] = *( pos++ );
                                               ^
src/dbtree/boardmachi.cpp:265:16: note: Array index out of bounds
        str_num[ i ] = '\0';
               ^
```

関連のpull request: #159