### PR TITLE
Remove preprocessor for zlib version check

### DIFF
--- a/src/jdlib/loader.h
+++ b/src/jdlib/loader.h
@@ -24,11 +24,6 @@
 #include <netdb.h>
 #endif
 
-// zlibのバージョンが1.2.0以上か判定する
-#if ! defined(ZLIB_VERNUM) || ZLIB_VERNUM < 0x1200
-#error "require zlib version >= 1.2.0."
-#endif
-
 
 namespace SKELETON
 {


### PR DESCRIPTION
Remove preprocessor for zlib version check

zlibのバージョンをチェックするプリプロセッサを削除します。
zlib 1.2.0は[2003-03-09][120]にリリースされているため現在サポートしている動作環境では使えるはずです。

[120]: https://github.com/madler/zlib/blob/master/ChangeLog#L985

