### PR TITLE
Add explicit keyword to constructors which have one argument

### DIFF
--- a/src/article/articleadmin.h
+++ b/src/article/articleadmin.h
@@ -43,7 +43,7 @@ namespace ARTICLE
         std::unique_ptr<JDLIB::Timeout> m_conn_timer;
 
       public:
-        ArticleAdmin( const std::string& url );
+        explicit ArticleAdmin( const std::string& url );
         ~ArticleAdmin();
 
         void save_session() override;

--- a/src/article/articleview.h
+++ b/src/article/articleview.h
@@ -33,7 +33,7 @@ namespace ARTICLE
         int m_cancel_reload_counter{};
 
       public:
-        ArticleViewMain( const std::string& url );
+        explicit ArticleViewMain( const std::string& url );
         ~ArticleViewMain();
 
         void clock_in() override;

--- a/src/article/articleviewetc.h
+++ b/src/article/articleviewetc.h
@@ -18,7 +18,7 @@ namespace ARTICLE
         std::string m_str_center;
 
       public:
-        ArticleViewRes( const std::string& url );
+        explicit ArticleViewRes( const std::string& url );
         ~ArticleViewRes();
 
         // SKELETON::View の関数のオーバロード
@@ -42,7 +42,7 @@ namespace ARTICLE
         std::string m_str_name;
 
       public:
-        ArticleViewName( const std::string& url );
+        explicit ArticleViewName( const std::string& url );
         ~ArticleViewName();
 
         // SKELETON::View の関数のオーバロード
@@ -66,7 +66,7 @@ namespace ARTICLE
         std::string m_str_id;
 
       public:
-        ArticleViewID( const std::string& url );
+        explicit ArticleViewID( const std::string& url );
         ~ArticleViewID();
 
         // SKELETON::View の関数のオーバロード
@@ -90,7 +90,7 @@ namespace ARTICLE
         std::string m_str_id;
 
       public:
-        ArticleViewBM( const std::string& url );
+        explicit ArticleViewBM( const std::string& url );
         ~ArticleViewBM();
 
         // SKELETON::View の関数のオーバロード
@@ -115,7 +115,7 @@ namespace ARTICLE
         std::string m_str_id;
 
       public:
-        ArticleViewPost( const std::string& url );
+        explicit ArticleViewPost( const std::string& url );
         ~ArticleViewPost();
 
         // SKELETON::View の関数のオーバロード
@@ -140,7 +140,7 @@ namespace ARTICLE
         std::string m_str_id;
 
       public:
-        ArticleViewHighRefRes( const std::string& url );
+        explicit ArticleViewHighRefRes( const std::string& url );
         ~ArticleViewHighRefRes();
 
         // SKELETON::View の関数のオーバロード
@@ -163,7 +163,7 @@ namespace ARTICLE
     class ArticleViewURL : public ArticleViewBase
     {
       public:
-        ArticleViewURL( const std::string& url );
+        explicit ArticleViewURL( const std::string& url );
         ~ArticleViewURL();
 
         // SKELETON::View の関数のオーバロード
@@ -187,7 +187,7 @@ namespace ARTICLE
         std::string m_str_num;
 
       public:
-        ArticleViewRefer( const std::string& url );
+        explicit ArticleViewRefer( const std::string& url );
         ~ArticleViewRefer();
 
         // SKELETON::View の関数のオーバロード
@@ -213,7 +213,7 @@ namespace ARTICLE
         bool m_mode_or;
 
       public:
-        ArticleViewDrawout( const std::string& url );
+        explicit ArticleViewDrawout( const std::string& url );
         ~ArticleViewDrawout();
 
         // SKELETON::View の関数のオーバロード
@@ -236,7 +236,7 @@ namespace ARTICLE
         int m_num;
 
       public:
-        ArticleViewPostlog( const std::string& url );
+        explicit ArticleViewPostlog( const std::string& url );
         ~ArticleViewPostlog();
 
         // SKELETON::View の関数のオーバロード

--- a/src/article/articleviewinfo.h
+++ b/src/article/articleviewinfo.h
@@ -13,7 +13,7 @@ namespace ARTICLE
     class ArticleViewInfo : public ArticleViewBase
     {
       public:
-        ArticleViewInfo( const std::string& url );
+        explicit ArticleViewInfo( const std::string& url );
         ~ArticleViewInfo();
 
         // viewの操作をキャンセル

--- a/src/article/articleviewpopup.h
+++ b/src/article/articleviewpopup.h
@@ -155,7 +155,7 @@ namespace ARTICLE
     class ArticleViewPopupBM : public ArticleViewPopup
     {
       public:
-      ArticleViewPopupBM( const std::string& url ) : ArticleViewPopup( url, false ){}
+        explicit ArticleViewPopupBM( const std::string& url ) : ArticleViewPopup( url, false ){}
         ~ArticleViewPopupBM() noexcept = default;
 
         void show_view() override

--- a/src/article/articleviewpreview.h
+++ b/src/article/articleviewpreview.h
@@ -15,7 +15,7 @@ namespace ARTICLE
         std::string m_url_messageview;
 
       public:
-        ArticleViewPreview( const std::string& url );
+        explicit ArticleViewPreview( const std::string& url );
         ~ArticleViewPreview();
 
         bool operate_view( const int control ) override;

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -274,7 +274,7 @@ namespace ARTICLE
         SIG_ON_URL sig_on_url(){ return m_sig_on_url; }
         SIG_LEAVE_URL sig_leave_url(){ return m_sig_leave_url; }
 
-        DrawAreaBase( const std::string& url );
+        explicit DrawAreaBase( const std::string& url );
         ~DrawAreaBase();
 
         const std::string& get_url() const { return m_url; }

--- a/src/article/drawareainfo.h
+++ b/src/article/drawareainfo.h
@@ -12,7 +12,7 @@ namespace ARTICLE
     class DrawAreaInfo : public ARTICLE::DrawAreaBase
     {
       public:
-        DrawAreaInfo( const std::string& url );
+        explicit DrawAreaInfo( const std::string& url );
     };
 }
 

--- a/src/article/drawareamain.h
+++ b/src/article/drawareamain.h
@@ -12,7 +12,7 @@ namespace ARTICLE
     class DrawAreaMain : public ARTICLE::DrawAreaBase
     {
       public:
-        DrawAreaMain( const std::string& url );
+        explicit DrawAreaMain( const std::string& url );
     };
 }
 

--- a/src/article/embeddedimage.h
+++ b/src/article/embeddedimage.h
@@ -32,7 +32,7 @@ namespace ARTICLE
 
       public:
 
-        EmbeddedImage( const std::string& url );
+        explicit EmbeddedImage( const std::string& url );
         ~EmbeddedImage();
 
         Glib::RefPtr< Gdk::Pixbuf > get_pixbuf(){ return m_pixbuf; }

--- a/src/bbslist/bbslistadmin.h
+++ b/src/bbslist/bbslistadmin.h
@@ -29,7 +29,7 @@ namespace BBSLIST
 
       public:
 
-        BBSListAdmin( const std::string& url );
+        explicit BBSListAdmin( const std::string& url );
         ~BBSListAdmin();
 
         void save_session() override;

--- a/src/bbslist/bbslistview.h
+++ b/src/bbslist/bbslistview.h
@@ -15,7 +15,7 @@ namespace BBSLIST
     class BBSListViewMain : public BBSListViewBase
     {
       public:
-        BBSListViewMain( const std::string& url, const std::string& arg1 = std::string() , const std::string& arg2 = std::string() );
+        explicit BBSListViewMain( const std::string& url, const std::string& arg1 = {}, const std::string& arg2 = {} );
         ~BBSListViewMain();
 
         void show_view() override;

--- a/src/bbslist/bbslistviewbase.h
+++ b/src/bbslist/bbslistviewbase.h
@@ -182,7 +182,7 @@ namespace BBSLIST
 
       public:
 
-        BBSListViewBase( const std::string& url, const std::string& arg1 = std::string() , const std::string& arg2 = std::string() );
+        explicit BBSListViewBase( const std::string& url, const std::string& arg1 = {}, const std::string& arg2 = {} );
         ~BBSListViewBase();
 
         //

--- a/src/bbslist/favoriteview.h
+++ b/src/bbslist/favoriteview.h
@@ -14,7 +14,7 @@ namespace BBSLIST
     {
       public:
 
-        FavoriteListView( const std::string& url, const std::string& arg1 = std::string() , const std::string& arg2 = std::string() );
+        explicit FavoriteListView( const std::string& url, const std::string& arg1 = {}, const std::string& arg2 = {} );
         ~FavoriteListView();
 
         void show_view() override;

--- a/src/bbslist/historyview.h
+++ b/src/bbslist/historyview.h
@@ -35,35 +35,35 @@ namespace BBSLIST
     {
       public:
 
-        HistoryThreadView( const std::string& url, const std::string& arg1 = std::string() , const std::string& arg2 = std::string() );
+        explicit HistoryThreadView( const std::string& url, const std::string& arg1 = {}, const std::string& arg2 = {} );
     };
 
     class HistoryCloseView : public HistoryViewBase
     {
       public:
 
-        HistoryCloseView( const std::string& url, const std::string& arg1 = std::string() , const std::string& arg2 = std::string() );
+        explicit HistoryCloseView( const std::string& url, const std::string& arg1 = {}, const std::string& arg2 = {} );
     };
 
     class HistoryBoardView : public HistoryViewBase
     {
       public:
 
-        HistoryBoardView( const std::string& url, const std::string& arg1 = std::string() , const std::string& arg2 = std::string() );
+        explicit HistoryBoardView( const std::string& url, const std::string& arg1 = {}, const std::string& arg2 = {} );
     };
 
     class HistoryCloseBoardView : public HistoryViewBase
     {
       public:
 
-        HistoryCloseBoardView( const std::string& url, const std::string& arg1 = std::string() , const std::string& arg2 = std::string() );
+        explicit HistoryCloseBoardView( const std::string& url, const std::string& arg1 = {}, const std::string& arg2 = {} );
     };
 
     class HistoryCloseImgView : public HistoryViewBase
     {
       public:
 
-        HistoryCloseImgView( const std::string& url, const std::string& arg1 = std::string() , const std::string& arg2 = std::string() );
+        explicit HistoryCloseImgView( const std::string& url, const std::string& arg1 = {}, const std::string& arg2 = {} );
     };
 }
 

--- a/src/bbslist/selectlistview.h
+++ b/src/bbslist/selectlistview.h
@@ -22,7 +22,7 @@ namespace BBSLIST
 
       public:
 
-        SelectListView( const std::string& url, const std::string& arg1 = std::string() , const std::string& arg2 = std::string() );
+        explicit SelectListView( const std::string& url, const std::string& arg1 = {}, const std::string& arg2 = {} );
         ~SelectListView() noexcept;
 
         SIG_CLOSE_DIALOG sig_close_dialog() { return m_sig_close_dialog; }

--- a/src/board/boardadmin.h
+++ b/src/board/boardadmin.h
@@ -21,7 +21,7 @@ namespace BOARD
         BoardToolBar* m_toolbar;
 
       public:
-        BoardAdmin( const std::string& url );
+        explicit BoardAdmin( const std::string& url );
         ~BoardAdmin();
 
         void save_session() override;

--- a/src/board/boardview.h
+++ b/src/board/boardview.h
@@ -13,7 +13,7 @@ namespace BOARD
     {
       public:
 
-        BoardView( const std::string& url );
+        explicit BoardView( const std::string& url );
         ~BoardView();
 
         // SKELETON::View の関数のオーバロード

--- a/src/board/boardviewlog.h
+++ b/src/board/boardviewlog.h
@@ -18,7 +18,7 @@ namespace BOARD
 
       public:
 
-        BoardViewLog( const std::string& url );
+        explicit BoardViewLog( const std::string& url );
         ~BoardViewLog();
 
         void stop() override;

--- a/src/board/preference.h
+++ b/src/board/preference.h
@@ -28,7 +28,7 @@ namespace BOARD
         SKELETON::LabelEntry entry_host;
         SKELETON::LabelEntry entry_port;
 
-        ProxyFrame( const std::string& title )
+        explicit ProxyFrame( const std::string& title )
         : rd_global( "全体設定を使用する" ), rd_disable( "全体設定を無効にする" ), rd_local( "ローカル設定を使用する" ),
         entry_host( true, "ホスト：" ), entry_port( true, "ポート：" )
         {

--- a/src/config/aboutconfig.h
+++ b/src/config/aboutconfig.h
@@ -59,7 +59,7 @@ namespace CONFIG
 
       public:
 
-        AboutConfig( Gtk::Window* parent );
+        explicit AboutConfig( Gtk::Window* parent );
         ~AboutConfig() noexcept = default;
 
       private:

--- a/src/core.h
+++ b/src/core.h
@@ -125,7 +125,7 @@ namespace CORE
 
     public:
 
-        Core( JDWinMain& win_main );
+        explicit Core( JDWinMain& win_main );
         ~Core();
 
         Gtk::Widget* get_toplevel();

--- a/src/dbimg/img.h
+++ b/src/dbimg/img.h
@@ -53,7 +53,7 @@ namespace DBIMG
         
       public:
 
-        Img( const std::string& url );
+        explicit Img( const std::string& url );
         ~Img();
 
         void clock_in();

--- a/src/dbtree/articlehash.h
+++ b/src/dbtree/articlehash.h
@@ -67,7 +67,7 @@ namespace DBTREE
 
       public:
 
-        ArticleHashIterator( ArticleHash* hashtable );
+        explicit ArticleHashIterator( ArticleHash* hashtable );
 
         ArticleBase* operator * ();
         ArticleBase* operator ++ ();

--- a/src/dbtree/frontloader.h
+++ b/src/dbtree/frontloader.h
@@ -23,7 +23,7 @@ namespace DBTREE
 
       public:
 
-        FrontLoader( const std::string& url_boardbase );
+        explicit FrontLoader( const std::string& url_boardbase );
         ~FrontLoader() = default;
 
       protected:

--- a/src/dbtree/nodetreedummy.h
+++ b/src/dbtree/nodetreedummy.h
@@ -15,7 +15,7 @@ namespace DBTREE
     {
       public:
 
-        NodeTreeDummy( const std::string& url );
+        explicit NodeTreeDummy( const std::string& url );
         ~NodeTreeDummy();
 
         // ダウンロードしない

--- a/src/dbtree/nodetreelocal.h
+++ b/src/dbtree/nodetreelocal.h
@@ -15,7 +15,7 @@ namespace DBTREE
     {
       public:
 
-        NodeTreeLocal( const std::string& url );
+        explicit NodeTreeLocal( const std::string& url );
         ~NodeTreeLocal();
 
         // ダウンロードしない

--- a/src/dbtree/ruleloader.h
+++ b/src/dbtree/ruleloader.h
@@ -23,7 +23,7 @@ namespace DBTREE
 
       public:
 
-        RuleLoader( const std::string& url_boardbase );
+        explicit RuleLoader( const std::string& url_boardbase );
         ~RuleLoader();
 
       protected:

--- a/src/dbtree/settingloader.h
+++ b/src/dbtree/settingloader.h
@@ -35,7 +35,7 @@ namespace DBTREE
 
       public:
 
-        SettingLoader( const std::string& url_boardbase );
+        explicit SettingLoader( const std::string& url_boardbase );
         ~SettingLoader();
 
         const std::string& default_noname() const { return m_default_noname; }

--- a/src/history/historysubmenu.h
+++ b/src/history/historysubmenu.h
@@ -25,7 +25,7 @@ namespace HISTORY
 
       public:
 
-        HistorySubMenu( const std::string& url_history );
+        explicit HistorySubMenu( const std::string& url_history );
         ~HistorySubMenu();
 
         // 履歴の先頭を復元

--- a/src/image/imageadmin.h
+++ b/src/image/imageadmin.h
@@ -39,7 +39,7 @@ namespace IMAGE
 
       public:
 
-        ImageAdmin( const std::string& url );
+        explicit ImageAdmin( const std::string& url );
         ~ImageAdmin();
 
         void save_session() override;

--- a/src/image/imagearea.h
+++ b/src/image/imagearea.h
@@ -15,7 +15,7 @@ namespace IMAGE
     {
       public:
 
-        ImageAreaMain( const std::string& url );
+        explicit ImageAreaMain( const std::string& url );
         ~ImageAreaMain();
 
         void show_image() override;

--- a/src/image/imageareaicon.h
+++ b/src/image/imageareaicon.h
@@ -31,7 +31,7 @@ namespace IMAGE
 
       public:
 
-        ImageAreaIcon( const std::string& url );
+        explicit ImageAreaIcon( const std::string& url );
         ~ImageAreaIcon();
 
         void show_image() override;

--- a/src/image/imageareapopup.h
+++ b/src/image/imageareapopup.h
@@ -15,7 +15,7 @@ namespace IMAGE
     {
       public:
 
-        ImageAreaPopup( const std::string& url );
+        explicit ImageAreaPopup( const std::string& url );
         ~ImageAreaPopup();
         
         void show_image() override;

--- a/src/image/imageview.h
+++ b/src/image/imageview.h
@@ -32,7 +32,7 @@ namespace IMAGE
         bool m_scrolled{};
 
       public:
-        ImageViewMain( const std::string& url );
+        explicit ImageViewMain( const std::string& url );
         ~ImageViewMain();
 
         void clock_in() override;

--- a/src/image/imageviewbase.h
+++ b/src/image/imageviewbase.h
@@ -69,7 +69,7 @@ namespace IMAGE
 
       public:
 
-        ImageViewBase( const std::string& url, const std::string& arg1 = std::string(), const std::string& arg2 = std::string() );
+        explicit ImageViewBase( const std::string& url, const std::string& arg1 = {}, const std::string& arg2 = {} );
         ~ImageViewBase();
 
         bool is_under_mouse() const { return m_under_mouse; }

--- a/src/image/imageviewicon.h
+++ b/src/image/imageviewicon.h
@@ -16,7 +16,7 @@ namespace IMAGE
         Gtk::EventBox* m_event_frame;
 
       public:
-        ImageViewIcon( const std::string& url );
+        explicit ImageViewIcon( const std::string& url );
         ~ImageViewIcon();
 
         void clock_in() override;

--- a/src/image/imageviewpopup.h
+++ b/src/image/imageviewpopup.h
@@ -22,7 +22,7 @@ namespace IMAGE
 
       public:
 
-        ImageViewPopup( const std::string& url );
+        explicit ImageViewPopup( const std::string& url );
         ~ImageViewPopup();
 
         void clock_in() override;

--- a/src/jdlib/heap.h
+++ b/src/jdlib/heap.h
@@ -19,7 +19,7 @@ namespace JDLIB
         void* m_ptr_head; // 検索開始位置
 
       public:
-        HEAP( std::size_t blocksize ) noexcept;
+        explicit HEAP( std::size_t blocksize ) noexcept;
         ~HEAP();
 
         HEAP( const HEAP& ) = delete;

--- a/src/jdlib/imgloader.h
+++ b/src/jdlib/imgloader.h
@@ -54,7 +54,7 @@ namespace JDLIB
         bool equals( const std::string& file ) const;
         
     private:
-        ImgLoader( const std::string& file );
+        explicit ImgLoader( const std::string& file );
         bool load_imgfile( const int loadlevel );
         
         void slot_size_prepared( int w, int h );

--- a/src/jdlib/jdiconv.cpp
+++ b/src/jdlib/jdiconv.cpp
@@ -20,7 +20,7 @@ struct iconv_cast
 {
     char** const m_t;
     iconv_cast() = delete;
-    iconv_cast( char** t ) noexcept : m_t{ t } {}
+    explicit iconv_cast( char** t ) noexcept : m_t{ t } {}
     ~iconv_cast() noexcept = default;
 
     // POSIX-1.2008 : https://pubs.opengroup.org/onlinepubs/9699919799/functions/iconv.html

--- a/src/jdlib/loader.h
+++ b/src/jdlib/loader.h
@@ -70,7 +70,7 @@ namespace JDLIB
     public:
 
         // low_priority = true の時はスレッド起動待ち状態になった時に、起動順のプライオリティを下げる
-        Loader( const bool low_priority );
+        explicit Loader( const bool low_priority );
         ~Loader();
 
         bool is_loading() const { return m_loading; }

--- a/src/jdlib/timeout.h
+++ b/src/jdlib/timeout.h
@@ -34,7 +34,7 @@ namespace JDLIB
         static std::unique_ptr<Timeout> connect( const sigc::slot< bool > slot_timeout, unsigned int interval );
 
     private:
-        Timeout( const sigc::slot< bool > slot_timeout );
+        explicit Timeout( const sigc::slot< bool > slot_timeout );
         
 #ifdef _WIN32
         void slot_timeout_callback();

--- a/src/message/messageadmin.h
+++ b/src/message/messageadmin.h
@@ -41,7 +41,7 @@ namespace MESSAGE
 
       public:
 
-        MessageAdmin( const std::string& url );
+        explicit MessageAdmin( const std::string& url );
         ~MessageAdmin();
 
         void save_session() override {}

--- a/src/message/messageviewbase.h
+++ b/src/message/messageviewbase.h
@@ -79,7 +79,7 @@ namespace MESSAGE
 
       public:
 
-        MessageViewBase( const std::string& url );
+        explicit MessageViewBase( const std::string& url );
         ~MessageViewBase();
 
         //

--- a/src/openurldiag.h
+++ b/src/openurldiag.h
@@ -18,7 +18,7 @@ namespace CORE
 
       public:
 
-        OpenURLDialog( const std::string& url );
+        explicit OpenURLDialog( const std::string& url );
         ~OpenURLDialog() noexcept = default;
 
       protected:

--- a/src/skeleton/aamenu.h
+++ b/src/skeleton/aamenu.h
@@ -30,7 +30,7 @@ namespace SKELETON
 
       public:
 
-        AAMenu( Gtk::Window& parent );
+        explicit AAMenu( Gtk::Window& parent );
         ~AAMenu();
 
         // 選択されたらemitされる

--- a/src/skeleton/aboutdiag.h
+++ b/src/skeleton/aboutdiag.h
@@ -48,7 +48,7 @@ namespace SKELETON
 
       public:
 
-        AboutDiag( const Glib::ustring& title );
+        explicit AboutDiag( const Glib::ustring& title );
         ~AboutDiag() noexcept;
 
         int run();

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -64,7 +64,7 @@ namespace SKELETON
 
     public:
 
-        Admin( const std::string& url );
+        explicit Admin( const std::string& url );
         ~Admin();
 
         // コピー禁止

--- a/src/skeleton/compentry.h
+++ b/src/skeleton/compentry.h
@@ -43,7 +43,7 @@ namespace SKELETON
       public:
 
         // mode は補完モード ( compmanager.h 参照 )
-        CompletionEntry( const int mode );
+        explicit CompletionEntry( const int mode );
         ~CompletionEntry() noexcept;
 
         SIG_OPERATE signal_operate(){ return m_sig_operate; }

--- a/src/skeleton/hpaned.h
+++ b/src/skeleton/hpaned.h
@@ -18,7 +18,7 @@ namespace SKELETON
 
       public:
 
-        JDHPaned( const int fixmode );
+        explicit JDHPaned( const int fixmode );
         ~JDHPaned() noexcept;
 
         HPaneControl& get_ctrl(){ return m_pctrl; }

--- a/src/skeleton/iconpopup.h
+++ b/src/skeleton/iconpopup.h
@@ -16,7 +16,7 @@ namespace SKELETON
 
       public:
 
-        IconPopup( const int icon_id )
+        explicit IconPopup( const int icon_id )
             : Gtk::Window( Gtk::WINDOW_POPUP )
             , m_pixbuf{ ICON::get_icon( icon_id ) }
         {

--- a/src/skeleton/imgbutton.h
+++ b/src/skeleton/imgbutton.h
@@ -18,11 +18,11 @@ namespace SKELETON
 
       public:
 
-        ImgButton( const int id, const std::string& label = {} );
+        explicit ImgButton( const int id, const std::string& label = {} );
 
-        ImgButton( const Gtk::StockID& stock_id,
-                   const std::string& label = {},
-                   const Gtk::BuiltinIconSize icon_size = Gtk::ICON_SIZE_MENU );
+        explicit ImgButton( const Gtk::StockID& stock_id,
+                            const std::string& label = {},
+                            const Gtk::BuiltinIconSize icon_size = Gtk::ICON_SIZE_MENU );
 
         ~ImgButton() noexcept;
 

--- a/src/skeleton/imgtogglebutton.h
+++ b/src/skeleton/imgtogglebutton.h
@@ -18,11 +18,11 @@ namespace SKELETON
 
       public:
 
-        ImgToggleButton( const int id, const std::string& label = {} );
+        explicit ImgToggleButton( const int id, const std::string& label = {} );
 
-        ImgToggleButton( const Gtk::StockID& stock_id,
-                         const std::string& label = {},
-                         const Gtk::BuiltinIconSize icon_size = Gtk::ICON_SIZE_MENU );
+        explicit ImgToggleButton( const Gtk::StockID& stock_id,
+                                  const std::string& label = {},
+                                  const Gtk::BuiltinIconSize icon_size = Gtk::ICON_SIZE_MENU );
 
       private:
 

--- a/src/skeleton/login.h
+++ b/src/skeleton/login.h
@@ -27,7 +27,7 @@ namespace SKELETON
 
       public:
 
-        Login( const std::string& url );
+        explicit Login( const std::string& url );
         ~Login();
 
         bool login_now() const { return m_login_now; }

--- a/src/skeleton/msgdiag.h
+++ b/src/skeleton/msgdiag.h
@@ -88,7 +88,7 @@ namespace SKELETON
     {
       public:
 
-        MsgOverwriteDiag( Gtk::Window* parent );
+        explicit MsgOverwriteDiag( Gtk::Window* parent );
         ~MsgOverwriteDiag() noexcept;
     };
 }

--- a/src/skeleton/popupwinbase.h
+++ b/src/skeleton/popupwinbase.h
@@ -34,7 +34,7 @@ namespace SKELETON
       public:
 
         // draw_frame == true なら枠を描画する
-        PopupWinBase( bool draw_frame );
+        explicit PopupWinBase( bool draw_frame );
         ~PopupWinBase() noexcept;
 
         SIG_CONFIGURED_POPUP sig_configured(){ return m_sig_configured; }

--- a/src/skeleton/tablabel.h
+++ b/src/skeleton/tablabel.h
@@ -45,7 +45,7 @@ namespace SKELETON
 
       public:
 
-        TabLabel( const std::string& url );
+        explicit TabLabel( const std::string& url );
         ~TabLabel();
 
         SIG_TAB_MOTION_EVENT sig_tab_motion_event(){ return  m_sig_tab_motion_event; }

--- a/src/skeleton/tabnote.h
+++ b/src/skeleton/tabnote.h
@@ -71,7 +71,7 @@ namespace SKELETON
 
         SIG_SCROLL_EVENT sig_scroll_event(){ return m_sig_scroll_event; }
 
-        TabNotebook( DragableNoteBook* parent );
+        explicit TabNotebook( DragableNoteBook* parent );
         ~TabNotebook() noexcept;
 
         void clock_in();

--- a/src/skeleton/tabswitchbutton.h
+++ b/src/skeleton/tabswitchbutton.h
@@ -30,7 +30,7 @@ namespace SKELETON
 
       public:
 
-        TabSwitchButton( DragableNoteBook* parent );
+        explicit TabSwitchButton( DragableNoteBook* parent );
         ~TabSwitchButton() noexcept;
 
         Gtk::Button& get_button(){ return m_button; }

--- a/src/skeleton/toolbar.h
+++ b/src/skeleton/toolbar.h
@@ -76,7 +76,7 @@ namespace SKELETON
 
       public:
 
-        ToolBar( Admin* admin );
+        explicit ToolBar( Admin* admin );
         ~ToolBar() noexcept;
 
         void set_url( const std::string& url );

--- a/src/skeleton/toolbarnote.h
+++ b/src/skeleton/toolbarnote.h
@@ -20,7 +20,7 @@ namespace SKELETON
 
       public:
 
-        ToolBarNotebook( DragableNoteBook* parent );
+        explicit ToolBarNotebook( DragableNoteBook* parent );
         ~ToolBarNotebook() noexcept;
 
 #if !GTKMM_CHECK_VERSION(3,0,0)

--- a/src/skeleton/view.h
+++ b/src/skeleton/view.h
@@ -163,7 +163,7 @@ namespace SKELETON
         SIG_HIDE_POPUP sig_hide_popup(){ return m_sig_hide_popup; }
         SIG_RESIZE_POPUP sig_resize_popup(){ return m_sig_resize_popup; }
         
-        View( const std::string& url, const std::string& arg1 = std::string(), const std::string& arg2 = std::string() );
+        explicit View( const std::string& url, const std::string& arg1 = {}, const std::string& arg2 = {} );
         ~View() noexcept = default;
 
         virtual void save_session() = 0;

--- a/src/skeleton/viewnote.h
+++ b/src/skeleton/viewnote.h
@@ -20,7 +20,7 @@ namespace SKELETON
 
       public:
 
-        ViewNotebook( DragableNoteBook* parent );
+        explicit ViewNotebook( DragableNoteBook* parent );
         ~ViewNotebook() noexcept;
 
         void redraw_scrollbar();

--- a/src/skeleton/vpaned.h
+++ b/src/skeleton/vpaned.h
@@ -18,7 +18,7 @@ namespace SKELETON
 
       public:
 
-        JDVPaned( const int fixmode );
+        explicit JDVPaned( const int fixmode );
         ~JDVPaned() noexcept;
 
         VPaneControl& get_ctrl(){ return m_pctrl; }

--- a/src/skeleton/window.h
+++ b/src/skeleton/window.h
@@ -53,7 +53,7 @@ namespace SKELETON
 
       public:
 
-        JDWindow( const bool fold_when_focusout, const bool need_mginfo = true );
+        explicit JDWindow( const bool fold_when_focusout, const bool need_mginfo = true );
         ~JDWindow();
 
         Gtk::HBox& get_statbar(){ return  m_statbar; }

--- a/src/xml/document.h
+++ b/src/xml/document.h
@@ -21,7 +21,7 @@ namespace XML
       public:
 
         // 文字列を元にノードツリーを作る場合( html = HTMLモード )
-        Document( const std::string& str, const bool html = false );
+        explicit Document( const std::string& str, const bool html = false );
 
         // Gtk::TreeStore を元にノードツリーを作る場合
         // ただし列は SKELETON::EditColumns を継承したものであること


### PR DESCRIPTION
Bug reported by the cppcheck.

<details>
<summary>cppcheckのレポート</summary>

```
src/article/embeddedimage.h:35:9: style: Class 'EmbeddedImage' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/articleadmin.h:46:9: style: Class 'ArticleAdmin' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/drawareabase.h:277:9: style: Class 'DrawAreaBase' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/drawareamain.h:15:9: style: Class 'DrawAreaMain' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/drawareainfo.h:15:9: style: Class 'DrawAreaInfo' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/articleviewpreview.h:18:9: style: Class 'ArticleViewPreview' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/articleviewpopup.h:158:7: style: Class 'ArticleViewPopupBM' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/articleviewinfo.h:16:9: style: Class 'ArticleViewInfo' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/xml/document.h:24:9: style: Class 'Document' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/articleviewetc.h:21:9: style: Class 'ArticleViewRes' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/articleviewetc.h:45:9: style: Class 'ArticleViewName' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/articleviewetc.h:69:9: style: Class 'ArticleViewID' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/articleviewetc.h:93:9: style: Class 'ArticleViewBM' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/articleviewetc.h:118:9: style: Class 'ArticleViewPost' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/articleviewetc.h:143:9: style: Class 'ArticleViewHighRefRes' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/articleviewetc.h:166:9: style: Class 'ArticleViewURL' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/articleviewetc.h:190:9: style: Class 'ArticleViewRefer' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/articleviewetc.h:216:9: style: Class 'ArticleViewDrawout' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/articleviewetc.h:239:9: style: Class 'ArticleViewPostlog' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/article/articleview.h:36:9: style: Class 'ArticleViewMain' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/imgbutton.h:21:9: style: Class 'ImgButton' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/imgbutton.h:23:9: style: Class 'ImgButton' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/msgdiag.h:91:9: style: Class 'MsgOverwriteDiag' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/bbslist/bbslistviewbase.h:185:9: style: Class 'BBSListViewBase' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/bbslist/bbslistview.h:18:9: style: Class 'BBSListViewMain' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/bbslist/bbslistadmin.h:32:9: style: Class 'BBSListAdmin' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/bbslist/favoriteview.h:17:9: style: Class 'FavoriteListView' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/bbslist/selectlistview.h:25:9: style: Class 'SelectListView' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/bbslist/historyview.h:38:9: style: Class 'HistoryThreadView' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/bbslist/historyview.h:45:9: style: Class 'HistoryCloseView' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/bbslist/historyview.h:52:9: style: Class 'HistoryBoardView' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/bbslist/historyview.h:59:9: style: Class 'HistoryCloseBoardView' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/bbslist/historyview.h:66:9: style: Class 'HistoryCloseImgView' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/board/boardadmin.h:24:9: style: Class 'BoardAdmin' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/board/boardview.h:16:9: style: Class 'BoardView' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/board/boardviewlog.h:21:9: style: Class 'BoardViewLog' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/board/preference.h:31:9: style: Class 'ProxyFrame' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/hpaned.h:21:9: style: Class 'JDHPaned' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/vpaned.h:21:9: style: Class 'JDVPaned' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/core.h:128:9: style: Class 'Core' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/config/aboutconfig.h:62:9: style: Class 'AboutConfig' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/dbimg/img.h:56:9: style: Class 'Img' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/jdlib/heap.h:22:9: style: Class 'HEAP' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/dbtree/articlehash.h:70:9: style: Class 'ArticleHashIterator' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/dbtree/nodetreelocal.h:18:9: style: Class 'NodeTreeLocal' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/dbtree/frontloader.h:26:9: style: Class 'FrontLoader' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/dbtree/settingloader.h:38:9: style: Class 'SettingLoader' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/dbtree/ruleloader.h:26:9: style: Class 'RuleLoader' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/dbtree/nodetreedummy.h:18:9: style: Class 'NodeTreeDummy' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/history/historysubmenu.h:28:9: style: Class 'HistorySubMenu' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/image/imagearea.h:18:9: style: Class 'ImageAreaMain' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/image/imageareapopup.h:18:9: style: Class 'ImageAreaPopup' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/image/imageadmin.h:42:9: style: Class 'ImageAdmin' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/image/imageareaicon.h:34:9: style: Class 'ImageAreaIcon' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/image/imageviewbase.h:72:9: style: Class 'ImageViewBase' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/image/imageview.h:35:9: style: Class 'ImageViewMain' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/image/imageviewpopup.h:25:9: style: Class 'ImageViewPopup' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/image/imageviewicon.h:19:9: style: Class 'ImageViewIcon' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/jdlib/imgloader.h:57:9: style: Class 'ImgLoader' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/jdlib/jdiconv.cpp:23:5: style: Struct 'iconv_cast' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/jdlib/timeout.h:37:9: style: Class 'Timeout' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/login.h:30:9: style: Class 'Login' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/window.h:56:9: style: Class 'JDWindow' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/toolbar.h:79:9: style: Class 'ToolBar' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/message/messageadmin.h:44:9: style: Class 'MessageAdmin' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/message/messageviewbase.h:82:9: style: Class 'MessageViewBase' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/openurldiag.h:21:9: style: Class 'OpenURLDialog' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/aboutdiag.h:51:9: style: Class 'AboutDiag' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/popupwinbase.h:37:9: style: Class 'PopupWinBase' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/aamenu.h:33:9: style: Class 'AAMenu' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/view.h:166:9: style: Class 'View' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/compentry.h:46:9: style: Class 'CompletionEntry' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/tabnote.h:74:9: style: Class 'TabNotebook' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/toolbarnote.h:23:9: style: Class 'ToolBarNotebook' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/viewnote.h:23:9: style: Class 'ViewNotebook' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/tabswitchbutton.h:33:9: style: Class 'TabSwitchButton' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/tablabel.h:48:9: style: Class 'TabLabel' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/iconpopup.h:19:9: style: Class 'IconPopup' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/imgtogglebutton.h:21:9: style: Class 'ImgToggleButton' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/imgtogglebutton.h:23:9: style: Class 'ImgToggleButton' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
src/skeleton/admin.h:67:9: style: Class 'Admin' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
```

</details>
