### PR TITLE
Remove deprecated configure options --with-[oniguruma|pcre]

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -130,14 +130,6 @@
        Perl互換の正規表現なので、従来の POSIX 拡張の正規表現から設定変更が必要になる場合がある。
        (v0.3.0+から追加)
 
-    --with-oniguruma
-
-       非推奨: かわりに --with-regex=oniguruma を使用してください。
-
-    --with-pcre
-
-       非推奨: かわりに --with-regex=glib を使用してください。
-
     --with-thread=[posix|glib|std]
 
        使用するスレッドライブラリを設定する。デフォルトでは std::thread を使用する。(v0.3.0以降)

--- a/configure.ac
+++ b/configure.ac
@@ -204,20 +204,18 @@ AS_IF(
 
 
 dnl
-dnl checking oniguruma (deprecated option)
+dnl checking oniguruma (removed)
 dnl
 AC_ARG_WITH(oniguruma,
-AS_HELP_STRING([--with-oniguruma], [DEPRECATED. use --with-regex=oniguruma]),
-[AC_MSG_WARN([--with-oniguruma is deprecated. Use --with-regex=oniguruma instead.])
- with_regex=oniguruma])
+AS_HELP_STRING([--with-oniguruma], [NO LONGER AVAILABLE. use --with-regex=oniguruma]),
+[AC_MSG_ERROR([--with-oniguruma has been removed. Use --with-regex=oniguruma instead.])])
 
 dnl
-dnl checking PCRE (deprecated option)
+dnl checking PCRE (removed)
 dnl
 AC_ARG_WITH(pcre,
-AS_HELP_STRING([--with-pcre], [DEPRECATED. use --with-regex=pcre]),
-[AC_MSG_WARN([--with-pcre is deprecated. Use --with-regex=pcre instead.])
- with_regex=pcre])
+AS_HELP_STRING([--with-pcre], [NO LONGER AVAILABLE. use --with-regex=pcre]),
+[AC_MSG_ERROR([--with-pcre has been removed. Use --with-regex=pcre instead.])])
 
 
 dnl

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -139,10 +139,6 @@ configure のかわりに [meson] を使ってビルドする方法は [GitHub][
     Perl互換の正規表現なので、従来の POSIX 拡張の正規表現から設定変更が必要になる場合がある。
     <small>(v0.3.0+から追加)</small>
   </dd>
-  <dt>--with-oniguruma</dt>
-  <dd><strong>非推奨</strong>: かわりに <code>--with-regex=oniguruma</code> を使用してください。</dd>
-  <dt>--with-pcre</dt>
-  <dd><strong>非推奨</strong>: かわりに <code>--with-regex=glib</code> を使用してください。</dd>
 
   <dt>--with-thread=[posix|glib|std]</dt>
   <dd>


### PR DESCRIPTION
非推奨のconfigureオプション`--with-oniguruma`と`--with-pcre`を削除します。
削除したオプションを指定すると明示的にエラーを発生させます。
