### PR TITLE
Add const qualifier to function parameters

### DIFF
--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -1039,7 +1039,7 @@ void BBSListViewBase::next_dir()
 //
 // 他のviewのtreestoreをcopyして表示
 //
-void BBSListViewBase::copy_treestore( Glib::RefPtr< Gtk::TreeStore >& store )
+void BBSListViewBase::copy_treestore( const Glib::RefPtr< Gtk::TreeStore >& store )
 {
 #ifdef _DEBUG
     std::cout << "BBSListViewBase::copy_treestore\n";

--- a/src/bbslist/bbslistviewbase.h
+++ b/src/bbslist/bbslistviewbase.h
@@ -246,7 +246,7 @@ namespace BBSLIST
 
         // selectdialogで使う
         Gtk::TreePath get_current_path() { return m_treeview.get_current_path(); }
-        void copy_treestore( Glib::RefPtr< Gtk::TreeStore >& store );
+        void copy_treestore( const Glib::RefPtr< Gtk::TreeStore >& store );
 
         // undo, redo
         void undo();

--- a/src/bbslist/editlistwin.cpp
+++ b/src/bbslist/editlistwin.cpp
@@ -22,7 +22,7 @@ enum
 };
 
 
-EditListWin::EditListWin( const std::string& url, Glib::RefPtr< Gtk::TreeStore >& treestore )
+EditListWin::EditListWin( const std::string& url, const Glib::RefPtr< Gtk::TreeStore >& treestore )
     : Gtk::Window( Gtk::WINDOW_TOPLEVEL ),
       m_label( "マウスの中ボタンドラッグで行の複数選択が可能です。" )
 {

--- a/src/bbslist/editlistwin.h
+++ b/src/bbslist/editlistwin.h
@@ -25,7 +25,7 @@ namespace BBSLIST
 
       public:
 
-        EditListWin( const std::string& url, Glib::RefPtr< Gtk::TreeStore >& treestore );
+        EditListWin( const std::string& url, const Glib::RefPtr< Gtk::TreeStore >& treestore );
         ~EditListWin() noexcept;
 
         void clock_in();

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -973,7 +973,7 @@ void BoardViewBase::slot_col_clicked( const int col )
 //
 // row_a が上か　row_b　が上かを返す。同じ状態なら 0
 //
-int BoardViewBase::compare_drawbg( Gtk::TreeModel::Row& row_a, Gtk::TreeModel::Row& row_b )
+int BoardViewBase::compare_drawbg( const Gtk::TreeModel::Row& row_a, const Gtk::TreeModel::Row& row_b ) const
 {
     const bool draw_a = row_a[ m_columns.m_col_drawbg ];
     const bool draw_b = row_b[ m_columns.m_col_drawbg ];
@@ -990,7 +990,8 @@ int BoardViewBase::compare_drawbg( Gtk::TreeModel::Row& row_a, Gtk::TreeModel::R
 //
 // row_a が上か　row_b　が上かを返す。同じなら 0
 //
-int BoardViewBase::compare_col( const int col, const int sortmode, Gtk::TreeModel::Row& row_a, Gtk::TreeModel::Row& row_b )
+int BoardViewBase::compare_col( const int col, const int sortmode,
+                                const Gtk::TreeModel::Row& row_a, const Gtk::TreeModel::Row& row_b ) const
 {
     int num_a = 0, num_b = 0;
     int ret = 0;
@@ -2438,7 +2439,7 @@ void BoardViewBase::slot_open_browser()
 //
 // 記事を開く
 //
-bool BoardViewBase::open_row( Gtk::TreePath& path, const bool tab, const bool reget )
+bool BoardViewBase::open_row( const Gtk::TreePath& path, const bool tab, const bool reget )
 {
     std::string str_tab = "false";
     if( tab ) str_tab = "opentab";

--- a/src/board/boardviewbase.h
+++ b/src/board/boardviewbase.h
@@ -245,8 +245,9 @@ namespace BOARD
         // ヘッダをクリックしたときのslot関数
         void slot_col_clicked( const int col );
 
-        int compare_drawbg( Gtk::TreeModel::Row& row_a, Gtk::TreeModel::Row& row_b );
-        int compare_col( const int col, const int sortmode, Gtk::TreeModel::Row& row_a, Gtk::TreeModel::Row& row_b );
+        int compare_drawbg( const Gtk::TreeModel::Row& row_a, const Gtk::TreeModel::Row& row_b ) const;
+        int compare_col( const int col, const int sortmode,
+                         const Gtk::TreeModel::Row& row_a, const Gtk::TreeModel::Row& row_b ) const;
         int slot_compare_row( const Gtk::TreeModel::iterator& a, const Gtk::TreeModel::iterator& b );
 
         // UI
@@ -277,7 +278,7 @@ namespace BOARD
                                  Gtk::SelectionData& selection_data, guint info, guint time );
         void slot_dropped_url_list( const std::list< std::string >& );
 
-        bool open_row( Gtk::TreePath& path, const bool tab, const bool reget );
+        bool open_row( const Gtk::TreePath& path, const bool tab, const bool reget );
         void open_selected_rows( const bool reget );
         std::string path2daturl( const Gtk::TreePath& path );
         std::string path2url_board( const Gtk::TreePath& path );

--- a/src/skeleton/dragnote.cpp
+++ b/src/skeleton/dragnote.cpp
@@ -480,7 +480,7 @@ void DragableNoteBook::focus_toolbar_search()
 //
 // ツールバーURL更新
 //
-void DragableNoteBook::update_toolbar_url( std::string& url_old, std::string& url_new )
+void DragableNoteBook::update_toolbar_url( const std::string& url_old, const std::string& url_new )
 {
     for( int i = 0; i < m_notebook_toolbar.get_n_pages(); ++i ){
         SKELETON::ToolBar* toolbar = get_toolbar( i );

--- a/src/skeleton/dragnote.h
+++ b/src/skeleton/dragnote.h
@@ -141,7 +141,7 @@ namespace SKELETON
         void set_current_toolbar( const int id_toolbar, SKELETON::View* view );
         int get_current_toolbar();
         void focus_toolbar_search(); // ツールバー内の検索entryにフォーカスを移す
-        void update_toolbar_url( std::string& url_old, std::string& url_new );
+        void update_toolbar_url( const std::string& url_old, const std::string& url_new );
         void update_toolbar_button();
 
         // タブの文字列取得/セット

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -907,7 +907,7 @@ void EditTreeView::draw_underline( const Gtk::TreePath& path, const bool draw )
 //
 // path は ディレクトリか
 //
-bool EditTreeView::is_dir( Gtk::TreeModel::iterator& it )
+bool EditTreeView::is_dir( const Gtk::TreeModel::iterator& it ) const
 {
     const Gtk::TreeRow row = ( *it );
     if( ! row ) return false;

--- a/src/skeleton/edittreeview.h
+++ b/src/skeleton/edittreeview.h
@@ -117,7 +117,7 @@ namespace SKELETON
         void set_editable_view( const bool editable );
 
         // 指定した path のタイプは ディレクトリか
-        bool is_dir( Gtk::TreeModel::iterator& it );
+        bool is_dir( const Gtk::TreeModel::iterator& it ) const;
         bool is_dir( const Gtk::TreePath& path );
 
         // 次のディレクトリに移動


### PR DESCRIPTION
関数の引数にconst修飾子を付けることができるとcppcheckに指摘されたため修正します。さらにconstメンバ関数にできる場合は変更します。

cppcheckのレポート
```
src/bbslist/bbslistviewbase.cpp:1042:71: style: Parameter 'store' can be declared with const [constParameter]
void BBSListViewBase::copy_treestore( Glib::RefPtr< Gtk::TreeStore >& store )
                                                                      ^
src/board/boardviewbase.cpp:976:57: style: Parameter 'row_a' can be declared with const [constParameter]
int BoardViewBase::compare_drawbg( Gtk::TreeModel::Row& row_a, Gtk::TreeModel::Row& row_b )
                                                        ^
src/board/boardviewbase.cpp:976:85: style: Parameter 'row_b' can be declared with const [constParameter]
int BoardViewBase::compare_drawbg( Gtk::TreeModel::Row& row_a, Gtk::TreeModel::Row& row_b )
                                                                                    ^
src/board/boardviewbase.cpp:993:89: style: Parameter 'row_a' can be declared with const [constParameter]
int BoardViewBase::compare_col( const int col, const int sortmode, Gtk::TreeModel::Row& row_a, Gtk::TreeModel::Row& row_b )
                                                                                        ^
src/board/boardviewbase.cpp:993:117: style: Parameter 'row_b' can be declared with const [constParameter]
int BoardViewBase::compare_col( const int col, const int sortmode, Gtk::TreeModel::Row& row_a, Gtk::TreeModel::Row& row_b )
                                                                                                                    ^
src/board/boardviewbase.cpp:2441:46: style: Parameter 'path' can be declared with const [constParameter]
bool BoardViewBase::open_row( Gtk::TreePath& path, const bool tab, const bool reget )
                                             ^
src/skeleton/dragnote.cpp:483:57: style: Parameter 'url_old' can be declared with const [constParameter]
void DragableNoteBook::update_toolbar_url( std::string& url_old, std::string& url_new )
                                                        ^
src/skeleton/dragnote.cpp:483:79: style: Parameter 'url_new' can be declared with const [constParameter]
void DragableNoteBook::update_toolbar_url( std::string& url_old, std::string& url_new )
                                                                              ^
src/skeleton/edittreeview.cpp:910:54: style: Parameter 'it' can be declared with const [constParameter]
bool EditTreeView::is_dir( Gtk::TreeModel::iterator& it )
                                                     ^
src/bbslist/editlistwin.cpp:25:83: style: Parameter 'treestore' can be declared with const [constParameter]
EditListWin::EditListWin( const std::string& url, Glib::RefPtr< Gtk::TreeStore >& treestore )
                                                                                  ^
```