### PR TITLE
Move local variables to inner scope to avoid unused value

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1661,7 +1661,6 @@ const char* NodeTreeBase::add_one_dat_line( const char* datline )
 //
 void NodeTreeBase::parse_name( NODE* header, const char* str, const int lng, const int color_name )
 {
-    bool digitlink = true;
     const bool bold = true;
     const bool ahref = false;
     NODE *node;
@@ -1683,7 +1682,7 @@ void NodeTreeBase::parse_name( NODE* header, const char* str, const int lng, con
 
     // デフォルト名無しと同じときはアンカーを作らない
     if( defaultname ){
-        digitlink = false;
+        constexpr bool digitlink = false;
         parse_html( str, lng, color_name, digitlink, bold, ahref, FONT_MAIL );
     }
     else{
@@ -1704,7 +1703,7 @@ void NodeTreeBase::parse_name( NODE* header, const char* str, const int lng, con
             // </b>の前までパース
             if( i != pos ){
                 // デフォルト名無しと同じときはアンカーを作らない
-                digitlink = ( strncmp( m_default_noname.data(), str + pos, i - pos ) != 0 );
+                const bool digitlink = ( strncmp( m_default_noname.data(), str + pos, i - pos ) != 0 );
                 parse_html( str + pos, i - pos, color_name, digitlink, bold, ahref, FONT_MAIL );
             }
             if( i >= lng ) break;
@@ -1731,7 +1730,7 @@ void NodeTreeBase::parse_name( NODE* header, const char* str, const int lng, con
 #endif
 
             // </b><b>の中をパース
-            digitlink = false; // 数字が入ってもリンクしない
+            constexpr bool digitlink = false; // 数字が入ってもリンクしない
             parse_html( str + pos, pos_end - pos, COLOR_CHAR_NAME_B, digitlink, bold, ahref, FONT_MAIL );
 
             pos = pos_end + 3; // 3 = strlen( "<b>" );

--- a/src/image/imagearea.cpp
+++ b/src/image/imagearea.cpp
@@ -11,9 +11,8 @@
 
 #include "session.h"
 
-#ifndef MIN
-#define MIN( a, b ) ( a < b ? a : b )
-#endif
+#include <cmath>
+
 
 using namespace IMAGE;
 
@@ -67,7 +66,6 @@ void ImageAreaMain::show_image()
     int size = get_img()->get_size();
 
     // スケール調整
-    double scale = 1;
     int w_org = get_img()->get_width();
     int h_org = get_img()->get_height();
     set_width( w_org );
@@ -78,8 +76,8 @@ void ImageAreaMain::show_image()
         double scale_w = ( double ) width_max / w_org;
         double scale_h = ( double ) height_max / h_org;
 
-        if( SESSION::get_img_fit_mode() == SESSION::IMG_FIT_NORMAL ) scale = MIN( scale_w, scale_h );
-        else scale = scale_w;
+        const double scale = ( SESSION::get_img_fit_mode() == SESSION::IMG_FIT_NORMAL ) ? std::fmin( scale_w, scale_h )
+                                                                                        : scale_w;
 
         if( scale < 1 ){
             set_width( (int)( w_org * scale ) );
@@ -89,7 +87,7 @@ void ImageAreaMain::show_image()
 
     // サイズ変更
     else if( size != 100 ){
-        scale = size/100.;
+        const double scale = size / 100.0;
         set_width( (int)( w_org * scale ) );
         set_height( (int)( h_org * scale ) );
     }

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -186,12 +186,10 @@ void JDWindow::clock_in()
     // 折りたたみ処理
     if( m_fold_when_focusout ){
 
-        int waitcount = 0;
-
         // 遅延リサイズ( focus_in()にある説明を参照 )
         if( m_mode == JDWIN_EXPANDING ){
 
-            waitcount = FOCUS_TIME / TIMER_TIMEOUT;
+            constexpr int waitcount = FOCUS_TIME / TIMER_TIMEOUT;
             ++m_counter;
             if( m_counter > waitcount && ! ( m_counter % waitcount ) ){
 
@@ -237,7 +235,7 @@ void JDWindow::clock_in()
             && ! SESSION::is_iconified_win_main() // メインウィンドウが最小化しているときに transient を外すとウィンドウが表示されなくなる
             && ! SESSION::is_focus_win_main() && ! is_focus_win() ){
 
-            waitcount = FOCUSOUT_TIMEOUT / TIMER_TIMEOUT;
+            constexpr int waitcount = FOCUSOUT_TIMEOUT / TIMER_TIMEOUT;
 
             if( m_count_focusout < waitcount  ) ++m_count_focusout;
             if( m_count_focusout == waitcount ){


### PR DESCRIPTION
代入した値を使っていないとcppcheckに指摘されたため内側のスコープへ変数宣言を移動します。

cppcheckのレポート
```
src/image/imagearea.cpp:70:18: style: Variable 'scale' is assigned a value that is never used. [unreadVariable]
    double scale = 1;
                 ^
src/dbtree/nodetreebase.cpp:1664:20: style: Variable 'digitlink' is assigned a value that is never used. [unreadVariable]
    bool digitlink = true;
                   ^
src/skeleton/window.cpp:189:23: style: Variable 'waitcount' is assigned a value that is never used. [unreadVariable]
        int waitcount = 0;
                      ^
```