### PR TITLE
JDTreeViewBase: Move local variable to inner scope

### DIFF
--- a/src/skeleton/treeviewbase.cpp
+++ b/src/skeleton/treeviewbase.cpp
@@ -93,12 +93,15 @@ void JDTreeViewBase::get_cell_xy_wh( int& cell_x, int& cell_y, int& cell_w, int&
 
     Gtk::TreeModel::Path path;
     Gtk::TreeViewColumn* column;
-    int x, y, o_x, o_y;
+    int x, y;
     Gdk::Rectangle rect;
 
     get_pointer( x, y );
     get_path_at_pos( x, y, path, column, cell_x, cell_y );
-    if( column ) column->cell_get_size( rect, o_x, o_y, cell_w, cell_h );
+    if( column ) {
+        int o_x, o_y;
+        column->cell_get_size( rect, o_x, o_y, cell_w, cell_h );
+    }
 }
 
 


### PR DESCRIPTION
変数のスコープを減らすことができるとcppcheckに指摘されたため内側のスコープへ変数宣言を移動します。

cppcheckのレポート
```
src/skeleton/treeviewbase.cpp:96:15: style: The scope of the variable 'o_x' can be reduced. [variableScope]
    int x, y, o_x, o_y;
              ^
src/skeleton/treeviewbase.cpp:96:20: style: The scope of the variable 'o_y' can be reduced. [variableScope]
    int x, y, o_x, o_y;
                   ^
```