### PR TITLE
JDWinMain: Fix calling virtual function from the ctor and dtor

### DIFF
--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -33,8 +33,8 @@ JDWinMain::JDWinMain( const bool init, const bool skip_setupdiag,
 {
 #ifdef _DEBUG
     std::cout << "JDWinMain::JDWinMain init = " << init << std::endl
-              << "x y w h = " << get_x_win() << " " << get_y_win()
-              << " " << get_width_win() << " " << get_height_win() << std::endl;
+              << "x y w h = " << JDWinMain::get_x_win() << " " << JDWinMain::get_y_win()
+              << " " << JDWinMain::get_width_win() << " " << JDWinMain::get_height_win() << std::endl;
 #endif
 
     setlocale( LC_ALL, "ja_JP.UTF-8" );
@@ -61,23 +61,23 @@ JDWinMain::JDWinMain( const bool init, const bool skip_setupdiag,
     bool cancel_maximize = false;
     if( init_w >= 0 ){
         cancel_maximize = true;
-        set_width_win( init_w );
+        JDWinMain::set_width_win( init_w );
     }
     if( init_h >= 0 ){
         cancel_maximize = true;
-        set_height_win( init_h );
+        JDWinMain::set_height_win( init_h );
     }
     if( init_x >= 0 ){
         cancel_maximize = true;
-        set_x_win( init_x );
+        JDWinMain::set_x_win( init_x );
     }
     if( init_y >= 0 ){
         cancel_maximize = true;
-        set_y_win( init_y );
+        JDWinMain::set_y_win( init_y );
     }
     if( cancel_maximize ){
-        set_maximized_win( false );
-        set_full_win( false );
+        JDWinMain::set_maximized_win( false );
+        JDWinMain::set_full_win( false );
     }
 
     // サイズ変更
@@ -109,8 +109,9 @@ JDWinMain::JDWinMain( const bool init, const bool skip_setupdiag,
 JDWinMain::~JDWinMain()
 {
 #ifdef _DEBUG
-    std::cout << "JDWinMain::~JDWinMain window size : x = " << get_x_win() << " y = " << get_y_win()
-              << " w = " << get_width_win() << " h = " << get_height_win() << " max = " << is_maximized_win() << std::endl;
+    std::cout << "JDWinMain::~JDWinMain window size : x = " << JDWinMain::get_x_win()
+              << " y = " << JDWinMain::get_y_win() << " w = " << JDWinMain::get_width_win()
+              << " h = " << JDWinMain::get_height_win() << " max = " << JDWinMain::is_maximized_win() << std::endl;
 #endif
 
     if( m_core ){


### PR DESCRIPTION
JDWinMainはコンストラクタ・デストラクタ内で仮想関数set_xxx(), get_xxx()を呼び出していますが仮想関数はコンストラクタ・デストラクタ内で派生クラスの関数として呼び出しできないためcppcheckに警告されます。
そのためスコープ解決演算子を使ってクラスを明示します。

<details>
<summary>cppcheckのレポート</summary>

```
src/winmain.h:45:10: warning: Virtual function 'set_width_win' is called from constructor 'JDWinMain(const bool init,const bool skip_setupdiag,const int init_w,const int init_h,const int init_x,const int init_y)' at line 64. Dynamic binding is not used. [virtualCallInConstructor]
    void set_width_win( const int width ) override;
         ^
src/winmain.cpp:64:9: note: Calling set_width_win
        set_width_win( init_w );
        ^
src/winmain.h:45:10: note: set_width_win is a virtual function
    void set_width_win( const int width ) override;
         ^
src/winmain.h:46:10: warning: Virtual function 'set_height_win' is called from constructor 'JDWinMain(const bool init,const bool skip_setupdiag,const int init_w,const int init_h,const int init_x,const int init_y)' at line 68. Dynamic binding is not used. [virtualCallInConstructor]
    void set_height_win( const int height ) override;
         ^
src/winmain.cpp:68:9: note: Calling set_height_win
        set_height_win( init_h );
        ^
src/winmain.h:46:10: note: set_height_win is a virtual function
    void set_height_win( const int height ) override;
         ^
src/winmain.h:40:10: warning: Virtual function 'set_x_win' is called from constructor 'JDWinMain(const bool init,const bool skip_setupdiag,const int init_w,const int init_h,const int init_x,const int init_y)' at line 72. Dynamic binding is not used. [virtualCallInConstructor]
    void set_x_win( const int x ) override;
         ^
src/winmain.cpp:72:9: note: Calling set_x_win
        set_x_win( init_x );
        ^
src/winmain.h:40:10: note: set_x_win is a virtual function
    void set_x_win( const int x ) override;
         ^
src/winmain.h:41:10: warning: Virtual function 'set_y_win' is called from constructor 'JDWinMain(const bool init,const bool skip_setupdiag,const int init_w,const int init_h,const int init_x,const int init_y)' at line 76. Dynamic binding is not used. [virtualCallInConstructor]
    void set_y_win( const int y ) override;
         ^
src/winmain.cpp:76:9: note: Calling set_y_win
        set_y_win( init_y );
        ^
src/winmain.h:41:10: note: set_y_win is a virtual function
    void set_y_win( const int y ) override;
         ^
src/winmain.h:52:10: warning: Virtual function 'set_maximized_win' is called from constructor 'JDWinMain(const bool init,const bool skip_setupdiag,const int init_w,const int init_h,const int init_x,const int init_y)' at line 79. Dynamic binding is not used. [virtualCallInConstructor]
    void set_maximized_win( const bool set ) override;
         ^
src/winmain.cpp:79:9: note: Calling set_maximized_win
        set_maximized_win( false );
        ^
src/winmain.h:52:10: note: set_maximized_win is a virtual function
    void set_maximized_win( const bool set ) override;
         ^
src/winmain.h:58:10: warning: Virtual function 'set_full_win' is called from constructor 'JDWinMain(const bool init,const bool skip_setupdiag,const int init_w,const int init_h,const int init_x,const int init_y)' at line 80. Dynamic binding is not used. [virtualCallInConstructor]
    void set_full_win( const bool set ) override;
         ^
src/winmain.cpp:80:9: note: Calling set_full_win
        set_full_win( false );
        ^
src/winmain.h:58:10: note: set_full_win is a virtual function
    void set_full_win( const bool set ) override;
         ^
src/winmain.h:38:9: warning: Virtual function 'get_x_win' is called from constructor 'JDWinMain(const bool init,const bool skip_setupdiag,const int init_w,const int init_h,const int init_x,const int init_y)' at line 36. Dynamic binding is not used. [virtualCallInConstructor]
    int get_x_win() override;
        ^
src/winmain.cpp:36:34: note: Calling get_x_win
              << "x y w h = " << get_x_win() << " " << get_y_win()
                                 ^
src/winmain.h:38:9: note: get_x_win is a virtual function
    int get_x_win() override;
        ^
src/winmain.h:39:9: warning: Virtual function 'get_y_win' is called from constructor 'JDWinMain(const bool init,const bool skip_setupdiag,const int init_w,const int init_h,const int init_x,const int init_y)' at line 36. Dynamic binding is not used. [virtualCallInConstructor]
    int get_y_win() override;
        ^
src/winmain.cpp:36:56: note: Calling get_y_win
              << "x y w h = " << get_x_win() << " " << get_y_win()
                                                       ^
src/winmain.h:39:9: note: get_y_win is a virtual function
    int get_y_win() override;
        ^
src/winmain.h:43:9: warning: Virtual function 'get_width_win' is called from constructor 'JDWinMain(const bool init,const bool skip_setupdiag,const int init_w,const int init_h,const int init_x,const int init_y)' at line 37. Dynamic binding is not used. [virtualCallInConstructor]
    int get_width_win() override;
        ^
src/winmain.cpp:37:25: note: Calling get_width_win
              << " " << get_width_win() << " " << get_height_win() << std::endl;
                        ^
src/winmain.h:43:9: note: get_width_win is a virtual function
    int get_width_win() override;
        ^
src/winmain.h:44:9: warning: Virtual function 'get_height_win' is called from constructor 'JDWinMain(const bool init,const bool skip_setupdiag,const int init_w,const int init_h,const int init_x,const int init_y)' at line 37. Dynamic binding is not used. [virtualCallInConstructor]
    int get_height_win() override;
        ^
src/winmain.cpp:37:51: note: Calling get_height_win
              << " " << get_width_win() << " " << get_height_win() << std::endl;
                                                  ^
src/winmain.h:44:9: note: get_height_win is a virtual function
    int get_height_win() override;
        ^
src/winmain.h:38:9: warning: Virtual function 'get_x_win' is called from destructor '~JDWinMain()' at line 112. Dynamic binding is not used. [virtualCallInConstructor]
    int get_x_win() override;
        ^
src/winmain.cpp:112:64: note: Calling get_x_win
    std::cout << "JDWinMain::~JDWinMain window size : x = " << get_x_win() << " y = " << get_y_win()
                                                               ^
src/winmain.h:38:9: note: get_x_win is a virtual function
    int get_x_win() override;
        ^
src/winmain.h:39:9: warning: Virtual function 'get_y_win' is called from destructor '~JDWinMain()' at line 112. Dynamic binding is not used. [virtualCallInConstructor]
    int get_y_win() override;
        ^
src/winmain.cpp:112:90: note: Calling get_y_win
    std::cout << "JDWinMain::~JDWinMain window size : x = " << get_x_win() << " y = " << get_y_win()
                                                                                         ^
src/winmain.h:39:9: note: get_y_win is a virtual function
    int get_y_win() override;
        ^
src/winmain.h:43:9: warning: Virtual function 'get_width_win' is called from destructor '~JDWinMain()' at line 113. Dynamic binding is not used. [virtualCallInConstructor]
    int get_width_win() override;
        ^
src/winmain.cpp:113:29: note: Calling get_width_win
              << " w = " << get_width_win() << " h = " << get_height_win() << " max = " << is_maximized_win() << std::endl;
                            ^
src/winmain.h:43:9: note: get_width_win is a virtual function
    int get_width_win() override;
        ^
src/winmain.h:44:9: warning: Virtual function 'get_height_win' is called from destructor '~JDWinMain()' at line 113. Dynamic binding is not used. [virtualCallInConstructor]
    int get_height_win() override;
        ^
src/winmain.cpp:113:59: note: Calling get_height_win
              << " w = " << get_width_win() << " h = " << get_height_win() << " max = " << is_maximized_win() << std::endl;
                                                          ^
src/winmain.h:44:9: note: get_height_win is a virtual function
    int get_height_win() override;
        ^
src/winmain.h:51:10: warning: Virtual function 'is_maximized_win' is called from destructor '~JDWinMain()' at line 113. Dynamic binding is not used. [virtualCallInConstructor]
    bool is_maximized_win() override;
         ^
src/winmain.cpp:113:92: note: Calling is_maximized_win
              << " w = " << get_width_win() << " h = " << get_height_win() << " max = " << is_maximized_win() << std::endl;
                                                                                           ^
src/winmain.h:51:10: note: is_maximized_win is a virtual function
    bool is_maximized_win() override;
         ^
```

</details>
