### PR TITLE
ImgProvider: Fix iterator loop to use std::find_if()

### DIFF
--- a/src/jdlib/imgloader.cpp
+++ b/src/jdlib/imgloader.cpp
@@ -250,17 +250,14 @@ ImgProvider& ImgProvider::get_provider()
 Glib::RefPtr< ImgLoader > ImgProvider::get_loader( const std::string& file )
 {
     // ImgLoaderキャッシュをサーチ
-    for( std::list< Glib::RefPtr< ImgLoader > >::iterator it = m_cache.begin();
-            it != m_cache.end(); it++ ) {
-        if( (*it)->equals( file ) ) {
-            Glib::RefPtr< ImgLoader > ret = *it;
-            // LRU: キャッシュをlistの先頭に移動
-            if( it != m_cache.begin() ) {
-                m_cache.erase( it );
-                m_cache.push_front( ret );
-            }
-            return ret;
-        }
+    auto it = std::find_if( m_cache.begin(), m_cache.end(),
+                            [&file]( const Glib::RefPtr<ImgLoader>& loader ) { return loader->equals( file ); } );
+    if( it != m_cache.begin() && it != m_cache.end() ) {
+        Glib::RefPtr<ImgLoader> ret = *it;
+        // LRU: キャッシュをlistの先頭に移動
+        m_cache.erase( it );
+        m_cache.push_front( ret );
+        return ret;
     }
     return Glib::RefPtr< ImgLoader >(); //null
 }


### PR DESCRIPTION
イテレーターのインクリメントを前置にしたほうがよいとcppcheckに指摘された箇所を標準ライブラリのアルゴリズムを使うように修正しました。

cppcheckのレポート
```
src/jdlib/imgloader.cpp:254:34: performance: Prefer prefix ++/-- operators for non-primitive types. [postfixOperator]
        it != m_cache.end(); it++ ) {
                             ^
```
