### PR TITLE
Update HTTP request for new article creation

### DIFF
--- a/src/dbtree/Makefile.am
+++ b/src/dbtree/Makefile.am
@@ -12,6 +12,7 @@ libdbtree_a_SOURCES = \
 	boardmachi.cpp \
 	boardlocal.cpp \
 \
+	frontloader.cpp \
 	settingloader.cpp \
 	ruleloader.cpp \
 	boardfactory.cpp \
@@ -46,6 +47,7 @@ noinst_HEADERS = \
 	boardjbbs.h \
 	boardmachi.h \
 \
+	frontloader.h \
 	settingloader.h \
 	ruleloader.h \
 	boardfactory.h \

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -6,6 +6,7 @@
 #include "board2ch.h"
 #include "article2ch.h"
 #include "articlehash.h"
+#include "frontloader.h"
 
 #include "config/globalconf.h"
 
@@ -29,7 +30,12 @@ Board2ch::Board2ch( const std::string& root, const std::string& path_board, cons
 }
 
 
-Board2ch::~Board2ch() noexcept = default;
+Board2ch::~Board2ch() noexcept
+{
+    if( m_frontloader ) {
+        m_frontloader->terminate_load();
+    }
+}
 
 
 // ユーザエージェント
@@ -178,6 +184,15 @@ std::string Board2ch::cookie_for_post() const
 std::string Board2ch::get_write_referer()
 {
     return Board2chCompati::get_write_referer();
+}
+
+
+// フロントページのダウンロード
+void Board2ch::download_front()
+{
+    if( ! m_frontloader ) m_frontloader.reset( new FrontLoader( url_boardbase() ) );
+    m_frontloader->reset();
+    m_frontloader->download_text();
 }
 
 

--- a/src/dbtree/board2ch.h
+++ b/src/dbtree/board2ch.h
@@ -9,8 +9,13 @@
 
 #include "board2chcompati.h"
 
+#include <memory>
+
+
 namespace DBTREE
 {
+    class FrontLoader;
+
     enum
     {
         DEFAULT_NUMBER_MAX_2CH = 1000,  // デフォルト最大レス数
@@ -19,6 +24,8 @@ namespace DBTREE
 
     class Board2ch : public Board2chCompati
     {
+        std::unique_ptr<FrontLoader> m_frontloader;
+
       public:
 
         Board2ch( const std::string& root, const std::string& path_board,const std::string& name );
@@ -45,6 +52,9 @@ namespace DBTREE
 
         // 書き込み時のリファラ
         std::string get_write_referer() override;
+
+        // フロントページのダウンロード
+        void download_front() override;
 
         // 新スレ作成用のメッセージ変換
         std::string create_newarticle_message( const std::string& subject, const std::string& name,

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -412,6 +412,9 @@ namespace DBTREE
         // article クラスのポインタ取得
         ArticleBase* get_article_fromURL( const std::string& url );
 
+        // フロントページのダウンロード
+        virtual void download_front() {}
+
         // subject.txt ダウンロード
         // url_update_view : CORE::core_set_command( "update_board" ) を送信するビューのアドレス
         // read_from_cache : まだスレ一覧を開いていないときにキャッシュのsubject.txtを読み込む

--- a/src/dbtree/frontloader.cpp
+++ b/src/dbtree/frontloader.cpp
@@ -1,0 +1,65 @@
+// ライセンス: GPL2
+
+//#define _DEBUG
+#include "jddebug.h"
+
+#include "frontloader.h"
+#include "interface.h"
+
+#include "jdlib/loaderdata.h"
+
+#include "config/globalconf.h"
+
+#include "cache.h"
+
+
+using namespace DBTREE;
+
+
+FrontLoader::FrontLoader( const std::string& url_boadbase )
+    : SKELETON::TextLoader()
+    , m_url_boadbase( url_boadbase )
+{
+}
+
+
+std::string FrontLoader::get_charset()
+{
+    return DBTREE::board_charset( m_url_boadbase );
+}
+
+
+// ロード用データ作成
+void FrontLoader::create_loaderdata( JDLIB::LOADERDATA& data )
+{
+    // 移転処理
+    std::string url_boardbase = DBTREE::url_boardbase( m_url_boadbase );
+    if( m_url_boadbase != url_boardbase ) m_url_boadbase = url_boardbase;
+
+    data.url = get_url();
+    data.agent = DBTREE::get_agent( m_url_boadbase );
+    data.host_proxy = DBTREE::get_proxy_host( m_url_boadbase );
+    data.port_proxy = DBTREE::get_proxy_port( m_url_boadbase );
+    data.basicauth_proxy = DBTREE::get_proxy_basicauth( m_url_boadbase );
+    data.size_buf = CONFIG::get_loader_bufsize();
+    data.timeout = CONFIG::get_loader_timeout();
+    if( ! get_date_modified().empty() ) data.modified = get_date_modified();
+    data.basicauth = DBTREE::board_basicauth( m_url_boadbase );
+    data.cookie_for_request = DBTREE::board_cookie_for_request( m_url_boadbase );
+}
+
+
+// ロード後に呼び出される
+void FrontLoader::parse_data()
+{
+    // フロントページからキーワードを解析して登録する
+    if( ! get_data().empty() ) {
+        DBTREE::board_analyze_keyword_for_newarticle( m_url_boadbase, get_data() );
+    }
+}
+
+
+void FrontLoader::receive_cookies()
+{
+    DBTREE::board_set_list_cookies( m_url_boadbase, SKELETON::Loadable::cookies() );
+}

--- a/src/dbtree/frontloader.h
+++ b/src/dbtree/frontloader.h
@@ -1,0 +1,47 @@
+// ライセンス: GPL2
+//
+// 板のフロントページのローダー
+//
+
+#ifndef JDIM_FRONTLOADER_H
+#define JDIM_FRONTLOADER_H
+
+#include "skeleton/textloader.h"
+
+#include <string>
+
+namespace JDLIB
+{
+    class LOADERDATA;
+}
+
+namespace DBTREE
+{
+    class FrontLoader : public SKELETON::TextLoader
+    {
+        std::string m_url_boadbase;
+
+      public:
+
+        FrontLoader( const std::string& url_boardbase );
+        ~FrontLoader() = default;
+
+      protected:
+
+        std::string get_url() override { return m_url_boadbase; }
+        std::string get_path() override { return {}; } // キャッシュには保存しない
+        std::string get_charset() override;
+
+        // ロード用データ作成
+        void create_loaderdata( JDLIB::LOADERDATA& data ) override;
+
+        // ロード後に呼び出される
+        void parse_data() override;
+
+      private:
+
+        void receive_cookies() override;
+    };
+}
+
+#endif // JDIM_FRONTLOADER_H

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -398,6 +398,12 @@ void DBTREE::board_save_info( const std::string& url )
 }
 
 
+void DBTREE::board_download_front( const std::string& url )
+{
+    DBTREE::get_board( url )->download_front();
+}
+
+
 void DBTREE::board_download_subject( const std::string& url, const std::string& url_update_view )
 {
     DBTREE::get_board( url )->download_subject( url_update_view, false );

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -120,6 +120,7 @@ namespace DBTREE
     int board_code( const std::string& url );
     std::string board_str_code( const std::string& url );
     void board_save_info( const std::string& url );
+    void board_download_front( const std::string& url );
     void board_download_subject( const std::string& url, const std::string& url_update_view );
     void board_read_subject_from_cache( const std::string& url );
     bool board_is_loading( const std::string& url );

--- a/src/message/messageview.cpp
+++ b/src/message/messageview.cpp
@@ -153,6 +153,9 @@ void MessageViewMain::reload()
 
     // メインウィンドウのタイトルに表示する文字
     set_title( "[ 新スレ作成 ] " + DBTREE::article_subject( get_url() ) );
+
+    // 板のフロントページをダウンロードしてスレ立てに使うキーワードを更新する
+    DBTREE::board_download_front( get_url() );
 }
 
 

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -404,6 +404,10 @@ void Post::receive_finish()
 #endif        
 
         DBTREE::article_update_writetime( m_url );
+        if( m_new_article ) {
+            // 板のフロントページをダウンロードしてスレ立てに使うキーワードを更新する
+            DBTREE::board_download_front( m_url );
+        }
         emit_sigfin();
         return;
     }


### PR DESCRIPTION
Fixes #317

新スレ作成時の書き込みメッセージ作成を更新します。
対応サイトでは板のフロントページを読み込む処理を追加してスレ立て用キーワードを解析します。

読み込みは以下の状況で行われます。ただし、受信したデータが空の時はキーワードの更新をしません。
- 書き込みビューを開く
- スレ立てに成功する
