### PR TITLE
Remove deprecated configure option --with-openssl

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -90,10 +90,6 @@
 
        GnuTLS のかわりに OpenSSL を使用する。ライセンス上バイナリ配布が出来なくなることに注意すること。
 
-    --with-openssl
-
-       非推奨: かわりに --with-tls=openssl を使用してください。
-
     --with-alsa
 
        ALSAによる効果音再生機能を有効にする。詳しくは"https://jdimproved.github.io/JDim/"の項を参照すること。

--- a/configure.ac
+++ b/configure.ac
@@ -258,12 +258,11 @@ AS_IF(
 
 
 dnl
-dnl checking OpenSSL (deprecated option)
+dnl checking OpenSSL (removed)
 dnl
 AC_ARG_WITH(openssl,
-AS_HELP_STRING([--with-openssl], [DEPRECATED. use --with-tls=openssl]),
-[AC_MSG_WARN([--with-openssl is deprecated. Use --with-tls=openssl instead.])
- with_tls=openssl])
+AS_HELP_STRING([--with-openssl], [NO LONGER AVAILABLE. use --with-tls=openssl]),
+[AC_MSG_ERROR([--with-openssl has been removed. Use --with-tls=openssl instead.])])
 
 dnl
 dnl TLS

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -99,8 +99,6 @@ OSやディストリビューション別の解説は[OS/ディストリビュ�
   <dd>使用するSSL/TLSライブラリを設定する。デフォルトでは GnuTLS を使用する。</dd>
   <dt>--with-tls=openssl</dt>
   <dd>GnuTLS のかわりに OpenSSL を使用する。ライセンス上バイナリ配布が出来なくなることに注意すること。</dd>
-  <dt>--with-openssl</dt>
-  <dd><strong>非推奨</strong>: かわりに <code>--with-tls=openssl</code> を使用してください。</dd>
 
   <dt>--with-alsa</dt>
   <dd>ALSA による効果音再生機能を有効にする。


### PR DESCRIPTION
非推奨のconfigureオプション`--with-openssl`を削除します。
削除したオプションを指定すると明示的にエラーを発生させます。