### PR TITLE
Support processing for moving bbsmenu by 301 Moved Permanently

### DIFF
--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -165,6 +165,7 @@ const std::string& CONFIG::get_url_login2ch() { return get_confitem()->url_login
 const std::string& CONFIG::get_url_loginbe() { return get_confitem()->url_loginbe; }
 
 const std::string& CONFIG::get_url_bbsmenu() { return get_confitem()->url_bbsmenu; }
+void CONFIG::set_url_bbsmenu( std::string url ) { get_confitem()->url_bbsmenu = std::move( url ); }
 
 bool CONFIG::use_link_as_board(){ return get_confitem()->use_link_as_board; }
 

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -112,7 +112,8 @@ namespace CONFIG
     const std::string& get_url_loginbe();
 
     // bbsmenu.htmlのURL
-    const std::string& get_url_bbsmenu();    
+    const std::string& get_url_bbsmenu();
+    void set_url_bbsmenu( std::string url );
 
     // bbsmenu.html内にあるリンクは全て板とみなす
     bool use_link_as_board();

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -378,6 +378,19 @@ void Root::receive_finish()
         return;
     }
 
+    if( get_code() == HTTP_MOVED_PERM && ! location().empty() ){
+
+        const std::string msg = get_str_code() + "\n\n板一覧が " + location() + " に移転しました。更新しますか？";
+        SKELETON::MsgDiag mdiag( nullptr, msg, false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
+        mdiag.set_default_response( Gtk::RESPONSE_YES );
+        if( mdiag.run() == Gtk::RESPONSE_YES ){
+            set_date_modified( std::string() );
+            CONFIG::set_url_bbsmenu( location() );
+            download_bbsmenu();
+        }
+        return;
+    }
+
     if( get_code() != HTTP_OK ){
 
         std::string msg = get_str_code() + "\n\n板一覧の読み込みに失敗したため板一覧は更新されませんでした。\n\nプロキシ設定や板一覧を取得するサーバのアドレスを確認して、ファイルメニューから板一覧の再読み込みをして下さい。\n板一覧取得サーバのアドレスはabout:configで確認出来ます。";


### PR DESCRIPTION
板一覧の取得で`301 Moved Permanently`が返ってきたときこれまでエラーとして処理していましたが、移転処理を新たにサポートし移転を行うか確認のダイアログを表示するようにします。

関連のissue: #332
