### PR TITLE
Use Gtk::Scrollbar instead of Gtk::VScrollbar

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -274,7 +274,7 @@ void DrawAreaBase::create_scrbar()
 
     // そのままHBoxにスクロールバーをパックすると、スクロールしたときに何故かHBox全体が
     // 再描画されて負荷が高くなるのでEventBoxを間に挟む
-    m_vscrbar = Gtk::manage( new Gtk::VScrollbar() );
+    m_vscrbar = Gtk::manage( new Gtk::Scrollbar( Glib::RefPtr<Gtk::Adjustment>{}, Gtk::ORIENTATION_VERTICAL ) );
     m_event = Gtk::manage( new Gtk::EventBox() );
     assert( m_vscrbar );
     assert( m_event );

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -108,7 +108,7 @@ namespace ARTICLE
         // HBoxに張り付けるウイジット
         Gtk::DrawingArea m_view;
         Gtk::EventBox* m_event{};
-        Gtk::VScrollbar* m_vscrbar{};
+        Gtk::Scrollbar* m_vscrbar{};
 
         // レイアウトツリー
         LayoutTree* m_layout_tree{};
@@ -389,7 +389,7 @@ namespace ARTICLE
         virtual bool slot_configure_event( GdkEventConfigure* event );
 
         Gtk::DrawingArea* get_view(){ return &m_view; }
-        Gtk::VScrollbar* get_vscrbar(){ return m_vscrbar; }
+        Gtk::Scrollbar* get_vscrbar(){ return m_vscrbar; }
 
       private:
 


### PR DESCRIPTION
GTK4で削除される`Gtk::VScrollbar`のかわりに`Gtk::Scrollbar`を使います。

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/article/drawareabase.h:111:14: error: 'VScrollbar' in namespace 'Gtk' does not name a type
  111 |         Gtk::VScrollbar* m_vscrbar{};
      |              ^~~~~~~~~~
../src/article/drawareabase.h:392:14: error: 'VScrollbar' in namespace 'Gtk' does not name a type
  392 |         Gtk::VScrollbar* get_vscrbar(){ return m_vscrbar; }
      |              ^~~~~~~~~~
```

関連のissue: #229 
