### PR TITLE
Replace snprintf with string format function

### DIFF
--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -1852,14 +1852,10 @@ void BoardViewBase::update_row_common( const Gtk::TreeModel::Row& row )
     // 読み込み数
 
     if( load ){
-        const int tmpsize = 32;
-        char tmp[ tmpsize ];
-        snprintf( tmp, tmpsize, "%d", load );
-        row[ m_columns.m_col_str_load ] = tmp;
-        snprintf( tmp, tmpsize, "%d", res - load );
-        row[ m_columns.m_col_str_new ] = tmp;
-
-        row[ m_columns.m_col_new ] = res - load;
+        row[ m_columns.m_col_str_load ] = Glib::ustring::compose( "%1", load );
+        const int new_arrival = res - load;
+        row[ m_columns.m_col_str_new ] = Glib::ustring::compose( "%1", new_arrival );;
+        row[ m_columns.m_col_new ] = new_arrival;
     }
     else{
         row[ m_columns.m_col_str_load ] = "";

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1551,13 +1551,12 @@ const char* NodeTreeBase::add_one_dat_line( const char* datline )
     m_vec_header.push_back( header );
 
     // レス番号
-    char tmplink[ LNG_RES ], tmpstr[ LNG_RES ];
-    snprintf( tmpstr, LNG_RES, "%d", header->id_header );
-    snprintf( tmplink, LNG_RES,"%s%d", PROTO_RES, header->id_header );    
+    const std::string tmpstr = std::to_string( header->id_header );
+    const std::string tmplink = PROTO_RES + tmpstr;
 
     node = header->headinfo->block[ BLOCK_NUMBER ] = create_node_block();
     node->fontid = FONT_MAIL;
-    create_node_link( tmpstr, strlen( tmpstr ) , tmplink, strlen( tmplink ), COLOR_CHAR_LINK_RES, true, FONT_MAIL );
+    create_node_link( tmpstr.c_str(), tmpstr.size(), tmplink.c_str(), tmplink.size(), COLOR_CHAR_LINK_RES, true, FONT_MAIL );
 
     const char* section[ SECTION_NUM ];
     int section_lng[ SECTION_NUM ];

--- a/src/jdlib/confloader.cpp
+++ b/src/jdlib/confloader.cpp
@@ -110,25 +110,14 @@ void ConfLoader::update( const std::string& name, const bool value )
 // 値を変更 (int型)
 void ConfLoader::update( const std::string& name, const int value )
 {
-    const int buflng = 256;
-    char str_value[ buflng ];
-    snprintf( str_value, buflng, "%d", value );
-    update( name, std::string( str_value ) );
+    update( name, std::to_string( value ) );
 }
 
 
 // 値を変更 (double型)
 void ConfLoader::update( const std::string& name, const double value )
 {
-    const int buflng = 256;
-    char str_value[ buflng ];
-#ifdef _WIN32
-    // not support to 'l' flag, error occurred if using
-    snprintf( str_value, buflng, "%f", value );
-#else
-    snprintf( str_value, buflng, "%lf", value );
-#endif
-    update( name, std::string( str_value ) );
+    update( name, std::to_string( value ) );
 }
 
 

--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -1098,15 +1098,13 @@ struct addrinfo* Loader::get_addrinfo( const std::string& hostname, const int po
 
     int ret;
     struct addrinfo hints, *res;
-    const int poststrlng = 256;
-    char port_str[ poststrlng ];
     memset( &hints, 0, sizeof( addrinfo ) );
     if( m_data.use_ipv6 ) hints.ai_family = AF_UNSPEC;
     else hints.ai_family = AF_INET;
     hints.ai_socktype = SOCK_STREAM;
 
-    snprintf( port_str, poststrlng, "%d", port );
-    ret = getaddrinfo( hostname.c_str(), port_str, &hints, &res );
+    const std::string port_str = std::to_string( port );
+    ret = getaddrinfo( hostname.c_str(), port_str.c_str(), &hints, &res );
     if( ret ) {
         MISC::ERRMSG( m_data.str_code );
         return nullptr;


### PR DESCRIPTION
- 数値の書式化を`Glib::ustring`の関数で行うように修正します。
- 数値から書式化して`std::string`に渡す変数を`snprintf()`から`std::to_string()`に変更します。
