### PR TITLE
Fix mouse wheel scrolling for thread list

### DIFF
--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -578,6 +578,9 @@ void BoardViewBase::update_columns()
         ++num;
     }
 
+    // 高さを取得するためのcolumn番号をリセット
+    m_treeview.set_column_for_height( 0 );
+
     // サイズを調整しつつソートの設定
     for( guint i = 0; i < COL_VISIBLE_END; i++ ){
 
@@ -605,7 +608,7 @@ void BoardViewBase::update_columns()
 
         case COL_SUBJECT:
             width = SESSION::col_subject();
-            m_treeview.set_column_for_height( id );
+            m_treeview.set_column_for_height( i );
             break;
 
         case COL_RES:


### PR DESCRIPTION
Fixes #295

スレ一覧の項目を3つ以下にするとマウスホイールでスクロールできない不具合を修正します。

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1584619744/323
