### PR TITLE
Remove compile conditions for value getting/setting part4

### DIFF
--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -220,15 +220,12 @@ void FontColorPref::pack_widget()
     m_hbox_change_color.pack_end( m_bt_change_color , Gtk::PACK_SHRINK );
     m_vbox_color.pack_start( m_hbox_change_color, Gtk::PACK_SHRINK );
 
-#if GTKMM_CHECK_VERSION(3,0,0)
     m_chk_use_gtktheme_message.add_label( "書き込みビューの配色設定に GTKテーマ を用いる(_W)", true );
     m_chk_use_gtktheme_message.set_active( CONFIG::get_use_message_gtktheme() );
     m_vbox_color.pack_start( m_chk_use_gtktheme_message, Gtk::PACK_SHRINK );
-#endif
 
     m_chk_use_gtkrc_tree.add_label( "ツリービューの背景色設定に gtkrc を用いる(_T)", true ),
     m_chk_use_gtkrc_tree.set_active( CONFIG::get_use_tree_gtkrc() );
-    m_chk_use_gtkrc_tree.signal_toggled().connect( sigc::mem_fun( *this, &FontColorPref::slot_chk_use_gtkrc_toggled ) );
     m_vbox_color.pack_start( m_chk_use_gtkrc_tree, Gtk::PACK_SHRINK );
 
     m_chk_use_gtkrc_selection.add_label( "スレビューの選択範囲の色設定に gtkrc を用いる(_S)", true ),
@@ -262,9 +259,7 @@ void FontColorPref::slot_ok_clicked()
 
     CONFIG::set_strict_char_width( m_checkbutton_font.property_active() );
 
-#if GTKMM_CHECK_VERSION(3,0,0)
     CONFIG::set_use_message_gtktheme( m_chk_use_gtktheme_message.property_active() );
-#endif
     CONFIG::set_use_tree_gtkrc( m_chk_use_gtkrc_tree.property_active() );
     CONFIG::set_use_select_gtkrc( m_chk_use_gtkrc_selection.property_active() );
 
@@ -338,17 +333,6 @@ void FontColorPref::slot_checkbutton_font_toggled()
         SKELETON::MsgDiag mdiag( nullptr, WARNING_STRICTCHAR );
         mdiag.run();
     }
-}
-
-void FontColorPref::slot_chk_use_gtkrc_toggled()
-{
-#if !GTKMM_CHECK_VERSION(3,0,0)
-    if( m_chk_use_gtkrc_tree.property_active() )
-    {
-        SKELETON::MsgDiag mdiag( nullptr, WARNING_GTKRC_TREE );
-        mdiag.run();
-    }
-#endif
 }
 
 
@@ -523,16 +507,7 @@ void FontColorPref::slot_reset_color()
 //
 void FontColorPref::slot_reset_all_colors()
 {
-#if !GTKMM_CHECK_VERSION(3,0,0)
-    if( m_chk_use_gtkrc_tree.property_active() )
-    {
-        SKELETON::MsgDiag mdiag( nullptr, WARNING_GTKRC_TREE );
-        mdiag.run();
-    }
-#endif
-#if GTKMM_CHECK_VERSION(3,0,0)
     m_chk_use_gtktheme_message.set_active( CONFIG::CONF_USE_MESSAGE_GTKTHEME );
-#endif
     m_chk_use_gtkrc_tree.set_active( CONFIG::CONF_USE_TREE_GTKRC );
     m_chk_use_gtkrc_selection.set_active( CONFIG::CONF_USE_SELECT_GTKRC );
 

--- a/src/fontcolorpref.h
+++ b/src/fontcolorpref.h
@@ -64,9 +64,7 @@ namespace CORE
         Gtk::Label m_label_warning_color;
         Gtk::VBox m_vbox_color;
 
-#if GTKMM_CHECK_VERSION(3,0,0)
         Gtk::CheckButton m_chk_use_gtktheme_message;
-#endif
         Gtk::CheckButton m_chk_use_gtkrc_tree;
         Gtk::CheckButton m_chk_use_gtkrc_selection;
 
@@ -94,7 +92,6 @@ namespace CORE
         void slot_combo_font_changed();
         void slot_fontbutton_on_set();
         void slot_checkbutton_font_toggled();
-        void slot_chk_use_gtkrc_toggled();
         void slot_reset_font();
 
         // 色の設定


### PR DESCRIPTION
GTK2とGTK3で値の取得・設定方法が異なりコンパイル条件で分かれている箇所を整理します。

関連のissue: #229 
