### PR TITLE
TabSwtichButton: Remove member function which are no longer in use

### DIFF
--- a/src/skeleton/tabswitchbutton.cpp
+++ b/src/skeleton/tabswitchbutton.cpp
@@ -4,18 +4,13 @@
 #include "jddebug.h"
 
 #include "tabswitchbutton.h"
-#if !GTKMM_CHECK_VERSION(3,0,0)
-#include "dragnote.h"
-#endif
+
 
 using namespace SKELETON;
 
 
-TabSwitchButton::TabSwitchButton( DragableNoteBook* parent )
+TabSwitchButton::TabSwitchButton( DragableNoteBook* )
     : Gtk::Notebook()
-#if !GTKMM_CHECK_VERSION(3,0,0)
-    , m_parent( parent )
-#endif
 {
     set_border_width( 0 );
 
@@ -25,15 +20,8 @@ TabSwitchButton::TabSwitchButton( DragableNoteBook* parent )
     m_button.set_focus_on_click( false );
 
     // フォーカス時にボタンの枠がはみ出さないようにする
-#if GTKMM_CHECK_VERSION(3,0,0)
-    static_cast< void >( parent );
     m_button.set_margin_top( 0 );
     m_button.set_margin_bottom( 0 );
-#else
-    Glib::RefPtr< Gtk::RcStyle > rcst = m_button.get_modifier_style();
-    rcst->set_ythickness( 0 );
-    m_button.modify_style( rcst );
-#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     m_vbox.pack_start( m_button, Gtk::PACK_SHRINK );
 
@@ -59,24 +47,3 @@ void TabSwitchButton::hide_button()
     remove_page( m_vbox );
     m_shown = false;
 }
-
-
-//
-// 描画イベント
-//
-// 自前でビュー領域の枠を描画する
-//
-#if !GTKMM_CHECK_VERSION(3,0,0)
-bool TabSwitchButton::on_expose_event( GdkEventExpose* event )
-{
-    if( ! m_shown ) return Gtk::Notebook::on_expose_event( event );
-
-    // 枠描画
-    m_parent->draw_box( this, event );
-
-    // ボタン描画
-    propagate_expose( m_vbox, event );
-
-    return true;
-}
-#endif // !GTKMM_CHECK_VERSION(3,0,0)

--- a/src/skeleton/tabswitchbutton.h
+++ b/src/skeleton/tabswitchbutton.h
@@ -2,10 +2,7 @@
 //
 // タブの切り替えボタン
 //
-// 枠の描画時に get_style()->paint_box_gap() で warning が出るので
-// 直接 Gtk::Button を継承するのではなくて Notebook の中にボタンを入れる
-// DragableNoteBook::draw_box() 参照
-//
+// TODO: 使われなくなったコンストラクタの引数を整理する
 
 #ifndef TABSWITCHBUTON_H
 #define TABSWITCHBUTON_H
@@ -18,10 +15,6 @@ namespace SKELETON
 
     class TabSwitchButton: public Gtk::Notebook
     {
-#if !GTKMM_CHECK_VERSION(3,0,0)
-        DragableNoteBook* m_parent;
-#endif
-
         Gtk::VBox m_vbox;
         Gtk::Button m_button;
         Gtk::Arrow m_arrow{ Gtk::ARROW_DOWN, Gtk::SHADOW_NONE };
@@ -30,18 +23,12 @@ namespace SKELETON
 
       public:
 
-        explicit TabSwitchButton( DragableNoteBook* parent );
+        explicit TabSwitchButton( DragableNoteBook* );
         ~TabSwitchButton() noexcept;
 
         Gtk::Button& get_button(){ return m_button; }
         void show_button();
         void hide_button();
-
-#if !GTKMM_CHECK_VERSION(3,0,0)
-      protected:
-
-        bool on_expose_event( GdkEventExpose* event ) override;
-#endif
     };
 }
 


### PR DESCRIPTION
使われなくなったメンバ関数を削除しGTK2対応コードを整理します。

関連のissue: #229 
