### PR TITLE
Fix thread title search for intial setting (2020-06)

### DIFF
--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -219,7 +219,7 @@ namespace CONFIG
 #define CONF_URL_SEARCH_TITLE "https://ff5ch.syoboi.jp/?q=$TEXTU"
 
 // スレタイ検索用正規表現
-#define CONF_REGEX_SEARCH_TITLE R"=(<a class="thread" href="(http[^"]+)">([^<]+)</a><span\n +class="count"> \(([0-9]+)\))="
+#define CONF_REGEX_SEARCH_TITLE R"=(<a [^>]*?href="(http[^"]+)">([^<]+)</a><span[[:space:]]+class="count"> \(([0-9]+)\))="
 
 // WEB検索用メニュータイトルアドレス
 #define CONF_MENU_SEARCH_WEB  "WEB検索 (google)"

--- a/src/searchmanager.cpp
+++ b/src/searchmanager.cpp
@@ -254,8 +254,7 @@ void Search_Manager::search_fin_title()
     const std::string& source = m_searchloader->get_data();
     if( ! source.empty() ){
 
-        // 正規表現の設定には改行は "\\n" で保存されているので "\n"　に変換する
-        const std::string pattern = MISC::replace_str( CONFIG::get_regex_search_title(), "\\n", "\n" );
+        const std::string pattern = CONFIG::get_regex_search_title();
 
         JDLIB::Regex regex;
         const bool icase = false;


### PR DESCRIPTION
#313 の修正です。

初期設定のスレタイ検索サイト https://ff5ch.syoboi.jp の検索結果が2020年6月から変更されてスレッド抽出に失敗するようになりました。
そのため正規表現パターン構築の修正とabout:config「スレタイ検索時にアドレスとスレタイを取得する正規表現」のデフォルト設定を更新します。

#### 互換性に関する注意
デフォルト設定はPOSIX Character class(`[:space:]`)を使いますが利用できない環境では他の方法(Perl互換の`\s`など)を使用してください。

2aa3488fbb の変更のうち"複数行に分かれているデータに対応するため正規表現パターン中の "\n" は改行文字に変換して検索する"を取り消します。