### PR TITLE
Add void cast for unread variables

### DIFF
--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -1544,6 +1544,7 @@ void BBSListViewBase::add_newetcboard( const bool move, // true なら編集モ�
             if( row ){
                 row[ m_columns.m_url ] = url;
                 row[ m_columns.m_name ] = name;
+                static_cast<void>( row ); // cppcheck: unreadVariable
             }
         }
 

--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -350,6 +350,7 @@ void AboutConfig::append_row( const std::string& comment )
 
     row[ m_columns.m_col_name ]  = comment;
     row[ m_columns.m_col_type ] = CONFTYPE_COMMENT;
+    static_cast<void>( row ); // cppcheck: unreadVariable
 }
 
 

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -412,7 +412,10 @@ void MouseKeyDiag::slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::Tr
     if( ! row ) return;
 
     std::string str_motion = show_inputdiag( false );
-    if( ! str_motion.empty() ) row[ m_columns.m_col_motion ] = str_motion;
+    if( ! str_motion.empty() ) {
+        row[ m_columns.m_col_motion ] = str_motion;
+        static_cast<void>( row ); // cppcheck: unreadVariable
+    }
 }
 
 
@@ -460,6 +463,7 @@ void MouseKeyDiag::slot_add()
 
     Gtk::TreeModel::iterator it_new = m_liststore->append();
     ( *it_new )[ m_columns.m_col_motion ] = str_motion;
+    static_cast<void>( *it_new ); // cppcheck: unreadVariable
 }
 
 
@@ -581,6 +585,7 @@ void MouseKeyPref::append_comment_row( const std::string& comment )
         row[ m_columns.m_col_motions ] = std::string();
         row[ m_columns.m_col_id ] = CONTROL::None;
         row[ m_columns.m_col_drawbg ] = false;
+        static_cast<void>( row ); // cppcheck: unreadVariable
     }
 }
 

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -401,6 +401,7 @@ void FontColorPref::set_color_settings( const int colorid, const std::string& na
     row[ m_columns_color.m_col_color ] = std::string();
     row[ m_columns_color.m_col_colorid ] = colorid;
     row[ m_columns_color.m_col_default ] = defaultval;
+    static_cast<void>( row ); // cppcheck: unreadVariable
 }
 
 

--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -233,6 +233,7 @@ void LinkFilterPref::slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::
     if( diag.run() == Gtk::RESPONSE_OK ){
         row[ m_columns.m_col_url ] = diag.get_url();
         row[ m_columns.m_col_cmd ] = diag.get_cmd();
+        static_cast<void>( row ); // cppcheck: unreadVariable
     }
 }
 

--- a/src/skeleton/aboutdiag.cpp
+++ b/src/skeleton/aboutdiag.cpp
@@ -322,6 +322,7 @@ void AboutDiag::set_environment_list()
     row[ column_name ] = "主なオプション";
     row[ column_value ] = ENVIRONMENT::get_configure_args( ENVIRONMENT::CONFIGURE_OMITTED );
 
+    static_cast<void>( row ); // cppcheck: unreadVariable
     m_scrollwindow_environment.add( m_treeview_environment );
 }
 

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -901,6 +901,7 @@ void EditTreeView::draw_underline( const Gtk::TreePath& path, const bool draw )
     if( ! row ) return;
 
     row[ m_columns.m_underline ] = draw;
+    static_cast<void>( row ); // cppcheck: unreadVariable
 }
 
 

--- a/src/usrcmdpref.cpp
+++ b/src/usrcmdpref.cpp
@@ -372,5 +372,6 @@ void UsrCmdPref::slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::Tree
     if( diag.run() == Gtk::RESPONSE_OK ){
         row[ m_columns.m_name ] = diag.get_name();
         row[ m_columns.m_data ] = diag.get_cmd();
+        static_cast<void>( row ); // cppcheck: unreadVariable
     }
 }


### PR DESCRIPTION
[]演算子で代入した値を使っていないとcppcheckに指摘されましたが参照先を書き換えているためvoidキャストで警告を抑制します。

cppcheckのレポート
```
src/config/aboutconfig.cpp:352:33: style: Variable 'row[m_columns.m_col_type]' is assigned a value that is never used. [unreadVariable]
    row[ m_columns.m_col_type ] = CONFTYPE_COMMENT;
                                ^
src/bbslist/bbslistviewbase.cpp:1546:41: style: Variable 'row[m_columns.m_name]' is assigned a value that is never used. [unreadVariable]
                row[ m_columns.m_name ] = name;
                                        ^
src/control/mousekeypref.cpp:415:62: style: Variable 'row[m_columns.m_col_motion]' is assigned a value that is never used. [unreadVariable]
    if( ! str_motion.empty() ) row[ m_columns.m_col_motion ] = str_motion;
                                                             ^
src/control/mousekeypref.cpp:462:43: style: Variable '(*it_new)[m_columns.m_col_motion]' is assigned a value that is never used. [unreadVariable]
    ( *it_new )[ m_columns.m_col_motion ] = str_motion;
                                          ^
src/control/mousekeypref.cpp:587:39: style: Variable 'row[m_columns.m_col_drawbg]' is assigned a value that is never used. [unreadVariable]
        row[ m_columns.m_col_drawbg ] = false;
                                      ^
src/fontcolorpref.cpp:403:42: style: Variable 'row[m_columns_color.m_col_default]' is assigned a value that is never used. [unreadVariable]
    row[ m_columns_color.m_col_default ] = defaultval;
                                         ^
src/linkfilterpref.cpp:235:36: style: Variable 'row[m_columns.m_col_cmd]' is assigned a value that is never used. [unreadVariable]
        row[ m_columns.m_col_cmd ] = diag.get_cmd();
                                   ^
src/skeleton/aboutdiag.cpp:323:25: style: Variable 'row[column_value]' is assigned a value that is never used. [unreadVariable]
    row[ column_value ] = ENVIRONMENT::get_configure_args( ENVIRONMENT::CONFIGURE_OMITTED );
                        ^
src/usrcmdpref.cpp:374:33: style: Variable 'row[m_columns.m_data]' is assigned a value that is never used. [unreadVariable]
        row[ m_columns.m_data ] = diag.get_cmd();
                                ^
```