### PR TITLE
ViewNotebook: Remove member functions which are no longer in use

### DIFF
--- a/src/skeleton/viewnote.cpp
+++ b/src/skeleton/viewnote.cpp
@@ -3,30 +3,17 @@
 //#define _DEBUG
 #include "jddebug.h"
 
-#if !GTKMM_CHECK_VERSION(3,0,0)
-#include "dragnote.h"
-#endif
 #include "viewnote.h"
-#include "view.h"
 
 #include "config/globalconf.h"
 
-#if !GTKMM_CHECK_VERSION(3,0,0)
-#include <gtk/gtk.h>
-#endif
 
 using namespace SKELETON;
 
 
-ViewNotebook::ViewNotebook( DragableNoteBook* parent )
+ViewNotebook::ViewNotebook( DragableNoteBook* )
     : Gtk::Notebook()
-#if !GTKMM_CHECK_VERSION(3,0,0)
-    , m_parent( parent )
-#endif
 {
-#if GTKMM_CHECK_VERSION(3,0,0)
-    static_cast< void >( parent );
-#endif
     set_show_border( true );
     set_show_tabs( false );
     set_border_width( CONFIG::get_view_margin() );
@@ -34,44 +21,3 @@ ViewNotebook::ViewNotebook( DragableNoteBook* parent )
 
 
 ViewNotebook::~ViewNotebook() noexcept = default;
-
-
-//
-// 描画イベント
-//
-// 自前で枠を描画する
-//
-#if !GTKMM_CHECK_VERSION(3,0,0)
-bool ViewNotebook::on_expose_event( GdkEventExpose* event )
-{
-    if( ! get_n_pages() ) return Notebook::on_expose_event( event );
-
-    // 枠描画
-    m_parent->draw_box( this, event );
-
-    // 枠は自前で書いたので gtk_notebook_expose では枠を描画させない
-    GtkNotebook *notebook = gobj();
-    notebook->show_border = false;
-    bool ret = Notebook::on_expose_event( event );
-    notebook->show_border = true;
-
-    return ret;
-}
-#endif // !GTKMM_CHECK_VERSION(3,0,0)
-
-
-//
-// スクロールバー再描画
-//
-// テーマによってはビューのスクロールバーが消えるときがあるので明示的に再描画する
-// DragableNoteBook::on_expose_event()を参照せよ
-//
-void ViewNotebook::redraw_scrollbar()
-{
-    int page = get_current_page();
-    if( page == -1 ) return;
-    SKELETON::View* view =  dynamic_cast< View* >( get_nth_page( page ) );
-    if( ! view ) return;
-
-    view->redraw_scrollbar();
-}

--- a/src/skeleton/viewnote.h
+++ b/src/skeleton/viewnote.h
@@ -2,6 +2,8 @@
 //
 // DragableNoteBookを構成するview表示用の Notebook
 //
+// TODO: 使われなくなったコンストラクタの引数を整理する
+// TODO: 使われなくなった SKELETON::View::redraw_scrollbar() を整理する
 
 #ifndef _VIEWNOTE_H
 #define _VIEWNOTE_H
@@ -14,22 +16,10 @@ namespace SKELETON
 
     class ViewNotebook : public Gtk::Notebook
     {
-#if !GTKMM_CHECK_VERSION(3,0,0)
-        DragableNoteBook* m_parent;
-#endif
-
       public:
 
-        explicit ViewNotebook( DragableNoteBook* parent );
+        explicit ViewNotebook( DragableNoteBook* );
         ~ViewNotebook() noexcept;
-
-        void redraw_scrollbar();
-
-#if !GTKMM_CHECK_VERSION(3,0,0)
-      protected:
-
-        bool on_expose_event( GdkEventExpose* event ) override;
-#endif
     };
 }
 


### PR DESCRIPTION
使われなくなったメンバ関数を削除しGTK2対応コードを整理します。

関連のissue: #229 
