### PR TITLE
main: Fix C-style pointer casting

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -194,7 +194,7 @@ void ice_watch_proc( IceConn ice_connect,
                      Bool opening,
                      IcePointer *watch_data )
 {
-    XSMPDATA *xsmpdata = ( XSMPDATA* ) client_data;
+    XSMPDATA *xsmpdata = reinterpret_cast<XSMPDATA*>( client_data );
     xsmpdata->ice_connect = ice_connect;
 
     if( xsmpdata->id_process_message ){


### PR DESCRIPTION
C-styleのポインターキャストを使っているとcppcheckに指摘されたためreinterpret_castを使って修正します。

```
src/main.cpp:197:26: style: C-style pointer casting [cstyleCast]
    XSMPDATA *xsmpdata = ( XSMPDATA* ) client_data;
                         ^
```