### PR TITLE
image: Replace printf format for image size with std::to_string()

### DIFF
--- a/src/image/imageview.cpp
+++ b/src/image/imageview.cpp
@@ -364,13 +364,10 @@ void ImageViewMain::show_status()
 
             m_length_prev = get_img()->current_length();
 
-            char tmpstr[ 256 ];
-#ifdef _WIN32
-            snprintf( tmpstr, sizeof( tmpstr ), "%u / %u KiB", m_length_prev/1024, get_img()->total_length()/1024 );
-#else
-            snprintf( tmpstr, sizeof( tmpstr ), "%zu / %zu KiB", m_length_prev/1024, get_img()->total_length()/1024 );
-#endif
-            tmpstr[ sizeof( tmpstr ) - 1 ] = '\0';
+            std::string tmpstr = std::to_string( m_length_prev / 1024 );
+            tmpstr.append( " / " );
+            tmpstr.append( std::to_string( get_img()->total_length() / 1024 ) );
+            tmpstr.append( " KiB" );
             set_status_local( tmpstr );
             add_tab_number();
 

--- a/src/image/imageviewpopup.cpp
+++ b/src/image/imageviewpopup.cpp
@@ -318,13 +318,10 @@ void ImageViewPopup::update_label()
 
         m_length_prev = get_img()->current_length();
 
-        char tmpstr[ 256 ];
-#if _WIN32
-        snprintf( tmpstr, sizeof( tmpstr ), "%u / %u KiB", m_length_prev/1024, get_img()->total_length()/1024 );
-#else
-        snprintf( tmpstr, sizeof( tmpstr ), "%zu / %zu KiB", m_length_prev/1024, get_img()->total_length()/1024 );
-#endif
-        tmpstr[ sizeof( tmpstr ) - 1 ] = '\0';
+        std::string tmpstr = std::to_string( m_length_prev / 1024 );
+        tmpstr.append( " / " );
+        tmpstr.append( std::to_string( get_img()->total_length() / 1024 ) );
+        tmpstr.append( " KiB" );
         m_label->set_text( tmpstr );
     }
 }


### PR DESCRIPTION
画像サイズ表示の書式フラグと変数の型の符号が異なっているとcppcheckに指摘されたためstd::to_string()を使って修正します。

cppcheckのレポート
```
src/image/imageviewpopup.cpp:323:9: portability: %u in format string (no. 1) requires 'unsigned int' but the argument type is 'size_t {aka unsigned long}'. [invalidPrintfArgType_uint]
        snprintf( tmpstr, sizeof( tmpstr ), "%u / %u KiB", m_length_prev/1024, get_img()->total_length()/1024 );
        ^
src/image/imageview.cpp:369:13: portability: %u in format string (no. 1) requires 'unsigned int' but the argument type is 'size_t {aka unsigned long}'. [invalidPrintfArgType_uint]
            snprintf( tmpstr, sizeof( tmpstr ), "%u / %u KiB", m_length_prev/1024, get_img()->total_length()/1024 );
            ^
```