### PR TITLE
post: Fix compiler waring for -Wnon-virtual-dtor

### DIFF
--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -32,6 +32,8 @@ namespace {
 // 書き込み用のインターフェース
 struct WriteStrategy : public MESSAGE::PostStrategy
 {
+    WriteStrategy() noexcept = default;
+    ~WriteStrategy() noexcept = default;
     std::string url_bbscgi( const std::string& url ) override { return DBTREE::url_bbscgi( url ); }
     std::string url_subbbscgi( const std::string& url ) override { return DBTREE::url_subbbscgi( url ); }
 
@@ -47,6 +49,8 @@ struct WriteStrategy : public MESSAGE::PostStrategy
 // スレ立て用のインターフェース
 struct NewArticleStrategy : public MESSAGE::PostStrategy
 {
+    NewArticleStrategy() noexcept = default;
+    ~NewArticleStrategy() noexcept = default;
     std::string url_bbscgi( const std::string& url ) override { return DBTREE::url_bbscgi_new( url ); }
     std::string url_subbbscgi( const std::string& url ) override { return DBTREE::url_subbbscgi_new( url ); }
 

--- a/src/message/post.h
+++ b/src/message/post.h
@@ -24,6 +24,7 @@ namespace MESSAGE
     // 実行時にコンストラクタでインターフェースを選択する
     struct PostStrategy
     {
+        virtual ~PostStrategy() noexcept = default;
         virtual std::string url_bbscgi( const std::string& url ) = 0; // 1回目の投稿先
         virtual std::string url_subbbscgi( const std::string& url ) = 0; // 2回目の投稿先
         virtual void analyze_keyword( const std::string& url, const std::string& html ) = 0; // キーワードを解析


### PR DESCRIPTION
仮想関数を持つクラスが非仮想のデストラクタにアクセスしているとgcc 9に指摘されたため修正します。

gcc 9のレポート
```
In file included from ../src/message/messageview.cpp:8:
../src/message/post.h:25:12: warning: ‘struct MESSAGE::PostStrategy’ has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
   25 |     struct PostStrategy
      |            ^~~~~~~~~~~~
[171/314] Compiling C++ object 'src/message/350ae8d@@message@sta/messageviewbase.cpp.o'
In file included from ../src/message/messageviewbase.cpp:10:
../src/message/post.h:25:12: warning: ‘struct MESSAGE::PostStrategy’ has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
   25 |     struct PostStrategy
      |            ^~~~~~~~~~~~
[174/314] Compiling C++ object 'src/message/350ae8d@@message@sta/post.cpp.o'
In file included from ../src/message/post.cpp:7:
../src/message/post.h:25:12: warning: ‘struct MESSAGE::PostStrategy’ has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
   25 |     struct PostStrategy
      |            ^~~~~~~~~~~~
../src/message/post.cpp:33:8: warning: base class ‘struct MESSAGE::PostStrategy’ has accessible non-virtual destructor [-Wnon-virtual-dtor]
   33 | struct WriteStrategy : public MESSAGE::PostStrategy
      |        ^~~~~~~~~~~~~
../src/message/post.cpp:33:8: warning: ‘struct {anonymous}::WriteStrategy’ has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
../src/message/post.cpp:48:8: warning: base class ‘struct MESSAGE::PostStrategy’ has accessible non-virtual destructor [-Wnon-virtual-dtor]
   48 | struct NewArticleStrategy : public MESSAGE::PostStrategy
      |        ^~~~~~~~~~~~~~~~~~
../src/message/post.cpp:48:8: warning: ‘struct {anonymous}::NewArticleStrategy’ has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
```