### PR TITLE
Fix re-assign value before the old one is used

### DIFF
--- a/src/article/preference.cpp
+++ b/src/article/preference.cpp
@@ -143,7 +143,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
         int save = 0;
         for( const int res : tmp_set ) {
             if( !pre_res ) {
-                pre_res = save = res;
+                save = res;
             }
             else if( res - pre_res > 1 ) {
                 str_res.append( std::to_string( save ) );

--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -368,7 +368,7 @@ CSS_PROPERTY Css_Manager::create_property( std::map< std::string, std::string >&
             {
                 css.border_left_width_em = size;
                 css.border_right_width_em = size;
-                css.border_right_width_em = size;
+                css.border_top_width_em = size;
                 css.border_bottom_width_em = size;
             }
             else
@@ -421,7 +421,7 @@ CSS_PROPERTY Css_Manager::create_property( std::map< std::string, std::string >&
             {
                 css.mrg_left_em = size;
                 css.mrg_right_em = size;
-                css.mrg_right_em = size;
+                css.mrg_top_em = size;
                 css.mrg_bottom_em = size;
             }
             else

--- a/src/dbimg/img.cpp
+++ b/src/dbimg/img.cpp
@@ -864,7 +864,7 @@ void Img::save_info()
     }
 
     if( m_protect ) path_info = CACHE::path_img_protect_info( m_url );
-    if( m_abone ) path_info = CACHE::path_img_abone( m_url );
+    else if( m_abone ) path_info = CACHE::path_img_abone( m_url );
     else path_info = CACHE::path_img_info( m_url );
 
     std::ostringstream oss;


### PR DESCRIPTION
古い値を使用する前に再度変数に代入しているとcppcheckい指摘されたため修正します。

- `src/article/preference.cpp` は二度代入していたので削除
- `src/cssmanager.cpp` は変数名の間違いを修正
- `src/dbimg/img.cpp` は条件が重ならないためelse ifに変更

cppcheckのレポート
```
src/article/preference.cpp:154:21: style: Variable 'pre_res' is reassigned a value before the old one has been used. [redundantAssignment]
            pre_res = res;
                    ^
src/article/preference.cpp:146:25: note: pre_res is assigned
                pre_res = save = res;
                        ^
src/article/preference.cpp:154:21: note: pre_res is overwritten
            pre_res = res;
                    ^
src/cssmanager.cpp:371:43: style: Variable 'css.border_right_width_em' is reassigned a value before the old one has been used. [redundantAssignment]
                css.border_right_width_em = size;
                                          ^
src/cssmanager.cpp:370:43: note: css.border_right_width_em is assigned
                css.border_right_width_em = size;
                                          ^
src/cssmanager.cpp:371:43: note: css.border_right_width_em is overwritten
                css.border_right_width_em = size;
                                          ^
src/cssmanager.cpp:424:34: style: Variable 'css.mrg_right_em' is reassigned a value before the old one has been used. [redundantAssignment]
                css.mrg_right_em = size;
                                 ^
src/cssmanager.cpp:423:34: note: css.mrg_right_em is assigned
                css.mrg_right_em = size;
                                 ^
src/cssmanager.cpp:424:34: note: css.mrg_right_em is overwritten
                css.mrg_right_em = size;
                                 ^
src/dbimg/img.cpp:867:29: style: Variable 'path_info' is reassigned a value before the old one has been used. [redundantAssignment]
    if( m_abone ) path_info = CACHE::path_img_abone( m_url );
                            ^
src/dbimg/img.cpp:866:31: note: path_info is assigned
    if( m_protect ) path_info = CACHE::path_img_protect_info( m_url );
                              ^
src/dbimg/img.cpp:867:29: note: path_info is overwritten
    if( m_abone ) path_info = CACHE::path_img_abone( m_url );
                            ^
```