### PR TITLE
Core: Add const qualifier to function parameters

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1384,7 +1384,8 @@ void Core::set_maintitle()
 
 
 
-static inline void toggle_sidebar_action( Glib::RefPtr< Gtk::ActionGroup >& group, const std::string& action, const std::string url )
+static inline void toggle_sidebar_action( Glib::RefPtr< Gtk::ActionGroup >& group,
+                                          const std::string& action, const std::string& url )
 {
     Glib::RefPtr< Gtk::Action > act;
     Glib::RefPtr< Gtk::ToggleAction > tact;


### PR DESCRIPTION
関数の引数にconst修飾子を付けることができるとcppcheckに指摘されたため
修正します。

cppcheckのレポート
```
src/core.cpp:1387:129: performance: Parameter 'url' is passed by value. It could be passed as a const reference which is usually faster and recommended in C++. [passedByValue]
static inline void toggle_sidebar_action( Glib::RefPtr< Gtk::ActionGroup >& group, const std::string& action, const std::string url )
                                                                                                                                ^
```