### PR TITLE
cache: Remove compile conditions for local variables

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -976,45 +976,25 @@ void CACHE::add_filter_to_diag( Gtk::FileChooserDialog& diag, const int type )
 {
     if( type == FILE_TYPE_ALL ) return;
 
-#if GTKMM_CHECK_VERSION(3,0,0)
     Glib::RefPtr< Gtk::FileFilter > filter = Gtk::FileFilter::create();
-#else
-    Gtk::FileFilter filter;
-#endif
     switch( type ) 
     {
         case FILE_TYPE_TEXT:
-#if GTKMM_CHECK_VERSION(3,0,0)
             filter->set_name( "全てのテキストファイル" );
             filter->add_mime_type( "text/plain" );
-#else
-            filter.set_name( "全てのテキストファイル" );
-            filter.add_mime_type( "text/plain" );
-#endif
             diag.add_filter( filter );
             break;
 
         case FILE_TYPE_DAT:
-#if GTKMM_CHECK_VERSION(3,0,0)
             filter->set_name( "全てのDATファイル" );
             filter->add_pattern( "*.dat" );
-#else
-            filter.set_name( "全てのDATファイル" );
-            filter.add_pattern( "*.dat" );
-#endif
             diag.add_filter( filter );
             break;
     }
 
-#if GTKMM_CHECK_VERSION(3,0,0)
     Glib::RefPtr< Gtk::FileFilter > all = Gtk::FileFilter::create();
     all->set_name( "全てのファイル" );
     all->add_pattern( "*" );
-#else
-    Gtk::FileFilter all;
-    all.set_name( "全てのファイル" );
-    all.add_pattern( "*" );
-#endif
     diag.add_filter( all );
 }
 


### PR DESCRIPTION
GTK2とGTK3で変数の型が異なりコンパイル条件で分かれている箇所を整理します。

関連のissue: #229 
