### PR TITLE
PopupWinBase: Remove member functions which are no longer in use

### DIFF
--- a/src/skeleton/popupwinbase.cpp
+++ b/src/skeleton/popupwinbase.cpp
@@ -5,9 +5,7 @@
 
 #include "popupwinbase.h"
 
-#if GTKMM_CHECK_VERSION(3,0,0)
 #include "command.h"
-#endif
 
 
 using namespace SKELETON;
@@ -17,34 +15,17 @@ PopupWinBase::PopupWinBase( bool draw_frame )
     : Gtk::Window( Gtk::WINDOW_POPUP )
     , m_draw_frame( draw_frame )
 {
-#ifdef _DEBUG
-    std::cout << "PopupWinBase::PopupWinBase\n";
-#endif
-
     if( m_draw_frame ) set_border_width( 1 );
-#if GTKMM_CHECK_VERSION(3,0,0)
+
     if ( auto main_window = CORE::get_mainwindow() ) {
         set_transient_for( *main_window );
     }
-#endif
 }
 
 
 PopupWinBase::~PopupWinBase() noexcept = default;
 
 
-void PopupWinBase::on_realize()
-{
-    Gtk::Window::on_realize();
-
-#if !GTKMM_CHECK_VERSION(3,0,0)
-    const Glib::RefPtr< Gdk::Window > window = get_window();
-    m_gc = Gdk::GC::create( window );
-#endif
-}
-
-
-#if GTKMM_CHECK_VERSION(3,0,0)
 bool PopupWinBase::on_draw( const Cairo::RefPtr< Cairo::Context >& cr )
 {
     const bool ret = Gtk::Window::on_draw( cr );
@@ -56,20 +37,6 @@ bool PopupWinBase::on_draw( const Cairo::RefPtr< Cairo::Context >& cr )
     }
     return ret;
 }
-#else
-bool PopupWinBase::on_expose_event( GdkEventExpose* event )
-{
-    const bool ret = Gtk::Window::on_expose_event( event );
-
-    // 枠の描画
-    if( m_draw_frame ) {
-        m_gc->set_foreground( Gdk::Color( "black" ) );
-        get_window()->draw_rectangle( m_gc, false, 0, 0, get_width()-1, get_height()-1 );
-    }
-
-    return ret;
-}
-#endif // GTKMM_CHECK_VERSION(3,0,0)
 
 
 bool PopupWinBase::on_configure_event( GdkEventConfigure* event )

--- a/src/skeleton/popupwinbase.h
+++ b/src/skeleton/popupwinbase.h
@@ -3,6 +3,7 @@
 //
 // ポップアップウィンドウの基底クラス
 //
+// TODO: 枠線はcssで設定する
 
 #ifndef POPUPWINBASE_H
 #define POPUPWINBASE_H
@@ -25,10 +26,6 @@ namespace SKELETON
     class PopupWinBase : public Gtk::Window
     {
         SIG_CONFIGURED_POPUP m_sig_configured;
-#if !GTKMM_CHECK_VERSION(3,0,0)
-        Glib::RefPtr< Gdk::GC > m_gc;
-#endif
-
         const bool m_draw_frame;
 
       public:
@@ -41,12 +38,7 @@ namespace SKELETON
 
       protected:
 
-        void on_realize() override;
-#if GTKMM_CHECK_VERSION(3,0,0)
         bool on_draw( const Cairo::RefPtr< Cairo::Context >& cr ) override;
-#else
-        bool on_expose_event( GdkEventExpose* event ) override;
-#endif
         bool on_configure_event( GdkEventConfigure* event ) override;
     };
 }


### PR DESCRIPTION
使われなくなったメンバ関数を削除しGTK2対応コードを整理します。

関連のissue: #229 
