### PR TITLE
Remove JDLIB::Thread implementations for pthread and gthread

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -351,8 +351,6 @@ AC_ARG_WITH(thread,
 AC_HELP_STRING([--with-thread=@<:@posix|glib|std@:>@], [NO LONGER AVAILABLE]),
 [AC_MSG_ERROR([thread library options have been removed. see https://github.com/JDimproved/JDim/issues/228])])
 
-AC_DEFINE(WITH_STD_THREAD, 1, [std::thread is now default.])
-
 
 dnl
 dnl checking pangolayout

--- a/meson.build
+++ b/meson.build
@@ -116,9 +116,6 @@ if cpp_compiler.has_header('sys/utsname.h')
   conf.set('HAVE_SYS_UTSNAME_H', 1)
 endif
 
-# thread
-conf.set('WITH_STD_THREAD', 1)
-
 
 #
 # オプションのパッケージ

--- a/src/jdlib/jdthread.cpp
+++ b/src/jdlib/jdthread.cpp
@@ -6,69 +6,25 @@
 #include "jdthread.h"
 #include "miscmsg.h"
 
-#include <limits.h>
-#include <cstring>
-#ifdef WITH_STD_THREAD
 #include <system_error>
-#endif
 
 using namespace JDLIB;
 
 
-#ifdef _DEBUG
-#ifdef WITH_STD_THREAD
-template < class CharT, class Traits >
-static std::basic_ostream< CharT, Traits >&
-operator<<( std::basic_ostream< CharT, Traits >& ost, const std::thread& pth )
-{
-    return ost << pth.get_id();
-}
-#endif // WITH_STD_THREAD
-#endif // _DEBUG
-
-
-Thread::Thread()
-{
-    JDTH_CLEAR( m_thread );
-#ifdef USE_GTHREAD
-    if( !Glib::thread_supported() ) Glib::thread_init();
-#endif
-}
-
-
 Thread::~Thread()
 {
-#ifdef _DEBUG
-    std::cout << "Thread::~Thread\n";
-    assert( ! is_running() );
-#endif
-
     join();
 }
 
 
-#ifdef USE_GTHREAD
-void Thread::slot_wrapper( STARTFUNC func, void* arg )
-{
-    func( arg );
-}
-#endif
-
-
 // スレッド作成
-bool Thread::create( STARTFUNC func , void* arg, const bool detach, const int stack_kbyte )
+bool Thread::create( STARTFUNC func , void* arg, const bool detach, const int )
 {
-    if( JDTH_ISRUNNING( m_thread ) ){
+    if( m_thread.joinable() ){
         MISC::ERRMSG( "Thread::create : thread is already running" );
         return false;
     }
 
-#if defined( WITH_STD_THREAD ) // std::thread 使用
-    static_cast< void >( stack_kbyte );
-
-#ifdef _DEBUG
-    std::cout << "Thread::create (stdthread)\n";
-#endif
     try {
         m_thread = std::thread( func, arg );
     }
@@ -79,67 +35,14 @@ bool Thread::create( STARTFUNC func , void* arg, const bool detach, const int st
 
     if( detach ) {
 #ifdef _DEBUG
-        std::cout << "detach\n";
+        std::cout << "Thread::create detach" << std::endl;
 #endif
         m_thread.detach();
-        assert( m_thread.get_id() == std::thread::id() );
+        assert( ! m_thread.joinable() );
     }
-
-#elif defined( USE_GTHREAD ) // gthread 使用
 
 #ifdef _DEBUG
-    std::cout << "Thread::create (gthread)\n";
-#endif
-
-    try {
-        m_thread = Glib::Thread::create(
-            sigc::bind( sigc::ptr_fun( Thread::slot_wrapper ), func, arg ),
-            stack_kbyte * 1024, ! detach, true, Glib::THREAD_PRIORITY_NORMAL );
-    }
-    catch( Glib::ThreadError& err )
-    {
-        MISC::ERRMSG( err.what() );
-        return false;
-    }
-
-    if( detach ){
-#ifdef _DEBUG
-        std::cout << "detach\n";
-#endif
-        JDTH_CLEAR( m_thread );
-    }
-
-#else // pthread 使用
-
-#ifdef _DEBUG
-    std::cout << "Thread::create (pthread)\n";
-#endif
-
-    int status;
-    pthread_attr_t attr;
-    size_t stacksize = PTHREAD_STACK_MIN + stack_kbyte * 1024;
-    pthread_attr_init( &attr );
-    pthread_attr_setstacksize( &attr, stacksize );
-    status = pthread_create( &m_thread, &attr, func, arg );
-    pthread_attr_destroy( &attr );
-
-    if( status ){
-        MISC::ERRMSG( std::string( "Thread::create : " ) + strerror( status ) );
-        return false;
-    }
-
-    if( detach ){
-#ifdef _DEBUG
-        std::cout << "detach\n";
-#endif
-        pthread_detach( m_thread );
-        JDTH_CLEAR( m_thread );
-    }
-
-#endif // USE_GTHREAD
-
-#ifdef _DEBUG
-    std::cout << "thread = " << m_thread << std::endl;
+    std::cout << "Thread::create thread = " << m_thread.get_id() << std::endl;
 #endif
 
     return true;
@@ -148,35 +51,12 @@ bool Thread::create( STARTFUNC func , void* arg, const bool detach, const int st
 
 bool Thread::join()
 {
-    if( ! JDTH_ISRUNNING( m_thread ) ) return true;
-
 #ifdef _DEBUG
-    std::cout << "Thread:join thread = " << m_thread << std::endl;
+    std::cout << "Thread::join thread = " << m_thread.get_id() << std::endl;
 #endif
 
-#if defined( WITH_STD_THREAD ) // std::thread 使用
     if( m_thread.joinable() ) {
         m_thread.join();
     }
-    JDTH_CLEAR( m_thread );
-
-#elif defined( USE_GTHREAD ) // gthread 使用
-
-    if( m_thread->joinable() ){
-        m_thread->join();
-    }
-    JDTH_CLEAR( m_thread );
-
-#else // pthread 使用
-
-    int status = pthread_join( m_thread, nullptr );
-    JDTH_CLEAR( m_thread );
-    if( status ){
-        MISC::ERRMSG( std::string( "Thread::join : " ) + strerror( status ) );
-        return false;
-    }
-
-#endif // USE_GTHREAD
-
     return true;
 }

--- a/src/jdlib/jdthread.h
+++ b/src/jdlib/jdthread.h
@@ -5,26 +5,8 @@
 #ifndef _JDTHREAD_H
 #define _JDTHREAD_H
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#if defined( WITH_STD_THREAD )
 #include <thread>
-#define JDTH_TYPE std::thread
-#define JDTH_ISRUNNING( pth ) ( ( pth ).get_id() != std::thread::id() )
-#define JDTH_CLEAR( pth ) ( ( pth ) = std::thread() )
-#elif defined( USE_GTHREAD )
-#include <gtkmm.h>
-#define JDTH_TYPE Glib::Thread*
-#define JDTH_ISRUNNING( pth ) ( ( pth ) != nullptr )
-#define JDTH_CLEAR( pth ) ( ( pth ) = nullptr )
-#else
-#include <pthread.h>
-#define JDTH_TYPE pthread_t
-#define JDTH_ISRUNNING( pth ) ( pth )
-#define JDTH_CLEAR( pth ) ( pth = 0 )
-#endif
+
 
 typedef void* ( *STARTFUNC )( void * );
 
@@ -43,18 +25,19 @@ namespace JDLIB
 
     class Thread
     {
-        JDTH_TYPE m_thread;
-
-#ifdef USE_GTHREAD
-        static void slot_wrapper( STARTFUNC func, void* arg );
-#endif
+        std::thread m_thread;
 
     public:
 
-        Thread();
+        Thread() noexcept = default;
+        Thread( Thread&& ) noexcept = delete;
+        Thread( const Thread& ) = delete;
         virtual ~Thread();
 
-        bool is_running() const { return JDTH_ISRUNNING( m_thread ); }
+        Thread& operator=( Thread&& ) noexcept = delete;
+        Thread& operator=( const Thread& ) = delete;
+
+        bool is_running() const noexcept { return m_thread.joinable(); }
 
         // スレッド作成
         bool create( STARTFUNC func , void * arg, const bool detach, const int stack_kbyte = DEFAULT_STACKSIZE );

--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -39,12 +39,6 @@ JDWinMain::JDWinMain( const bool init, const bool skip_setupdiag,
 
     setlocale( LC_ALL, "ja_JP.UTF-8" );
 
-#ifndef WITH_STD_THREAD
-    // GLIBのスレッドシステム初期化
-    if( !Glib::thread_supported() ) Glib::thread_init();
-    assert( Glib::thread_supported() );
-#endif
-
 #ifndef _WIN32
     // アイコンをセット
     // WindowsはwindresのデフォルトICONが初期適用されるので不要


### PR DESCRIPTION
`JDLIB::Thread`クラスの実装から廃止されたPOSIX threadとGlib Threadを削除します。
また、不慮の事故を避けるためThreadクラスのコピーやムーブを禁止しておきます。

