### PR TITLE
ToolMenuButton: Fix mutable member function in assert macro

### DIFF
--- a/src/skeleton/toolmenubutton.cpp
+++ b/src/skeleton/toolmenubutton.cpp
@@ -36,12 +36,14 @@ void ToolMenuButton::setup( SKELETON::MenuButton* button, const std::string& lab
 {
     m_button = button;
     assert( m_button != nullptr );
-    assert( m_button->get_label_widget() != nullptr );
+
+    Gtk::Widget* label_widget = m_button->get_label_widget();
+    assert( label_widget );
 
     Gtk::MenuItem* item = nullptr;
 
     // アイコンの場合はアイコン表示
-    Gtk::Image* image = dynamic_cast< Gtk::Image* >( m_button->get_label_widget() );
+    Gtk::Image* image = dynamic_cast< Gtk::Image* >( label_widget );
     if( image ){
         const Gtk::ImageType type = image->get_storage_type();
         if( type == Gtk::IMAGE_STOCK ) {


### PR DESCRIPTION
メンバーm_buttonがassertマクロの中で関数を呼び出していますがcppcheckがconstメンバ関数でなく副作用がある可能性を警告していたため修正します。

cppcheckのレポート
```
src/skeleton/toolmenubutton.cpp:39:23: warning: Assert statement calls a function which may have desired side effects: 'get_label_widget'. [assertWithSideEffect]
    assert( m_button->get_label_widget() != nullptr );
                      ^
```