### PR TITLE
ICON_Manager: Remove compile condition for rendering icon

### DIFF
--- a/src/icons/iconmanager.cpp
+++ b/src/icons/iconmanager.cpp
@@ -84,7 +84,7 @@ using namespace ICON;
 
 ICON_Manager::ICON_Manager()
 {
-#if GTKMM_CHECK_VERSION(3,0,0)
+    // TODO: Use Gtk::IconTheme::load_icon() instead of Gtk::Widget::render_icon_pixbuf()
     struct Dummy : public Gtk::Image
     {
         Glib::RefPtr< Gdk::Pixbuf > render_icon( Gtk::BuiltinStockID stock, Gtk::BuiltinIconSize size )
@@ -92,9 +92,6 @@ ICON_Manager::ICON_Manager()
             return render_icon_pixbuf( stock, size );
         }
     } m_dummy;
-#else
-    Gtk::Image m_dummy;
-#endif
 
     m_list_icons.resize( NUM_ICONS );
 


### PR DESCRIPTION
アイコンのレンダーに使うオブジェクトの条件コンパイルを整理します。

関連のissue: #229 
