### PR TITLE
Dom: Fix accessing first character for std::string

### DIFF
--- a/src/xml/dom.cpp
+++ b/src/xml/dom.cpp
@@ -128,14 +128,16 @@ void Dom::parse( const std::string& str )
 
             // 開始タグの中身( <element attr="value"> )を取り出す
             std::string open_tag = str.substr( tag_lt_pos + 1, tag_gt_pos - tag_lt_pos - 1 );
+            if( open_tag.empty() ) continue;
 
-            // タグの中身がアルファベットで始まっているか
-            bool is_alpha = ( ( open_tag[0] >= 'A' && open_tag[0] <= 'Z' ) || ( open_tag[0] >= 'a' && open_tag[0] <= 'z' ) );
+            // タグの中身がアルファベットで始まっているかチェック
+            if( !( open_tag[0] >= 'A' && open_tag[0] <= 'Z' ) && !( open_tag[0] >= 'a' && open_tag[0] <= 'z' ) ) {
+                continue;
+            }
 
             // タグ構造が壊れてる場合
             size_t broken_pos = 0;
-            if( open_tag.empty() || ! is_alpha ) continue;
-            else if( ( broken_pos = open_tag.find( '<' ) ) != std::string::npos )
+            if( ( broken_pos = open_tag.find( '<' ) ) != std::string::npos )
             {
                  current_pos += broken_pos;
                  continue;


### PR DESCRIPTION
std::stringの変数について冗長または範囲外なアクセスの可能性をcppcheckに警告されたため条件文を整理して修正します。

cppcheckのレポート
```
src/xml/dom.cpp:133:41: warning: Either the condition 'open_tag.empty()' is redundant or expression 'open_tag[0]' cause access out of bounds. [containerOutOfBounds]
            bool is_alpha = ( ( open_tag[0] >= 'A' && open_tag[0] <= 'Z' ) || ( open_tag[0] >= 'a' && open_tag[0] <= 'z' ) );
                                        ^
src/xml/dom.cpp:137:31: note: Assuming that condition 'open_tag.empty()' is not redundant
            if( open_tag.empty() || ! is_alpha ) continue;
                              ^
src/xml/dom.cpp:133:41: note: Access out of bounds
            bool is_alpha = ( ( open_tag[0] >= 'A' && open_tag[0] <= 'Z' ) || ( open_tag[0] >= 'a' && open_tag[0] <= 'z' ) );
                                        ^
```