### PR TITLE
Remove compile conditions for supporting smooth scroll

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -139,9 +139,7 @@ void ArticleViewBase::setup_view()
     assert( m_article );
     assert( m_drawarea );
 
-#if GTKMM_CHECK_VERSION(3,3,18)
     m_drawarea->add_events( Gdk::SMOOTH_SCROLL_MASK );
-#endif
 
     m_drawarea->sig_button_press().connect(  sigc::mem_fun( *this, &ArticleViewBase::slot_button_press ));
     m_drawarea->sig_button_release().connect(  sigc::mem_fun( *this, &ArticleViewBase::slot_button_release ));

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -178,9 +178,7 @@ void DrawAreaBase::setup( const bool show_abone, const bool show_scrbar, const b
     m_view.add_events( Gdk::BUTTON_PRESS_MASK );
     m_view.add_events( Gdk::BUTTON_RELEASE_MASK );
     m_view.add_events( Gdk::SCROLL_MASK );
-#if GTKMM_CHECK_VERSION(3,3,18)
     m_view.add_events( Gdk::SMOOTH_SCROLL_MASK );
-#endif
     m_view.add_events( Gdk::POINTER_MOTION_MASK );
     m_view.add_events( Gdk::LEAVE_NOTIFY_MASK );
     m_view.add_events( Gdk::VISIBILITY_NOTIFY_MASK );
@@ -3364,7 +3362,6 @@ void DrawAreaBase::wheelscroll( GdkEventScroll* event )
 
             if( event->direction == GDK_SCROLL_UP ) m_scrollinfo.dy = -( int ) adjust->get_step_increment() * speed;
             else if( event->direction == GDK_SCROLL_DOWN ) m_scrollinfo.dy = ( int ) adjust->get_step_increment() * speed;
-#if GTKMM_CHECK_VERSION(3,3,18)
             else if( event->direction == GDK_SCROLL_SMOOTH ) {
                 constexpr double smooth_scroll_factor = 4.0;
                 m_smooth_dy += smooth_scroll_factor * event->delta_y;
@@ -3374,7 +3371,6 @@ void DrawAreaBase::wheelscroll( GdkEventScroll* event )
                     m_smooth_dy = 0.0;
                 }
             }
-#endif
 
             exec_scroll();
 

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -195,9 +195,7 @@ namespace ARTICLE
         int m_configure_height{};
 
         // スクロール情報
-#if GTKMM_CHECK_VERSION(3,3,18)
         double m_smooth_dy{}; // GDK_SCROLL_SMOOTH のスクロール変化量
-#endif
         SCROLLINFO m_scrollinfo{};
         guint32 m_wheel_scroll_time{}; // 前回ホイールを回した時刻
         int m_goto_num_reserve{}; // 初期化時のジャンプ予約(レス番号)

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -172,9 +172,7 @@ BBSListViewBase::BBSListViewBase( const std::string& url,const std::string& arg1
     m_treeview.set_show_expanders( CONFIG::get_tree_show_expanders() );
     m_treeview.set_level_indentation( CONFIG::get_tree_level_indent() );
 
-#if GTKMM_CHECK_VERSION(3,3,18)
     m_treeview.add_events( Gdk::SMOOTH_SCROLL_MASK );
-#endif
 
     // treeviewのシグナルにコネクト
     m_treeview.signal_row_expanded().connect( sigc::mem_fun(*this, &BBSListViewBase::slot_row_exp ) );

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -162,9 +162,7 @@ BoardViewBase::BoardViewBase( const std::string& url, const bool show_col_board 
     m_liststore->set_sort_func( COL_SPEED, sigc::mem_fun( *this, &BoardViewBase::slot_compare_row ) );
     m_liststore->set_sort_func( COL_DIFF, sigc::mem_fun( *this, &BoardViewBase::slot_compare_row ) );
 
-#if GTKMM_CHECK_VERSION(3,3,18)
     m_treeview.add_events( Gdk::SMOOTH_SCROLL_MASK );
-#endif
 
     m_treeview.sig_button_press().connect( sigc::mem_fun(*this, &BoardViewBase::slot_button_press ) );
     m_treeview.sig_button_release().connect( sigc::mem_fun(*this, &BoardViewBase::slot_button_release ) );

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -417,7 +417,6 @@ int Control::MG_wheel_scroll( const GdkEventScroll* event )
 
     else if( ( mask & button ) && direction == GDK_SCROLL_DOWN ) control = CONTROL::TabRight;
 
-#if GTKMM_CHECK_VERSION(3,3,18)
     else if( ( mask & button ) && direction == GDK_SCROLL_SMOOTH ) {
         if( event->delta_y < 0.0 ) {
             control = CONTROL::TabLeft;
@@ -426,7 +425,6 @@ int Control::MG_wheel_scroll( const GdkEventScroll* event )
             control = CONTROL::TabRight;
         }
     }
-#endif
 
 #ifdef _DEBUG
     std::cout << "Control::MG_wheel_scroll control = " << control << std::endl;

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -70,9 +70,7 @@ ImageAdmin::ImageAdmin( const std::string& url )
 
     // マウスホイールによる画像ビューのタブ切り替えを設定する
     m_tab.add_events( Gdk::SCROLL_MASK );
-#if GTKMM_CHECK_VERSION(3,3,18)
     m_tab.add_events( Gdk::SMOOTH_SCROLL_MASK );
-#endif
     m_tab.signal_scroll_event().connect( sigc::mem_fun( *this, &ImageAdmin::slot_scroll_event ) );
 
     m_tab.pack_start( m_scrwin );
@@ -1035,7 +1033,6 @@ bool ImageAdmin::slot_scroll_event( GdkEventScroll* event )
     const char* command_name = nullptr;
     if( event->direction == GDK_SCROLL_UP ) command_name = "tab_left";
     else if( event->direction == GDK_SCROLL_DOWN ) command_name = "tab_right";
-#if GTKMM_CHECK_VERSION(3,3,18)
     else if( event->direction == GDK_SCROLL_SMOOTH ) {
         constexpr double smooth_scroll_factor{ 2.0 };
         m_smooth_dy += smooth_scroll_factor * event->delta_y;
@@ -1048,7 +1045,6 @@ bool ImageAdmin::slot_scroll_event( GdkEventScroll* event )
             m_smooth_dy = 0.0;
         }
     }
-#endif // GTKMM_CHECK_VERSION(3,3,18)
 
     if( command_name ) set_command( command_name );
     set_command( "switch_admin" );

--- a/src/image/imageadmin.h
+++ b/src/image/imageadmin.h
@@ -33,9 +33,7 @@ namespace IMAGE
         int m_scroll;
         int m_counter_scroll;
 
-#if GTKMM_CHECK_VERSION(3,3,18)
         double m_smooth_dy{ 0.0 }; // GDK_SCROLL_SMOOTH のスクロール変化量
-#endif
 
       public:
 

--- a/src/image/imageviewbase.cpp
+++ b/src/image/imageviewbase.cpp
@@ -91,9 +91,7 @@ void ImageViewBase::setup_common()
     // focus 可、モーションキャプチャ可
     m_event.set_can_focus( true );
     m_event.add_events( Gdk::POINTER_MOTION_MASK );
-#if GTKMM_CHECK_VERSION(3,3,18)
     m_event.add_events( Gdk::SMOOTH_SCROLL_MASK );
-#endif
 
     m_event.signal_button_press_event().connect( sigc::mem_fun( *this, &ImageViewBase::slot_button_press ) );
     m_event.signal_button_release_event().connect( sigc::mem_fun( *this, &ImageViewBase::slot_button_release ) );

--- a/src/skeleton/dragnote.cpp
+++ b/src/skeleton/dragnote.cpp
@@ -522,7 +522,6 @@ bool DragableNoteBook::slot_scroll_event( GdkEventScroll* event )
         next_page = ( get_current_page() + 1 ) % get_n_pages();
         ret = true;
     }
-#if GTKMM_CHECK_VERSION(3,3,18)
     else if( event->direction == GDK_SCROLL_SMOOTH ) {
         constexpr double smooth_scroll_factor{ 4.0 };
         m_smooth_dy += smooth_scroll_factor * event->delta_y;
@@ -537,7 +536,6 @@ bool DragableNoteBook::slot_scroll_event( GdkEventScroll* event )
             m_smooth_dy = 0.0;
         }
     }
-#endif // GTKMM_CHECK_VERSION(3,3,18)
 
     if( ret ) {
         set_current_page( next_page );

--- a/src/skeleton/dragnote.h
+++ b/src/skeleton/dragnote.h
@@ -95,9 +95,7 @@ namespace SKELETON
 
         Alloc_NoteBook m_alloc_old;
 
-#if GTKMM_CHECK_VERSION(3,3,18)
         double m_smooth_dy{ 0.0 }; // GDK_SCROLL_SMOOTH のスクロール変化量
-#endif
 
       public:
 

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -504,7 +504,6 @@ void DragTreeView::wheelscroll( GdkEventScroll* event )
 
     if( event->direction == GDK_SCROLL_UP ) val = MAX( 0, val - scr_inc );
     else if( event->direction == GDK_SCROLL_DOWN ) val = MIN( adj->get_upper() - adj->get_page_size(), val + scr_inc );
-#if GTKMM_CHECK_VERSION(3,3,18)
     else if( event->direction == GDK_SCROLL_SMOOTH ) {
         constexpr double smooth_scroll_factor = 4.0;
         m_smooth_dy += smooth_scroll_factor * event->delta_y;
@@ -518,7 +517,6 @@ void DragTreeView::wheelscroll( GdkEventScroll* event )
         auto hadj = get_hadjustment();
         hadj->set_value( hadj->get_value() + scr_inc * smooth_scroll_factor_x * event->delta_x );
     }
-#endif
     adj->set_value( val );
 
 #ifdef _DEBUG

--- a/src/skeleton/dragtreeview.h
+++ b/src/skeleton/dragtreeview.h
@@ -64,9 +64,7 @@ namespace SKELETON
         // text/uri-list をドロップされた
         SIG_DROPPED_URI_LIST m_sig_dropped_url_list;
 
-#if GTKMM_CHECK_VERSION(3,3,18)
         double m_smooth_dy{ 0.0 }; // GDK_SCROLL_SMOOTH のスクロール変化量
-#endif
 
       public:
 

--- a/src/skeleton/tablabel.cpp
+++ b/src/skeleton/tablabel.cpp
@@ -32,9 +32,7 @@ TabLabel::TabLabel( const std::string& url )
 
     add_events( Gdk::POINTER_MOTION_MASK );
     add_events( Gdk::LEAVE_NOTIFY_MASK );
-#if GTKMM_CHECK_VERSION(3,3,18)
     add_events( Gdk::SMOOTH_SCROLL_MASK ); // マウスホイールによるタブの切り替え
-#endif
 
     add( m_hbox );
     m_hbox.pack_start( m_label, Gtk::PACK_SHRINK );


### PR DESCRIPTION
マウスホイール操作のGTK3対応で導入されたコンパイル条件を整理します。

関連のissue: #229 
