### PR TITLE
JDEntry: Use member initializer

### DIFF
--- a/src/skeleton/entry.h
+++ b/src/skeleton/entry.h
@@ -24,7 +24,7 @@ namespace SKELETON
 
         // 入力コントローラ
         CONTROL::Control m_control;
-        int m_controlid;
+        int m_controlid{};
 
       public:
 


### PR DESCRIPTION
privateメンバが存在するのにコンストラクタが無いとcppcheckに指摘されたためデフォルトメンバ初期化子を指定して修正します。

cppcheckのレポート
```
src/skeleton/entry.h:15:5: style: The class 'JDEntry' does not have a constructor although it has private member variables. [noConstructor]
    class JDEntry : public Gtk::Entry
    ^
```