### PR TITLE
Remove deprecated configure option --with-xdgopen

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -142,7 +142,7 @@ jobs:
             packages: libssl-dev libonig-dev libmigemo-dev
           - config_args: --with-tls=gnutls --with-regex=pcre --with-alsa
             packages: libgnutls28-dev libpcre3-dev libasound2-dev
-          - config_args: --with-tls=openssl --with-regex=glib --with-xdgopen
+          - config_args: --with-tls=openssl --with-regex=glib
             packages: libssl-dev
     steps:
     - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ cache:
 
 matrix:
   include:
-    - name: "CONFIG_ARG=\"--with-tls=gnutls --with-regex=posix --with-migemo --with-xdgopen\""
+    - name: "CONFIG_ARG=\"--with-tls=gnutls --with-regex=posix --with-migemo\""
       os: linux
       compiler: gcc
-      env: CONFIG_ARG="--with-tls=gnutls --with-regex=posix --with-migemo --with-xdgopen"
+      env: CONFIG_ARG="--with-tls=gnutls --with-regex=posix --with-migemo"
       addons:
         apt:
           update: true

--- a/INSTALL
+++ b/INSTALL
@@ -96,11 +96,6 @@
 
        ALSAによる効果音再生機能を有効にする。詳しくは"https://jdimproved.github.io/JDim/"の項を参照すること。
 
-    --with-xdgopen
-
-       デフォルトブラウザとしてxdg-openを使用する。
-       xdg-openは将来のリリースでデフォルトブラウザになりこのオプションは廃止される予定です。
-
     --enable-gprof
 
        gprofによるプロファイリングを行う。コンパイルオプションに -pg が付き、JDimを実行すると

--- a/configure.ac
+++ b/configure.ac
@@ -319,22 +319,6 @@ AS_IF(
 
 
 dnl
-dnl checking xdg-open
-dnl
-AC_MSG_CHECKING(for --with-xdgopen)
-AC_ARG_WITH(xdgopen,
-AC_HELP_STRING([--with-xdgopen],[use xdg-open as default browser]),
-[with_xdgopen="$withval"], [with_xdgopen=no])
-AC_MSG_RESULT($with_xdgopen)
-
-AS_IF(
-  [test "x$with_xdgopen" = xyes],
-  [AC_DEFINE(XDGOPEN, , [use xdg-open])
-   AC_MSG_WARN([--with-xdgopen will be removed and as default in the future release.])]
-)
-
-
-dnl
 dnl checking alsa
 dnl
 case "${host_os}" in

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -106,11 +106,6 @@ configure のかわりに [meson] を使ってビルドする方法は [GitHub][
   <dt>--with-alsa</dt>
   <dd>ALSA による効果音再生機能を有効にする。
   詳しくは<a href="{{ site.baseurl }}/sound/">効果音の再生</a>の項を参照すること。</dd>
-  <dt>--with-xdgopen</dt>
-  <dd>
-    デフォルトブラウザとしてxdg-openを使用する。<br>
-    xdg-openは将来のリリースでデフォルトブラウザになりこのオプションは廃止される予定です。
-  </dd>
   <dt>--enable-gprof</dt>
   <dd>
     gprof によるプロファイリングを行う。

--- a/meson.build
+++ b/meson.build
@@ -216,9 +216,6 @@ else
   message('Use compatible cache directory: NO')
 endif
 
-# xdg-open
-conf.set('XDGOPEN', 1)
-
 
 #
 # コンパイラーの追加オプション

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -167,18 +167,11 @@ namespace CONFIG
     };
 
 // browsers.cpp のデフォルトのラベル番号
-// configure で --with-xdg-open を指定すると xdg-open をデフォルトにする
 // browsers.cpp のブラウザの順番に気をつけること
     enum{
-#ifndef _WIN32
-#ifdef XDGOPEN
-        CONF_BROWSER_NO = 1  // xdg-open をデフォルトにする
-#else
-        CONF_BROWSER_NO = 2  // firefox をデフォルトにする
-#endif
-#else /* _WIN32 */
-        CONF_BROWSER_NO = 1  // ie をデフォルトにする
-#endif /* _WIN32 */
+        // _WIN32 : ie をデフォルトにする
+        // not _WIN32 : xdg-open をデフォルトにする
+        CONF_BROWSER_NO = 1
     };
 
 #define CONF_FONTSIZE_THREAD "12"


### PR DESCRIPTION
非推奨のconfigureオプション`--with-xdgopen`を削除します。
削除したオプションを指定しても無視されますので注意してください。
合わせてCIマトリックスの設定からxdg-openのオプションを取り除きソースコードを整理します。

Closes #253