### PR TITLE
Core: Fix member initialization

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -84,16 +84,12 @@ MESSAGE::get_admin()->set_command_immediately( "focus_out" ); \
 
 
 Core::Core( JDWinMain& win_main )
-    : m_win_main( win_main ),
-      m_hpaned( SKELETON::PANE_FIXSIZE_PAGE1 ),
-      m_vpaned_r( SKELETON::PANE_FIXSIZE_PAGE1 ),
-      m_hpaned_r( SKELETON::PANE_FIXSIZE_PAGE1 ),
-      m_imagetab_shown( 0 ),
-      m_vpaned_message( SKELETON::PANE_FIXSIZE_PAGE2 ),
-      m_toolbar( nullptr ),
-      m_enable_menuslot( true ),
-      m_init( false ),
-      m_count_savesession( 0 )
+    : m_win_main( win_main )
+    , m_hpaned( SKELETON::PANE_FIXSIZE_PAGE1 )
+    , m_vpaned_r( SKELETON::PANE_FIXSIZE_PAGE1 )
+    , m_hpaned_r( SKELETON::PANE_FIXSIZE_PAGE1 )
+    , m_vpaned_message( SKELETON::PANE_FIXSIZE_PAGE2 )
+    , m_enable_menuslot( true )
 {
     // ディスパッチマネージャ作成
     CORE::get_dispmanager();

--- a/src/core.h
+++ b/src/core.h
@@ -87,7 +87,7 @@ namespace CORE
         SKELETON::JDHPaned m_hpaned;
 
         // サイドバー
-        Gtk::Widget* m_sidebar;
+        Gtk::Widget* m_sidebar{};
 
         // (縦/横) 3ペーンモード時の右側ペーン
         SKELETON::JDVPaned m_vpaned_r; 
@@ -97,29 +97,29 @@ namespace CORE
         SKELETON::JDVBox m_vbox_article;
         SKELETON::JDVBox m_vbox_toolbar;
         SKELETON::JDNotebook m_notebook_right;
-        bool m_imagetab_shown;
+        bool m_imagetab_shown{};
         SKELETON::JDVPaned m_vpaned_message; // 埋め込み書き込みビュー用
 
         // ツールバー
-        MainToolBar* m_toolbar;
+        MainToolBar* m_toolbar{};
 
         // タイトルに表示する文字列
         // set_maintitle() 参照
         std::string m_title;
 
-        Gtk::MenuBar* m_menubar;
-        Gtk::MenuItem *m_menuitem_prevview;
-        Gtk::MenuItem *m_menuitem_nextview;
+        Gtk::MenuBar* m_menubar{};
+        Gtk::MenuItem* m_menuitem_prevview{};
+        Gtk::MenuItem* m_menuitem_nextview{};
 
         Glib::RefPtr< Gtk::ActionGroup > m_action_group;
         Glib::RefPtr< Gtk::UIManager > m_ui_manager;
         bool m_enable_menuslot;
 
         // 初期設定中
-        bool m_init;
+        bool m_init{};
 
         // セッション保存までのカウンタ
-        int m_count_savesession;
+        int m_count_savesession{};
 
         std::unique_ptr<JDLIB::Timeout> m_conn_timer;
 


### PR DESCRIPTION
メンバ変数の初期化を変更してcppcheckの警告 `(warning) Member variable 'Core::xxx' is not initialized in the constructor.` を修正します。

cppcheckのレポート
```
src/core.cpp:86:7: warning: Member variable 'Core::m_sidebar' is not initialized in the constructor. [uninitMemberVar]
Core::Core( JDWinMain& win_main )
      ^
src/core.cpp:86:7: warning: Member variable 'Core::m_menubar' is not initialized in the constructor. [uninitMemberVar]
Core::Core( JDWinMain& win_main )
      ^
src/core.cpp:86:7: warning: Member variable 'Core::m_menuitem_prevview' is not initialized in the constructor. [uninitMemberVar]
Core::Core( JDWinMain& win_main )
      ^
src/core.cpp:86:7: warning: Member variable 'Core::m_menuitem_nextview' is not initialized in the constructor. [uninitMemberVar]
Core::Core( JDWinMain& win_main )
      ^
```

関連のpull request: #208
