### PR TITLE
Fix ignored return value for MISC::get_hostname()

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1651,7 +1651,7 @@ std::string MISC::get_hostname( const std::string& path, bool protocol )
 
     size_t i = path.find( "/", lng ); 
 
-    if( i == std::string::npos ) path.substr( pos );
+    if( i == std::string::npos ) return path.substr( pos );
 
     return path.substr( pos, i - pos );
 }


### PR DESCRIPTION
return文が抜けているとcppcheckに警告された箇所があったため修正します。

cppcheckのレポート
```
src/jdlib/miscutil.cpp:1654:39: warning: Return value of function path.substr() is not used. [ignoredReturnValue]
    if( i == std::string::npos ) path.substr( pos );
                                      ^
```