### PR TITLE
Remove unused local variables

### DIFF
--- a/src/article/embeddedimage.cpp
+++ b/src/article/embeddedimage.cpp
@@ -132,7 +132,6 @@ void EmbeddedImage::resize_thread()
     const int width = m_img->get_width_emb();
     const int height = m_img->get_height_emb();
 
-    std::string errmsg;
     bool pixbufonly = true;
 
     if( m_img->get_type() == DBIMG::T_BMP ) pixbufonly = false; // BMP の場合 pixbufonly = true にすると真っ黒になる

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -3001,8 +3001,6 @@ void BBSListViewBase::get_threads( const size_t dirid, std::vector< std::string 
     std::cout << "BBSListViewBase::get_threads " << dirid << std::endl;
 #endif
 
-    std::list< Gtk::TreePath > list_path;
-
     Gtk::TreePath path = m_treeview.dirid_to_path( dirid );
     if( dirid && path.empty() ) return;
 

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -482,9 +482,6 @@ bool ConfigItems::load( const bool restore )
     // ツールバーの背景描画
     draw_toolbarback = cf.get_option_bool( "draw_toolbarback", CONF_DRAW_TOOLBARBACK );
 
-    std::list< std::string > list_tmp;
-    std::list< std::string >::iterator it_tmp;
-
     // スレ あぼーん word
     str_tmp = cf.get_option_str( "abonewordthread", "" );
     if( ! str_tmp.empty() ) list_abone_word_thread = MISC::strtolist( str_tmp );

--- a/src/dbimg/img.cpp
+++ b/src/dbimg/img.cpp
@@ -777,8 +777,6 @@ void Img::read_info()
 */
         // TODO : JDLIB::ConfLoaderFast を作る
         std::string str_info, str_tmp;
-        std::list< std::string > list_tmp;
-        std::list< std::string >::iterator it_tmp;
         CACHE::load_rawdata( path_info, str_info );
 
         std::list< std::string > lines = MISC::get_lines( str_info );

--- a/src/globalabonethreadpref.h
+++ b/src/globalabonethreadpref.h
@@ -62,7 +62,7 @@ namespace CORE
         GlobalAboneThreadPref( Gtk::Window* parent, const std::string& url )
         : SKELETON::PrefDiag( parent, url )
         {
-            std::string str_name, str_word, str_regex;
+            std::string str_word, str_regex;
             std::list< std::string >::iterator it;
 
             // スレ数、時間


### PR DESCRIPTION
未使用の変数が存在するとcppcheckに指摘されたため削除します。

cppcheckのレポート
```
src/article/embeddedimage.cpp:135:17: style: Unused variable: errmsg [unusedVariable]
    std::string errmsg;
                ^
src/config/configitems.cpp:485:30: style: Unused variable: list_tmp [unusedVariable]
    std::list< std::string > list_tmp;
                             ^
src/config/configitems.cpp:486:40: style: Unused variable: it_tmp [unusedVariable]
    std::list< std::string >::iterator it_tmp;
                                       ^
src/bbslist/bbslistviewbase.cpp:3004:32: style: Unused variable: list_path [unusedVariable]
    std::list< Gtk::TreePath > list_path;
                               ^
src/dbimg/img.cpp:780:34: style: Unused variable: list_tmp [unusedVariable]
        std::list< std::string > list_tmp;
                                 ^
src/dbimg/img.cpp:781:44: style: Unused variable: it_tmp [unusedVariable]
        std::list< std::string >::iterator it_tmp;
                                           ^
src/globalabonethreadpref.h:65:25: style: Unused variable: str_name [unusedVariable]
            std::string str_name, str_word, str_regex;
                        ^
```