### PR TITLE
Fix array bounds checking

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1769,7 +1769,7 @@ void NodeTreeBase::parse_mail( NODE* header, const char* str, const int lng )
     int color = COLOR_CHAR;
     int i = 0;
     NODE *node;
-    while( str[ i ] != 's' && i < lng ) ++i;
+    while( i < lng && str[ i ] != 's' ) ++i;
     if( str[ i ] != 's' || str[ i+1 ] != 'a' || str[ i+2 ] != 'g' || str[ i+3 ] != 'e' ){
         color = COLOR_CHAR_AGE;
         header->headinfo->sage = FALSE;

--- a/src/dbtree/nodetreejbbs.cpp
+++ b/src/dbtree/nodetreejbbs.cpp
@@ -237,7 +237,7 @@ const char* NodeTreeJBBS::raw2dat( char* rawlines, int& byte )
                 set_broken( true );
 
                 // その行は飛ばす
-                while( lines[ pos ] != '\n' && pos < byte_lines ) ++pos;
+                while( pos < byte_lines && lines[ pos ] != '\n' ) ++pos;
                 ++pos;
                 section = 0;
                 memset( lng_sec, 0, sizeof( int ) * MAX_SECTION );

--- a/src/jdlib/misctrip.cpp
+++ b/src/jdlib/misctrip.cpp
@@ -126,7 +126,7 @@ std::string create_trip_newtype( const std::string& key )
                 size_t n;
 
                 // salt 候補の17〜18文字目を検証
-                for( n = 17; key[n] && n < 19; ++n )
+                for( n = 17; n < 19 && key[n]; ++n )
                 {
                     // [./0-9A-Za-z]
                     if( isalnum( key[n] ) != 0 || (unsigned char)( key[n] - 0x2e ) < 2 )

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -136,7 +136,7 @@ std::list< std::string > MISC::split_line( const std::string& str )
 
         // " から始まる ( \"は除く )
         dquote = false;
-        if( str[ i ] == '\"' && (i < 1 || str[ i -1 ] != '\\') ){
+        if( (i < 1 || str[ i -1 ] != '\\') && str[ i ] == '\"' ){
             dquote = true;
             ++i;
         }


### PR DESCRIPTION
配列にアクセスした後で境界のチェックをしているとcppehckに指摘された箇所があったため条件の順序を修正します。

cppcheckのレポート
```
src/dbtree/nodetreejbbs.cpp:240:29: style: Array index 'pos' is used before limits check. [arrayIndexThenCheck]
            while( lines[ pos ] != '\n' && pos < byte_lines ) ++pos;
                        ^
src/dbtree/nodetreebase.cpp:1772:15: style: Array index 'i' is used before limits check. [arrayIndexThenCheck]
while( str[ i ] != 's' && i < lng ) ++i;
          ^
src/jdlib/misctrip.cpp:129:33: style: Array index 'n' is used before limits check. [arrayIndexThenCheck]
            for( n = 17; key[n] && n < 19; ++n )
                            ^
src/jdlib/miscutil.cpp:139:16: style: Array index 'i' is used before limits check. [arrayIndexThenCheck]
    if( str[ i ] == '\"' && (i < 1 || str[ i -1 ] != '\\') ){
           ^
```

