### PR TITLE
Root: Change parameters to pass by value

### DIFF
--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -970,7 +970,7 @@ void Root::push_movetable( std::string old_root,
             str += str_tmp;
 
             m_movetable.erase( it_move );
-            m_movetable.push_back( movetable );
+            m_movetable.push_back( std::move( movetable ) );
             it_move = m_movetable.begin();
             continue;
         }
@@ -981,11 +981,11 @@ void Root::push_movetable( std::string old_root,
     if( ! str.empty() ) MISC::MSG( "\n" + str );
 
     MOVETABLE movetable;
-    movetable.old_root = old_root;
-    movetable.old_path_board = old_path_board;
-    movetable.new_root = new_root;
-    movetable.new_path_board = new_path_board;
-    m_movetable.push_back( movetable );
+    movetable.old_root = std::move( old_root );
+    movetable.old_path_board = std::move( old_path_board );
+    movetable.new_root = std::move( new_root );
+    movetable.new_path_board = std::move( new_path_board );
+    m_movetable.push_back( std::move( movetable ) );
 }
 
 

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -786,8 +786,8 @@ bool Root::move_board( const std::string& url_old, const std::string& url_new, c
     if( ! exec_move_board( board,
                            board->get_root(),
                            board->get_path_board(),
-                           root,
-                           path_board
+                           std::move( root ),
+                           std::move( path_board )
             ) ) return false;
 
     // キャッシュを移動した
@@ -811,11 +811,13 @@ bool Root::move_board( const std::string& url_old, const std::string& url_new, c
 //
 // 板移転処理実行
 //
+// 引数を参照渡し(const std::string&)するとDB更新で値が変わるため値渡しする
+//
 bool Root::exec_move_board( BoardBase* board,
-                            const std::string& old_root,
-                            const std::string& old_path_board,
-                            const std::string& new_root,
-                            const std::string& new_path_board )
+                            std::string old_root,
+                            std::string old_path_board,
+                            std::string new_root,
+                            std::string new_path_board )
 {
     if( ! board ) return false;
 
@@ -880,7 +882,8 @@ bool Root::exec_move_board( BoardBase* board,
                   << "old_path_board = " << old_path_board << std::endl
                   << "new_path_board = " << new_path_board << std::endl;
 #endif
-        push_movetable( old_root, old_path_board, new_root, new_path_board );
+        push_movetable( std::move( old_root ), std::move( old_path_board ),
+                        std::move( new_root ), std::move( new_path_board ) );
 
         // この板に関連する表示中のviewのURLを更新
         CORE::core_set_command( "update_url", old_url, new_url );
@@ -893,10 +896,10 @@ bool Root::exec_move_board( BoardBase* board,
 //
 // 板移転テーブルを更新
 //
-void Root::push_movetable( const std::string& old_root,
-                           const std::string& old_path_board,
-                           const std::string& new_root,
-                           const std::string& new_path_board )
+void Root::push_movetable( std::string old_root,
+                           std::string old_path_board,
+                           std::string new_root,
+                           std::string new_path_board )
 {
 #ifdef _DEBUG
     std::cout << "Root::push_movetable : " << old_root << old_path_board << " -> " << new_root << new_path_board << std::endl;

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -169,16 +169,16 @@ namespace DBTREE
 
         // 板移転処理
         bool exec_move_board( BoardBase* board,
-                              const std::string& old_root,
-                              const std::string& old_path_board,
-                              const std::string& new_root,
-                              const std::string& new_path_board );
+                              std::string old_root,
+                              std::string old_path_board,
+                              std::string new_root,
+                              std::string new_path_board );
 
         // 板移転テーブルに追加
-        void push_movetable( const std::string& old_root,
-                             const std::string& old_path_board,
-                             const std::string& new_root,
-                             const std::string& new_path_board );
+        void push_movetable( std::string old_root,
+                             std::string old_path_board,
+                             std::string new_root,
+                             std::string new_path_board );
 
         // 板をデータベースから削除
         bool remove_board( const std::string& url );


### PR DESCRIPTION
45e0ec4d7c の修正でメンバ関数の引数を参照渡しに変更しましたが、関数内処理の影響で引数の参照値が変化し板移転の処理に支障が生じることが分かりました。
そのため引数を値渡しに変更することで意図しない値の更新を防ぎます。
