### PR TITLE
DrawAreaBase: Add null check before dereferencing pointer

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -4303,6 +4303,7 @@ LAYOUT* DrawAreaBase::set_caret( CARET_POSITION& caret_pos, int x, int y )
                 // 次のノードが画像ノード場合
                 // 現在のノードの右端にキャレットをセットして画像ノードを返す
                 if( ( layout_next->type == DBTREE::NODE_IMG || layout_next->type == DBTREE::NODE_SSSP )
+                    && layout_next->rect
                     && ( layout_next->rect->x <= x && x <= layout_next->rect->x + layout_next->rect->width )
                     && ( layout_next->rect->y <= y && y <= layout_next->rect->y + layout_next->rect->height ) ){
 


### PR DESCRIPTION
nullの可能性があるポインターをデリファレンスしているとclang-analyzerに指摘されたためnullチェックを追加します。

Bug reported by the clang static analyzer.
```
Description: Access to field 'x' results in a dereference of a null pointer (loaded from field 'rect')
File: /home/ma8ma/var/repos/worktree/jdim-echo/src/article/drawareabase.cpp
Line: 4306
```