### PR TITLE
Remove local var declaration to avoid shadowing

### DIFF
--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -105,13 +105,13 @@ std::string BoardMachi::url_dat( const std::string& url, int& num_from, int& num
     if( empty() ) return std::string();
 
     // read.cgi 型の判定
-    const std::string urldat = BoardBase::url_dat( url, num_from, num_to, num_str );
+    std::string urldat = BoardBase::url_dat( url, num_from, num_to, num_str );
     if( ! urldat.empty() ) return urldat;
 
     // 旧形式(read.pl)型の場合
     if( url.find( "read.pl" ) != std::string::npos ){
 
-        const std::string urldat = BoardBase::url_dat( MISC::replace_str( url, "read.pl", "read.cgi" ), num_from, num_to, num_str );
+        urldat = BoardBase::url_dat( MISC::replace_str( url, "read.pl", "read.cgi" ), num_from, num_to, num_str );
         if( ! urldat.empty() ) return urldat;
     }
 

--- a/src/history/historysubmenu.cpp
+++ b/src/history/historysubmenu.cpp
@@ -78,7 +78,7 @@ HistorySubMenu::HistorySubMenu( const std::string& url_history )
         hbox->pack_start( *label, Gtk::PACK_SHRINK );
         hbox->pack_end( *label_motion, Gtk::PACK_SHRINK );
 
-        Gtk::MenuItem* item = Gtk::manage( new Gtk::MenuItem( *hbox ) );
+        item = Gtk::manage( new Gtk::MenuItem( *hbox ) );
         append( *item );
         item->signal_activate().connect( sigc::bind< int >( sigc::mem_fun( *this, &HistorySubMenu::slot_active ), i ) );
         item->signal_button_press_event().connect( sigc::bind< int >( sigc::mem_fun( *this, &HistorySubMenu::slot_button_press ), i ) );

--- a/src/message/messageadmin.cpp
+++ b/src/message/messageadmin.cpp
@@ -128,7 +128,6 @@ void MessageAdmin::command_local( const COMMAND_ARGS& command )
     // かつ書き込みビューが空なら閉じる
     else if( command.command == "close_message" ){
 
-        SKELETON::View *view = get_current_view();
         if( view && view->set_command( "empty" ) && view->get_url().find( command.url ) != std::string::npos ){
             close_current_view();
         }

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -355,7 +355,7 @@ void Admin::clock_in()
     const int pages = m_notebook->get_n_pages();
     if( pages ){
         for( int i = 0; i < pages; ++i ){
-            SKELETON::View* view = dynamic_cast< SKELETON::View* >( m_notebook->get_nth_page( i ) );
+            view = dynamic_cast< SKELETON::View* >( m_notebook->get_nth_page( i ) );
             if( view ) view->clock_in_always();
         }
     }
@@ -1952,7 +1952,7 @@ View* Admin::get_view( const std::string& url )
     if( pages ){
 
         for( int i = 0; i < pages; ++i ){
-            SKELETON::View* view = dynamic_cast< View* >( m_notebook->get_nth_page( i ) );
+            view = dynamic_cast< View* >( m_notebook->get_nth_page( i ) );
             if( view && view->get_url() == url ) return view;
         }
     }


### PR DESCRIPTION
ローカル変数の名前がシャドウイングされているとcppcheckに指摘されたため重複している変数を統廃合します。

cppcheckのレポートはコミットメッセージを参照してください。
