### PR TITLE
Separate cookie generation for posting

### DIFF
--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -104,7 +104,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
 
     // cookie と 書き込みキーワード の設定
     std::string str_cookies;
-    const std::string temp_cookies = DBTREE::board_cookie_for_request( get_url() );
+    const std::string temp_cookies = DBTREE::board_cookie_by_host( get_url() );
     if( temp_cookies.empty() ) {
         str_cookies = "クッキー:\n未取得\n";
     }

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -109,18 +109,23 @@ bool ConfigItems::load( const bool restore )
 
     // 読み込み用プロクシとポート番号
     use_proxy_for2ch = cf.get_option_bool( "use_proxy_for2ch", CONF_USE_PROXY_FOR2CH );
+    send_cookie_to_proxy_for2ch = cf.get_option_bool( "send_cookie_to_proxy_for2ch", CONF_SEND_COOKIE_TO_PROXY_FOR2CH );
     str_tmp = cf.get_option_str( "proxy_for2ch", "" );
     set_proxy_for2ch( str_tmp );
     proxy_port_for2ch = cf.get_option_int( "proxy_port_for2ch", CONF_PROXY_PORT_FOR2CH, 1, 65535 );
 
     // 書き込み用プロクシとポート番号
     use_proxy_for2ch_w = cf.get_option_bool( "use_proxy_for2ch_w", CONF_USE_PROXY_FOR2CH_W );
+    send_cookie_to_proxy_for2ch_w = cf.get_option_bool( "send_cookie_to_proxy_for2ch_w",
+                                                        CONF_SEND_COOKIE_TO_PROXY_FOR2CH_W );
     str_tmp = cf.get_option_str( "proxy_for2ch_w", "" );
     set_proxy_for2ch_w( str_tmp );
     proxy_port_for2ch_w = cf.get_option_int( "proxy_port_for2ch_w", CONF_PROXY_PORT_FOR2CH_W, 1, 65535 );
 
     // 2chの外にアクセスするときのプロクシとポート番号
     use_proxy_for_data = cf.get_option_bool( "use_proxy_for_data", CONF_USE_PROXY_FOR_DATA );
+    send_cookie_to_proxy_for_data = cf.get_option_bool( "send_cookie_to_proxy_for_data",
+                                                        CONF_SEND_COOKIE_TO_PROXY_FOR_DATA );
     str_tmp = cf.get_option_str( "proxy_for_data", "" );
     set_proxy_for_data( str_tmp );
     proxy_port_for_data = cf.get_option_int( "proxy_port_for_data", CONF_PROXY_PORT_FOR_DATA, 1, 65535 );
@@ -670,12 +675,14 @@ void ConfigItems::save_impl( const std::string& path )
     if( proxy_basicauth_for2ch.empty() ) tmp_proxy = proxy_for2ch;
     else tmp_proxy = proxy_basicauth_for2ch + "@" + proxy_for2ch;
     cf.update( "use_proxy_for2ch", use_proxy_for2ch );
+    cf.update( "send_cookie_to_proxy_for2ch", send_cookie_to_proxy_for2ch );
     cf.update( "proxy_for2ch", tmp_proxy );
     cf.update( "proxy_port_for2ch", proxy_port_for2ch );
 
     if( proxy_basicauth_for2ch_w.empty() ) tmp_proxy = proxy_for2ch_w;
     else tmp_proxy = proxy_basicauth_for2ch_w + "@" + proxy_for2ch_w;
     cf.update( "use_proxy_for2ch_w", use_proxy_for2ch_w );
+    cf.update( "send_cookie_to_proxy_for2ch_w", send_cookie_to_proxy_for2ch_w );
     cf.update( "proxy_for2ch_w", tmp_proxy );
     cf.update( "proxy_port_for2ch_w", proxy_port_for2ch_w );
 
@@ -684,6 +691,7 @@ void ConfigItems::save_impl( const std::string& path )
     if( proxy_basicauth_for_data.empty() ) tmp_proxy = proxy_for_data;
     else tmp_proxy = proxy_basicauth_for_data + "@" + proxy_for_data;
     cf.update( "use_proxy_for_data", use_proxy_for_data );
+    cf.update( "send_cookie_to_proxy_for_data", send_cookie_to_proxy_for_data );
     cf.update( "proxy_for_data", tmp_proxy );
     cf.update( "proxy_port_for_data", proxy_port_for_data );
 

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -49,18 +49,21 @@ namespace CONFIG
 
         // 読み込み用プロクシとポート番号
         bool use_proxy_for2ch{};
+        bool send_cookie_to_proxy_for2ch{};
         std::string proxy_for2ch;
         int proxy_port_for2ch{};
         std::string proxy_basicauth_for2ch;
 
         // 書き込み用プロクシとポート番号
         bool use_proxy_for2ch_w{};
+        bool send_cookie_to_proxy_for2ch_w{};
         std::string proxy_for2ch_w;
         int proxy_port_for2ch_w{};
         std::string proxy_basicauth_for2ch_w;
 
         // 2chの外にアクセスするときのプロクシとポート番号
         bool use_proxy_for_data{};
+        bool send_cookie_to_proxy_for_data{};
         std::string proxy_for_data;
         int proxy_port_for_data{};
         std::string proxy_basicauth_for_data;

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -23,10 +23,13 @@ namespace CONFIG
 #endif
         CONF_REF_PREFIX_SPACE = 1, // 参照文字( CONF_REF_PREFIX ) の後のスペースの数
         CONF_USE_PROXY_FOR2CH = 0, // 2ch 読み込み用プロクシを使用するか
+        CONF_SEND_COOKIE_TO_PROXY_FOR2CH = 0, // 2ch 読み込み用プロクシにクッキーを送信するか
         CONF_PROXY_PORT_FOR2CH = 8080, // 2ch 読み込み用プロクシポート番号
         CONF_USE_PROXY_FOR2CH_W = 0, // 2ch 書き込み用プロクシを使用するか
+        CONF_SEND_COOKIE_TO_PROXY_FOR2CH_W = 0, // 2ch 書き込み用プロクシにクッキーを送信するか
         CONF_PROXY_PORT_FOR2CH_W = 8080, // 2ch 書き込み用プロクシポート番号
         CONF_USE_PROXY_FOR_DATA = 0, // 2ch 以外にアクセスするときにプロクシを使用するか
+        CONF_SEND_COOKIE_TO_PROXY_FOR_DATA = 0, // 2ch 以外にアクセスするときのプロクシにクッキーを送信するか
         CONF_PROXY_PORT_FOR_DATA = 8080, // 2ch 以外にアクセスするときのプロクシポート番号
         CONF_LOADER_BUFSIZE = 32,   // ローダのバッファサイズ (一般)
         CONF_LOADER_BUFSIZE_BOARD = 2,   // ローダのバッファサイズ (スレ一覧用)

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -181,26 +181,31 @@ const std::string& CONFIG::get_url_search_web(){ return get_confitem()->url_sear
 const std::string& CONFIG::get_agent_for2ch() { return get_confitem()->agent_for2ch; }
 
 bool CONFIG::get_use_proxy_for2ch() { return get_confitem()->use_proxy_for2ch; }
+bool CONFIG::get_send_cookie_to_proxy_for2ch() { return get_confitem()->send_cookie_to_proxy_for2ch; }
 const std::string& CONFIG::get_proxy_for2ch() { return get_confitem()->proxy_for2ch; }
 int CONFIG::get_proxy_port_for2ch() { return get_confitem()->proxy_port_for2ch; }
 const std::string& CONFIG::get_proxy_basicauth_for2ch() { return get_confitem()->proxy_basicauth_for2ch; }
 
 void CONFIG::set_use_proxy_for2ch( bool set ){ get_confitem()->use_proxy_for2ch = set; }
+void CONFIG::set_send_cookie_to_proxy_for2ch( bool set ){ get_confitem()->send_cookie_to_proxy_for2ch = set; }
 void CONFIG::set_proxy_for2ch( const std::string& proxy ){ get_confitem()->set_proxy_for2ch( proxy ); }
 void CONFIG::set_proxy_port_for2ch( int port ){ get_confitem()->proxy_port_for2ch = port; }
 
 bool CONFIG::get_use_proxy_for2ch_w() { return get_confitem()->use_proxy_for2ch_w; }
+bool CONFIG::get_send_cookie_to_proxy_for2ch_w() { return get_confitem()->send_cookie_to_proxy_for2ch_w; }
 const std::string& CONFIG::get_proxy_for2ch_w() { return get_confitem()->proxy_for2ch_w; }
 int CONFIG::get_proxy_port_for2ch_w() { return get_confitem()->proxy_port_for2ch_w; }
 const std::string& CONFIG::get_proxy_basicauth_for2ch_w() { return get_confitem()->proxy_basicauth_for2ch_w; }
 
 void CONFIG::set_use_proxy_for2ch_w( bool set ){ get_confitem()->use_proxy_for2ch_w = set; }
+void CONFIG::set_send_cookie_to_proxy_for2ch_w( bool set ){ get_confitem()->send_cookie_to_proxy_for2ch_w = set; }
 void CONFIG::set_proxy_for2ch_w( const std::string& proxy ){ get_confitem()->set_proxy_for2ch_w( proxy ); }
 void CONFIG::set_proxy_port_for2ch_w( int port ){ get_confitem()->proxy_port_for2ch_w = port; }
 
 const std::string& CONFIG::get_agent_for_data() { return get_confitem()->agent_for_data; }
 
 bool CONFIG::get_use_proxy_for_data() { return get_confitem()->use_proxy_for_data; }
+bool CONFIG::get_send_cookie_to_proxy_for_data() { return get_confitem()->send_cookie_to_proxy_for_data; }
 const std::string& CONFIG::get_proxy_for_data() { return get_confitem()->proxy_for_data; }
 int CONFIG::get_proxy_port_for_data() { return get_confitem()->proxy_port_for_data; }
 const std::string& CONFIG::get_proxy_basicauth_for_data() { return get_confitem()->proxy_basicauth_for_data; }
@@ -208,6 +213,7 @@ const std::string& CONFIG::get_proxy_basicauth_for_data() { return get_confitem(
 const std::string& CONFIG::get_x_2ch_ua() { return get_confitem()->x_2ch_ua; }
 
 void CONFIG::set_use_proxy_for_data( bool set ){ get_confitem()->use_proxy_for_data = set; }
+void CONFIG::set_send_cookie_to_proxy_for_data( bool set ){ get_confitem()->send_cookie_to_proxy_for_data = set; }
 void CONFIG::set_proxy_for_data( const std::string& proxy ){ get_confitem()->set_proxy_for_data( proxy ); }
 void CONFIG::set_proxy_port_for_data( int port ){ get_confitem()->proxy_port_for_data = port; }
 

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -143,21 +143,25 @@ namespace CONFIG
 
     // 2ch 読み込み用プロクシとポート番号
     bool get_use_proxy_for2ch();
+    bool get_send_cookie_to_proxy_for2ch();
     const std::string& get_proxy_for2ch();
     int get_proxy_port_for2ch();
     const std::string& get_proxy_basicauth_for2ch();
 
     void set_use_proxy_for2ch( const bool set );
+    void set_send_cookie_to_proxy_for2ch( bool set );
     void set_proxy_for2ch( const std::string& proxy );
     void set_proxy_port_for2ch( const int port );
 
     // 2ch 書き込み用プロクシとポート番号
     bool get_use_proxy_for2ch_w();
+    bool get_send_cookie_to_proxy_for2ch_w();
     const std::string& get_proxy_for2ch_w();
     int get_proxy_port_for2ch_w();
     const std::string& get_proxy_basicauth_for2ch_w();
 
     void set_use_proxy_for2ch_w( const bool set );
+    void set_send_cookie_to_proxy_for2ch_w( bool set );
     void set_proxy_for2ch_w( const std::string& proxy );
     void set_proxy_port_for2ch_w( const int port );
 
@@ -166,11 +170,13 @@ namespace CONFIG
 
     // 2chの外にアクセスするときのプロクシとポート番号
     bool get_use_proxy_for_data();
+    bool get_send_cookie_to_proxy_for_data();
     const std::string& get_proxy_for_data();
     int get_proxy_port_for_data();
     const std::string& get_proxy_basicauth_for_data();
 
     void set_use_proxy_for_data( const bool set );
+    void set_send_cookie_to_proxy_for_data( bool set );
     void set_proxy_for_data( const std::string& proxy );
     void set_proxy_port_for_data( const int port );
 

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -116,26 +116,61 @@ std::string Board2ch::get_proxy_basicauth_w()
 }
 
 
-// 読み書き用クッキー作成
-std::string Board2ch::cookie_for_request() const
+// BE 用クッキー作成
+void Board2ch::set_cookie_for_be( std::string& cookie ) const
 {
-#ifdef _DEBUG
-    std::cout << "Board2ch::cookie_for_request\n";
-#endif
-
-    std::string cookie = Board2chCompati::cookie_for_request();
-    if( cookie.empty() ) cookie = get_hap();
-
     // BE ログイン中
-    if( CORE::get_loginbe()->login_now() ){
+    if( CORE::get_loginbe()->login_now() ) {
         if( ! cookie.empty() ) cookie += "; ";
         cookie += "DMDM=" + CORE::get_loginbe()->get_sessionid() + "; MDMD=" + CORE::get_loginbe()->get_sessiondata();
     }
+}
+
+
+//
+// 読み込み用クッキー作成
+//
+// プロキシの2ch読み込み用設定がoffのとき
+// またはプロキシにクッキーを送る設定のときは対象サイトにcookieを送信する
+//
+std::string Board2ch::cookie_for_request() const
+{
+    std::string cookie;
+
+    if( ! CONFIG::get_use_proxy_for2ch() || CONFIG::get_send_cookie_to_proxy_for2ch() ) {
+        cookie = cookie_by_host();
+        if( cookie.empty() ) cookie = get_hap();
+    }
+
+    set_cookie_for_be( cookie );
 
 #ifdef _DEBUG
-    std::cout << "cookie = " << cookie << std::endl;
-#endif 
+    std::cout << "Board2ch::cookie_for_request cookie = " << cookie << std::endl;
+#endif
+    return cookie;
+}
 
+
+//
+// 書き込み用クッキー作成
+//
+// プロキシの2ch書き込み用設定がoffのとき
+// またはプロキシにクッキーを送る設定のときは対象サイトにcookieを送信する
+//
+std::string Board2ch::cookie_for_post() const
+{
+    std::string cookie;
+
+    if( ! CONFIG::get_use_proxy_for2ch_w() || CONFIG::get_send_cookie_to_proxy_for2ch_w() ) {
+        cookie = cookie_by_host();
+        if( cookie.empty() ) cookie = get_hap();
+    }
+
+    set_cookie_for_be( cookie );
+
+#ifdef _DEBUG
+    std::cout << "Board2ch::cookie_for_post cookie = " << cookie << std::endl;
+#endif
     return cookie;
 }
 

--- a/src/dbtree/board2ch.h
+++ b/src/dbtree/board2ch.h
@@ -38,8 +38,10 @@ namespace DBTREE
         int get_proxy_port_w() override;
         std::string get_proxy_basicauth_w() override;
 
-        // 読み書き用クッキー
+        // 読み込み用クッキー
         std::string cookie_for_request() const override;
+        // 書き込み用クッキー
+        std::string cookie_for_post() const override;
 
         // 書き込み時のリファラ
         std::string get_write_referer() override;
@@ -72,6 +74,8 @@ namespace DBTREE
         int get_default_number_max_res() override { return DEFAULT_NUMBER_MAX_2CH; }
 
         ArticleBase* append_article( const std::string& datbase, const std::string& id, const bool cached ) override;
+
+        void set_cookie_for_be( std::string& cookie ) const;
     };
 }
 

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -87,13 +87,6 @@ bool Board2chCompati::is_valid( const std::string& filename )
 }
 
 
-// 読み書き用クッキー作成
-std::string Board2chCompati::cookie_for_request() const
-{
-    return BoardBase::cookie_for_request();
-}
-
-
 // 書き込み時に必要なキーワード( hana=mogera や suka=pontan など )を
 // 確認画面のhtmlから解析する      
 void Board2chCompati::analyze_keyword_for_write( const std::string& html )

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -24,8 +24,10 @@ namespace DBTREE
         Board2chCompati( const std::string& root, const std::string& path_board, const std::string& name, const std::string& basicauth );
         ~Board2chCompati();
 
-        // 読み書き用クッキー
-        std::string cookie_for_request() const override;
+        // 読み込み用クッキー
+        using BoardBase::cookie_for_request;
+        // 書き込み用クッキー
+        using BoardBase::cookie_for_post;
 
         // 書き込み時に必要なキーワード( hana=mogera や suka=pontan など )を
         // 確認画面のhtmlから解析する      

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -276,12 +276,46 @@ std::string BoardBase::get_unicode()
 
 
 // 板のホストを指定してクッキーを取得
-std::string BoardBase::cookie_for_request() const
+std::string BoardBase::cookie_by_host() const
 {
     const JDLIB::CookieManager* cookie_manager = JDLIB::get_cookie_manager();
     const std::string hostname = MISC::get_hostname( get_root(), false );
 
     return cookie_manager->get_cookie_by_host( hostname );
+}
+
+
+//
+// 読み込み用クッキー作成
+//
+// プロキシの読み込み用設定がoffのとき
+// またはプロキシにクッキーを送る設定がonのときはサイトにcookieを送信する
+//
+std::string BoardBase::cookie_for_request() const
+{
+    std::string cookie;
+
+    if( ! CONFIG::get_use_proxy_for_data() || CONFIG::get_send_cookie_to_proxy_for_data() ) {
+        cookie = cookie_by_host();
+    }
+    return cookie;
+}
+
+
+//
+// 書き込み用クッキー作成
+//
+// プロキシの書き込み用設定がoffのとき
+// またはプロキシにクッキーを送る設定がonのときはサイトにcookieを送信する
+//
+std::string BoardBase::cookie_for_post() const
+{
+    std::string cookie;
+
+    if( ! CONFIG::get_use_proxy_for_data() || CONFIG::get_send_cookie_to_proxy_for_data() ) {
+        cookie = cookie_by_host();
+    }
+    return cookie;
 }
 
 

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -325,7 +325,9 @@ namespace DBTREE
         virtual std::string get_unicode();
 
         // 板のホストを指定してクッキーのやり取り
+        std::string cookie_by_host() const;
         virtual std::string cookie_for_request() const;
+        virtual std::string cookie_for_post() const;
         void set_list_cookies( const std::list< std::string >& list_cookies );
         void delete_cookies();
 

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -298,9 +298,21 @@ std::string DBTREE::board_charset( const std::string& url )
 }
 
 
+std::string DBTREE::board_cookie_by_host( const std::string& url )
+{
+    return DBTREE::get_board( url )->cookie_by_host();
+}
+
+
 std::string DBTREE::board_cookie_for_request( const std::string& url )
 {
     return DBTREE::get_board( url )->cookie_for_request();
+}
+
+
+std::string DBTREE::board_cookie_for_post( const std::string& url )
+{
+    return DBTREE::get_board( url )->cookie_for_post();
 }
 
 

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -103,7 +103,9 @@ namespace DBTREE
     std::string board_name( const std::string& url );
     std::string board_subjecttxt( const std::string& url );
     std::string board_charset( const std::string& url );
+    std::string board_cookie_by_host( const std::string& url );
     std::string board_cookie_for_request( const std::string& url );
+    std::string board_cookie_for_post( const std::string& url );
     void board_set_list_cookies( const std::string& url, const std::list< std::string>& list_cookies );
     void board_delete_cookies( const std::string& url );
     std::string board_keyword_for_write( const std::string& url );

--- a/src/dbtree/nodetree2ch.cpp
+++ b/src/dbtree/nodetree2ch.cpp
@@ -189,10 +189,7 @@ void NodeTree2ch::create_loaderdata( JDLIB::LOADERDATA& data )
     data.host_proxy = DBTREE::get_proxy_host( get_url() );
     data.port_proxy = DBTREE::get_proxy_port( get_url() );
     data.basicauth_proxy = DBTREE::get_proxy_basicauth( get_url() );
-    // プロキシの読み込み用設定がonのときスレ読み込みではcookieを送信しない
-    if( ! CONFIG::get_use_proxy_for2ch() ) {
-        data.cookie_for_request = DBTREE::board_cookie_for_request( get_url() );
-    }
+    data.cookie_for_request = DBTREE::board_cookie_for_request( get_url() );
 
     data.size_buf = CONFIG::get_loader_bufsize();
     data.timeout = CONFIG::get_loader_timeout();

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -168,7 +168,7 @@ void Post::post_msg()
     data.basicauth_proxy = DBTREE::get_proxy_basicauth_w( m_url );
     data.size_buf = CONFIG::get_loader_bufsize();
     data.timeout = CONFIG::get_loader_timeout_post();
-    data.cookie_for_request = DBTREE::board_cookie_for_request( m_url );
+    data.cookie_for_request = DBTREE::board_cookie_for_post( m_url );
     data.basicauth = DBTREE::board_basicauth( m_url );
 
 #ifdef _DEBUG

--- a/src/proxypref.h
+++ b/src/proxypref.h
@@ -14,6 +14,9 @@
 
 namespace CORE
 {
+    constexpr const char kSendCookieTooltip[] = "JDimからプロキシへサイトのクッキーを送信します。\n"
+                                                "プロキシのクッキー処理にあわせて設定してください。";
+
     class ProxyFrame : public Gtk::Frame
     {
         Gtk::VBox m_vbox;
@@ -22,17 +25,22 @@ namespace CORE
       public:
 
         Gtk::CheckButton ckbt;
+        Gtk::CheckButton send_cookie_check;
         SKELETON::LabelEntry entry_host;
         SKELETON::LabelEntry entry_port;
 
-        ProxyFrame( const std::string& title, const Glib::ustring& ckbt_label,
+        ProxyFrame( const std::string& title, const Glib::ustring& ckbt_label, const Glib::ustring& send_label,
                     const Glib::ustring& host_label, const Glib::ustring& port_label )
             : ckbt( ckbt_label, true )
-            , entry_host( true, host_label )
+            , send_cookie_check( send_label, true )
+            , entry_host( true, host_label)
             , entry_port( true, port_label )
         {
+            send_cookie_check.set_tooltip_text( kSendCookieTooltip );
+
             m_hbox.set_spacing( 8 );
             m_hbox.pack_start( ckbt, Gtk::PACK_SHRINK );
+            m_hbox.pack_start( send_cookie_check, Gtk::PACK_SHRINK );
             m_hbox.pack_start( entry_host );
             m_hbox.pack_start( entry_port, Gtk::PACK_SHRINK );
 
@@ -64,16 +72,19 @@ namespace CORE
         {
             // 2ch
             CONFIG::set_use_proxy_for2ch( m_frame_2ch.ckbt.get_active() );
+            CONFIG::set_send_cookie_to_proxy_for2ch( m_frame_2ch.send_cookie_check.get_active() );
             CONFIG::set_proxy_for2ch( MISC::remove_space( m_frame_2ch.entry_host.get_text() ) );
             CONFIG::set_proxy_port_for2ch( atoi( m_frame_2ch.entry_port.get_text().c_str() ) );
 
             // 2ch書き込み用
             CONFIG::set_use_proxy_for2ch_w( m_frame_2ch_w.ckbt.get_active() );
+            CONFIG::set_send_cookie_to_proxy_for2ch_w( m_frame_2ch_w.send_cookie_check.get_active() );
             CONFIG::set_proxy_for2ch_w( MISC::remove_space( m_frame_2ch_w.entry_host.get_text() ) );
             CONFIG::set_proxy_port_for2ch_w( atoi( m_frame_2ch_w.entry_port.get_text().c_str() ) );
 
             // 一般
             CONFIG::set_use_proxy_for_data( m_frame_data.ckbt.get_active() );
+            CONFIG::set_send_cookie_to_proxy_for_data( m_frame_data.send_cookie_check.get_active() );
             CONFIG::set_proxy_for_data( MISC::remove_space( m_frame_data.entry_host.get_text() ) );
             CONFIG::set_proxy_port_for_data( atoi( m_frame_data.entry_port.get_text().c_str() ) );
         }
@@ -83,15 +94,18 @@ namespace CORE
         ProxyPref( Gtk::Window* parent, const std::string& url )
             : SKELETON::PrefDiag( parent, url )
             , m_label( "認証を行う場合はホスト名を「ユーザID:パスワード@ホスト名」としてください。" )
-            , m_frame_2ch( "2ch読み込み用", "使用する(_U)", "ホスト名(_H)： ", "ポート番号(_P)： " )
-            , m_frame_2ch_w( "2ch書き込み用", "使用する(_S)", "ホスト名(_N)： ", "ポート番号(_R)： " )
-            , m_frame_data( "その他のサーバ用(板一覧、外部板、画像など)", "使用する(_E)", "ホスト名(_A)： ",
-                            "ポート番号(_T)： " )
+            , m_frame_2ch( "2ch読み込み用", "使用する(_U)", "クッキーを送る(_I)",
+                           "ホスト名(_H)： ", "ポート番号(_P)： " )
+            , m_frame_2ch_w( "2ch書き込み用", "使用する(_S)", "クッキーを送る(_J)",
+                             "ホスト名(_N)： ", "ポート番号(_R)： " )
+            , m_frame_data( "その他のサーバ用(板一覧、外部板、画像など)", "使用する(_E)", "クッキーを送る(_K)",
+                            "ホスト名(_A)： ", "ポート番号(_T)： " )
         {
             std::string host;
 
             // 2ch用
             m_frame_2ch.ckbt.set_active( CONFIG::get_use_proxy_for2ch() );
+            m_frame_2ch.send_cookie_check.set_active( CONFIG::get_send_cookie_to_proxy_for2ch() );
             if( CONFIG::get_proxy_basicauth_for2ch().empty() ) host = CONFIG::get_proxy_for2ch();
             else host = CONFIG::get_proxy_basicauth_for2ch() + "@" + CONFIG::get_proxy_for2ch();
             m_frame_2ch.entry_host.set_text( host );
@@ -102,6 +116,7 @@ namespace CORE
 
             // 2ch書き込み用
             m_frame_2ch_w.ckbt.set_active( CONFIG::get_use_proxy_for2ch_w() );
+            m_frame_2ch_w.send_cookie_check.set_active( CONFIG::get_send_cookie_to_proxy_for2ch_w() );
             if( CONFIG::get_proxy_basicauth_for2ch_w().empty() ) host = CONFIG::get_proxy_for2ch_w();
             else host = CONFIG::get_proxy_basicauth_for2ch_w() + "@" + CONFIG::get_proxy_for2ch_w();
             m_frame_2ch_w.entry_host.set_text( host );
@@ -112,6 +127,7 @@ namespace CORE
 
             // 一般用
             m_frame_data.ckbt.set_active( CONFIG::get_use_proxy_for_data() );
+            m_frame_data.send_cookie_check.set_active( CONFIG::get_send_cookie_to_proxy_for_data() );
             if( CONFIG::get_proxy_basicauth_for_data().empty() ) host = CONFIG::get_proxy_for_data();
             else host = CONFIG::get_proxy_basicauth_for_data() + "@" + CONFIG::get_proxy_for_data();
             m_frame_data.entry_host.set_text( host );

--- a/src/proxypref.h
+++ b/src/proxypref.h
@@ -25,8 +25,11 @@ namespace CORE
         SKELETON::LabelEntry entry_host;
         SKELETON::LabelEntry entry_port;
 
-        ProxyFrame( const std::string& title, const Glib::ustring& ckbt_label, const Glib::ustring& host_label, const Glib::ustring& port_label )
-        : ckbt( ckbt_label, true ), entry_host( true, host_label), entry_port( true, port_label ) 
+        ProxyFrame( const std::string& title, const Glib::ustring& ckbt_label,
+                    const Glib::ustring& host_label, const Glib::ustring& port_label )
+            : ckbt( ckbt_label, true )
+            , entry_host( true, host_label )
+            , entry_port( true, port_label )
         {
             m_hbox.set_spacing( 8 );
             m_hbox.pack_start( ckbt, Gtk::PACK_SHRINK );
@@ -60,20 +63,17 @@ namespace CORE
         void slot_ok_clicked() override
         {
             // 2ch
-            if( m_frame_2ch.ckbt.get_active() ) CONFIG::set_use_proxy_for2ch( true );
-            else CONFIG::set_use_proxy_for2ch( false );
+            CONFIG::set_use_proxy_for2ch( m_frame_2ch.ckbt.get_active() );
             CONFIG::set_proxy_for2ch( MISC::remove_space( m_frame_2ch.entry_host.get_text() ) );
             CONFIG::set_proxy_port_for2ch( atoi( m_frame_2ch.entry_port.get_text().c_str() ) );
 
             // 2ch書き込み用
-            if( m_frame_2ch_w.ckbt.get_active() ) CONFIG::set_use_proxy_for2ch_w( true );
-            else CONFIG::set_use_proxy_for2ch_w( false );
+            CONFIG::set_use_proxy_for2ch_w( m_frame_2ch_w.ckbt.get_active() );
             CONFIG::set_proxy_for2ch_w( MISC::remove_space( m_frame_2ch_w.entry_host.get_text() ) );
             CONFIG::set_proxy_port_for2ch_w( atoi( m_frame_2ch_w.entry_port.get_text().c_str() ) );
 
             // 一般
-            if( m_frame_data.ckbt.get_active() ) CONFIG::set_use_proxy_for_data( true );
-            else CONFIG::set_use_proxy_for_data( false );
+            CONFIG::set_use_proxy_for_data( m_frame_data.ckbt.get_active() );
             CONFIG::set_proxy_for_data( MISC::remove_space( m_frame_data.entry_host.get_text() ) );
             CONFIG::set_proxy_port_for_data( atoi( m_frame_data.entry_port.get_text().c_str() ) );
         }
@@ -81,17 +81,17 @@ namespace CORE
       public:
 
         ProxyPref( Gtk::Window* parent, const std::string& url )
-        : SKELETON::PrefDiag( parent, url ),
-        m_label( "認証を行う場合はホスト名を「ユーザID:パスワード@ホスト名」としてください。" ),
-        m_frame_2ch( "2ch読み込み用", "使用する(_U)", "ホスト名(_H)： ", "ポート番号(_P)： " ), 
-        m_frame_2ch_w( "2ch書き込み用", "使用する(_S)", "ホスト名(_N)： ", "ポート番号(_R)： " ),
-        m_frame_data( "その他のサーバ用(板一覧、外部板、画像など)", "使用する(_E)", "ホスト名(_A)： ", "ポート番号(_T)： " )
+            : SKELETON::PrefDiag( parent, url )
+            , m_label( "認証を行う場合はホスト名を「ユーザID:パスワード@ホスト名」としてください。" )
+            , m_frame_2ch( "2ch読み込み用", "使用する(_U)", "ホスト名(_H)： ", "ポート番号(_P)： " )
+            , m_frame_2ch_w( "2ch書き込み用", "使用する(_S)", "ホスト名(_N)： ", "ポート番号(_R)： " )
+            , m_frame_data( "その他のサーバ用(板一覧、外部板、画像など)", "使用する(_E)", "ホスト名(_A)： ",
+                            "ポート番号(_T)： " )
         {
             std::string host;
 
             // 2ch用
-            if( CONFIG::get_use_proxy_for2ch() ) m_frame_2ch.ckbt.set_active( true );
-            else m_frame_2ch.ckbt.set_active( false );
+            m_frame_2ch.ckbt.set_active( CONFIG::get_use_proxy_for2ch() );
             if( CONFIG::get_proxy_basicauth_for2ch().empty() ) host = CONFIG::get_proxy_for2ch();
             else host = CONFIG::get_proxy_basicauth_for2ch() + "@" + CONFIG::get_proxy_for2ch();
             m_frame_2ch.entry_host.set_text( host );
@@ -101,8 +101,7 @@ namespace CORE
             set_activate_entry( m_frame_2ch.entry_port );
 
             // 2ch書き込み用
-            if( CONFIG::get_use_proxy_for2ch_w() ) m_frame_2ch_w.ckbt.set_active( true );
-            else m_frame_2ch_w.ckbt.set_active( false );
+            m_frame_2ch_w.ckbt.set_active( CONFIG::get_use_proxy_for2ch_w() );
             if( CONFIG::get_proxy_basicauth_for2ch_w().empty() ) host = CONFIG::get_proxy_for2ch_w();
             else host = CONFIG::get_proxy_basicauth_for2ch_w() + "@" + CONFIG::get_proxy_for2ch_w();
             m_frame_2ch_w.entry_host.set_text( host );
@@ -112,8 +111,7 @@ namespace CORE
             set_activate_entry( m_frame_2ch_w.entry_port );
 
             // 一般用
-            if( CONFIG::get_use_proxy_for_data() ) m_frame_data.ckbt.set_active( true );
-            else m_frame_data.ckbt.set_active( false );
+            m_frame_data.ckbt.set_active( CONFIG::get_use_proxy_for_data() );
             if( CONFIG::get_proxy_basicauth_for_data().empty() ) host = CONFIG::get_proxy_for_data();
             else host = CONFIG::get_proxy_basicauth_for_data() + "@" + CONFIG::get_proxy_for_data();
             m_frame_data.entry_host.set_text( host );


### PR DESCRIPTION
#317 の修正です。

プロキシ側のクッキー処理と整合性を取るため書き込み用クッキーの生成処理を読み込み用の処理から分離します。
プロキシ利用がoffのとき、またはプロキシ利用時にプロキシにクッキーを送る設定がonのときはサイトにcookieを送信します。

プロキシ設定にチェック項目「クッキーを送る」を追加します。(初期設定はoff)
チェックを入れるとプロキシ利用時にJDimからプロキシへサイトのクッキーを送信します。
プロキシのクッキー処理にあわせて設定してください。

[![thumb][]][screenshot]

[thumb]: https://i.imgur.com/qplOu2el.png
[screenshot]: https://i.imgur.com/qplOu2e.png
