### PR TITLE
DrawAreaBase: Use standard library math functions

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -3507,8 +3507,11 @@ void DrawAreaBase::exec_scroll()
 
                 // この辺の式は経験的に決定
                 if( -AUTOSCR_CIRCLE/4 <= dy && dy <= AUTOSCR_CIRCLE/4 ) dy = 0;
-                else dy =  ( dy / fabs( dy ) ) * MIN( ( exp( ( fabs( dy ) - AUTOSCR_CIRCLE/4 ) /50 ) -1 ) * 5,
-                                                      adjust->get_page_size() * 3 );
+                else {
+                    dy = std::copysign( std::fmin( std::expm1( ( std::fabs( dy ) - AUTOSCR_CIRCLE/4 ) /50 ) * 5,
+                                                   adjust->get_page_size() * 3 ),
+                                        dy );
+                }
                 if( m_drugging ) dy *= 4;  // 範囲選択中ならスピード上げる
             }
 


### PR DESCRIPTION
特定の式で標準ライブラリの数学関数が使えるとcppcheckに指摘されたためコードを修正します。

- `( dy / fabs( dy ) ) * X` -> `std::copysign( X, dy )`
- `MIN( X, Y )` -> `std::fmin( X, Y )`
- `exp( X ) -1` -> `std::expm1( X )`

cppcheckのレポート
```
src/article/drawareabase.cpp:3510:57: style: Expression 'exp(x) - 1' can be replaced by 'expm1(x)' to avoid loss of precision. [unpreciseMathCall]
                else dy =  ( dy / fabs( dy ) ) * MIN( ( exp( ( fabs( dy ) - AUTOSCR_CIRCLE/4 ) /50 ) -1 ) * 5,
                                                                        ^
```