### PR TITLE
Replace GtkNotebookPage* with Gtk::Widget*

### DIFF
--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -459,7 +459,7 @@ void Preferences::slot_remove_old_title()
 }
 
 
-void Preferences::slot_switch_page( GtkNotebookPage*, guint page )
+void Preferences::slot_switch_page( Gtk::Widget*, guint page )
 {
     if( m_notebook.get_nth_page( page ) == m_localrule ){
         m_localrule->set_command( "clear_screen" );

--- a/src/board/preference.h
+++ b/src/board/preference.h
@@ -11,10 +11,6 @@
 #include "skeleton/label_entry.h"
 
 
-#if GTKMM_CHECK_VERSION(3,0,0)
-using GtkNotebookPage = Gtk::Widget;
-#endif
-
 namespace BOARD
 {
     class ProxyFrame : public Gtk::Frame
@@ -159,7 +155,7 @@ namespace BOARD
         void slot_delete_cookie();
         void slot_check_live();
         void slot_remove_old_title();
-        void slot_switch_page( GtkNotebookPage*, guint page );
+        void slot_switch_page( Gtk::Widget*, guint page );
         void slot_ok_clicked() override;
         void timeout() override;
     };

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -3493,7 +3493,7 @@ bool Core::slot_timeout( int timer_number )
 //
 // 右ペーンのnotebookのタブの切替え
 //
-void Core::slot_switch_page( GtkNotebookPage*, guint )
+void Core::slot_switch_page( Gtk::Widget*, guint )
 {
     const bool present = false;
     const int page = get_right_current_page();

--- a/src/core.h
+++ b/src/core.h
@@ -25,10 +25,6 @@
 
 class JDWinMain;
 
-#if GTKMM_CHECK_VERSION(3,0,0)
-using GtkNotebookPage = Gtk::Widget;
-#endif
-
 
 namespace BOARD
 {
@@ -200,7 +196,7 @@ namespace CORE
         bool slot_timeout( int timer_number );
 
         // 右ペーンのnotebookのタブの切替え
-        void slot_switch_page( GtkNotebookPage*, guint page );
+        void slot_switch_page( Gtk::Widget*, guint page );
 
         // 右ペーンのnotebookのページ番号
         int get_right_current_page();

--- a/src/message/confirmdiag.cpp
+++ b/src/message/confirmdiag.cpp
@@ -34,7 +34,7 @@ ConfirmDiag::ConfirmDiag( const std::string& url, const std::string& message )
 ConfirmDiag::~ConfirmDiag() noexcept = default;
 
 
-void ConfirmDiag::slot_switch_page( GtkNotebookPage*, guint page )
+void ConfirmDiag::slot_switch_page( Gtk::Widget*, guint page )
 {
     if( get_notebook().get_nth_page( page ) == get_detail() ){
         get_detail()->set_command( "clear_screen" );

--- a/src/message/confirmdiag.h
+++ b/src/message/confirmdiag.h
@@ -24,7 +24,7 @@ namespace MESSAGE
 
       private:
 
-        void slot_switch_page( GtkNotebookPage*, guint page ) override;
+        void slot_switch_page( Gtk::Widget*, guint page ) override;
     };
 }
 

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -887,7 +887,7 @@ void MessageViewBase::post_fin()
 //
 // タブのページが切り替わったら呼ばれるslot
 //
-void MessageViewBase::slot_switch_page( GtkNotebookPage*, guint page )
+void MessageViewBase::slot_switch_page( Gtk::Widget*, guint page )
 {
 #ifdef _DEBUG
     std::cout << "MessageViewBase::slot_switch_page : " << get_url() << " page = " << page << std::endl;

--- a/src/message/messageviewbase.h
+++ b/src/message/messageviewbase.h
@@ -10,10 +10,6 @@
 #include "skeleton/compentry.h"
 #include "skeleton/jdtoolbar.h"
 
-#if GTKMM_CHECK_VERSION(3,0,0)
-using GtkNotebookPage = Gtk::Widget;
-#endif
-
 
 namespace JDLIB
 {
@@ -150,7 +146,7 @@ namespace MESSAGE
         void insert_draft();
 
         bool slot_button_press( GdkEventButton* event );
-        void slot_switch_page( GtkNotebookPage*, guint page );
+        void slot_switch_page( Gtk::Widget*, guint page );
         void slot_text_changed();
 
         virtual std::string create_message() = 0;

--- a/src/setupwizard.cpp
+++ b/src/setupwizard.cpp
@@ -306,7 +306,7 @@ SetupWizard::~SetupWizard()
 }
 
 
-void SetupWizard::slot_switch_page( GtkNotebookPage* notebookpage, guint page )
+void SetupWizard::slot_switch_page( Gtk::Widget* notebookpage, guint page )
 {
     switch( page ){
 

--- a/src/setupwizard.h
+++ b/src/setupwizard.h
@@ -11,9 +11,6 @@
 
 #include <gtkmm.h>
 
-#if GTKMM_CHECK_VERSION(3,0,0)
-using GtkNotebookPage = Gtk::Widget;
-#endif
 
 namespace CORE
 {
@@ -166,7 +163,7 @@ namespace CORE
         ~SetupWizard();
 
       private:
-        void slot_switch_page( GtkNotebookPage* notebookpage, guint page );
+        void slot_switch_page( Gtk::Widget* notebookpage, guint page );
 
         void slot_back();
         void slot_next();

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -2065,7 +2065,7 @@ std::string Admin::get_current_url()
 //
 // notebookのタブのページが切り替わったら呼ばれるslot
 //
-void Admin::slot_switch_page( GtkNotebookPage*, guint page )
+void Admin::slot_switch_page( Gtk::Widget*, guint page )
 {
     // 起動中とシャットダウン中は処理しない
     if( SESSION::is_booting() ) return;

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -17,9 +17,6 @@
 
 #include "command_args.h"
 
-#if GTKMM_CHECK_VERSION(3,0,0)
-using GtkNotebookPage = Gtk::Widget;
-#endif
 
 namespace SKELETON
 {
@@ -268,7 +265,7 @@ namespace SKELETON
         void reload_all_tabs( const int from_page );
 
         // notebookのタブが切り替わったときに呼ばれるslot
-        void slot_switch_page( GtkNotebookPage*, guint page );
+        void slot_switch_page( Gtk::Widget*, guint page );
 
         // タブをクリックした
         void slot_tab_clicked( const int page );

--- a/src/skeleton/detaildiag.cpp
+++ b/src/skeleton/detaildiag.cpp
@@ -51,7 +51,7 @@ void DetailDiag::timeout()
 }
 
 
-void DetailDiag::slot_switch_page( GtkNotebookPage*, guint page )
+void DetailDiag::slot_switch_page( Gtk::Widget*, guint page )
 {
     if( get_notebook().get_nth_page( page ) == m_detail ) m_detail->redraw_view();
 }

--- a/src/skeleton/detaildiag.h
+++ b/src/skeleton/detaildiag.h
@@ -9,9 +9,6 @@
 
 #include "prefdiag.h"
 
-#if GTKMM_CHECK_VERSION(3,0,0)
-using GtkNotebookPage = Gtk::Widget;
-#endif
 
 namespace SKELETON
 {
@@ -39,7 +36,7 @@ namespace SKELETON
 
       private:
 
-        virtual void slot_switch_page( GtkNotebookPage*, guint page );
+        virtual void slot_switch_page( Gtk::Widget*, guint page );
         void timeout() override;
     };
 }

--- a/src/skeleton/dragnote.cpp
+++ b/src/skeleton/dragnote.cpp
@@ -564,7 +564,7 @@ bool DragableNoteBook::adjust_tabwidth()
 //
 // notebook_tabのタブが切り替わったときに呼ばれるslot
 //
-void DragableNoteBook::slot_switch_page_tab( GtkNotebookPage* bookpage, guint page )
+void DragableNoteBook::slot_switch_page_tab( Gtk::Widget* bookpage, guint page )
 {
     // view も切り替える
     m_notebook_view.set_current_page( page );

--- a/src/skeleton/dragnote.h
+++ b/src/skeleton/dragnote.h
@@ -27,7 +27,7 @@ namespace SKELETON
     class TabLabel;
     class IconPopup;
 
-    typedef sigc::signal< void, GtkNotebookPage*, int > SIG_SWITCH_PAGE;
+    typedef sigc::signal< void, Gtk::Widget*, int > SIG_SWITCH_PAGE;
     typedef sigc::signal< void, int > SIG_TAB_CLICKED;
     typedef sigc::signal< void, int > SIG_TAB_CLOSE;
     typedef sigc::signal< void, int > SIG_TAB_RELOAD;
@@ -183,7 +183,7 @@ namespace SKELETON
         SKELETON::TabLabel* create_tablabel( const std::string& url );
 
         // notebook_tabのタブが切り替わったときに呼び出されるslot
-        void slot_switch_page_tab( GtkNotebookPage*, guint page );
+        void slot_switch_page_tab( Gtk::Widget*, guint page );
 
         // notebook_tab の上でボタンを押した/離した
         bool slot_button_press_event( GdkEventButton* event );

--- a/src/skeleton/tabnote.h
+++ b/src/skeleton/tabnote.h
@@ -10,9 +10,6 @@
 
 #include <gtkmm.h>
 
-#if GTKMM_CHECK_VERSION(3,0,0)
-using GtkNotebookPage = Gtk::Widget;
-#endif
 
 namespace SKELETON
 {


### PR DESCRIPTION
シグナルハンドラーの引数の型を更新してGTK2対応コードを整理します。