### PR TITLE
ArticleBase: Fix integer overflow

### DIFF
--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -155,7 +155,7 @@ const std::string& ArticleBase::get_since_date()
 int ArticleBase::get_speed()
 {
     time_t current_t = time( nullptr );
-    return ( get_number() * 60 * 60 * 24 ) / MAX( 1, current_t - get_since_time() );
+    return ( static_cast<std::time_t>( get_number() ) * 60 * 60 * 24 ) / MAX( 1, current_t - get_since_time() );
 }
 
 


### PR DESCRIPTION
gccのサニタイザーが算術オーバーフローを検出したためintの値をtime_tにキャストします。

サニタイザーのレポート
```
../src/dbtree/articlebase.cpp:158:37: runtime error: signed integer overflow: 37693 * 86400 cannot be represented in type 'int'
```