### PR TITLE
message: Add missing headers for Makefile.am

### DIFF
--- a/src/message/Makefile.am
+++ b/src/message/Makefile.am
@@ -17,6 +17,7 @@ noinst_HEADERS = \
 	messageview.h \
 	post.h \
 	toolbar.h \
+	logitem.h \
 	logmanager.h \
 	confirmdiag.h \
 	logitem.h


### PR DESCRIPTION
makefileから記載が漏れていたヘッダーファイルを追加します。