### PR TITLE
Use STL Algorithm for raw loops

### DIFF
--- a/src/jdlib/confloader.cpp
+++ b/src/jdlib/confloader.cpp
@@ -69,7 +69,7 @@ void ConfLoader::save()
     std::string str_conf;
 
     for( const ConfData& conf : m_data ) {
-        str_conf += conf.name + " = " + conf.value + "\n";
+        str_conf.append( conf.name + " = " + conf.value + "\n" );
     }
 
 #ifdef _DEBUG
@@ -88,11 +88,11 @@ void ConfLoader::update( const std::string& name, const std::string& value )
 {
     if( name.empty() ) return;
 
-    for( ConfData& conf : m_data ) {
-        if( conf.name == name ) {
-            conf.value = value;
-            return;
-        }
+    auto it = std::find_if( m_data.begin(), m_data.end(),
+                            [&name]( const ConfData& c ) { return c.name == name; } );
+    if( it != m_data.end() ) {
+        it->value = value;
+        return;
     }
 
     // 追加

--- a/src/xml/document.cpp
+++ b/src/xml/document.cpp
@@ -113,22 +113,15 @@ void Document::set_treestore( Glib::RefPtr< Gtk::TreeStore >& treestore, SKELETO
 //
 // ルート要素を取得
 //
+// node_name : 要素名で限定、空の時は要素名問わず取得
+//
 Dom* Document::get_root_element( const std::string& node_name ) const
 {
-    Dom* node = nullptr;
+    const std::list<Dom*> children = childNodes();
+    auto it = std::find_if( children.cbegin(), children.cend(),
+                            []( const Dom* c ) { return c->nodeType() == NODE_TYPE_ELEMENT; } );
 
-    for( Dom* child : childNodes() )
-    {
-        if( child->nodeType() == NODE_TYPE_ELEMENT )
-        {
-            // 要素名問わず
-            if( node_name.empty() ) node = child;
-            // 要素名限定
-            else if( child->nodeName() == node_name ) node = child;
-
-            break;
-        }
-    }
-
-    return node;
+    if( it != children.cend()
+        && ( node_name.empty() || (*it)->nodeName() == node_name ) ) return *it;
+    return nullptr;
 }


### PR DESCRIPTION
生のループに対してSTLアルゴリズム関数を使用することをcppcheckに指摘されたため修正します。

cppcheckのレポート
```
src/jdlib/confloader.cpp:72:18: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]
        str_conf += conf.name + " = " + conf.value + "\n";
                 ^
src/jdlib/confloader.cpp:92:33: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
        if( conf.name == name ) {
                                ^
src/xml/document.cpp:123:9: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
        {
        ^
```