### PR TITLE
Snap: Drop architectures i386, ppc64el and s390x

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,10 @@ base: core18
 grade: stable
 icon: jdim.png
 
+# https://snapcraft.io/gnome-3-34-1804
+# Snap Store does not provide gnome-3-34-1804 package for i386, ppc64el and s390x
+architectures: [amd64, arm64, armhf]
+
 # https://snapcraft.io/blog/gnome-3-34-snapcraft-extension
 parts:
   jdim:


### PR DESCRIPTION
SnapがサポートするCPUアーキテクチャのうち i386, ppc64el, s390x ではgnome-3-34 extensionを使ったパッケージの構築ができないためパッケージのビルドと頒布を止めます。

- i386: https://build.snapcraft.io/user/JDimproved/JDim/1038357
  ```
  Could not install snap defined in plug 'gnome-3-34-1804'.
  The missing library report may have false positives listed if those libraries are provided by the content snap.
  ```

- ppc64el: https://build.snapcraft.io/user/JDimproved/JDim/1038309
  ```
  Failed to install or refresh a snap: 'gnome-3-34-1804-sdk' does not exist or is not available on the desired channel 'latest/stable'.
  Use `snap info gnome-3-34-1804-sdk` to get a list of channels the snap is available on.
  ```

- s390x: https://build.snapcraft.io/user/JDimproved/JDim/1038361
  ```
  Failed to install or refresh a snap: 'gnome-3-34-1804-sdk' does not exist or is not available on the desired channel 'latest/stable'.
  Use `snap info gnome-3-34-1804-sdk` to get a list of channels the snap is available on.
  ```

関連のissue: https://github.com/JDimproved/JDim/issues/314