### PR TITLE
Rename local variable to avoid shadowing

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -3616,8 +3616,8 @@ void DrawAreaBase::exec_scroll()
         }
 
         // カーソル形状の更新
-        CARET_POSITION caret_pos;
-        m_layout_current = set_caret( caret_pos, m_x_pointer , m_y_pointer + get_vscr_val() );
+        CARET_POSITION unused_caret_pos;
+        m_layout_current = set_caret( unused_caret_pos, m_x_pointer , m_y_pointer + get_vscr_val() );
         change_cursor( get_cursor_type() );
     }
 }

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -2523,10 +2523,10 @@ void BBSListViewBase::select_item( const std::string& url )
     }
 
     // 現在選択しているものと一致する場合は何もしない
-    Gtk::TreePath path = m_treeview.get_current_path();
-    if( ! path.empty() ){
+    Gtk::TreePath current_path = m_treeview.get_current_path();
+    if( ! current_path.empty() ){
         // 板一覧やお気に入りに、該当するURLが2つある場合がある
-        if( url_item == path2rawurl( path ) || url_item == path2url( path ) ) return;
+        if( url_item == path2rawurl( current_path ) || url_item == path2url( current_path ) ) return;
     }
 
     Gtk::TreePath closed_path;

--- a/src/control/controlutil.cpp
+++ b/src/control/controlutil.cpp
@@ -211,11 +211,11 @@ void CONTROL::set_menu_motion( Gtk::Menu* menu )
                 label->set_text_with_mnemonic( str_label + ( str_motions.empty() ? "" : "\t" + str_motions ) );
 #else
                 item->remove();
-                Gtk::Label *label = Gtk::manage( new Gtk::Label( str_label + ( str_motions.empty() ? "" : "  " ), true ) );
+                Gtk::Label *label_subject = Gtk::manage( new Gtk::Label( str_label + ( str_motions.empty() ? "" : "  " ), true ) );
                 Gtk::Label *label_motion = Gtk::manage( new Gtk::Label( str_motions ) );
                 Gtk::HBox *box = Gtk::manage( new Gtk::HBox() );
 
-                box->pack_start( *label, Gtk::PACK_SHRINK );
+                box->pack_start( *label_subject, Gtk::PACK_SHRINK );
                 box->pack_end( *label_motion, Gtk::PACK_SHRINK );
                 item->add( *box );
                 box->show_all();

--- a/src/history/historymanager.cpp
+++ b/src/history/historymanager.cpp
@@ -255,14 +255,14 @@ void History_Manager::xml2viewhistory()
 
             if( histitem->nodeType() != XML::NODE_TYPE_ELEMENT ) continue;
 
-            const int type = XML::get_type( histitem->nodeName() );
-            if( type != TYPE_HISTITEM ) continue;
+            const int item_type = XML::get_type( histitem->nodeName() );
+            if( item_type != TYPE_HISTITEM ) continue;
 
             const std::string name = histitem->getAttribute( "name" );
             const std::string url = histitem->getAttribute( "url" );
 
 #ifdef _DEBUG
-            std::cout << "type = " << type << std::endl
+            std::cout << "type = " << item_type << std::endl
                       << "name = " << name << std::endl
                       << "url = " << url << std::endl;
 #endif

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -431,9 +431,9 @@ void Post::receive_finish()
             }
 
             ConfirmDiag mdiag( m_url, diagmsg );
-            const int ret = mdiag.run();
+            const int response = mdiag.run();
             mdiag.hide();
-            if( ret != Gtk::RESPONSE_OK ){
+            if( response != Gtk::RESPONSE_OK ){
 
                 set_code( HTTP_CANCEL );
                 emit_sigfin();

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -1192,8 +1192,8 @@ void EditTreeView::delete_selected_rows( const bool force )
 
     // 削除する行を取得
     CORE::DATA_INFO_LIST list_info;
-    const bool dir = true;
-    get_info_in_selection( list_info, dir );
+    constexpr bool scan_in_dir = true;
+    get_info_in_selection( list_info, scan_in_dir );
 
     // カーソルを最後の行の次の行に移動するため、あらかじめ削除範囲の最後の行に移動しておく
     const Gtk::TreePath next = next_path( Gtk::TreePath( ( list_info.back() ).path ), true );
@@ -1207,8 +1207,8 @@ void EditTreeView::delete_selected_rows( const bool force )
         m_undo_buffer->set_list_info( CORE::DATA_INFO_LIST(), list_info );
 
         CORE::DATA_INFO_LIST list_info_selected;
-        const bool dir = false;
-        get_info_in_selection( list_info_selected, dir );
+        constexpr bool not_scan_in_dir = false;
+        get_info_in_selection( list_info_selected, not_scan_in_dir );
         m_undo_buffer->set_list_info_selected( list_info_selected );  // redo したときに選択する列
 
         m_undo_buffer->commit();


### PR DESCRIPTION
ローカル変数の名前がシャドウイングされているとcppcheckに指摘されたため重複している変数名を変更します。

cppcheckのレポートはコミットメッセージを参照してください。

