### PR TITLE
ImageAdmin: Add null check before dereferencing pointer

### DIFF
--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -551,7 +551,7 @@ void ImageAdmin::close_view( const std::string& url )
     SKELETON::View* view = get_view( url );
 
     if( ! icon && ! view ) return;
-    if( DBIMG::is_cached( url ) && icon->is_locked() ) return;
+    if( DBIMG::is_cached( url ) && icon && icon->is_locked() ) return;
 
     // 現在表示中のviewを閉じた場合は次か前の画像に切り替える
     if( view && view == get_current_view() ){


### PR DESCRIPTION
nullの可能性があるポインターをデリファレンスしているとclang-analyzerに指摘されたためnullチェックを追加します。

Bug reported by the clang static analyzer.
```
Description: Called C++ object pointer is null
File: /home/ma8ma/var/repos/JDim/src/image/imageadmin.cpp
Line: 554
```