### PR TITLE
Fix unmatched paren for MISC::getenv_limited()

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1699,7 +1699,7 @@ std::string MISC::getenv_limited( const char *name, const size_t size )
     strncpy( env.data(), getenv( name ), size );
 
 #ifdef _WIN32
-    return recover_path( Glib::locale_to_utf8( std::string( env.data() ) );
+    return recover_path( Glib::locale_to_utf8( std::string( env.data() ) ) );
 #else
     return env.data();
 #endif


### PR DESCRIPTION
括弧が一致しないとcppcheckから警告されたため修正します。

cppcheckのレポート
```
src/jdlib/miscutil.cpp:1702:24: error: Unmatched '('. Configuration: '_WIN32'. [syntaxError]
    return recover_path( Glib::locale_to_utf8( std::string( env.data() ) );
                       ^
```