### PR TITLE
Remove unnecessary condition for assigning value

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -5442,8 +5442,8 @@ bool DrawAreaBase::slot_motion_notify_event( GdkEventMotion* event )
                m_scrollinfo.counter_nomotion - abs( m_scrollinfo.x - m_x_pointer ) - abs( m_scrollinfo.y - m_y_pointer )
             );
 
-        if( m_scrollinfo.x != m_x_pointer ) m_scrollinfo.x = m_x_pointer;
-        if( m_scrollinfo.y != m_y_pointer ) m_scrollinfo.y = m_y_pointer;
+        m_scrollinfo.x = m_x_pointer;
+        m_scrollinfo.y = m_y_pointer;
 
 #ifdef _DEBUG
         std::cout << " -> " << m_scrollinfo.counter_nomotion << std::endl;

--- a/src/dbtree/frontloader.cpp
+++ b/src/dbtree/frontloader.cpp
@@ -33,8 +33,7 @@ std::string FrontLoader::get_charset()
 void FrontLoader::create_loaderdata( JDLIB::LOADERDATA& data )
 {
     // 移転処理
-    std::string url_boardbase = DBTREE::url_boardbase( m_url_boadbase );
-    if( m_url_boadbase != url_boardbase ) m_url_boadbase = url_boardbase;
+    m_url_boadbase = DBTREE::url_boardbase( m_url_boadbase );
 
     data.url = get_url();
     data.agent = DBTREE::get_agent( m_url_boadbase );

--- a/src/dbtree/ruleloader.cpp
+++ b/src/dbtree/ruleloader.cpp
@@ -62,8 +62,7 @@ void RuleLoader::create_loaderdata( JDLIB::LOADERDATA& data )
     else{
 
         // 移転処理
-        std::string url_boardbase = DBTREE::url_boardbase( m_url_boadbase );
-        if( m_url_boadbase != url_boardbase ) m_url_boadbase = url_boardbase;
+        m_url_boadbase = DBTREE::url_boardbase( m_url_boadbase );
 
         data.url = get_url();
         data.agent = DBTREE::get_agent( m_url_boadbase );

--- a/src/dbtree/settingloader.cpp
+++ b/src/dbtree/settingloader.cpp
@@ -64,8 +64,7 @@ void SettingLoader::create_loaderdata( JDLIB::LOADERDATA& data )
     else{
 
         // 移転処理
-        std::string url_boardbase = DBTREE::url_boardbase( m_url_boadbase );
-        if( m_url_boadbase != url_boardbase ) m_url_boadbase = url_boardbase;
+        m_url_boadbase = DBTREE::url_boardbase( m_url_boadbase );
 
         data.url = get_url();
         data.agent = DBTREE::get_agent( m_url_boadbase );

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -66,13 +66,13 @@ int get_uptodate_type( const std::string& url, const int type_org )
     if( type == TYPE_BOARD || type == TYPE_BOARD_UPDATE ){
 
         if( DBTREE::board_status( url ) & STATUS_UPDATE ) type = TYPE_BOARD_UPDATE;
-        else if( type != TYPE_BOARD ) type = TYPE_BOARD;
+        else type = TYPE_BOARD;
     }
     else if( type == TYPE_THREAD || type == TYPE_THREAD_UPDATE || type == TYPE_THREAD_OLD ){
 
         if( DBTREE::article_status( url ) & STATUS_OLD ) type = TYPE_THREAD_OLD;
         else if( DBTREE::article_status( url ) & STATUS_UPDATE ) type = TYPE_THREAD_UPDATE;
-        else if( type != TYPE_THREAD ) type = TYPE_THREAD;
+        else type = TYPE_THREAD;
     }
 
     return type;


### PR DESCRIPTION
条件に関係なく代入の結果と同じになるとcppcheckに指摘されたため代入の条件文を削除します。

cppcheckのレポート
```
src/article/drawareabase.cpp:5442:28: style: The statement 'if (m_scrollinfo.x!=m_x_pointer) m_scrollinfo.x=m_x_pointer' is logically equivalent to 'm_scrollinfo.x=m_x_pointer'. [duplicateConditionalAssign]
        if( m_scrollinfo.x != m_x_pointer ) m_scrollinfo.x = m_x_pointer;
                           ^
src/article/drawareabase.cpp:5442:60: note: Assignment 'm_scrollinfo.x=m_x_pointer'
        if( m_scrollinfo.x != m_x_pointer ) m_scrollinfo.x = m_x_pointer;
                                                           ^
src/article/drawareabase.cpp:5442:28: note: Condition 'm_scrollinfo.x!=m_x_pointer' is redundant
        if( m_scrollinfo.x != m_x_pointer ) m_scrollinfo.x = m_x_pointer;
                           ^
src/article/drawareabase.cpp:5443:28: style: The statement 'if (m_scrollinfo.y!=m_y_pointer) m_scrollinfo.y=m_y_pointer' is logically equivalent to 'm_scrollinfo.y=m_y_pointer'. [duplicateConditionalAssign]
        if( m_scrollinfo.y != m_y_pointer ) m_scrollinfo.y = m_y_pointer;
                           ^
src/article/drawareabase.cpp:5443:60: note: Assignment 'm_scrollinfo.y=m_y_pointer'
        if( m_scrollinfo.y != m_y_pointer ) m_scrollinfo.y = m_y_pointer;
                                                           ^
src/article/drawareabase.cpp:5443:28: note: Condition 'm_scrollinfo.y!=m_y_pointer' is redundant
        if( m_scrollinfo.y != m_y_pointer ) m_scrollinfo.y = m_y_pointer;
                           ^
src/dbtree/frontloader.cpp:37:24: style: The statement 'if (m_url_boadbase!=url_boardbase) m_url_boadbase=url_boardbase' is logically equivalent to 'm_url_boadbase=url_boardbase'. [duplicateConditionalAssign]
    if( m_url_boadbase != url_boardbase ) m_url_boadbase = url_boardbase;
                       ^
src/dbtree/frontloader.cpp:37:58: note: Assignment 'm_url_boadbase=url_boardbase'
    if( m_url_boadbase != url_boardbase ) m_url_boadbase = url_boardbase;
                                                         ^
src/dbtree/frontloader.cpp:37:24: note: Condition 'm_url_boadbase!=url_boardbase' is redundant
    if( m_url_boadbase != url_boardbase ) m_url_boadbase = url_boardbase;
                       ^
src/dbtree/ruleloader.cpp:66:28: style: The statement 'if (m_url_boadbase!=url_boardbase) m_url_boadbase=url_boardbase' is logically equivalent to 'm_url_boadbase=url_boardbase'. [duplicateConditionalAssign]
        if( m_url_boadbase != url_boardbase ) m_url_boadbase = url_boardbase;
                           ^
src/dbtree/ruleloader.cpp:66:62: note: Assignment 'm_url_boadbase=url_boardbase'
        if( m_url_boadbase != url_boardbase ) m_url_boadbase = url_boardbase;
                                                             ^
src/dbtree/ruleloader.cpp:66:28: note: Condition 'm_url_boadbase!=url_boardbase' is redundant
        if( m_url_boadbase != url_boardbase ) m_url_boadbase = url_boardbase;
                           ^
src/dbtree/settingloader.cpp:68:28: style: The statement 'if (m_url_boadbase!=url_boardbase) m_url_boadbase=url_boardbase' is logically equivalent to 'm_url_boadbase=url_boardbase'. [duplicateConditionalAssign]
        if( m_url_boadbase != url_boardbase ) m_url_boadbase = url_boardbase;
                           ^
src/dbtree/settingloader.cpp:68:62: note: Assignment 'm_url_boadbase=url_boardbase'
        if( m_url_boadbase != url_boardbase ) m_url_boadbase = url_boardbase;
                                                             ^
src/dbtree/settingloader.cpp:68:28: note: Condition 'm_url_boadbase!=url_boardbase' is redundant
        if( m_url_boadbase != url_boardbase ) m_url_boadbase = url_boardbase;
                           ^
src/skeleton/edittreeview.cpp:69:23: style: The statement 'if (type!=TYPE_BOARD) type=TYPE_BOARD' is logically equivalent to 'type=TYPE_BOARD'. [duplicateConditionalAssign]
        else if( type != TYPE_BOARD ) type = TYPE_BOARD;
                      ^
src/skeleton/edittreeview.cpp:69:44: note: Assignment 'type=TYPE_BOARD'
        else if( type != TYPE_BOARD ) type = TYPE_BOARD;
                                           ^
src/skeleton/edittreeview.cpp:69:23: note: Condition 'type!=TYPE_BOARD' is redundant
        else if( type != TYPE_BOARD ) type = TYPE_BOARD;
                      ^
src/skeleton/edittreeview.cpp:75:23: style: The statement 'if (type!=TYPE_THREAD) type=TYPE_THREAD' is logically equivalent to 'type=TYPE_THREAD'. [duplicateConditionalAssign]
        else if( type != TYPE_THREAD ) type = TYPE_THREAD;
                      ^
src/skeleton/edittreeview.cpp:75:45: note: Assignment 'type=TYPE_THREAD'
        else if( type != TYPE_THREAD ) type = TYPE_THREAD;
                                            ^
src/skeleton/edittreeview.cpp:75:23: note: Condition 'type!=TYPE_THREAD' is redundant
        else if( type != TYPE_THREAD ) type = TYPE_THREAD;
                      ^
```