### PR TITLE
MessageAdmin: Fix if-statement which is always true

### DIFF
--- a/src/message/messageadmin.cpp
+++ b/src/message/messageadmin.cpp
@@ -135,7 +135,7 @@ void MessageAdmin::command_local( const COMMAND_ARGS& command )
     }
 
     // ビューの wrap 切り替え
-    else if( "toggle_wrap" ){
+    else if( command.command == "toggle_wrap" ){
 
         if( view ) view->set_command( command.command );
     }


### PR DESCRIPTION
条件文で常にtrueになる箇所があるとcppcheckに警告されたため修正します。

cppcheckのレポート
```
src/message/messageadmin.cpp:138:14: warning: Conversion of string literal "toggle_wrap" to bool always evaluates to true. [incorrectStringBooleanError]
    else if( "toggle_wrap" ){
             ^
```