### PR TITLE
JDWinMain: Unite if-statement blocks for same condition

### DIFF
--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -271,13 +271,13 @@ bool JDWinMain::on_delete_event( GdkEventAny* event )
 // 最大、最小化
 bool JDWinMain::on_window_state_event( GdkEventWindowState* event )
 {
-#ifdef _DEBUG
-    std::cout << "JDWinMain::on_window_state_event\n";
-    if( m_cancel_state_event ) std::cout << "cancel\n";
-#endif     
-
     // キャンセル ( JDWinMain::on_delete_even() の説明を参照せよ )
-    if( m_cancel_state_event ) return Gtk::Window::on_window_state_event( event );
+    if( m_cancel_state_event ) {
+#ifdef _DEBUG
+        std::cout << "JDWinMain::on_window_state_event cancel" << std::endl;
+#endif
+        return Gtk::Window::on_window_state_event( event );
+    }
 
     return SKELETON::JDWindow::on_window_state_event( event );
 }
@@ -285,13 +285,13 @@ bool JDWinMain::on_window_state_event( GdkEventWindowState* event )
 
 bool JDWinMain::on_configure_event( GdkEventConfigure* event )
 {
-#ifdef _DEBUG
-    std::cout << "JDWinMain::on_configure_event\n";
-    if( m_cancel_state_event ) std::cout << "cancel\n";
-#endif     
-
     // キャンセル ( JDWinMain::on_delete_event() の説明を参照せよ )
-    if( m_cancel_state_event ) return Gtk::Window::on_configure_event( event );
+    if( m_cancel_state_event ) {
+#ifdef _DEBUG
+        std::cout << "JDWinMain::on_configure_event cancel" << std::endl;
+#endif
+        return Gtk::Window::on_configure_event( event );
+    }
 
     return SKELETON::JDWindow::on_configure_event( event );
 }


### PR DESCRIPTION
隣り合うif文が同じ条件であるとcppcheckに指摘されたためブロックをまとめます。

cppcheckのレポート
```
src/winmain.cpp:281:9: style: The if condition is the same as the previous if condition [duplicateCondition]
    if( m_cancel_state_event ) return Gtk::Window::on_window_state_event( event );
        ^
src/winmain.cpp:277:9: note: First condition
    if( m_cancel_state_event ) std::cout << "cancel\n";
        ^
src/winmain.cpp:281:9: note: Second condition
    if( m_cancel_state_event ) return Gtk::Window::on_window_state_event( event );
        ^
src/winmain.cpp:295:9: style: The if condition is the same as the previous if condition [duplicateCondition]
    if( m_cancel_state_event ) return Gtk::Window::on_configure_event( event );
        ^
src/winmain.cpp:291:9: note: First condition
    if( m_cancel_state_event ) std::cout << "cancel\n";
        ^
src/winmain.cpp:295:9: note: Second condition
    if( m_cancel_state_event ) return Gtk::Window::on_configure_event( event );
        ^
```