### PR TITLE
Remove compile conditions for value getting/setting part5

### DIFF
--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -650,10 +650,8 @@ void BoardViewBase::update_columns()
 
         // ヘッダをクリックしたときに呼ぶslot
         column->signal_clicked().connect( sigc::bind< int >( sigc::mem_fun( *this, &BoardViewBase::slot_col_clicked ), id ) );
-#if GTKMM_CHECK_VERSION(3,0,0)
         // 列の幅が変わったらセッション情報に記憶する
         column->connect_property_changed( "width", [this]{ save_column_width(); } );
-#endif
 
         // ヘッダの位置
         switch( id ){

--- a/src/jdlib/miscgtk.cpp
+++ b/src/jdlib/miscgtk.cpp
@@ -41,7 +41,6 @@ std::string MISC::color_to_str( const int* l_rgb )
     return str_value;
 }
 
-#if GTKMM_CHECK_VERSION(3,0,0)
 // Gdk::RGBA -> 16進数表記の文字列
 std::string MISC::color_to_str( const Gdk::RGBA& rgba )
 {
@@ -51,7 +50,6 @@ std::string MISC::color_to_str( const Gdk::RGBA& rgba )
     l_rgb[ 2 ] = rgba.get_blue_u();
     return color_to_str( l_rgb );
 }
-#endif // GTKMM_CHECK_VERSION(3,0,0)
 
 
 // htmlカラー (#ffffffなど) -> 16進数表記の文字列
@@ -132,11 +130,7 @@ std::set< std::string > MISC::get_font_families()
 std::string MISC::get_entry_font()
 {
     Gtk::Entry entry;
-#if GTKMM_CHECK_VERSION(3,0,0)
     return entry.get_style_context()->get_font().to_string();
-#else
-    return entry.get_style()->get_font().to_string();
-#endif
 }
 
 
@@ -144,19 +138,8 @@ std::string MISC::get_entry_font()
 std::string MISC::get_entry_color_text()
 {
     Gtk::Entry entry;
-#if GTKMM_CHECK_VERSION(3,0,0)
     auto rgba = entry.get_style_context()->get_color( Gtk::STATE_FLAG_NORMAL );
     return color_to_str( rgba );
-#else
-    Gtk::Window win( Gtk::WINDOW_POPUP );
-
-    win.add( entry );
-    win.move( 0,0 );
-    win.resize( 1,1 );
-    win.show_all();
-
-    return color_to_str( entry.get_style()->get_text( Gtk::STATE_NORMAL ) );
-#endif
 }
 
 
@@ -164,7 +147,6 @@ std::string MISC::get_entry_color_text()
 std::string MISC::get_entry_color_base()
 {
     Gtk::Entry entry;
-#if GTKMM_CHECK_VERSION(3,0,0)
     // REVIEW: get_background_color()が期待通りに背景色を返さない環境があった
     auto context = entry.get_style_context();
     Gdk::RGBA rgba;
@@ -175,16 +157,6 @@ std::string MISC::get_entry_color_base()
 #endif
     }
     return color_to_str( rgba );
-#else
-    Gtk::Window win( Gtk::WINDOW_POPUP );
-
-    win.add( entry );
-    win.move( 0,0 );
-    win.resize( 1,1 );
-    win.show_all();
-
-    return color_to_str( entry.get_style()->get_base( Gtk::STATE_NORMAL ) );
-#endif
 }
 
 

--- a/src/jdlib/miscgtk.h
+++ b/src/jdlib/miscgtk.h
@@ -19,10 +19,8 @@ namespace MISC
     // int[3] -> 16進数表記の文字列
     std::string color_to_str( const int* l_rgb );
 
-#if GTKMM_CHECK_VERSION(3,0,0)
     // Gdk::RGBA -> 16進数表記の文字列
     std::string color_to_str( const Gdk::RGBA& rgba );
-#endif
 
     // htmlカラー (#ffffffなど) -> 16進数表記の文字列
     std::string htmlcolor_to_str( const std::string& htmlcolor );

--- a/src/skeleton/aboutdiag.cpp
+++ b/src/skeleton/aboutdiag.cpp
@@ -166,11 +166,7 @@ void AboutDiag::set_version( const Glib::ustring& version )
     m_label_version.set_label( version );
 
     // TODO: GTKのcssで設定するか？
-#if GTKMM_CHECK_VERSION(3,0,0)
     Pango::FontDescription font_discription_version = m_label_version.get_style_context()->get_font();
-#else
-    Pango::FontDescription font_discription_version = m_label_version.get_style()->get_font();
-#endif
     const int label_version_font_size = font_discription_version.get_size();
     font_discription_version.set_size( label_version_font_size * 5 / 3 );
     font_discription_version.set_weight( Pango::WEIGHT_BOLD );

--- a/src/skeleton/compentry.cpp
+++ b/src/skeleton/compentry.cpp
@@ -153,7 +153,6 @@ void CompletionEntry::show_popup( const bool show_all )
 
     m_treeview.unset_cursor();
     m_treeview.scroll_to_point( -1, 0 );
-#if GTKMM_CHECK_VERSION(3,0,0)
     Gdk::RGBA rgba;
     if( !get_style_context()->lookup_color( "theme_bg_color", rgba ) ) {
 #ifdef _DEBUG
@@ -162,9 +161,6 @@ void CompletionEntry::show_popup( const bool show_all )
 #endif
     }
     m_treeview.get_column_cell_renderer( 0 )->property_cell_background_rgba() = rgba;
-#else
-    m_treeview.get_column_cell_renderer( 0 )->property_cell_background_gdk() = get_style()->get_bg( Gtk::STATE_NORMAL );
-#endif // GTKMM_CHECK_VERSION(3,0,0)
 }
 
 


### PR DESCRIPTION
GTK2とGTK3で値の取得・設定方法が異なりコンパイル条件で分かれている箇所を整理します。

関連のissue: #229 
