### PR TITLE
Rename local variable names to avoid shadowing

### DIFF
--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -3052,7 +3052,7 @@ void BBSListViewBase::remove_item( const std::string& url )
     for( ; ! it.end(); ++it ){
 
         Gtk::TreeModel::Row row = *it;
-        const Glib::ustring url = row[ m_columns.m_url ];
+        const Glib::ustring& url_row = row[ m_columns.m_url ];
         const int type = row[ m_columns.m_type ];
 
         switch( type ){
@@ -3066,9 +3066,9 @@ void BBSListViewBase::remove_item( const std::string& url )
 
             case TYPE_IMAGE: // 画像
 
-                if( url == url_target ){
+                if( url_row.raw() == url_target ){
 #ifdef _DEBUG
-                    std::cout << "hit " << url << " == " << url_target << std::endl;
+                    std::cout << "hit " << url_row << " == " << url_target << std::endl;
                     std::cout << row2name( row ) << std::endl;
 #endif
                     list_path.push_back( it.get_path() );

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -576,13 +576,10 @@ std::list< int > NodeTreeBase::get_res_query( const std::string& query, const bo
     const bool wchar = true; // 全角半角の区別をしない
 
     const std::list< std::string > list_query = MISC::split_line( query );
-    std::list< std::string >::const_iterator it_query;
-    for( it_query = list_query.begin(); it_query != list_query.end() ; ++it_query ){
+    for( const std::string& keyword : list_query ) {
 
-        const std::string &query = ( *it_query );
-        
         list_regex.push_back( JDLIB::Regex() );
-        list_regex.back().compile( query, icase, newline, usemigemo, wchar );
+        list_regex.back().compile( keyword, icase, newline, usemigemo, wchar );
     }
 
     for( int i = 1; i <= m_id_header ; ++i ){


### PR DESCRIPTION
ローカル変数をシャドーイングしているとcppcheckから指摘されたため内側のスコープにある変数名を変更します。

cppcheckのレポート
```
src/bbslist/bbslistviewbase.cpp:3055:29: style: Local variable 'url' shadows outer argument [shadowArgument]
        const Glib::ustring url = row[ m_columns.m_url ];
                            ^
src/dbtree/nodetreebase.cpp:582:28: style: Local variable 'query' shadows outer argument [shadowArgument]
        const std::string &query = ( *it_query );
                           ^
```