### PR TITLE
Snap: Fix wrong keyword "runs-on" to "run-on" for snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,11 +11,11 @@ icon: jdim.png
 # Snap Store does not provide gnome-3-34-1804 package for i386, ppc64el and s390x
 architectures:
   - build-on: amd64
-    runs-on: amd64
+    run-on: amd64
   - build-on: arm64
-    runs-on: arm64
+    run-on: arm64
   - build-on: armhf
-    runs-on: armhf
+    run-on: armhf
 
 # https://snapcraft.io/blog/gnome-3-34-snapcraft-extension
 parts:


### PR DESCRIPTION
設定項目名が間違っていたため修正します。

https://build.snapcraft.io/user/JDimproved/JDim/1038575
```
Issues while validating snapcraft.yaml: The 'architectures[0]' property does not match the required schema:
additional properties are not allowed ('runs-on' was unexpected) or orderedDict([('build-on', 'amd64'), ('runs-on', 'amd64')]) is not of type 'string'
```

関連のissue: https://github.com/JDimproved/JDim/issues/314