### PR TITLE
Modify parameter type from reference to value

### DIFF
--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -40,7 +40,7 @@
 // 2バイト目 0xA1〜0xFE
 #define EUC_RANGE_MULTI( target ) ( (unsigned char)( target - 0xA1 ) < 0x5E )
 //
-bool MISC::is_euc( const char* input, size_t& read_byte )
+bool MISC::is_euc( const char* input, size_t read_byte )
 {
     if( ! input ) return false;
 
@@ -131,7 +131,7 @@ bool MISC::is_jis( const char* input, size_t& byte )
 // 0x80〜0xFC
 #define SJIS_RANGE_2_T( target ) ( (unsigned char)( target - 0x80 ) < 0x7D )
 //
-bool MISC::is_sjis( const char* input, size_t& read_byte )
+bool MISC::is_sjis( const char* input, size_t read_byte )
 {
     if( ! input ) return false;
 
@@ -187,7 +187,7 @@ bool MISC::is_sjis( const char* input, size_t& read_byte )
 // [ 2バイト目以降 ] 0x80〜0xBF
 #define UTF_RANGE_MULTI_BYTE( target ) ( (unsigned char)( target - 0x80 ) < 0x40 )
 //
-bool MISC::is_utf( const char* input, size_t& read_byte )
+bool MISC::is_utf( const char* input, size_t read_byte )
 {
     if( ! input ) return false;
 
@@ -258,6 +258,7 @@ int MISC::judge_char_code( const std::string& str )
     if( is_jis( str.c_str(), read_byte ) ) code = CHARCODE_JIS;
     // JISの判定で最後まで進んでいたら制御文字かアスキー
     else if( read_byte == str.length() ) code = CHARCODE_ASCII;
+    // is_jis()でASCII範囲外のバイトが現れた箇所から判定する
     // UTF-8の範囲
     else if( is_utf( str.c_str(), read_byte ) ) code = CHARCODE_UTF;
     // EUC-JPの範囲

--- a/src/jdlib/misccharcode.h
+++ b/src/jdlib/misccharcode.h
@@ -19,10 +19,10 @@ namespace MISC
         CHARCODE_UTF
     };
 
-    bool is_euc( const char* input, size_t& read_byte );
+    bool is_euc( const char* input, size_t read_byte );
     bool is_jis( const char* input, size_t& read_byte );
-    bool is_sjis( const char* input, size_t& read_byte );
-    bool is_utf( const char* input, size_t& read_byte );
+    bool is_sjis( const char* input, size_t read_byte );
+    bool is_utf( const char* input, size_t read_byte );
     int judge_char_code( const std::string& str );
 }
 


### PR DESCRIPTION
関数の引数にconst修飾子を付けることができるとcppcheckに指摘されたため整数の参照渡しを値渡しに変更します。

cppcheckのレポート
```
src/jdlib/misccharcode.cpp:43:47: style: Parameter 'read_byte' can be declared with const [constParameter]
bool MISC::is_euc( const char* input, size_t& read_byte )
                                              ^
src/jdlib/misccharcode.cpp:134:48: style: Parameter 'read_byte' can be declared with const [constParameter]
bool MISC::is_sjis( const char* input, size_t& read_byte )
                                               ^
src/jdlib/misccharcode.cpp:190:47: style: Parameter 'read_byte' can be declared with const [constParameter]
bool MISC::is_utf( const char* input, size_t& read_byte )
                                              ^
```