### PR TITLE
DrawAreaBase: Fix dead increment

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -2683,7 +2683,6 @@ bool NodeTreeBase::check_anchor( const int mode, const char* str_in,
             // アンカー文字をもう一度作成
             snprintf( str_link, lng_link, "%d-%d", ancinfo->anc_from, ancinfo->anc_to );
             pos += offset + n;
-            lng_out += offset + n;
         }
     }
 


### PR DESCRIPTION
無意味なインクリメントがあるとclang analyzerに指摘されたため削除します。

Bug reported by the clang static analyzer.
```
Description: Value stored to 'lng_out' is never read
File: /home/ma8ma/var/repos/worktree/jdim-echo/src/dbtree/nodetreebase.cpp
Line: 2686
```