### PR TITLE
DrawAreaBase: Fix bitwise OR operation to logical OR for if condition

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -4642,7 +4642,7 @@ bool DrawAreaBase::set_selection( const CARET_POSITION& caret_pos, RECTANGLE* re
 
     RECTANGLE* rect_from = layout->rect;
     RECTANGLE* rect_to = layout_to->rect;
-    if( ! rect_from | ! rect_to ) return false;
+    if( ! rect_from || ! rect_to ) return false;
     while( rect_to->next_rect ) rect_to = rect_to->next_rect;
 
     // 範囲外


### PR DESCRIPTION
if文の中で論理和(`||`)であるべき箇所がビット単位和(`|`)になっているとcppcheckに指摘されたため修正します。

cppcheckのレポート
```
src/article/drawareabase.cpp:4645:21: style: Boolean result is used in bitwise operation. Clarify expression with parentheses. [clarifyCondition]
    if( ! rect_from | ! rect_to ) return false;
                    ^
```