### PR TITLE
Improve compile conditions for MISC::WarpPointer()

### DIFF
--- a/src/jdlib/miscx.cpp
+++ b/src/jdlib/miscx.cpp
@@ -6,16 +6,17 @@
 
 #include "miscx.h"
 
+#include <gdk/gdk.h>
+
 #ifndef _WIN32
+#ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
+#endif // GDK_WINDOWING_X11
 #else
 #include <gdk/gdkwin32.h>
 #include <windows.h>
 #endif
 
-#if !defined( GDK_WINDOW_XWINDOW ) && GTKMM_CHECK_VERSION(3,0,0)
-#define GDK_WINDOW_XWINDOW( win ) gdk_x11_window_get_xid( win )
-#endif
 
 //
 // dest ウインドウ上の、クライアント座標 x,y に移動する
@@ -23,16 +24,16 @@
 void MISC::WarpPointer( Glib::RefPtr< Gdk::Window > src, Glib::RefPtr< Gdk::Window > dest, int x, int y ){
 
 #ifndef _WIN32
+#ifdef GDK_WINDOWING_X11
     GdkDisplay* display = gdk_window_get_display( Glib::unwrap( src ) );
-#if GTKMM_CHECK_VERSION(3,0,0)
     // X11環境でない場合は何もしない
     if( ! GDK_IS_X11_DISPLAY( display ) ) return;
-#endif
     // XXX: X11やXwaylandがインストールされていない環境ではコンパイルエラーになるかもしれない
     XWarpPointer( gdk_x11_display_get_xdisplay( display ),
                   None,
-                  GDK_WINDOW_XWINDOW( Glib::unwrap( dest ) )
+                  gdk_x11_window_get_xid( Glib::unwrap( dest ) )
                   , 0, 0, 0, 0, x, y );
+#endif // GDK_WINDOWING_X11
 #else
     HWND hWnd;
     POINT pos;


### PR DESCRIPTION
GTK2とGTK3でコンパイル条件で分かれている箇所を整理します。
また、X11環境をサポートしない環境に対応するためのコンパイル条件を追加します。

関連のissue: #229 
