### PR TITLE
CookieManager: Accept empty value Cookie

### DIFF
--- a/src/jdlib/cookiemanager.cpp
+++ b/src/jdlib/cookiemanager.cpp
@@ -121,9 +121,6 @@ bool SimpleCookieParser::parse( const std::string& input, SimpleCookie& result )
 
     // クオート(")やエスケープ(\)が含まれているクッキーは解析失敗にする
     if( regex.exec( R"-(([^"\=;]+)=([^"\=;]*))-", input, offset, icase, newline, usemigemo, wchar ) ) {
-        // 値のないクッキーは解析失敗にする
-        if( regex.str( 2 ).empty() ) return false;
-
         result.name = regex.str( 1 );
         result.value = regex.str( 0 );
         offset = regex.str( 0 ).size();

--- a/test/gtest_jdlib_cookiemanager.cpp
+++ b/test/gtest_jdlib_cookiemanager.cpp
@@ -27,7 +27,7 @@ public:
 
 class CookieManager_GetCookieByHost : public CookieManager_TestBase {};
 
-TEST_F(CookieManager_GetCookieByHost, empty_value)
+TEST_F(CookieManager_GetCookieByHost, no_data)
 {
     const std::string expect = "";
     EXPECT_EQ( expect, the_cookie_manager->get_cookie_by_host( "example.com" ) );
@@ -46,6 +46,14 @@ TEST_F(CookieManager_GetCookieByHost, multiple_values)
     the_cookie_manager->feed( "example.com", "baz=qux" );
     // 現在の実装ではクッキー名を辞書順でソートする
     const std::string expect = "baz=qux; foo=bar";
+    EXPECT_EQ( expect, the_cookie_manager->get_cookie_by_host( "example.com" ) );
+}
+
+TEST_F(CookieManager_GetCookieByHost, empty_values)
+{
+    the_cookie_manager->feed( "example.com", "foo=" );
+    the_cookie_manager->feed( "example.com", "bar=" );
+    const std::string expect = "bar=; foo=";
     EXPECT_EQ( expect, the_cookie_manager->get_cookie_by_host( "example.com" ) );
 }
 


### PR DESCRIPTION
Fixes #412

JDサポートBBSに書き込めない不具合を修正するため空の値のCookieを送受信に含めるように変更します。
