### PR TITLE
Fix dangling pointer for logging file

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -501,10 +501,10 @@ int main( int argc, char **argv )
     // メッセージをログファイルに出力
     if( logfile_mode && CACHE::mkdir_logroot() ){
         FILE *tmp; // warning 消し
-        const char *logfile = to_locale_cstr( CACHE::path_msglog() );
-        tmp = freopen( logfile, "ab", stdout );
+        const std::string logfile = Glib::locale_from_utf8( CACHE::path_msglog() );
+        tmp = freopen( logfile.c_str(), "ab", stdout );
         setbuf( tmp, nullptr );
-        tmp = freopen( logfile, "ab", stderr );
+        tmp = freopen( logfile.c_str(), "ab", stderr );
         setbuf( tmp, nullptr );
     }
 


### PR DESCRIPTION
標準出力をログファイルにリダイレクトさせる処理の中で一時変数の文字列からポインターを使っている、つまりダングリングポインターになっているとcppcheckに警告されたため修正します。

cppcheckのレポート
```
src/main.cpp:505:24: error: Using pointer to temporary. [danglingTemporaryLifetime]
        tmp = freopen( logfile, "ab", stdout );
                       ^
src/main.cpp:504:31: note: Pointer to container is created here.
        const char *logfile = to_locale_cstr( CACHE::path_msglog() );
                              ^
src/main.cpp:505:24: note: Using pointer to temporary.
        tmp = freopen( logfile, "ab", stdout );
                       ^
src/main.cpp:507:24: error: Using pointer to temporary. [danglingTemporaryLifetime]
        tmp = freopen( logfile, "ab", stderr );
                       ^
src/main.cpp:504:31: note: Pointer to container is created here.
        const char *logfile = to_locale_cstr( CACHE::path_msglog() );
                              ^
src/main.cpp:507:24: note: Using pointer to temporary.
        tmp = freopen( logfile, "ab", stderr );
                       ^
```