### PR TITLE
Remove compile conditions for value getting/setting part3

### DIFF
--- a/src/image/imageviewicon.cpp
+++ b/src/image/imageviewicon.cpp
@@ -22,11 +22,9 @@
 
 
 // 枠を描く
-#if GTKMM_CHECK_VERSION(3,0,0)
+// TODO: GTKのcssで設定する
 #define DRAW_FRAME( color ) m_event_frame->override_background_color( Gdk::RGBA( color ), Gtk::STATE_FLAG_NORMAL )
-#else
-#define DRAW_FRAME( color ) m_event_frame->modify_bg( Gtk::STATE_NORMAL, Gdk::Color( color ) )
-#endif
+
 
 using namespace IMAGE;
 

--- a/src/image/imageviewpopup.cpp
+++ b/src/image/imageviewpopup.cpp
@@ -31,6 +31,7 @@ ImageViewPopup::ImageViewPopup( const std::string& url )
     get_control().add_mode( CONTROL::MODE_IMAGEVIEW );
     get_control().add_mode( CONTROL::MODE_IMAGEICON );
 
+    // TODO: JDimのスタイルシート機能からGTKのcssに切り替えるか？
     int border_width = 1;
     int margin = 0;
     std::string border_color = "black";
@@ -56,22 +57,12 @@ ImageViewPopup::ImageViewPopup( const std::string& url )
     get_event().set_border_width( margin );
 
     // 枠色
-#if GTKMM_CHECK_VERSION(3,0,0)
     m_event_frame.override_background_color( Gdk::RGBA( border_color ), Gtk::STATE_FLAG_NORMAL );
-#else
-    m_event_frame.modify_bg( Gtk::STATE_NORMAL, Gdk::Color( border_color ) );
-#endif
 
     // 背景色
-#if GTKMM_CHECK_VERSION(3,0,0)
     const Gdk::RGBA color_bg( bg_color );
     m_event_margin.override_background_color( color_bg, Gtk::STATE_FLAG_NORMAL );
     get_event().override_background_color( color_bg, Gtk::STATE_FLAG_NORMAL );
-#else
-    const Gdk::Color color_bg( bg_color );
-    m_event_margin.modify_bg( Gtk::STATE_NORMAL, color_bg );
-    get_event().modify_bg( Gtk::STATE_NORMAL, color_bg );
-#endif
 
     // 全ての領域を表示できないならカーソルの上に表示
     set_popup_upside( true );
@@ -137,13 +128,8 @@ void ImageViewPopup::set_label( const std::string& status )
             CORE::CSS_PROPERTY css = CORE::get_css_manager()->get_property( classid );
             if( css.color >= 0 ) text_color = CORE::get_css_manager()->get_color( css.color );
         }
-#if GTKMM_CHECK_VERSION(3,0,0)
         const Gdk::RGBA color_text( text_color );
         m_label->override_color( color_text, Gtk::STATE_FLAG_NORMAL );
-#else
-        const Gdk::Color color_text( text_color );
-        m_label->modify_fg( Gtk::STATE_NORMAL, color_text );
-#endif
 
         m_label->show();
     }

--- a/src/skeleton/aamenu.cpp
+++ b/src/skeleton/aamenu.cpp
@@ -24,17 +24,11 @@ AAMenu::AAMenu( Gtk::Window& parent )
 
     Pango::FontDescription pfd( CONFIG::get_fontname( FONT_MESSAGE ) );
     pfd.set_weight( Pango::WEIGHT_NORMAL );
-#if GTKMM_CHECK_VERSION(3,0,0)
     m_textview.override_font( pfd );
     m_textview.override_color( Gdk::RGBA( CONFIG::get_color( COLOR_CHAR_SELECTION ) ),
                                Gtk::STATE_FLAG_NORMAL );
     m_textview.override_background_color( Gdk::RGBA( CONFIG::get_color( COLOR_BACK_SELECTION ) ),
                                           Gtk::STATE_FLAG_NORMAL );
-#else
-    m_textview.modify_font( pfd );
-    m_textview.modify_text( Gtk::STATE_NORMAL, Gdk::Color( CONFIG::get_color( COLOR_CHAR_SELECTION ) ) );
-    m_textview.modify_base( Gtk::STATE_NORMAL, Gdk::Color( CONFIG::get_color( COLOR_BACK_SELECTION ) ) );
-#endif
 
     m_popup.sig_configured().connect( sigc::mem_fun( *this, &AAMenu::slot_configured_popup ) );
     m_popup.add( m_textview );

--- a/src/skeleton/aboutdiag.cpp
+++ b/src/skeleton/aboutdiag.cpp
@@ -165,6 +165,7 @@ void AboutDiag::set_version( const Glib::ustring& version )
 {
     m_label_version.set_label( version );
 
+    // TODO: GTKのcssで設定するか？
 #if GTKMM_CHECK_VERSION(3,0,0)
     Pango::FontDescription font_discription_version = m_label_version.get_style_context()->get_font();
 #else
@@ -173,11 +174,7 @@ void AboutDiag::set_version( const Glib::ustring& version )
     const int label_version_font_size = font_discription_version.get_size();
     font_discription_version.set_size( label_version_font_size * 5 / 3 );
     font_discription_version.set_weight( Pango::WEIGHT_BOLD );
-#if GTKMM_CHECK_VERSION(3,0,0)
     m_label_version.override_font( font_discription_version );
-#else
-    m_label_version.modify_font( font_discription_version );
-#endif
 }
 
 Glib::ustring AboutDiag::get_version()

--- a/src/skeleton/compentry.h
+++ b/src/skeleton/compentry.h
@@ -61,14 +61,10 @@ namespace SKELETON
         void set_text( const Glib::ustring& text );
         void grab_focus();
 
-#if GTKMM_CHECK_VERSION(3,0,0)
         void modify_font( const Pango::FontDescription& pfd )
         {
             m_entry.override_font( pfd );
         }
-#else
-        void modify_font( Pango::FontDescription& pfd ){ m_entry.modify_font( pfd ); }
-#endif
 
       private:
 

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -170,11 +170,7 @@ void DragTreeView::init_font( const std::string& fontname )
 {
     Pango::FontDescription pfd( fontname );
     pfd.set_weight( Pango::WEIGHT_NORMAL );
-#if GTKMM_CHECK_VERSION(3,0,0)
     override_font( pfd );
-#else
-    modify_font( pfd );
-#endif
 }
 
 

--- a/src/skeleton/editview.h
+++ b/src/skeleton/editview.h
@@ -164,14 +164,10 @@ namespace SKELETON
         void set_editable( bool editable ){ m_textview.set_editable( editable ); }
         void set_accepts_tab( bool accept ){ m_textview.set_accepts_tab( accept ); }
 
-#if GTKMM_CHECK_VERSION(3,0,0)
         void modify_font( const Pango::FontDescription& font_desc )
         {
             m_textview.override_font( font_desc );
         }
-#else
-        void modify_font( const Pango::FontDescription& font_desc ){ m_textview.modify_font( font_desc ); }
-#endif
 
         void focus_view(){ m_textview.grab_focus(); }
 


### PR DESCRIPTION
GTK2とGTK3で値の取得・設定方法が異なりコンパイル条件で分かれている箇所を整理します。

関連のissue: #229 
