### PR TITLE
Rename local variables to avoid shadowing

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1118,9 +1118,9 @@ void Core::run( const bool init, const bool skip_setupdiag )
 
     // メニューにショートカットキーやマウスジェスチャを表示
     for( auto&& widget : items ) {
-        auto item = dynamic_cast< Gtk::MenuItem* >( widget );
-        CONTROL::set_menu_motion( item->get_submenu() );
-        item->signal_activate().connect( sigc::mem_fun( *this, &Core::slot_activate_menubar ) );
+        auto menu_item = dynamic_cast< Gtk::MenuItem* >( widget );
+        CONTROL::set_menu_motion( menu_item->get_submenu() );
+        menu_item->signal_activate().connect( sigc::mem_fun( *this, &Core::slot_activate_menubar ) );
     }
 
     // ツールバー作成

--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -935,14 +935,14 @@ void Loader::run_main()
                 // ヘッダ取得
                 if( receiving_header ){
 
-                    const int ret = receive_header( m_buf, read_size );
-                    if( ret == HTTP_ERR ){
+                    const int http_code = receive_header( m_buf, read_size );
+                    if( http_code == HTTP_ERR ){
 
                         m_data.code = HTTP_ERR;
                         errmsg = "invalid header : " + m_data.url;
                         goto EXIT_LOADING;
                     }
-                    else if( ret == HTTP_OK ) receiving_header = false;
+                    else if( http_code == HTTP_OK ) receiving_header = false;
                 }
 
                 if( m_data.length && m_data.length <= m_data.length_current + read_size ) break;


### PR DESCRIPTION
ローカル変数の名前がシャドウイングされているとcppcheckに指摘されたため名前を変更します。

cppcheckのレポート
```
src/core.cpp:1113:14: style: Local variable 'item' shadows outer variable [shadowVariable]
        auto item = dynamic_cast< Gtk::MenuItem* >( widget );
             ^
src/core.cpp:1087:10: note: Shadowed declaration
    auto item = dynamic_cast< Gtk::MenuItem* >( *std::next( items.begin(), 2 ) );
         ^
src/core.cpp:1113:14: note: Shadow variable
        auto item = dynamic_cast< Gtk::MenuItem* >( widget );
             ^
src/jdlib/loader.cpp:938:31: style: Local variable 'ret' shadows outer variable [shadowVariable]
                    const int ret = receive_header( m_buf, read_size );
                              ^
src/jdlib/loader.cpp:732:9: note: Shadowed declaration
    int ret;
        ^
src/jdlib/loader.cpp:938:31: note: Shadow variable
                    const int ret = receive_header( m_buf, read_size );
                              ^
```