### PR TITLE
Fix std::set insertation to avoid double searching

### DIFF
--- a/src/jdlib/tfidf.cpp
+++ b/src/jdlib/tfidf.cpp
@@ -33,9 +33,9 @@ void MISC::tfidf_create_vec_words( VEC_WORDS& vec_words, const Glib::ustring& do
     for( int i = 0; i < n; ++i ){
 
         Glib::ustring word = document.substr( i, 2 );
-        if( set_words.find( word ) == set_words.end() ){
-
-            set_words.insert( word );
+        const auto result = set_words.insert( word );
+        if( result.second ) {
+            // 重複しないように単語をvec_wordsへ追加する
             vec_words.push_back( word );
         }
     }

--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -198,9 +198,8 @@ void View::show_popupmenu( const std::string& url, bool use_slot )
         std::cout << "View::show_popupmenu\n";
 #endif
 
-        if( m_url_popup.find( url ) == m_url_popup.end() ){
-
-            m_url_popup.insert( url );
+        const auto result = m_url_popup.insert( url );
+        if( result.second ) {
             popupmenu->signal_map().connect( sigc::mem_fun( *this, &View::slot_map_popupmenu ) ); 
             popupmenu->signal_hide().connect( sigc::mem_fun( *this, &View::slot_hide_popupmenu ) );
         }


### PR DESCRIPTION
std::setの挿入操作のために事前検索は必要ないとcppcheckに指摘されたため挿入結果を使って条件分岐するように修正します。

cppcheckのレポート
```
src/skeleton/view.cpp:203:33: performance: Searching before insertion is not necessary. [stlFindInsert]
        m_url_popup.insert( url );
                            ^
src/jdlib/tfidf.cpp:38:31: performance: Searching before insertion is not necessary. [stlFindInsert]
        set_words.insert( word );
                          ^
```
