### PR TITLE
Remove compile conditions for value getting/setting part1

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1102,15 +1102,8 @@ void Core::run( const bool init, const bool skip_setupdiag )
     // その他設定とwidgetのパッキング
     m_notebook_right.set_show_tabs( false );
     m_notebook_right.set_show_border( false );
-#if GTKMM_CHECK_VERSION(3,12,0)
     m_notebook_right.set_margin_start( 0 );
     m_notebook_right.set_margin_end( 0 );
-#elif GTKMM_CHECK_VERSION(3,0,0)
-    m_notebook_right.set_margin_left( 0 );
-    m_notebook_right.set_margin_right( 0 );
-#else
-    m_notebook_right.get_style()->set_xthickness( 10 );
-#endif
 
     if( CONFIG::get_open_sidebar_by_click() ) m_hpaned.get_ctrl().set_click_fold( SKELETON::PANE_CLICK_FOLD_PAGE1 );
     m_hpaned.get_ctrl().add_remove1( false, *m_sidebar );

--- a/src/skeleton/tabnote.cpp
+++ b/src/skeleton/tabnote.cpp
@@ -54,22 +54,10 @@ TabNotebook::TabNotebook( DragableNoteBook* parent )
     targets.push_back( Gtk::TargetEntry( DNDTARGET_TAB, Gtk::TARGET_SAME_APP, 0 ) );
     drag_dest_set( targets, Gtk::DEST_DEFAULT_MOTION | Gtk::DEST_DEFAULT_DROP );
 
-#if GTKMM_CHECK_VERSION(3,0,0)
-#if GTKMM_CHECK_VERSION(3,12,0)
     m_tab_mrg = get_margin_start();
-#else
-    m_tab_mrg = get_margin_left();
-#endif
     if( m_tab_mrg <= 0 ) {
         m_tab_mrg = get_style_context()->get_margin().get_left();
     }
-#else
-    Glib::RefPtr< Gtk::RcStyle > rcst = get_modifier_style();
-    Glib::RefPtr< Gtk::Style > st = get_style();
-
-    m_tab_mrg = rcst->get_xthickness() * 2;
-    if( m_tab_mrg <= 0 ) m_tab_mrg = st->get_xthickness() * 2;
-#endif // GTKMM_CHECK_VERSION(3,0,0)
 
     m_pre_width = get_width();
 }


### PR DESCRIPTION
GTK2とGTK3で値の取得・設定方法が異なりコンパイル条件で分かれている箇所を整理します。

関連のissue: #229 
