### PR TITLE
Add configure option for Glib Regex

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -121,7 +121,7 @@ jobs:
             packages: libgtkmm-3.0-dev libssl-dev libonig-dev libmigemo-dev
           - config_args: --with-gtkmm3 --with-thread=std --with-tls=gnutls --with-regex=pcre --with-alsa
             packages: libgtkmm-3.0-dev libgnutls28-dev libpcre3-dev libasound2-dev
-          - config_args: --with-gtkmm3 --with-thread=std --with-tls=openssl --with-regex=posix --with-xdgopen
+          - config_args: --with-gtkmm3 --with-thread=std --with-tls=openssl --with-regex=glib --with-xdgopen
             packages: libgtkmm-3.0-dev libssl-dev
     steps:
     - uses: actions/checkout@v2

--- a/INSTALL
+++ b/INSTALL
@@ -102,7 +102,7 @@
        gprofによるプロファイリングを行う。コンパイルオプションに -pg が付き、JDimを実行すると
        gmon.out が出来るのでgprof./jdgmon.out で解析できる。CPUの最適化は効かなくなるので注意する。
 
-    --with-regex=[posix|oniguruma|pcre]
+    --with-regex=[posix|oniguruma|pcre|glib]
 
        使用する正規表現ライブラリを設定する。デフォルトでは POSIX regex を使用する。
 
@@ -117,6 +117,12 @@
        PCREはBSDライセンスなのでJDimをバイナリ配布する場合には注意すること(ライセンスはGPLになる)。
        UTF-8が有効な ( --enable-utf オプションを用いて make する ) PCRE 6.5 以降が必要となる。
        Perl互換の正規表現なので、従来の POSIX 拡張の正規表現から設定変更が必要になる場合がある。
+
+    --with-regex=glib
+
+       POSIX regex のかわりに GRegex を使用する。
+       Perl互換の正規表現なので、従来の POSIX 拡張の正規表現から設定変更が必要になる場合がある。
+       (v0.3.0+から追加)
 
     --with-oniguruma
 

--- a/configure.ac
+++ b/configure.ac
@@ -225,7 +225,7 @@ dnl 正規表現ライブラリ
 dnl
 AC_MSG_CHECKING(for --with-regex)
 AC_ARG_WITH(regex,
-AC_HELP_STRING([--with-regex=@<:@posix|pcre|oniguruma@:>@],
+AC_HELP_STRING([--with-regex=@<:@posix|pcre|oniguruma|glib@:>@],
                [use regular expression library @<:@default=posix@:>@]),
 [], [with_regex=posix])
 AC_MSG_RESULT($with_regex)
@@ -237,7 +237,6 @@ AS_IF(
 
   [test "x$with_regex" = xpcre],
   [PKG_CHECK_MODULES(PCRE, [libpcre >= 6.5])
-   AC_DEFINE(USE_PCRE, , [use PCRE])
    AC_SUBST(PCRE_CFLAGS)
    AC_SUBST(PCRE_LIBS)
    AC_CHECK_HEADERS([pcreposix.h], , [AC_MSG_ERROR([pcreposix.h not found])])
@@ -245,11 +244,13 @@ AS_IF(
 
   [test "x$with_regex" = xoniguruma],
   [PKG_CHECK_MODULES(ONIG, [oniguruma])
-   AC_DEFINE(USE_ONIG, , [use oniguruma regular expressions library])
    AC_SUBST(ONIG_CFLAGS)
    AC_SUBST(ONIG_LIBS)
    AC_CHECK_HEADERS([onigposix.h], , [AC_MSG_ERROR([onigposix.h not found])])
    AC_CHECK_LIB([onig], [regexec], , [AC_MSG_ERROR([libonig.a not found])])],
+
+  [test "x$with_regex" = xglib],
+  [PKG_CHECK_MODULES(GLIB, [glib-2.0 >= 2.14.0])],
 
   [AC_MSG_ERROR([regular expression library not found])]
 )

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -109,7 +109,7 @@ OSやディストリビューション別の解説は[OS/ディストリビュ�
     <code>gprof  ./jdim  gmon.out</code> で解析できる。CPUの最適化は効かなくなるので注意する。
   </dd>
 
-  <dt>--with-regex=[posix|oniguruma|pcre]</dt>
+  <dt>--with-regex=[posix|oniguruma|pcre|glib]</dt>
   <dd>使用する正規表現ライブラリを設定する。デフォルトでは POSIX regex を使用する。</dd>
   <dt>--with-regex=oniguruma</dt>
   <dd>
@@ -122,6 +122,12 @@ OSやディストリビューション別の解説は[OS/ディストリビュ�
     PCREはBSDライセンスなのでJDimをバイナリ配布する場合には注意すること(ライセンスはGPLになる)。
     UTF-8が有効な ( <code>--enable-utf</code> オプションを用いて make する ) PCRE 6.5 以降が必要となる。
     Perl互換の正規表現なので、従来の POSIX 拡張の正規表現から設定変更が必要になる場合がある。
+  </dd>
+  <dt>--with-regex=glib</dt>
+  <dd>
+    POSIX regex のかわりに GRegex を使用する。
+    Perl互換の正規表現なので、従来の POSIX 拡張の正規表現から設定変更が必要になる場合がある。
+    <small>(v0.3.0+から追加)</small>
   </dd>
   <dt>--with-oniguruma</dt>
   <dd><strong>非推奨</strong>: かわりに <code>--with-regex=oniguruma</code> を使用してください。</dd>

--- a/src/jdlib/jdregex.cpp
+++ b/src/jdlib/jdregex.cpp
@@ -19,15 +19,6 @@ constexpr std::size_t REGEX_MAX_NMATCH = 32;
 
 using namespace JDLIB;
 
-Regex::Regex()
-    : m_compiled(false),
-      m_newline(false),
-      m_wchar(false)
-{
-    m_results.clear();
-    m_pos.clear();
-}
-
 
 Regex::~Regex()
 {

--- a/src/jdlib/jdregex.h
+++ b/src/jdlib/jdregex.h
@@ -38,9 +38,9 @@ namespace JDLIB
         GRegex* m_reg{};
 #endif
 
-        bool m_compiled;
-        bool m_newline;
-        bool m_wchar;
+        bool m_compiled{};
+        bool m_newline{};
+        bool m_wchar{};
 
         // 全角半角を区別しないときに使う変換用バッファ
         // 処理可能なバッファ長は regoff_t (= int) のサイズに制限される
@@ -49,7 +49,7 @@ namespace JDLIB
 
     public:
 
-        Regex();
+        Regex() = default;
         ~Regex();
 
         void dispose();

--- a/src/jdlib/jdregex.h
+++ b/src/jdlib/jdregex.h
@@ -10,13 +10,19 @@
 #include "config.h"
 #endif
 
-#ifdef USE_ONIG
+#if defined(HAVE_ONIGPOSIX_H)
 #include <onigposix.h>
-#elif defined( USE_PCRE )
+#elif defined(HAVE_PCREPOSIX_H)
 #include <pcreposix.h>
-#else
+#elif defined(HAVE_REGEX_H)
 #include <regex.h>
-#endif	/** USE_ONIG **/
+#else
+#include <glib.h>
+#endif
+
+#if defined(HAVE_ONIGPOSIX_H) || defined(HAVE_PCREPOSIX_H) || defined(HAVE_REGEX_H)
+#define POSIX_STYLE_REGEX_API 1
+#endif
 
 
 namespace JDLIB
@@ -25,7 +31,13 @@ namespace JDLIB
     {
         std::vector< int > m_pos;
         std::vector< std::string > m_results;
+
+#ifdef POSIX_STYLE_REGEX_API
         regex_t m_reg;
+#else
+        GRegex* m_reg{};
+#endif
+
         bool m_compiled;
         bool m_newline;
         bool m_wchar;


### PR DESCRIPTION
使用する正規表現ライブラリを指定するconfigureオプションに[Glib Regex][gregex](`--with-regex=glib`)を追加します。

Glib Regex(GRegex)はGlibに含まれており現在の要件では依存関係を追加せずに使用することが可能です。

[gregex]: https://developer.gnome.org/glib/stable/glib-regex-syntax.html

関連のissue: #361
