### PR TITLE
Remove compile conditions for style setting

### DIFF
--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -229,7 +229,6 @@ void MessageViewBase::init_color()
 {
     if( m_text_message ){
 
-#if GTKMM_CHECK_VERSION(3,0,0)
         if( CONFIG::get_use_message_gtktheme() ) {
             m_text_message->update_style( u8"" );
         }
@@ -253,12 +252,6 @@ void MessageViewBase::init_color()
                 )",
                 classname, fg, bg, caret_prop, sel_fg, sel_bg ) );
         }
-#else
-        m_text_message->modify_text( Gtk::STATE_NORMAL, Gdk::Color( CONFIG::get_color( COLOR_CHAR_MESSAGE ) ) );
-        m_text_message->modify_text( Gtk::STATE_SELECTED, Gdk::Color( CONFIG::get_color( COLOR_CHAR_MESSAGE_SELECTION ) ) );
-        m_text_message->modify_base( Gtk::STATE_NORMAL, Gdk::Color( CONFIG::get_color( COLOR_BACK_MESSAGE ) ) );
-        m_text_message->modify_base( Gtk::STATE_SELECTED, Gdk::Color( CONFIG::get_color( COLOR_BACK_MESSAGE_SELECTION ) ) );
-#endif // GTKMM_CHECK_VERSION(3,0,0)
     }
 }
 

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -32,9 +32,7 @@
 using namespace SKELETON;
 
 
-#if GTKMM_CHECK_VERSION(3,0,0)
 constexpr const char* DragTreeView::s_css_classname;
-#endif
 
 DragTreeView::DragTreeView( const std::string& url, const std::string& dndtarget,
     const bool use_usr_fontcolor, const std::string& fontname, const int colorid_text, const int colorid_bg, const int colorid_bg_even )
@@ -54,11 +52,9 @@ DragTreeView::DragTreeView( const std::string& url, const std::string& dndtarget
     set_rules_hint( CONFIG::get_use_tree_gtkrc() );
     add_events( Gdk::LEAVE_NOTIFY_MASK );
 
-#if GTKMM_CHECK_VERSION(3,0,0)
     auto context = get_style_context();
     context->add_class( s_css_classname );
     context->add_provider( m_provider, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION );
-#endif
 
     if( use_usr_fontcolor ){
         init_color( colorid_text, colorid_bg, colorid_bg_even );
@@ -126,10 +122,8 @@ void DragTreeView::redraw_view()
 void DragTreeView::init_color( const int colorid_text, const int colorid_bg, const int colorid_bg_even )
 {
     if( CONFIG::get_use_tree_gtkrc() ) {
-#if GTKMM_CHECK_VERSION(3,0,0)
         m_use_bg_even = false;
         m_provider->load_from_data( u8"" );
-#endif
         return;
     }
 
@@ -141,7 +135,6 @@ void DragTreeView::init_color( const int colorid_text, const int colorid_bg, con
     m_use_bg_even = ! ( CONFIG::get_color( colorid_bg ) == CONFIG::get_color( colorid_bg_even ) );
     m_color_bg_even.set( CONFIG::get_color( colorid_bg_even ) );
 
-#if GTKMM_CHECK_VERSION(3,0,0)
     // TreeViewの偶数/奇数行を指定するCSSセレクタは動作しないバージョンが
     // 存在するため偶数行の背景色設定は既存のコードをそのまま使う
     // https://gitlab.gnome.org/GNOME/gtk/issues/581
@@ -156,10 +149,6 @@ void DragTreeView::init_color( const int colorid_text, const int colorid_bg, con
                   << err.what() << std::endl;
 #endif
     }
-#else // !GTKMM_CHECK_VERSION(3,0,0)
-    modify_text( get_state(), m_color_text );
-    modify_base( get_state(), m_color_bg );
-#endif
 }
 
 
@@ -589,11 +578,7 @@ void DragTreeView::slot_cell_data( Gtk::CellRenderer* cell, const Gtk::TreeModel
 
     // 偶数行に色を塗る
     if( even ){
-#if GTKMM_CHECK_VERSION(3,0,0)
         cell->property_cell_background_rgba() = m_color_bg_even;
-#else
-        cell->property_cell_background_gdk() = m_color_bg_even;
-#endif
         cell->property_cell_background_set() = true;
     }
 

--- a/src/skeleton/dragtreeview.h
+++ b/src/skeleton/dragtreeview.h
@@ -38,20 +38,14 @@ namespace SKELETON
         Gtk::TreeModel::Path m_path_dragstart;
         Gtk::TreeModel::Path m_path_dragpre;
 
-#if GTKMM_CHECK_VERSION(3,0,0)
         static constexpr const char* s_css_classname = u8"jd-dragtreeview";
         Glib::RefPtr< Gtk::CssProvider > m_provider = Gtk::CssProvider::create();
 
-        using Color = Gdk::RGBA;
-#else
-        using Color = Gdk::Color;
-#endif
-
         // 色
         bool m_use_bg_even;
-        Color m_color_text;
-        Color m_color_bg;
-        Color m_color_bg_even;
+        Gdk::RGBA m_color_text;
+        Gdk::RGBA m_color_bg;
+        Gdk::RGBA m_color_bg_even;
 
         // ポップアップウィンドウ用
         PopupWin* m_popup_win;

--- a/src/skeleton/editview.cpp
+++ b/src/skeleton/editview.cpp
@@ -780,11 +780,9 @@ EditView::EditView()
 {
     set_policy( Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC );
     add( m_textview );
-#if GTKMM_CHECK_VERSION(3,0,0)
     auto context = m_textview.get_style_context();
     context->add_class( s_css_classname );
     context->add_provider( m_provider, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION );
-#endif
     show_all_children();
 }
 
@@ -792,14 +790,11 @@ EditView::EditView()
 EditView::~EditView() noexcept = default;
 
 
-#if GTKMM_CHECK_VERSION(3,0,0)
 constexpr const char* EditView::s_css_classname;
-#endif
 
 //
 // EditTextViewのスタイルを更新する
 //
-#if GTKMM_CHECK_VERSION(3,0,0)
 void EditView::update_style( const Glib::ustring& custom_css )
 {
 #ifdef _DEBUG
@@ -814,4 +809,3 @@ void EditView::update_style( const Glib::ustring& custom_css )
 #endif
     }
 }
-#endif // GTKMM_CHECK_VERSION(3,0,0)

--- a/src/skeleton/editview.h
+++ b/src/skeleton/editview.h
@@ -123,10 +123,8 @@ namespace SKELETON
     class EditView : public Gtk::ScrolledWindow
     {
         EditTextView m_textview;
-#if GTKMM_CHECK_VERSION(3,0,0)
         static constexpr const char* s_css_classname = u8"jd-editview";
         Glib::RefPtr< Gtk::CssProvider > m_provider = Gtk::CssProvider::create();
-#endif
 
     public:
 
@@ -150,14 +148,9 @@ namespace SKELETON
 
         void set_wrap_mode( Gtk::WrapMode wrap_mode ){ m_textview.set_wrap_mode( wrap_mode ); }
 
-#if GTKMM_CHECK_VERSION(3,0,0)
         const char* get_css_classname() const noexcept { return s_css_classname; }
         // EditTextViewのスタイルを更新する
         void update_style( const Glib::ustring& custom_css );
-#else
-        void modify_text( Gtk::StateType state, const Gdk::Color& color ){ m_textview.modify_text( state, color ); }
-        void modify_base( Gtk::StateType state, const Gdk::Color& color ){ m_textview.modify_base( state, color ); }
-#endif
 
         void insert_str( const std::string& str, bool use_br ){ m_textview.insert_str( str, use_br ); }
 

--- a/src/skeleton/toolbar.h
+++ b/src/skeleton/toolbar.h
@@ -69,10 +69,8 @@ namespace SKELETON
         SKELETON::ToolBackForwardButton* m_button_back;
         SKELETON::ToolBackForwardButton* m_button_forward;
 
-#if GTKMM_CHECK_VERSION(3,0,0)
         static constexpr const char* s_css_label = u8"jd-toolbar-label";
         Glib::RefPtr< Gtk::CssProvider > m_label_provider = Gtk::CssProvider::create();
-#endif
 
       public:
 
@@ -176,15 +174,11 @@ namespace SKELETON
         void set_color( const std::string& color );
 
         // 書き込みボタン関係
-        void drawframe_button_write( const bool draw );
         bool slot_focusout_write_button( GdkEventFocus* event );
 
-#if GTKMM_CHECK_VERSION(3,0,0)
         // 閉じるボタン関係
         static constexpr const char* s_css_leave = u8"jd-leave";
         void setup_manual_styling( Gtk::ToolButton& toolbutton );
-#endif
-
 
         // 検索関係
         void slot_toggle_searchbar();

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -46,9 +46,7 @@ enum
 
 using namespace SKELETON;
 
-#if GTKMM_CHECK_VERSION(3,0,0)
 constexpr const char* JDWindow::s_css_stat_label;
-#endif
 
 // メッセージウィンドウでは m_mginfo が不要なので need_mginfo = false になる
 JDWindow::JDWindow( const bool fold_when_focusout, const bool need_mginfo )
@@ -87,7 +85,6 @@ JDWindow::JDWindow( const bool fold_when_focusout, const bool need_mginfo )
     gpointer parent_class = g_type_class_peek_parent( G_OBJECT_GET_CLASS( gobj() ) );
     m_grand_parent_class = g_type_class_peek_parent( parent_class );
 
-#if GTKMM_CHECK_VERSION(3,0,0)
     auto context = m_label_stat.get_style_context();
     context->add_class( s_css_stat_label );
     context->add_provider( m_stat_provider, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION );
@@ -97,7 +94,6 @@ JDWindow::JDWindow( const bool fold_when_focusout, const bool need_mginfo )
         context->add_class( s_css_stat_label );
         context->add_provider( m_stat_provider, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION );
     }
-#endif // GTKMM_CHECK_VERSION(3,0,0)
 }
 
 
@@ -424,7 +420,7 @@ void JDWindow::set_status_color( const std::string& color )
     std::cout << "JDWindow::set_status_color " << color << std::endl;
 #endif
 
-#if GTKMM_CHECK_VERSION(3,0,0)
+    // TODO: 色を毎回指定するかわりにcssクラスの交換でスタイルを変更する
     Glib::ustring css;
     if( color.empty() ) {
         // テキスト部分が上手く配色されないGTKテーマがあるので明示的に設定する
@@ -443,32 +439,6 @@ void JDWindow::set_status_color( const std::string& color )
         std::cout << "ERROR:JDWindow::set_status_color fail " << err.what() << std::endl;
 #endif
     }
-
-#else
-    if( color.empty() ){
-
-        if( m_label_stat_ebox.get_visible_window() ){
-            m_label_stat.unset_fg( Gtk::STATE_NORMAL );
-            m_mginfo.unset_fg( Gtk::STATE_NORMAL );
-
-            m_label_stat_ebox.set_visible_window( false );
-            m_mginfo_ebox.set_visible_window( false );
-        }
-    }
-    else{
-
-        m_label_stat.modify_fg( Gtk::STATE_NORMAL, Gdk::Color( "white" ) );
-        m_mginfo.modify_fg( Gtk::STATE_NORMAL, Gdk::Color( "white" ) );
-
-        m_label_stat_ebox.set_visible_window( true );
-        m_label_stat_ebox.modify_bg( Gtk::STATE_NORMAL, Gdk::Color( color ) );
-        m_label_stat_ebox.modify_bg( Gtk::STATE_ACTIVE, Gdk::Color( color ) );
-
-        m_mginfo_ebox.set_visible_window( true );
-        m_mginfo_ebox.modify_bg( Gtk::STATE_NORMAL, Gdk::Color( color ) );
-        m_mginfo_ebox.modify_bg( Gtk::STATE_ACTIVE, Gdk::Color( color ) );
-    }
-#endif
 }
 
 

--- a/src/skeleton/window.h
+++ b/src/skeleton/window.h
@@ -46,10 +46,8 @@ namespace SKELETON
         Gtk::EventBox m_mginfo_ebox;
         Gtk::Label m_mginfo;
 
-#if GTKMM_CHECK_VERSION(3,0,0)
         static constexpr const char* s_css_stat_label = u8"jd-stat-label";
         Glib::RefPtr< Gtk::CssProvider > m_stat_provider = Gtk::CssProvider::create();
-#endif
 
       public:
 


### PR DESCRIPTION
GTK2とGTK3でスタイル設定方法が異なりコンパイル条件で分かれている箇所を整理します。

関連のissue: #229 
