### PR TITLE
Tweak meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -222,11 +222,12 @@ conf.set('XDGOPEN', 1)
 # gprof support
 if get_option('gprof').enabled()
   args = ['-pg']
-  found = cpp_compiler.has_multi_arguments(args)
-  if found
+  if cpp_compiler.has_multi_arguments(args)
     add_project_arguments(args, language: 'cpp')
     add_project_link_arguments(args,  language: 'cpp')
     configure_args += '\'--enable-gprof\''
+  else
+    error('not support -pg')
   endif
   message('Output profile information for gprof : YES')
 endif

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@
 # Fedora
 #   ディストロのパッケージをインストールする
 #   ```
-#   dnf meson ninja-build
+#   dnf install meson ninja-build
 #   ```
 #
 # Debian Buster, Ubuntu 20.04


### PR DESCRIPTION
mesonの設定を調整します。

- `gprof`オプションを利用するときコンパイラーが `-pg` オプションをサポートしない場合はエラーにします。
- meson.buildの導入説明でFedoraのコマンド例が間違っていたため修正します。

