### PR TITLE
Dom: Fix comparison condition for unsigned integer

### DIFF
--- a/src/xml/dom.cpp
+++ b/src/xml/dom.cpp
@@ -205,7 +205,7 @@ void Dom::parse( const std::string& str )
                     else if( close_tag.compare( 0, name.length() + 1, "/" + name ) == 0 ) --count;
 
                     // 終了タグを見つける必要数が 0 になったらループを抜ける
-                    if( count <= 0 ) break;
+                    if( count == 0 ) break;
                 }
 
                 // 必要な終了タグが見付からないまま上記のループを抜けた場合は、全体のループを抜ける


### PR DESCRIPTION
符号なし整数で負の数を想定した比較になっているとcppcheckに指摘されたため条件文を修正します。

cppcheckのレポート
```
src/xml/dom.cpp:208:31: style: Checking if unsigned expression 'count' is less than zero. [unsignedLessThanZero]
                    if( count <= 0 ) break;
                              ^
```