### PR TITLE
Deprecate configure option for PCRE

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -36,7 +36,7 @@
   ・alsa-lib (--with-alsa)
   ・openssl (--with-tls=openssl)
   ・oniguruma (--with-regex=oniguruma)
-  ・libpcre (--with-regex=pcre)
+  ・libpcre (--with-regex=pcre, 非推奨)
   ・migemo (--with-migemo)
 
   OSやディストリビューション別の解説は"OS/ディストリビューション別インストール方法 [https://ja.osdn.net/projects/jd4linux/wiki/OS%2f%E3%83%87%E3%82%A3%E3%82%B9%E3%83%88%E3%83%AA%E3%83%93%E3%83%A5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E5%88%A5%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95]"(wiki) を参照。
@@ -117,6 +117,7 @@
        PCREはBSDライセンスなのでJDimをバイナリ配布する場合には注意すること(ライセンスはGPLになる)。
        UTF-8が有効な ( --enable-utf オプションを用いて make する ) PCRE 6.5 以降が必要となる。
        Perl互換の正規表現なので、従来の POSIX 拡張の正規表現から設定変更が必要になる場合がある。
+       非推奨: かわりに --with-regex=glib を使用してください。
 
     --with-regex=glib
 
@@ -130,7 +131,7 @@
 
     --with-pcre
 
-       非推奨: かわりに --with-regex=pcre を使用してください。
+       非推奨: かわりに --with-regex=glib を使用してください。
 
     --with-thread=[posix|glib|std]
 

--- a/configure.ac
+++ b/configure.ac
@@ -240,7 +240,8 @@ AS_IF(
    AC_SUBST(PCRE_CFLAGS)
    AC_SUBST(PCRE_LIBS)
    AC_CHECK_HEADERS([pcreposix.h], , [AC_MSG_ERROR([pcreposix.h not found])])
-   AC_CHECK_LIB([pcreposix], [regexec], , [AC_MSG_ERROR([libpcreposix.a not found])])],
+   AC_CHECK_LIB([pcreposix], [regexec], , [AC_MSG_ERROR([libpcreposix.a not found])])
+   AC_MSG_WARN([--with-regex=pcre will be removed in the future release.])],
 
   [test "x$with_regex" = xoniguruma],
   [PKG_CHECK_MODULES(ONIG, [oniguruma])

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -49,7 +49,7 @@ layout: default
 - alsa-lib (`--with-alsa`)
 - openssl (`--with-tls=openssl`)
 - oniguruma (`--with-regex=oniguruma`)
-- libpcre (`--with-regex=pcre`)
+- libpcre (`--with-regex=pcre`, 非推奨)
 - migemo (`--with-migemo`)
 
 OSやディストリビューション別の解説は[OS/ディストリビューション別インストール方法][wiki-install] (JD wiki) を参照。
@@ -122,6 +122,7 @@ OSやディストリビューション別の解説は[OS/ディストリビュ�
     PCREはBSDライセンスなのでJDimをバイナリ配布する場合には注意すること(ライセンスはGPLになる)。
     UTF-8が有効な ( <code>--enable-utf</code> オプションを用いて make する ) PCRE 6.5 以降が必要となる。
     Perl互換の正規表現なので、従来の POSIX 拡張の正規表現から設定変更が必要になる場合がある。
+    <br><strong>非推奨</strong>: かわりに <code>--with-regex=glib</code> を使用してください。
   </dd>
   <dt>--with-regex=glib</dt>
   <dd>
@@ -132,7 +133,7 @@ OSやディストリビューション別の解説は[OS/ディストリビュ�
   <dt>--with-oniguruma</dt>
   <dd><strong>非推奨</strong>: かわりに <code>--with-regex=oniguruma</code> を使用してください。</dd>
   <dt>--with-pcre</dt>
-  <dd><strong>非推奨</strong>: かわりに <code>--with-regex=pcre</code> を使用してください。</dd>
+  <dd><strong>非推奨</strong>: かわりに <code>--with-regex=glib</code> を使用してください。</dd>
 
   <dt>--with-thread=[posix|glib|std]</dt>
   <dd>


### PR DESCRIPTION
ビルドオプションを増やすとテストにかかる時間が増えるため
新たに追加されたGlib Regexと同じPerl互換であるPCREを廃止予定にしてオプション数を維持します。

関連のissue: #361
