### PR TITLE
Snap: Update dependencies to use GNOME 3.34 snapcraft extension

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,36 +7,41 @@ base: core18
 grade: stable
 icon: jdim.png
 
-# https://forum.snapcraft.io/t/gtk3-applications/13483
+# https://snapcraft.io/blog/gnome-3-34-snapcraft-extension
 parts:
   jdim:
-    plugin: autotools
+    plugin: meson
     source: https://github.com/JDimproved/JDim.git
     source-type: git
     source-branch: master
     source-depth: 1
-    configflags:
-      - --disable-compat-cache-dir
-      - --with-gtkmm3
-      - --with-pangolayout
-      - --with-xdgopen
+    meson-parameters:
+      # Use dpkg-buildflags to set compiler flags instead of meson options
+      - --buildtype=plain
+      - --prefix=/
+      - -Dcompat_cache_dir=disabled
+      - -Dpangolayout=enabled
+      - -Dregex=glib
     build-environment:
       # https://wiki.debian.org/Hardening
-      - CFLAGS: "$(dpkg-buildflags --get CFLAGS)"
-      - CPPFLAGS: "$(dpkg-buildflags --get CPPFLAGS)"
+      # Use -isystem to suppress compiler warning:
+      # /snap/gnome-3-34-1804-sdk/current/usr/include/limits.h:124:3: warning: #include_next is a GCC extension
+      - CPPFLAGS: "$(dpkg-buildflags --get CPPFLAGS) -isystem /snap/gnome-3-34-1804-sdk/current/usr/include"
       - CXXFLAGS: "$(dpkg-buildflags --get CXXFLAGS)"
       - LDFLAGS: "$(dpkg-buildflags --get LDFLAGS)"
     build-packages:
-      # https://packages.ubuntu.com/source/focal/jdim
+      - build-essential
+      - git
       - libgnutls28-dev
-      - libgtkmm-3.0-dev
-      - zlib1g-dev
-      - autoconf-archive
+      - libsigc++-2.0-dev
+    stage-packages:
+      # base or gnome-3-34 extension do not include the follow package:
+      - libsigc++-2.0-0v5
     override-build: |
       set -eu
       snapcraftctl build
       strip -s ${SNAPCRAFT_PART_INSTALL}/bin/jdim
-      VER="$(./src/jdim -V | sed -n -e '1s%^[^0-9]*\([^-]\+\)-\([^(]\+\)(git:\([0-9a-f]\+\).*$%\1-\2-\3%p')"
+      VER="$(${SNAPCRAFT_PART_INSTALL}/bin/jdim -V | sed -n -e '1s%^[^0-9]*\([^-]\+\)-\([^(]\+\)(git:\([0-9a-f]\+\).*$%\1-\2-\3%p')"
       echo "version ${VER}"
       snapcraftctl set-version "${VER}"
     override-prime: |
@@ -46,51 +51,12 @@ parts:
       ${SNAPCRAFT_PRIME}/share/applications/jdim.desktop
     parse-info: [jdim.metainfo.xml]
 
-  # gnome-3-28 extension does not bundle shared objects for C++ library.
-  jdim-depends:
-    plugin: nil
-    stage-packages:
-      # Exclude packages provided by gnome-3-28 extension and core18.
-      # https://gitlab.gnome.org/Community/Ubuntu/gnome-3-28-1804/blob/master/snapcraft.yaml
-      - libatkmm-1.6-1v5
-      - libcairomm-1.0-1v5
-      - libfribidi0
-      - libglibmm-2.4-1v5
-      - libgtkmm-3.0-1v5
-      - libpangomm-1.4-1v5
-      - libpcre2-8-0
-      - libsigc++-2.0-0v5
-    prime:
-      - -./etc
-      - -./lib
-      - -./usr/bin
-      - -./usr/sbin
-      - -./usr/share
-      - -./var
-      # Include shared objects for C++ library and a few missings.
-      - ./usr/lib/**/libatkmm-1.6.so*
-      - ./usr/lib/**/libcairomm-1.0.so*
-      - ./usr/lib/**/libfribidi.so*
-      - ./usr/lib/**/libgdkmm-3.0.so*
-      - ./usr/lib/**/libgiomm-2.4.so*
-      - ./usr/lib/**/libglibmm-2.4.so*
-      - ./usr/lib/**/libglibmm_generate_extra_defs-2.4.so*
-      - ./usr/lib/**/libgtkmm-3.0.so*
-      - ./usr/lib/**/libpangomm-1.4.so*
-      - ./usr/lib/**/libpcre2-8.so*
-      - ./usr/lib/**/libsigc-2.0.so*
-
 apps:
   jdim:
     command: bin/jdim
     common-id: com.github.jdimproved.JDim
     desktop: share/applications/jdim.desktop
-    # https://forum.snapcraft.io/t/the-gnome-3-28-extension/13485
-    extensions: [gnome-3-28]
+    extensions: [gnome-3-34]
     plugs:
-      - gsettings
       - home
       - network
-      - unity7
-    command-chain:
-      - snap/command-chain/desktop-launch


### PR DESCRIPTION
snapcraftに新たに導入された[GNOME 3.34 extension][gnome-3-34-1804]を使ってjdimを構築、頒布するようにsnapcraft.yamlを更新します。
また、正規表現ライブラリにGlib Regexを使うよう変更します。

Snapパッケージのビルドオプション
- `-Dcompat_cache_dir=disabled`
- `-Dpangolayout=enabled`
- `-Dregex=glib`

build時にgcc拡張を使用しているとメッセージが出るのでコンパイラーオプションで警告を抑制します。
```
/snap/gnome-3-34-1804-sdk/current/usr/include/limits.h:124:3: warning: #include_next is a GCC extension
# include_next <limits.h>
^~~~~~~~~~~~
```

prime時にライブラリが欠けているとメッセージが出るので指摘されたパッケージをバンドルします。
```
The 'jdim' part is missing libraries that are not included in the snap or base. They can be satisfied by adding the following entry for this part
stage-packages:
- libsigc++-2.0-0v5
```

[gnome-3-34-1804]: https://snapcraft.io/blog/gnome-3-34-snapcraft-extension

関連のissue: https://github.com/JDimproved/JDim/issues/314
