### PR TITLE
Remove local variable to avoid unread value

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -2355,7 +2355,6 @@ bool DrawAreaBase::draw_one_node( LAYOUT* layout, const CLIPINFO& ci )
                             paint_backscreen( m_pixbuf_refer_post, 0, s_top, 1, y - ci.pos_y + s_top,
                                               m_pixbuf_refer_post->get_width(), height );
                         }
-                        y += height_refer_post;
                     }
                 }
 
@@ -3984,7 +3983,10 @@ int DrawAreaBase::search( const std::list< std::string >& list_query, const bool
     if( ! reverse ){
         if( it != m_multi_selection.end() ) ( *it ).select = false;
         if( it == m_multi_selection.begin() )  m_multi_selection.back().select = true;
-        else ( *( --it ) ).select = true;
+        else {
+            --it;
+            it->select = true;
+        }
     }
 
     redraw_view_force();

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -1153,7 +1153,6 @@ bool BBSListViewBase::slot_motion_notify( GdkEventMotion* event )
     if( m_treeview.get_path_at_pos( x, y, path, column, cell_x, cell_y ) && m_treeview.get_row( path ) ){
 
         Gtk::TreeModel::Row row = m_treeview.get_row( path );
-        Glib::ustring subject = row[ m_columns.m_name ];
         Glib::ustring url = row[ m_columns.m_url ];
         int type = row[ m_columns.m_type ];
 

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -838,11 +838,6 @@ void BoardViewBase::save_column_width()
 void BoardViewBase::slot_cell_data( Gtk::CellRenderer* cell, const Gtk::TreeModel::iterator& it )
 {
     Gtk::TreeModel::Row row = *it;
-    Gtk::TreePath path = GET_PATH( row );
-
-#ifdef _DEBUG
-//    std::cout << "BoardViewBase::slot_cell_data path = " << path.to_string() << std::endl;
-#endif
 
     // ハイライト色 ( 抽出状態 )
     if( row[ m_columns.m_col_drawbg ] ){

--- a/src/dbimg/delimgcachediag.cpp
+++ b/src/dbimg/delimgcachediag.cpp
@@ -100,7 +100,7 @@ void DelImgCacheDiag::main_thread()
     std::cout << "DelImgCacheDiag::main_thread start\n";
 #endif
 
-    time_t days = 0;
+    std::time_t days{};
 
     // info と 画像キャッシュ
     std::list< std::string >list_infofile;

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -316,7 +316,9 @@ void Board2ch::update_hap()
     const std::string new_cookie = Board2chCompati::cookie_for_request();
 
     if( ! new_cookie.empty() ) {
+#ifdef _DEBUG
         const std::string old_cookie = get_hap();
+#endif
         set_hap( new_cookie );
 #ifdef _DEBUG
         std::cout << "Board2ch::update_hap old = " << old_cookie << std::endl;

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1963,7 +1963,6 @@ std::string BoardBase::import_dat( const std::string& filename )
         return std::string();
     }
 
-    const std::string dir = MISC::get_dir( filename );
     const std::string id = MISC::get_filename( filename );
     if( id.empty() || ! is_valid( id ) ){
         SKELETON::MsgDiag mdiag( nullptr, "ファイル名が正しくありません" );
@@ -2148,7 +2147,7 @@ void BoardBase::save_jdboard_info()
 #endif
 
     // あぼーん情報
-    std::string str_abone_id = MISC::listtostr( m_list_abone_id );
+//    std::string str_abone_id = MISC::listtostr( m_list_abone_id );
     std::string str_abone_name = MISC::listtostr( m_list_abone_name );
     std::string str_abone_word = MISC::listtostr( m_list_abone_word );
     std::string str_abone_regex = MISC::listtostr( m_list_abone_regex );

--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -207,7 +207,6 @@ bool MISC::is_utf( const char* input, size_t read_byte )
         // UTF-8の1バイト目の範囲ではない
         else if( ! UTF_RANGE_1( input[ byte ] ) )
         {
-            byte = 0;
             return false;
         }
 

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -280,8 +280,6 @@ void Post::receive_finish()
     std::string msg;
     std::string conf;
 
-    bool ret;
-
     // タイトル
     icase = true;
     newline = false; // . に改行をマッチさせる
@@ -366,12 +364,10 @@ void Post::receive_finish()
     // 2ch 型
     icase = false;
     newline = false; // . に改行をマッチさせる
-    ret = regex.exec( ".*</ul>.*<b>(.*)</b>.*<form.*", m_return_html, offset, icase, newline, usemigemo, wchar );
-
-    // 0ch 型
-    icase = false;
-    newline = false; // . に改行をマッチさせる
-    if( ! ret ) ret = regex.exec( ".*</ul>.*<b>(.*)</b>.*<input.*", m_return_html, offset, icase, newline, usemigemo, wchar );
+    if( ! regex.exec( ".*</ul>.*<b>(.*)</b>.*<form.*", m_return_html, offset, icase, newline, usemigemo, wchar ) ) {
+        // 0ch 型
+        regex.exec( ".*</ul>.*<b>(.*)</b>.*<input.*", m_return_html, offset, icase, newline, usemigemo, wchar );
+    }
 
     msg = MISC::remove_space( regex.str( 1 ) );
     const::std::list< std::string > list_cookies = SKELETON::Loadable::cookies();

--- a/src/skeleton/editview.cpp
+++ b/src/skeleton/editview.cpp
@@ -290,9 +290,6 @@ void EditTextView::undo()
     std::cout << udata.str_diff << std::endl;
 #endif
 
-    Glib::ustring text;
-    Glib::ustring text_head = get_buffer()->get_text().substr( 0, udata.pos );
-
     m_cancel_change = true; // slot_buffer_changed() の呼出をキャンセル
 
     // 追加と削除を逆転


### PR DESCRIPTION
値を代入した後使っていないとcppcheckに指摘されたため変数宣言や代入文を整理します。

cppcheckのレポート
```
src/article/drawareabase.cpp:2358:27: style: Variable 'y' is assigned a value that is never used. [unreadVariable]
                        y += height_refer_post;
                          ^
src/article/drawareabase.cpp:3987:35: style: Variable '(*(--it)).select' is assigned a value that is never used. [unreadVariable]
        else ( *( --it ) ).select = true;
                                  ^
src/bbslist/bbslistviewbase.cpp:1156:31: style: Variable 'subject' is assigned a value that is never used. [unreadVariable]
        Glib::ustring subject = row[ m_columns.m_name ];
                              ^
src/board/boardviewbase.cpp:841:24: style: Variable 'path' is assigned a value that is never used. [unreadVariable]
    Gtk::TreePath path = GET_PATH( row );
                       ^
src/dbimg/delimgcachediag.cpp:103:17: style: Variable 'days' is assigned a value that is never used. [unreadVariable]
    time_t days = 0;
                ^
src/dbtree/board2ch.cpp:319:38: style: Variable 'old_cookie' is assigned a value that is never used. [unreadVariable]
        const std::string old_cookie = get_hap();
                                     ^
src/dbtree/boardbase.cpp:1966:27: style: Variable 'dir' is assigned a value that is never used. [unreadVariable]
    const std::string dir = MISC::get_dir( filename );
                          ^
src/dbtree/boardbase.cpp:2151:30: style: Variable 'str_abone_id' is assigned a value that is never used. [unreadVariable]
    std::string str_abone_id = MISC::listtostr( m_list_abone_id );
                             ^
src/jdlib/misccharcode.cpp:210:18: style: Variable 'byte' is assigned a value that is never used. [unreadVariable]
            byte = 0;
                 ^
src/message/post.cpp:374:21: style: Variable 'ret' is assigned a value that is never used. [unreadVariable]
    if( ! ret ) ret = regex.exec( ".*</ul>.*<b>(.*)</b>.*<input.*", m_return_html, offset, icase, newline, usemigemo, wchar );
                    ^
src/skeleton/editview.cpp:294:29: style: Variable 'text_head' is assigned a value that is never used. [unreadVariable]
    Glib::ustring text_head = get_buffer()->get_text().substr( 0, udata.pos );
                            ^
```