### PR TITLE
Admin: Fix the class to be compliant with rule of three

### DIFF
--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -67,6 +67,10 @@ namespace SKELETON
         Admin( const std::string& url );
         ~Admin();
 
+        // コピー禁止
+        Admin( const Admin& ) = delete;
+        Admin& operator=( const Admin& ) = delete;
+
         virtual void save_session();
 
         void setup_menu();


### PR DESCRIPTION
SKELETON::Adminはコンストラクタ/デストラクタでメモリの確保/解放をしているためcppcheckからコピー対応するよう警告されました。(Rule of three)
実際のコードではAdminのコピーはしていないのでメンバ関数のdelete宣言でコピーできないように修正します。

cppcheckのレポート
```
src/skeleton/admin.cpp:63:5: warning: Class 'Admin' does not have a copy constructor which is recommended since it has dynamic memory/resource allocation(s). [noCopyConstructor]
    m_notebook = new DragableNoteBook();
    ^
src/skeleton/admin.cpp:63:5: warning: Class 'Admin' does not have a operator= which is recommended since it has dynamic memory/resource allocation(s). [noOperatorEq]
    m_notebook = new DragableNoteBook();
    ^
```