### PR TITLE
MessageViewBase: Remove redundant null check

### DIFF
--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -985,11 +985,9 @@ void MessageViewBase::show_status()
 
     std::stringstream ss;
 
-    int line_count = 0;
-    if( m_text_message ){
-        line_count = m_text_message->get_buffer()->get_line_count();
-        ss << " [ 行数 " << line_count;
-    }
+    const int line_count = m_text_message->get_buffer()->get_line_count();
+    ss << " [ 行数 " << line_count;
+
     if( m_max_line ){
         ss << "/ " << m_max_line;
         if( m_max_line < line_count ) m_over_lines = true;


### PR DESCRIPTION
ポインターがnullの可能性があるとclang analyzerに指摘されましたが冗長なnullチェックを削除して検出しないように修正します。

Bug reported by the clang static analyzer.
```
Description: Called C++ object pointer is null
File: /home/ma8ma/var/repos/worktree/jdim-echo/src/message/messageviewbase.cpp
Line: 999
```