### PR TITLE
Remove deprecated configure option --with-regex=pcre

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -140,8 +140,8 @@ jobs:
             packages: libgnutls28-dev
           - config_args: --with-tls=openssl --with-regex=oniguruma --with-migemo --with-pangolayout
             packages: libssl-dev libonig-dev libmigemo-dev
-          - config_args: --with-tls=gnutls --with-regex=pcre --with-alsa
-            packages: libgnutls28-dev libpcre3-dev libasound2-dev
+          - config_args: --with-tls=gnutls --with-regex=glib --with-alsa
+            packages: libgnutls28-dev libasound2-dev
           - config_args: --with-tls=openssl --with-regex=glib
             packages: libssl-dev
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,10 @@ matrix:
             - libgnutls28-dev
             - libmigemo-dev
 
-    - name: "CONFIG_ARG=\"--with-tls=openssl --with-regex=pcre --with-alsa --with-compat-cache-dir\""
+    - name: "CONFIG_ARG=\"--with-tls=openssl --with-regex=glib --with-alsa --with-compat-cache-dir\""
       os: linux
       compiler: gcc
-      env: CONFIG_ARG="--with-tls=openssl --with-regex=pcre --with-alsa --with-compat-cache-dir"
+      env: CONFIG_ARG="--with-tls=openssl --with-regex=glib --with-alsa --with-compat-cache-dir"
       addons:
         apt:
           update: true
@@ -36,7 +36,6 @@ matrix:
             - libgtkmm-3.0-dev
             - zlib1g-dev
             - libssl-dev
-            - libpcre3-dev
             - libasound2-dev
 
     - name: "CONFIG_ARG=\"--with-tls=gnutls --with-regex=oniguruma --with-sessionlib=no --with-pangolayout\""

--- a/INSTALL
+++ b/INSTALL
@@ -37,7 +37,6 @@
   ・alsa-lib (--with-alsa)
   ・openssl (--with-tls=openssl)
   ・oniguruma (--with-regex=oniguruma)
-  ・libpcre (--with-regex=pcre, 非推奨)
   ・migemo (--with-migemo)
 
   OSやディストリビューション別の解説は"OS/ディストリビューション別インストール方法 [https://ja.osdn.net/projects/jd4linux/wiki/OS%2f%E3%83%87%E3%82%A3%E3%82%B9%E3%83%88%E3%83%AA%E3%83%93%E3%83%A5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E5%88%A5%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95]"(wiki) を参照。
@@ -101,7 +100,7 @@
        gprofによるプロファイリングを行う。コンパイルオプションに -pg が付き、JDimを実行すると
        gmon.out が出来るのでgprof./jdgmon.out で解析できる。CPUの最適化は効かなくなるので注意する。
 
-    --with-regex=[posix|oniguruma|pcre|glib]
+    --with-regex=[posix|oniguruma|glib]
 
        使用する正規表現ライブラリを設定する。デフォルトでは POSIX regex を使用する。
 
@@ -109,14 +108,6 @@
 
        POSIX regex のかわりに鬼車を使用する。
        鬼車はBSDライセンスなのでJDimをバイナリ配布する場合には注意すること(ライセンスはGPLになる)。
-
-    --with-regex=pcre
-
-       POSIX regex のかわりに PCRE を使用する。
-       PCREはBSDライセンスなのでJDimをバイナリ配布する場合には注意すること(ライセンスはGPLになる)。
-       UTF-8が有効な ( --enable-utf オプションを用いて make する ) PCRE 6.5 以降が必要となる。
-       Perl互換の正規表現なので、従来の POSIX 拡張の正規表現から設定変更が必要になる場合がある。
-       非推奨: かわりに --with-regex=glib を使用してください。
 
     --with-regex=glib
 

--- a/configure.ac
+++ b/configure.ac
@@ -200,8 +200,8 @@ dnl
 dnl checking PCRE (removed)
 dnl
 AC_ARG_WITH(pcre,
-AS_HELP_STRING([--with-pcre], [NO LONGER AVAILABLE. use --with-regex=pcre]),
-[AC_MSG_ERROR([--with-pcre has been removed. Use --with-regex=pcre instead.])])
+AS_HELP_STRING([--with-pcre], [NO LONGER AVAILABLE. use --with-regex=glib]),
+[AC_MSG_ERROR([--with-pcre has been removed. Use --with-regex=glib instead.])])
 
 
 dnl
@@ -209,7 +209,7 @@ dnl 正規表現ライブラリ
 dnl
 AC_MSG_CHECKING(for --with-regex)
 AC_ARG_WITH(regex,
-AC_HELP_STRING([--with-regex=@<:@posix|pcre|oniguruma|glib@:>@],
+AC_HELP_STRING([--with-regex=@<:@posix|oniguruma|glib@:>@],
                [use regular expression library @<:@default=posix@:>@]),
 [], [with_regex=posix])
 AC_MSG_RESULT($with_regex)
@@ -220,12 +220,7 @@ AS_IF(
    AC_CHECK_LIB([regex], [regexec])],
 
   [test "x$with_regex" = xpcre],
-  [PKG_CHECK_MODULES(PCRE, [libpcre >= 6.5])
-   AC_SUBST(PCRE_CFLAGS)
-   AC_SUBST(PCRE_LIBS)
-   AC_CHECK_HEADERS([pcreposix.h], , [AC_MSG_ERROR([pcreposix.h not found])])
-   AC_CHECK_LIB([pcreposix], [regexec], , [AC_MSG_ERROR([libpcreposix.a not found])])
-   AC_MSG_WARN([--with-regex=pcre will be removed in the future release.])],
+  [AC_MSG_ERROR([--with-regex=pcre has been removed. Use --with-regex=glib instead.])],
 
   [test "x$with_regex" = xoniguruma],
   [PKG_CHECK_MODULES(ONIG, [oniguruma])

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -50,7 +50,6 @@ layout: default
 - alsa-lib (`--with-alsa`)
 - openssl (`--with-tls=openssl`)
 - oniguruma (`--with-regex=oniguruma`)
-- libpcre (`--with-regex=pcre`, 非推奨)
 - migemo (`--with-migemo`)
 
 OSやディストリビューション別の解説は[OS/ディストリビューション別インストール方法][wiki-install] (JD wiki) を参照。
@@ -113,20 +112,12 @@ configure のかわりに [meson] を使ってビルドする方法は [GitHub][
     <code>gprof  ./jdim  gmon.out</code> で解析できる。CPUの最適化は効かなくなるので注意する。
   </dd>
 
-  <dt>--with-regex=[posix|oniguruma|pcre|glib]</dt>
+  <dt>--with-regex=[posix|oniguruma|glib]</dt>
   <dd>使用する正規表現ライブラリを設定する。デフォルトでは POSIX regex を使用する。</dd>
   <dt>--with-regex=oniguruma</dt>
   <dd>
     POSIX regex のかわりに鬼車を使用する。
     鬼車はBSDライセンスなのでJDimをバイナリ配布する場合には注意すること(ライセンスはGPLになる)。
-  </dd>
-  <dt>--with-regex=pcre</dt>
-  <dd>
-    POSIX regex のかわりに PCRE を使用する。
-    PCREはBSDライセンスなのでJDimをバイナリ配布する場合には注意すること(ライセンスはGPLになる)。
-    UTF-8が有効な ( <code>--enable-utf</code> オプションを用いて make する ) PCRE 6.5 以降が必要となる。
-    Perl互換の正規表現なので、従来の POSIX 拡張の正規表現から設定変更が必要になる場合がある。
-    <br><strong>非推奨</strong>: かわりに <code>--with-regex=glib</code> を使用してください。
   </dd>
   <dt>--with-regex=glib</dt>
   <dd>

--- a/src/jdlib/jdregex.cpp
+++ b/src/jdlib/jdregex.cpp
@@ -58,12 +58,7 @@ bool Regex::compile( const std::string& reg, const bool icase, const bool newlin
     if( reg.empty() ) return false;
 
 #if POSIX_STYLE_REGEX_API
-#ifdef HAVE_PCREPOSIX_H
-    int cflags = REG_UTF8;
-    if( ! newline ) cflags |= REG_DOTALL; // . を改行にマッチさせる
-#else
     int cflags = REG_EXTENDED;
-#endif
     if( newline ) cflags |= REG_NEWLINE;
     if( icase ) cflags |= REG_ICASE;
 #else

--- a/src/jdlib/jdregex.h
+++ b/src/jdlib/jdregex.h
@@ -12,15 +12,13 @@
 
 #if defined(HAVE_ONIGPOSIX_H)
 #include <onigposix.h>
-#elif defined(HAVE_PCREPOSIX_H)
-#include <pcreposix.h>
 #elif defined(HAVE_REGEX_H)
 #include <regex.h>
 #else
 #include <glib.h>
 #endif
 
-#if defined(HAVE_ONIGPOSIX_H) || defined(HAVE_PCREPOSIX_H) || defined(HAVE_REGEX_H)
+#if defined(HAVE_ONIGPOSIX_H) || defined(HAVE_REGEX_H)
 #define POSIX_STYLE_REGEX_API 1
 #endif
 


### PR DESCRIPTION
非推奨のconfigureオプション`--with-regex=pcre`を削除します。
削除したオプションを指定すると明示的にエラーを発生させます。
合わせてCIマトリックスの設定とソースコードを整理します。

関連のissue: #361 