### PR TITLE
Support processing for moving board by 301 Moved Permanently

### DIFF
--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1151,7 +1151,18 @@ void BoardBase::receive_finish()
         set_date_modified( std::string() );
         send_update_board();
 
-        if( !m_rawdata.empty() && get_code() == HTTP_OK
+        // Locationヘッダーで移転先を指定された場合
+        if( get_code() == HTTP_MOVED_PERM && ! location().empty() ) {
+
+            // location() は url_boardbase() の移転先 (start_checkking_if_board_moved() を参照)
+            if( DBTREE::move_board( url_boardbase(), location() ) ) {
+                // 再読み込み
+                const std::string str_tab = "false";
+                CORE::core_set_command( "open_board", url_subject(), str_tab );
+            }
+        }
+        // HTMLの埋め込みスクリプトで移動を指示された場合
+        else if( !m_rawdata.empty() && get_code() == HTTP_OK
                 && m_rawdata.find( "window.location.href" ) != std::string::npos ) {
 
 #ifdef _DEBUG


### PR DESCRIPTION
板のsubject.txtを取得するとき`301 Moved Permanently`が返ってきたときは板のフロントページを取得して移転の確認を行っています。
確認でHTMLから移転先が見つからなかったときはこれまで板一覧の更新を行っていましたが、新たに処理を追加し再び`301`が返ってきた場合はLocationレスポンスヘッダーで示されたURLへ板を移転するようにします。

関連のissue: #332
