### PR TITLE
Remove compile conditions for value getting/setting part2

### DIFF
--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -368,15 +368,7 @@ int Control::MG_wheel_scroll( const GdkEventScroll* event )
     if( m_wheel_scroll_time && time_tmp < time_cancel ) return control;
     m_wheel_scroll_time = event->time;
 
-#if GTKMM_CHECK_VERSION(3,0,0)
     Gdk::ModifierType mask = static_cast< Gdk::ModifierType >( event->state );
-#else
-    // 押しているボタンは event から取れないので
-    // get_pointer()から取る
-    int x, y;
-    Gdk::ModifierType mask;
-    Gdk::Display::get_default()->get_pointer( x, y, mask );
-#endif
 
     int button = 0;
     GdkEventButton ev = GdkEventButton();

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -48,13 +48,9 @@ ImageAdmin::ImageAdmin( const std::string& url )
     , m_scroll( SCROLL_NO )
 {
     m_scrwin.add( m_iconbox );
-#if GTKMM_CHECK_VERSION(3,16,0)
     // Gtk::POLICY_NEVERだとスクロール機能自体がなくなり
     // コンテンツに合わせてGtk::ScrolledWindowのサイズが拡大してしまう
     m_scrwin.set_policy( Gtk::POLICY_EXTERNAL, Gtk::POLICY_NEVER );
-#else
-    m_scrwin.set_policy( Gtk::POLICY_NEVER, Gtk::POLICY_NEVER );
-#endif
     m_scrwin.set_size_request( ICON_SIZE ,  ICON_SIZE + 4);
 
     m_left.set_label( "<" );

--- a/src/skeleton/compentry.cpp
+++ b/src/skeleton/compentry.cpp
@@ -30,11 +30,9 @@ CompletionEntry::CompletionEntry( const int mode )
     m_entry.signal_activate().connect( sigc::mem_fun( *this, &CompletionEntry::slot_entry_acivate ) );
     m_entry.signal_changed().connect( sigc::mem_fun( *this, &CompletionEntry::slot_entry_changed ) );
     m_entry.signal_focus_out_event().connect( sigc::mem_fun(*this, &CompletionEntry::slot_entry_focus_out ) );
-#if GTKMM_CHECK_VERSION(3,0,0)
     m_entry.set_max_width_chars( 1 );
     m_entry.set_width_chars( 1 );
     m_entry.set_hexpand( true );
-#endif
     pack_start( m_entry );
 
     // ポップアップ

--- a/src/skeleton/iconpopup.h
+++ b/src/skeleton/iconpopup.h
@@ -22,7 +22,6 @@ namespace SKELETON
         {
             m_img.set( m_pixbuf );
 
-#if GTKMM_CHECK_VERSION(3,0,0)
             // NOTE: アルファチャンネルが利用できない環境では背景を透過できない
             set_decorated( false );
             set_app_paintable( true );
@@ -31,13 +30,6 @@ namespace SKELETON
             if( visual && screen->is_composited() ) {
                 gtk_widget_set_visual( GTK_WIDGET( gobj() ), visual->gobj() );
             }
-#else
-            Glib::RefPtr< Gdk::Pixmap > pixmap;
-            Glib::RefPtr< Gdk::Bitmap > bitmap;
-
-            m_pixbuf->render_pixmap_and_mask( pixmap, bitmap, 255 );
-            shape_combine_mask( bitmap, 0, 0 );
-#endif // GTKMM_CHECK_VERSION(3,0,0)
 
             add( m_img );
             show_all_children();

--- a/src/skeleton/popupwin.cpp
+++ b/src/skeleton/popupwin.cpp
@@ -47,12 +47,8 @@ void PopupWin::slot_resize_popup()
     
     // マウス座標
     int x_mouse, y_mouse;
-#if GTKMM_CHECK_VERSION(3,0,0)
+    // TODO: Use Gdk::Display::get_default_seat() instead of get_device_manager() (since 3.20)
     Gdk::Display::get_default()->get_device_manager()->get_client_pointer()->get_position( x_mouse, y_mouse );
-#else
-    Gdk::ModifierType mod;
-    Gdk::Display::get_default()->get_pointer( x_mouse, y_mouse,  mod );
-#endif
 
     // クライアントのサイズを取得
     const int width_client = m_view->width_client();


### PR DESCRIPTION
GTK2とGTK3で値の取得・設定方法が異なりコンパイル条件で分かれている箇所を整理します。

関連のissue: #229 
