### PR TITLE
Loader: Fix dead assignment

### DIFF
--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -1547,7 +1547,6 @@ bool Loader::unzip( char* buf, std::size_t read_size )
         // 出力バッファセット
         m_zstream.next_out = m_buf_zlib_out;
         m_zstream.avail_out = m_lng_buf_zlib_out;
-        byte_out = 0;
 
         // 解凍
         int ret = inflate( &m_zstream, Z_NO_FLUSH );


### PR DESCRIPTION
無意味な代入があるとclang analyzerに指摘されたため削除します。

Bug reported by the clang static analyzer.
```
Description: Value stored to 'byte_out' is never read
File: /home/ma8ma/var/repos/worktree/jdim-echo/src/jdlib/loader.cpp
Line: 1550
```