### PR TITLE
misc: Remove redundant condition for NUL character check

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -61,7 +61,7 @@ std::list< std::string > MISC::get_elisp_lists( const std::string& str )
     while( data[ pos ] != '\0' ){
 
         // 空白削除
-        while( data[ pos ] == ' ' && data[ pos ] != '\0' ) ++pos;
+        while( data[ pos ] == ' ' ) ++pos;
         if( data[ pos ] == '\0' ) break;
 
         length = 1;


### PR DESCRIPTION
条件文の中でヌル文字チェックが常にtrueになるとcppcheckに指摘されたため当該の部分を削除します。

cppcheckのレポート
```
src/jdlib/miscutil.cpp:64:35: style: Redundant condition: If 'EXPR == ' '', the comparison 'EXPR != '\0'' is always true. [redundantCondition]
        while( data[ pos ] == ' ' && data[ pos ] != '\0' ) ++pos;
                                  ^
```