### PR TITLE
DrawAreaBase: Remove compile conditions for drawing thread view

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -44,7 +44,7 @@
 #include <sstream>
 #include <cstring>
 
-#if GTKMM_CHECK_VERSION(3,0,0) && !defined( USE_PANGOLAYOUT )
+#ifndef USE_PANGOLAYOUT
 #include <pangomm/glyphstring.h>
 #endif
 
@@ -100,20 +100,14 @@ struct LAYOUT_TABLE
 
 DrawAreaBase::DrawAreaBase( const std::string& url )
     : m_url( url )
-#if GTKMM_CHECK_VERSION(3,0,0)
     , m_cr( nullptr, cairo_destroy )
     , m_backscreen( nullptr, cairo_surface_destroy )
-#endif
     , m_enable_draw{ true }
     , m_scroll_window{ true }
-#if GTKMM_CHECK_VERSION(3,0,0)
     , m_back_frame_top( nullptr, cairo_surface_destroy )
     , m_back_frame_bottom( nullptr, cairo_surface_destroy )
-#endif
     , m_pre_pos_y{ -1 }
-#if GTKMM_CHECK_VERSION(3,0,0)
     , m_back_marker( nullptr, cairo_surface_destroy )
-#endif
     , m_cursor_type( Gdk::ARROW )
 {
 #ifdef _DEBUG
@@ -185,11 +179,7 @@ void DrawAreaBase::setup( const bool show_abone, const bool show_scrbar, const b
     m_view.signal_leave_notify_event().connect(  sigc::mem_fun( *this, &DrawAreaBase::slot_leave_notify_event ) );
     m_view.signal_realize().connect( sigc::mem_fun( *this, &DrawAreaBase::slot_realize ));
     m_view.signal_configure_event().connect(  sigc::mem_fun( *this, &DrawAreaBase::slot_configure_event ));
-#if GTKMM_CHECK_VERSION(3,0,0)
     m_view.signal_draw().connect( sigc::mem_fun( *this, &DrawAreaBase::slot_draw ) );
-#else
-    m_view.signal_expose_event().connect(  sigc::mem_fun( *this, &DrawAreaBase::slot_expose_event ));
-#endif
     m_view.signal_scroll_event().connect(  sigc::mem_fun( *this, &DrawAreaBase::slot_scroll_event ));
 #if GTKMM_CHECK_VERSION(3,14,0)
     setup_event_controller();
@@ -319,26 +309,16 @@ void DrawAreaBase::init_color()
     const int usrcolor = colors.size();
     m_color.resize( END_COLOR_FOR_THREAD + usrcolor );
 
-#if GTKMM_CHECK_VERSION(3,0,0)
-    using Color = Gdk::RGBA;
     Glib::RefPtr< Gtk::StyleContext > context = get_style_context();
-#else
-    using Color = Gdk::Color;
-    Glib::RefPtr< Gdk::Colormap > colormap = get_default_colormap();
-#endif
 
     int i = COLOR_FOR_THREAD +1;
     for( ; i < END_COLOR_FOR_THREAD; ++i ){
 
-        m_color[ i ] = Color( CONFIG::get_color( i ) );
-#if !GTKMM_CHECK_VERSION(3,0,0)
-        colormap->alloc_color( m_color[ i ] );
-#endif
+        m_color[ i ] = Gdk::RGBA( CONFIG::get_color( i ) );
     }
 
     // スレビューの選択色でgtkrcの設定を使用
     if( CONFIG::get_use_select_gtkrc() ){
-#if GTKMM_CHECK_VERSION(3,0,0)
         const bool fg_ok = context->lookup_color( u8"theme_selected_fg_color", m_color[ COLOR_CHAR_SELECTION ] );
         const bool bg_ok = context->lookup_color( u8"theme_selected_bg_color", m_color[ COLOR_BACK_SELECTION ] );
         if( !fg_ok || !bg_ok ) {
@@ -346,20 +326,10 @@ void DrawAreaBase::init_color()
             std::cout << "ERROR:DrawAreaBase::init_color lookup theme color failed." << std::endl;
 #endif
         }
-#else
-        m_color[ COLOR_CHAR_SELECTION ] = get_style()->get_text( Gtk::STATE_SELECTED );
-        colormap->alloc_color( m_color[ COLOR_CHAR_SELECTION ] );
-
-        m_color[ COLOR_BACK_SELECTION ] = get_style()->get_base( Gtk::STATE_SELECTED );
-        colormap->alloc_color( m_color[ COLOR_BACK_SELECTION ] );
-#endif
     }
 
     for( const auto& color : colors ) {
-        m_color[ i ] = Color( color );
-#if !GTKMM_CHECK_VERSION(3,0,0)
-        colormap->alloc_color( m_color[ i ] );
-#endif
+        m_color[ i ] = Gdk::RGBA( color );
         ++i;
     }
 }
@@ -406,11 +376,7 @@ void DrawAreaBase::init_font()
     // layoutにフォントをセット
     m_font = &m_defaultfont;
     m_pango_layout->set_font_description( m_font->pfd );
-#if GTKMM_CHECK_VERSION(3,0,0)
     m_context->set_font_description( m_font->pfd );
-#else
-    modify_font( m_font->pfd );
-#endif
 }
 
 
@@ -499,11 +465,7 @@ void DrawAreaBase::focus_view()
 void DrawAreaBase::focus_out()
 {
     // realize していない
-#if GTKMM_CHECK_VERSION(3,0,0)
     if( !m_window ) return;
-#else
-    if( !m_gc ) return;
-#endif
 
 #ifdef _DEBUG
     std::cout << "DrawAreaBase::focus_out\n";
@@ -1189,26 +1151,16 @@ bool DrawAreaBase::exec_layout_impl( const bool is_popup, const int offset_y )
     std::cout << "create backscreen : width = " << m_view.get_width() << " height = " << m_view.get_height() << std::endl;
 #endif
 
-#if GTKMM_CHECK_VERSION(3,0,0)
     m_backscreen.reset( gdk_window_create_similar_surface(
         m_window->gobj(), CAIRO_CONTENT_COLOR, m_view.get_width(), m_view.get_height() ) );
-#else
-    m_backscreen.reset();
-    m_backscreen = Gdk::Pixmap::create( m_window, m_view.get_width(), m_view.get_height() );
-#endif
 
     m_rect_backscreen.y = 0;
     m_rect_backscreen.height = 0;
 
-#if GTKMM_CHECK_VERSION(3,0,0)
     m_back_frame_top.reset( gdk_window_create_similar_surface(
         m_window->gobj(), CAIRO_CONTENT_COLOR, m_view.get_width(), WIDTH_FRAME ) );
     m_back_frame_bottom.reset( gdk_window_create_similar_surface(
         m_window->gobj(), CAIRO_CONTENT_COLOR, m_view.get_width(), WIDTH_FRAME ) );
-#else
-    m_back_frame.reset();
-    m_back_frame = Gdk::Pixmap::create( m_window, m_view.get_width(), WIDTH_FRAME * 2 );
-#endif
 
     m_ready_back_frame = false;
 
@@ -1753,9 +1705,6 @@ int DrawAreaBase::get_width_of_one_char( const char* utfstr, int& byte, char& pr
 bool DrawAreaBase::draw_screen( const int y, const int height )
 {
     if( ! m_enable_draw ) return false;
-#if !GTKMM_CHECK_VERSION(3,0,0)
-    if( ! m_gc ) return false;
-#endif
     if( ! m_backscreen ) return false;
     if( ! m_layout_tree ) return false;
     if( ! m_layout_tree->top_header() ) return false;
@@ -1773,11 +1722,7 @@ bool DrawAreaBase::draw_screen( const int y, const int height )
     // キューに expose イベントが溜まっている時は全画面再描画
     auto* const updated = gdk_window_get_update_area( m_window->gobj() );
     if( updated ) {
-#if GTKMM_CHECK_VERSION(3,0,0)
         cairo_region_destroy( updated );
-#else
-        gdk_region_destroy( updated );
-#endif
         redraw_view_force();
         return true;
     }
@@ -1837,11 +1782,6 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
     m_rect_backscreen.y = y_screen;
     m_rect_backscreen.width = width_view;
     m_rect_backscreen.height = height_screen;
-
-#if !GTKMM_CHECK_VERSION(3,0,0)
-    Gdk::Rectangle rect_clip( 0, y_screen, width_view, height_screen );
-    m_gc->set_clip_rectangle( rect_clip );
-#endif
 
     // 一番最後のレスが半分以上表示されていたら最後のレス番号をm_seen_currentにセット
     m_seen_current = 0;
@@ -2000,23 +1940,12 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
 
             m_ready_back_marker = false;
 
-#if GTKMM_CHECK_VERSION(3,0,0)
             cairo_save( m_cr.get() );
             cairo_rectangle( m_cr.get(), m_clip_marker.x, m_clip_marker.y, m_clip_marker.width, m_clip_marker.height );
             cairo_clip( m_cr.get() );
             cairo_set_source_surface( m_cr.get(), m_back_marker.get(), m_clip_marker.x, m_clip_marker.y );
             cairo_paint( m_cr.get() );
             cairo_restore( m_cr.get() );
-#else
-            // [gtkmm <= 2.8] Gdk::GC::set_clip_rectangle( Gdk::Rectangle& rectangle )
-            // Gdk::GC::set_clip_rectangle( const Gdk::Rectangle& rectangle )
-            Gdk::Rectangle rect_window( m_clip_marker.x, m_clip_marker.y, m_clip_marker.width, m_clip_marker.height );
-            m_gc->set_clip_rectangle( rect_window );
-            m_window->draw_drawable( m_gc, m_back_marker, 0, 0,
-                                     m_clip_marker.x, m_clip_marker.y, m_clip_marker.width, m_clip_marker.height );
-
-            m_gc->set_clip_rectangle( rect_clip );
-#endif
         }
 
         // 前回描画したフレームを消す
@@ -2024,7 +1953,6 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
 
             m_ready_back_frame = false;
 
-#if GTKMM_CHECK_VERSION(3,0,0)
             cairo_save( m_cr.get() );
             cairo_rectangle( m_cr.get(), 0.0, 0.0, width_view, height_view );
             cairo_clip( m_cr.get() );
@@ -2033,29 +1961,15 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
             cairo_set_source_surface( m_cr.get(), m_back_frame_bottom.get(), 0.0, height_view - WIDTH_FRAME );
             cairo_paint( m_cr.get() );
             cairo_restore( m_cr.get() );
-#else
-            // [gtkmm <= 2.8] Gdk::GC::set_clip_rectangle( Gdk::Rectangle& rectangle )
-            // Gdk::GC::set_clip_rectangle( const Gdk::Rectangle& rectangle )
-            Gdk::Rectangle rect_frame( 0, 0, width_view, height_view );
-            m_gc->set_clip_rectangle( rect_frame );
-            m_window->draw_drawable( m_gc, m_back_frame, 0, 0, 0, 0, width_view, WIDTH_FRAME );
-            m_window->draw_drawable( m_gc, m_back_frame, 0, WIDTH_FRAME, 0, height_view - WIDTH_FRAME, width_view, WIDTH_FRAME );
-
-            m_gc->set_clip_rectangle( rect_clip );
-#endif
         }
 
         // バックスクリーンをウィンドウにコピー
-#if GTKMM_CHECK_VERSION(3,0,0)
         cairo_save( m_cr.get() );
         cairo_rectangle( m_cr.get(), 0.0, y_screen, width_view, height_screen );
         cairo_clip( m_cr.get() );
         cairo_set_source_surface( m_cr.get(), m_backscreen.get(), 0.0, 0.0 );
         cairo_paint( m_cr.get() );
         cairo_restore( m_cr.get() );
-#else
-        m_window->draw_drawable( m_gc, m_backscreen, 0, y_screen, 0, y_screen, width_view, height_screen );
-#endif
     }
 
     // バックスクリーンを全てウィンドウにコピー
@@ -2064,16 +1978,12 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
 #ifdef _DEBUG
         std::cout << "copy all\n";
 #endif
-#if GTKMM_CHECK_VERSION(3,0,0)
         cairo_save( m_cr.get() );
         cairo_rectangle( m_cr.get(), 0.0, 0.0, width_view, height_view );
         cairo_clip( m_cr.get() );
         cairo_set_source_surface( m_cr.get(), m_backscreen.get(), 0.0, 0.0 );
         cairo_paint( m_cr.get() );
         cairo_restore( m_cr.get() );
-#else
-        m_window->draw_drawable( m_gc, m_backscreen, 0, 0, 0, 0, width_view, height_view );
-#endif
     }
 
     // オートスクロールマーカと枠の描画
@@ -2256,7 +2166,7 @@ bool DrawAreaBase::draw_one_node( LAYOUT* layout, const CLIPINFO& ci )
                 const int x = layout->rect->x;
                 const int y = layout->rect->y - ci.pos_y;
                 const int color_text = get_colorid_text();
-#if GTKMM_CHECK_VERSION(3,0,0)
+
                 cairo_t* const cr = cairo_create( m_backscreen.get() );
                 gdk_cairo_set_source_rgba( cr, m_color[ color_text ].gobj() );
                 cairo_set_line_width( cr, 1.0 );
@@ -2264,10 +2174,6 @@ bool DrawAreaBase::draw_one_node( LAYOUT* layout, const CLIPINFO& ci )
                 cairo_line_to( cr, x + layout->rect->width - 1.0, y );
                 cairo_stroke( cr );
                 cairo_destroy( cr );
-#else
-                m_gc->set_foreground( m_color[ color_text ] );
-                m_backscreen->draw_line( m_gc, x, y, x + layout->rect->width - 1, y );
-#endif
             }
             break;
 
@@ -2402,25 +2308,16 @@ void DrawAreaBase::draw_marker()
     // exec_draw_screen() 参照
     if( m_scroll_window ){
 
-#if GTKMM_CHECK_VERSION(3,0,0)
         cairo_t* const cr = cairo_create( m_back_marker.get() );
         cairo_rectangle( cr, 0.0, 0.0, m_clip_marker.width, m_clip_marker.height );
         cairo_clip( cr );
         cairo_set_source_surface( cr, cairo_get_target( m_cr.get() ), -m_clip_marker.x, -m_clip_marker.y );
         cairo_paint( cr );
         cairo_destroy( cr );
-#else
-        // [gtkmm <= 2.8] Gdk::GC::set_clip_rectangle( Gdk::Rectangle& rectangle )
-        // Gdk::GC::set_clip_rectangle( const Gdk::Rectangle& rectangle )
-        Gdk::Rectangle rect_marker( 0, 0, m_clip_marker.width, m_clip_marker.height );
-        m_gc->set_clip_rectangle( rect_marker );
-        m_back_marker->draw_drawable( m_gc, m_window, m_clip_marker.x, m_clip_marker.y,
-                                      0, 0, m_clip_marker.width, m_clip_marker.height );
-#endif
+
         m_ready_back_marker = true;
     }
 
-#if GTKMM_CHECK_VERSION(3,0,0)
     constexpr const double r = AUTOSCR_CIRCLE / 2.0;
     cairo_save( m_cr.get() );
     cairo_rectangle( m_cr.get(), m_clip_marker.x, m_clip_marker.y, m_clip_marker.width, m_clip_marker.height );
@@ -2429,16 +2326,6 @@ void DrawAreaBase::draw_marker()
     cairo_arc( m_cr.get(), x_marker + r, y_marker + r, r - 1.0, 0.0, 2.0 * M_PI );
     cairo_stroke( m_cr.get() );
     cairo_restore( m_cr.get() );
-#else
-    // [gtkmm <= 2.8] Gdk::GC::set_clip_rectangle( Gdk::Rectangle& rectangle )
-    // Gdk::GC::set_clip_rectangle( const Gdk::Rectangle& rectangle )
-    Gdk::Rectangle rect_window( m_clip_marker.x, m_clip_marker.y, m_clip_marker.width, m_clip_marker.height );
-    m_gc->set_clip_rectangle( rect_window );
-    m_gc->set_foreground( m_color[ COLOR_MARKER ] );
-    m_window->draw_arc( m_gc, false,
-                        x_marker, y_marker, AUTOSCR_CIRCLE-1, AUTOSCR_CIRCLE-1,
-                        0, 360 * 64 );
-#endif
 }
 
 
@@ -2454,7 +2341,6 @@ void DrawAreaBase::draw_frame()
 
     if( m_scroll_window ){
 
-#if GTKMM_CHECK_VERSION(3,0,0)
         cairo_surface_t* const borrowed_sf = cairo_get_target( m_cr.get() );
         cairo_t* cr = cairo_create( m_back_frame_top.get() );
         cairo_rectangle( cr, 0.0, 0.0, width_win, WIDTH_FRAME );
@@ -2469,31 +2355,16 @@ void DrawAreaBase::draw_frame()
         cairo_set_source_surface( cr, borrowed_sf, 0.0, WIDTH_FRAME - height_win );
         cairo_paint( cr );
         cairo_destroy( cr );
-#else
-        // [gtkmm <= 2.8] Gdk::GC::set_clip_rectangle( Gdk::Rectangle& rectangle )
-        // Gdk::GC::set_clip_rectangle( const Gdk::Rectangle& rectangle )
-        Gdk::Rectangle rect_frame( 0, 0, width_win, WIDTH_FRAME * 2 );
-        m_gc->set_clip_rectangle( rect_frame );
-        m_back_frame->draw_drawable( m_gc, m_window, 0, 0, 0, 0, width_win, WIDTH_FRAME );
-        m_back_frame->draw_drawable( m_gc, m_window, 0, height_win - WIDTH_FRAME, 0, WIDTH_FRAME, width_win, WIDTH_FRAME );
-#endif
+
         m_ready_back_frame = true;
     }
 
-#if GTKMM_CHECK_VERSION(3,0,0)
     cairo_save( m_cr.get() );
     gdk_cairo_set_source_rgba( m_cr.get(), m_color[ COLOR_FRAME ].gobj() );
     cairo_set_line_width( m_cr.get(), 2.0 );
     cairo_rectangle( m_cr.get(), 0.0, 0.0, width_win, height_win );
     cairo_stroke( m_cr.get() );
     cairo_restore( m_cr.get() );
-#else
-    Gdk::Rectangle rect_clip( 0, 0, width_win, height_win );
-    m_gc->set_clip_rectangle( rect_clip );
-
-    m_gc->set_foreground( m_color[ COLOR_FRAME ] );
-    m_window->draw_rectangle( m_gc, false, WIDTH_FRAME-1, WIDTH_FRAME-1, width_win-WIDTH_FRAME, height_win-WIDTH_FRAME );
-#endif
 }
 
 
@@ -2502,16 +2373,11 @@ void DrawAreaBase::draw_frame()
 //
 void DrawAreaBase::fill_backscreen( const int colorid, int x, int y, int width, int height )
 {
-#if GTKMM_CHECK_VERSION(3,0,0)
     cairo_t* const cr = cairo_create( m_backscreen.get() );
     gdk_cairo_set_source_rgba( cr, m_color[ colorid ].gobj() );
     cairo_rectangle( cr, x, y, width, height );
     cairo_fill( cr );
     cairo_destroy( cr );
-#else
-    m_gc->set_foreground( m_color[ colorid ] );
-    m_backscreen->draw_rectangle( m_gc, true, x, y, width, height );
-#endif
 }
 
 
@@ -2521,7 +2387,6 @@ void DrawAreaBase::fill_backscreen( const int colorid, int x, int y, int width, 
 void DrawAreaBase::paint_backscreen( const Glib::RefPtr< Gdk::Pixbuf >& pixbuf,
                                      int src_x, int src_y, int dest_x, int dest_y, int width, int height )
 {
-#if GTKMM_CHECK_VERSION(3,0,0)
     // Cairoバージョンではsrc_x, src_yを使わない
     // 呼び出しをgdkバージョンと揃えるために引数の数合わせをしている
     static_cast< void >( src_x );
@@ -2532,10 +2397,6 @@ void DrawAreaBase::paint_backscreen( const Glib::RefPtr< Gdk::Pixbuf >& pixbuf,
     gdk_cairo_set_source_pixbuf( cr, pixbuf->gobj(), dest_x, dest_y );
     cairo_paint( cr );
     cairo_destroy( cr );
-#else
-    m_backscreen->draw_pixbuf( m_gc, pixbuf, src_x, src_y, dest_x, dest_y,
-                               width, height, Gdk::RGB_DITHER_NONE, 0, 0 );
-#endif
 }
 
 
@@ -2658,11 +2519,7 @@ void DrawAreaBase::set_node_font( LAYOUT* layout )
 
         // layoutにフォントをセット
         m_pango_layout->set_font_description( m_font->pfd );
-#if GTKMM_CHECK_VERSION(3,0,0)
         m_context->set_font_description( m_font->pfd );
-#else
-        modify_font( m_font->pfd );
-#endif
     }
 }
 
@@ -2838,7 +2695,6 @@ bool DrawAreaBase::draw_one_img_node( LAYOUT* layout, const CLIPINFO& ci )
     }
 
     // 枠の描画
-#if GTKMM_CHECK_VERSION(3,0,0)
     {
         cairo_t* const cr = cairo_create( m_backscreen.get() );
         gdk_cairo_set_source_rgba( cr, m_color[ color ].gobj() );
@@ -2846,11 +2702,6 @@ bool DrawAreaBase::draw_one_img_node( LAYOUT* layout, const CLIPINFO& ci )
         cairo_stroke( cr );
         cairo_destroy( cr );
     }
-#else
-    // !! draw_rectangle()の filled を false にすると、1 pixel 幅と高さが大きくなるのに注意 !!
-    m_gc->set_foreground( m_color[ color ] );
-    m_backscreen->draw_rectangle( m_gc, false, rect->x , rect->y  - ci.pos_y, rect->width -1, rect->height -1 );
-#endif
 
     // 右上のアイコン
     if( code != HTTP_OK || img->is_loading() ){
@@ -2948,7 +2799,6 @@ void DrawAreaBase::draw_string( LAYOUT* node, const CLIPINFO& ci,
 
 #ifdef USE_PANGOLAYOUT  // Pango::Layout を使って文字を描画
 
-#if GTKMM_CHECK_VERSION(3,0,0)
             const Gdk::RGBA& fg = m_color[ color ];
             const Gdk::RGBA& bg = m_color[ color_back ];
             using PA = Pango::Attribute;
@@ -2975,42 +2825,22 @@ void DrawAreaBase::draw_string( LAYOUT* node, const CLIPINFO& ci,
                 cairo_move_to( text_cr, x + 1.0, y );
                 pango_cairo_show_layout( text_cr, m_pango_layout->gobj() );
             }
-#else
-            // Glib::ustringのコンストラクタでchar*から変換するとUTF-8が
-            // 壊れている場合にインスタンスが生成されない
-            // (例外をキャッチしないとクラッシュする)ので
-            // std::stringからGlib::ustringに変換するコンストラクタを使う
-            m_pango_layout->set_text( std::string( node->text + pos_start, n_byte ) );
-            m_backscreen->draw_layout( m_gc,x, y, m_pango_layout, m_color[ color ], m_color[ color_back ] );
-
-            if( node->bold ){
-                m_gc->set_foreground( m_color[ color ] );
-                m_backscreen->draw_layout( m_gc, x+1, y, m_pango_layout );
-            }
-#endif // GTKMM_CHECK_VERSION(3,0,0)
 
 #else // Pango::GlyphString を使って文字を描画
 
             assert( m_context );
 
             fill_backscreen( color_back, x, y, width_line, m_font->height );
-#if GTKMM_CHECK_VERSION(3,0,0)
+
             cairo_t* const text_cr = cairo_create( m_backscreen.get() );
 
             gdk_cairo_set_source_rgba( text_cr, m_color[ color ].gobj() );
-#else
-            m_gc->set_foreground( m_color[ color ] );
-#endif
 
             Pango::AttrList attr;
             std::string text = std::string( node->text + pos_start, n_byte );
             std::list< Pango::Item > list_item = m_context->itemize( text, attr );
 
-#if GTKMM_CHECK_VERSION(3,0,0)
             Glib::RefPtr< Pango::Font > font;
-#else
-            Glib::RefPtr< const Pango::Font > font;
-#endif
             Pango::GlyphString grl;
             Pango::Rectangle pango_rect;
 
@@ -3023,17 +2853,13 @@ void DrawAreaBase::draw_string( LAYOUT* node, const CLIPINFO& ci,
                 pango_rect = grl.get_logical_extents( font );
                 int width = PANGO_PIXELS( pango_rect.get_width() );
 
-#if GTKMM_CHECK_VERSION(3,0,0)
                 cairo_move_to( text_cr, x, y + m_font->ascent );
                 pango_cairo_show_glyph_string( text_cr, font->gobj(), grl.gobj() );
                 if( node->bold ) {
                     cairo_move_to( text_cr, x + 1.0, y + m_font->ascent );
                     pango_cairo_show_glyph_string( text_cr, font->gobj(), grl.gobj() );
                 }
-#else
-                m_backscreen->draw_glyphs( m_gc, font, x, y + m_font->ascent, grl );
-                if( node->bold ) m_backscreen->draw_glyphs( m_gc, font, x +1, y + m_font->ascent, grl );
-#endif
+
                 x += width;
             }
 
@@ -3044,20 +2870,14 @@ void DrawAreaBase::draw_string( LAYOUT* node, const CLIPINFO& ci,
 
             // リンクの時は下線を引く
             if( node->link && CONFIG::get_draw_underline() ){
-#if GTKMM_CHECK_VERSION(3,0,0)
                 gdk_cairo_set_source_rgba( text_cr, m_color[ color ].gobj() );
                 cairo_set_line_width( text_cr, 1.0 );
                 cairo_move_to( text_cr, xx, y + m_font->underline_pos );
                 cairo_line_to( text_cr, xx + width_line, y + m_font->underline_pos );
                 cairo_stroke( text_cr );
-#else
-                m_gc->set_foreground( m_color[ color ] );
-                m_backscreen->draw_line( m_gc, xx, y + m_font->underline_pos, xx + width_line, y + m_font->underline_pos );
-#endif
             }
-#if GTKMM_CHECK_VERSION(3,0,0)
+
             cairo_destroy( text_cr );
-#endif
         }
 
         if( rect->end ) break;
@@ -4884,7 +4704,6 @@ void DrawAreaBase::configure_impl()
 //
 // drawarea の再描画イベント
 //
-#if GTKMM_CHECK_VERSION(3,0,0)
 bool DrawAreaBase::slot_draw( const Cairo::RefPtr< Cairo::Context >& cr )
 {
     double x1, y1, x2, y2;
@@ -4957,76 +4776,6 @@ bool DrawAreaBase::slot_draw( const Cairo::RefPtr< Cairo::Context >& cr )
     m_cr.release();
     return true;
 }
-#else // !GTKMM_CHECK_VERSION(3,0,0)
-bool DrawAreaBase::slot_expose_event( GdkEventExpose* event )
-{
-    const int x = event->area.x;
-    const int y = event->area.y;
-    const int width = event->area.width;
-    const int height = event->area.height;
-
-    // タブ操作中は再描画しない
-    if( SESSION::is_tab_operating( URL_ARTICLEADMIN ) ) return true;
-
-#ifdef _DEBUG
-    std::cout << "DrawAreaBase::slot_expose_event"
-              << " y = " << y << " height = " << height << " draw_screen = " << m_drawinfo.draw
-              << " url = " << m_url
-              << std::endl;
-#endif
-
-    // draw_screen からの呼び出し
-    if(  m_drawinfo.draw  ){
-
-#ifdef _DEBUG
-        std::cout << "draw\n";
-#endif
-
-        m_drawinfo.draw = false;
-        exec_draw_screen( m_drawinfo.y, m_drawinfo.height );
-    }
-
-    // バックスクリーンに描画済みならコピー
-    else if( y >= m_rect_backscreen.y && y + height <= m_rect_backscreen.y + m_rect_backscreen.height ){
-
-#ifdef _DEBUG
-        std::cout << "copy from backscreen\n";
-#endif
-
-        // [gtkmm <= 2.8] Gdk::GC::set_clip_rectangle( Gdk::Rectangle& rectangle )
-        // Gdk::GC::set_clip_rectangle( const Gdk::Rectangle& rectangle )
-        Gdk::Rectangle rect( x, y, width, height );
-        m_gc->set_clip_rectangle( rect );
-        m_window->draw_drawable( m_gc, m_backscreen, x, y, x, y, width, height );
-
-        // オートスクロールマーカと枠の描画
-        draw_marker();
-        draw_frame();
-    }
-
-    // レイアウトがセットされていない or まだリサイズしていない( m_backscreen == nullptr )なら画面消去
-    else if( ! m_layout_tree->top_header() || ! m_backscreen ){
-
-#ifdef _DEBUG
-        std::cout << "clear window\n";
-#endif
-
-        m_window->set_background( m_color[ get_colorid_back() ] );
-        m_window->clear();
-        return false;
-    }
-
-    // 必要な所だけ再描画
-    else{
-#ifdef _DEBUG
-        std::cout << "expose\n";
-#endif
-        exec_draw_screen( y, height );
-    }
-
-    return true;
-}
-#endif // GTKMM_CHECK_VERSION(3,0,0)
 
 
 
@@ -5108,20 +4857,11 @@ void DrawAreaBase::slot_realize()
     m_window = m_view.get_window();
     assert( m_window );
 
-#if !GTKMM_CHECK_VERSION(3,0,0)
-    m_gc = Gdk::GC::create( m_window );
-    assert( m_gc );
-#endif
-
     // 色初期化
     init_color();
 
-#if GTKMM_CHECK_VERSION(3,0,0)
     m_back_marker.reset( gdk_window_create_similar_surface(
         m_window->gobj(), CAIRO_CONTENT_COLOR, AUTOSCR_CIRCLE, AUTOSCR_CIRCLE ) );
-#else
-    m_back_marker = Gdk::Pixmap::create( m_window, AUTOSCR_CIRCLE, AUTOSCR_CIRCLE );
-#endif
     assert( m_back_marker );
 
     exec_layout();
@@ -5491,11 +5231,7 @@ void DrawAreaBase::change_cursor( const Gdk::CursorType type )
         m_cursor_type = type;
         if( m_cursor_type == Gdk::ARROW ) m_window->set_cursor();
         else {
-#if GTKMM_CHECK_VERSION(3,0,0)
             m_window->set_cursor( Gdk::Cursor::create( m_cursor_type ) );
-#else
-            m_window->set_cursor( Gdk::Cursor( m_cursor_type ) );
-#endif
         }
     }
 }

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -122,15 +122,12 @@ namespace ARTICLE
 
         // 描画用
         Glib::RefPtr< Gdk::Window > m_window;
-#if GTKMM_CHECK_VERSION(3,0,0)
+
         // cairomm 1.12.0 がメモリリークを起こしたので
         // C API を使うことで問題を回避する
         std::unique_ptr< cairo_t, void ( * )( cairo_t* ) > m_cr;
         std::unique_ptr< cairo_surface_t, void ( * )( cairo_surface_t* ) > m_backscreen;
-#else
-        Glib::RefPtr< Gdk::GC > m_gc;
-        Glib::RefPtr< Gdk::Pixmap > m_backscreen;
-#endif
+
         Glib::RefPtr< Pango::Layout > m_pango_layout;
         Glib::RefPtr< Pango::Context > m_context;
         RECTANGLE m_rect_backscreen{}; // バックスクリーンが描画されている範囲
@@ -150,21 +147,13 @@ namespace ARTICLE
         // 色
         int m_colorid_text{}; // デフォルトの文字色
         int m_colorid_back{}; // デフォルトの背景色
-#if GTKMM_CHECK_VERSION(3,0,0)
         std::vector< Gdk::RGBA > m_color;
-#else
-        std::vector< Gdk::Color > m_color;
-#endif
 
         // 枠
         bool m_draw_frame{};  // 枠を描画する
-#if GTKMM_CHECK_VERSION(3,0,0)
         // 枠線に隠れる部分のバックアップを分ける
         std::unique_ptr< cairo_surface_t, void ( * )( cairo_surface_t* ) > m_back_frame_top;
         std::unique_ptr< cairo_surface_t, void ( * )( cairo_surface_t* ) > m_back_frame_bottom;
-#else
-        Glib::RefPtr< Gdk::Pixmap > m_back_frame; // 枠の背景
-#endif
         bool m_ready_back_frame{};
 
         // 範囲選択
@@ -203,11 +192,8 @@ namespace ARTICLE
         int m_pre_pos_y; // ひとつ前のスクロールバーの位置。スクロールした時の差分量計算に使用する
         std::vector< int > m_jump_history;  // ジャンプ履歴
         bool m_cancel_change_adjust{}; // adjust の値変更イベントをキャンセル
-#if GTKMM_CHECK_VERSION(3,0,0)
+
         std::unique_ptr< cairo_surface_t, void ( * )( cairo_surface_t* ) > m_back_marker;
-#else
-        Glib::RefPtr< Gdk::Pixmap > m_back_marker; // オートスクロールマーカの背景
-#endif
         RECTANGLE m_clip_marker{};
         bool m_ready_back_marker{};
         time_t m_wait_scroll{};  // 処理落ちした時にスクロールにウエイトを入れる
@@ -496,11 +482,7 @@ namespace ARTICLE
 
         // スロット
         void slot_change_adjust();
-#if GTKMM_CHECK_VERSION(3,0,0)
         bool slot_draw( const Cairo::RefPtr< Cairo::Context >& cr );
-#else
-        bool slot_expose_event( GdkEventExpose* event );
-#endif
         bool slot_scroll_event( GdkEventScroll* event );
         bool slot_leave_notify_event( GdkEventCrossing* event );
         bool slot_visibility_notify_event( GdkEventVisibility* event );


### PR DESCRIPTION
GTK2とGTK3で描画処理が異なりコンパイル条件で分かれている箇所を整理します。

関連のissue: #229 
