### PR TITLE
Unite if-statement blocks for same condition

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -670,11 +670,13 @@ const char* ArticleViewBase::get_menu_item( const int item )
 //
 int ArticleViewBase::width_client() const
 {
+    if( m_drawarea ) {
+        const int width_client = m_drawarea->width_client();
 #ifdef _DEBUG
-    if( m_drawarea ) std::cout << "ArticleViewBase::width_client : " << m_drawarea->width_client() << std::endl;
+        std::cout << "ArticleViewBase::width_client : " << width_client << std::endl;
 #endif
-
-    if( m_drawarea ) return m_drawarea->width_client();
+        return width_client;
+    }
 
     return SKELETON::View::width_client();
 }
@@ -685,11 +687,15 @@ int ArticleViewBase::width_client() const
 //
 int ArticleViewBase::height_client() const
 {
+    if( m_drawarea ) {
+        const int height_client = m_drawarea->height_client();
 #ifdef _DEBUG
-    if( m_drawarea ) std::cout << "ArticleViewBase::height_client : " << m_drawarea->height_client() << std::endl;
+        std::cout << "ArticleViewBase::height_client : " << height_client << std::endl;
 #endif
+        return height_client;
+    }
 
-    if( m_drawarea ) return m_drawarea->height_client();
+
 
     return SKELETON::View::height_client();
 }

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -2361,8 +2361,10 @@ std::list< std::string > BoardBase::get_check_update_articles()
     if( empty() ) return list_url;
     if( is_loading() ) return list_url;
     if( m_status & STATUS_UPDATE ) return list_url;
-    if( ! m_list_subject_created ) download_subject( std::string(), true );
-    if( ! m_list_subject_created ) return list_url;
+    if( ! m_list_subject_created ) {
+        download_subject( std::string(), true );
+        return list_url;
+    }
 
 #ifdef _DEBUG
     std::cout << "BoardBase::get_check_update_articles url = " << url_boardbase() << std::endl;


### PR DESCRIPTION
隣り合うif文が同じ条件であるとcppcheckに指摘されたためブロックをまとめます。

cppcheckのレポート
```
src/dbtree/boardbase.cpp:2365:9: style: The if condition is the same as the previous if condition [duplicateCondition]
    if( ! m_list_subject_created ) return list_url;
        ^
src/dbtree/boardbase.cpp:2364:9: note: First condition
    if( ! m_list_subject_created ) download_subject( std::string(), true );
        ^
src/dbtree/boardbase.cpp:2365:9: note: Second condition
    if( ! m_list_subject_created ) return list_url;
        ^
src/article/articleviewbase.cpp:677:9: style: The if condition is the same as the previous if condition [duplicateCondition]
    if( m_drawarea ) return m_drawarea->width_client();
        ^
src/article/articleviewbase.cpp:674:9: note: First condition
    if( m_drawarea ) std::cout << "ArticleViewBase::width_client : " << m_drawarea->width_client() << std::endl;
        ^
src/article/articleviewbase.cpp:677:9: note: Second condition
    if( m_drawarea ) return m_drawarea->width_client();
        ^
src/article/articleviewbase.cpp:692:9: style: The if condition is the same as the previous if condition [duplicateCondition]
    if( m_drawarea ) return m_drawarea->height_client();
        ^
src/article/articleviewbase.cpp:689:9: note: First condition
    if( m_drawarea ) std::cout << "ArticleViewBase::height_client : " << m_drawarea->height_client() << std::endl;
        ^
src/article/articleviewbase.cpp:692:9: note: Second condition
    if( m_drawarea ) return m_drawarea->height_client();
        ^
```