### PR TITLE
Fix loading local dat file specified by command line arguments

### DIFF
--- a/src/dbtree/boardlocal.h
+++ b/src/dbtree/boardlocal.h
@@ -23,6 +23,7 @@ namespace DBTREE
 
         std::string url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str ) override;
         std::string url_readcgi( const std::string& url, int num_from, int num_to ) override;
+        std::string url_datpath() override { return {}; }
 
         void download_subject( const std::string& url_update_view, const bool ) override;
 

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -583,7 +583,7 @@ int Root::get_board_type( const std::string& url, std::string& root, std::string
     // ローカルファイル
     else if( is_local( url ) ){
 
-        root = URL_BOARD_LOCAL;
+        root = "file://";
         path_board = "/local";
 
         type = TYPE_BOARD_LOCAL;


### PR DESCRIPTION
Fixes #297

コマンドライン引数にローカルのDATファイルを指定して起動しても内容が表示されない問題を修正します。
