### PR TITLE
Snap: Fix architectures settings

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,7 +9,13 @@ icon: jdim.png
 
 # https://snapcraft.io/gnome-3-34-1804
 # Snap Store does not provide gnome-3-34-1804 package for i386, ppc64el and s390x
-architectures: [amd64, arm64, armhf]
+architectures:
+  - build-on: amd64
+    runs-on: amd64
+  - build-on: arm64
+    runs-on: arm64
+  - build-on: armhf
+    runs-on: armhf
 
 # https://snapcraft.io/blog/gnome-3-34-snapcraft-extension
 parts:


### PR DESCRIPTION
前のコミット(fe1458eb3f6)はsnapcraft.yamlのarchitecturesにamd64, arm64, armhf 3つのアーキテクチャで実行可能なパッケージをビルドするように設定しています。
これは意図した設定と異なるため、CPUアーキテクチャ毎にパッケージをビルドするように修正します。

参考文献: https://snapcraft.io/docs/architectures