### PR TITLE
Use Gdk::RGBA instead of Gdk::Color

### DIFF
--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -614,7 +614,7 @@ void BBSListViewBase::set_fgcolor_of_comment( const Gtk::TreeModel::Children& ch
         Gtk::TreeModel::Row row = *it;
 
         const int type = row2type( row );
-        if( type == TYPE_COMMENT ) row[ m_columns.m_fgcolor ] = Gdk::Color( CONFIG::get_color( COLOR_CHAR_BBS_COMMENT ) );
+        if( type == TYPE_COMMENT ) row[ m_columns.m_fgcolor ] = Gdk::RGBA( CONFIG::get_color( COLOR_CHAR_BBS_COMMENT ) );
         else if( type == TYPE_DIR ) set_fgcolor_of_comment( row.children() );
     }
 }

--- a/src/bbslist/columns.cpp
+++ b/src/bbslist/columns.cpp
@@ -23,5 +23,5 @@ void TreeColumns::setup_row( Gtk::TreeModel::Row& row,
 {
     SKELETON::EditColumns::setup_row( row, url, name, data, type, dirid );
 
-    if( type == TYPE_COMMENT ) row[ m_fgcolor ] = Gdk::Color( CONFIG::get_color( COLOR_CHAR_BBS_COMMENT ) );
+    if( type == TYPE_COMMENT ) row[ m_fgcolor ] = Gdk::RGBA( CONFIG::get_color( COLOR_CHAR_BBS_COMMENT ) );
 }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1676,14 +1676,14 @@ void Core::slot_clear_mail()
 //
 bool Core::open_color_diag( std::string title, int id )
 {
-    Gdk::Color color( CONFIG::get_color( id ) );
+    Gdk::RGBA color( CONFIG::get_color( id ) );
 
     Gtk::ColorSelectionDialog diag( title );
-    diag.get_color_selection()->set_current_color( color );
+    diag.get_color_selection()->set_current_rgba( color );
     diag.set_transient_for( *CORE::get_mainwindow() );
     if( diag.run() == Gtk::RESPONSE_OK ){
         Gtk::ColorSelection* sel = diag.get_color_selection();
-        CONFIG::set_color( id, MISC::color_to_str( sel->get_current_color() ) );
+        CONFIG::set_color( id, MISC::color_to_str( sel->get_current_rgba() ) );
         return true;
     }
 

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -454,7 +454,7 @@ void FontColorPref::slot_change_color()
     Gtk::ColorSelectionDialog colordiag;
     if( colorid != COLOR_NONE ) {
         Gtk::ColorSelection* sel = colordiag.get_color_selection();
-        sel->set_current_color( Gdk::Color( CONFIG::get_color( colorid ) ) );
+        sel->set_current_rgba( Gdk::RGBA( CONFIG::get_color( colorid ) ) );
     }
     colordiag.set_transient_for( *CORE::get_mainwindow() );
     const int ret = colordiag.run();
@@ -469,7 +469,7 @@ void FontColorPref::slot_change_color()
             colorid = row[ m_columns_color.m_col_colorid ];
             if( colorid != COLOR_NONE ) {
                 Gtk::ColorSelection* sel = colordiag.get_color_selection();
-                CONFIG::set_color( colorid, MISC::color_to_str( sel->get_current_color() ) );
+                CONFIG::set_color( colorid, MISC::color_to_str( sel->get_current_rgba() ) );
             }
         }
     }

--- a/src/image/imageareaicon.cpp
+++ b/src/image/imageareaicon.cpp
@@ -167,8 +167,8 @@ void ImageAreaIcon::show_indicator( bool loading )
         assert( m_pixbuf_loading );
 
         m_pixbuf->fill( 0xffffff00 );
-        m_pixbuf_loading->fill( MISC::color_to_int( Gdk::Color( CONFIG::get_color( COLOR_IMG_LOADING ) ) ) );
-        m_pixbuf_err->fill( MISC::color_to_int( Gdk::Color( CONFIG::get_color( COLOR_IMG_ERR ) ) ) );
+        m_pixbuf_loading->fill( MISC::color_to_int( Gdk::RGBA( CONFIG::get_color( COLOR_IMG_LOADING ) ) ) );
+        m_pixbuf_err->fill( MISC::color_to_int( Gdk::RGBA( CONFIG::get_color( COLOR_IMG_ERR ) ) ) );
     }
 
     // 読み込み中

--- a/src/jdlib/miscgtk.cpp
+++ b/src/jdlib/miscgtk.cpp
@@ -13,18 +13,6 @@ enum
 };
 
 
-// Gdk::Color -> 16進数表記の文字列
-std::string MISC::color_to_str( const Gdk::Color& color )
-{
-    // R,G,Bを取得
-    int l_rgb[3];
-    l_rgb[0] = color.get_red();
-    l_rgb[1] = color.get_green();
-    l_rgb[2] = color.get_blue();
-
-    return color_to_str( l_rgb );
-}
-
 // int[3] -> 16進数表記の文字列
 std::string MISC::color_to_str( const int* l_rgb )
 {
@@ -96,12 +84,12 @@ std::string MISC::htmlcolor_to_str( const std::string& _htmlcolor )
 }
 
 
-// Gdk::Color -> int 変換
-guint32 MISC::color_to_int( const Gdk::Color& color )
+// Gdk::RGBA -> int 変換
+guint32 MISC::color_to_int( const Gdk::RGBA& color )
 {
-    guint32 red = color.get_red() >> 8;
-    guint32 green = color.get_green() >> 8;
-    guint32 blue = color.get_blue() >> 8;
+    guint32 red = color.get_red_u() >> 8;
+    guint32 green = color.get_green_u() >> 8;
+    guint32 blue = color.get_blue_u() >> 8;
 
     return ( red << 24 ) + ( green << 16 ) + ( blue << 8 );
 }

--- a/src/jdlib/miscgtk.h
+++ b/src/jdlib/miscgtk.h
@@ -13,9 +13,6 @@
 
 namespace MISC
 {
-    // Gdk::Color -> 16進数表記の文字列
-    std::string color_to_str( const Gdk::Color& color );
-
     // int[3] -> 16進数表記の文字列
     std::string color_to_str( const int* l_rgb );
 
@@ -25,8 +22,8 @@ namespace MISC
     // htmlカラー (#ffffffなど) -> 16進数表記の文字列
     std::string htmlcolor_to_str( const std::string& htmlcolor );
 
-    // Gdk::Color -> int 変換
-    guint32 color_to_int( const Gdk::Color& color );
+    // Gdk::RGBA -> int 変換
+    guint32 color_to_int( const Gdk::RGBA& color );
 
     // 使用可能なフォントの一覧を取得
     std::set< std::string > get_font_families();

--- a/src/skeleton/editcolumns.h
+++ b/src/skeleton/editcolumns.h
@@ -45,7 +45,7 @@ namespace SKELETON
         Gtk::TreeModelColumn< Glib::ustring > m_data; // ユーザデータ
         Gtk::TreeModelColumn< bool > m_underline; // 行に下線を引く
         Gtk::TreeModelColumn< bool > m_expand; // Dom::parse() で使用
-        Gtk::TreeModelColumn< Gdk::Color > m_fgcolor; // 文字色
+        Gtk::TreeModelColumn< Gdk::RGBA > m_fgcolor; // 文字色
         Gtk::TreeModelColumn< size_t > m_dirid; // ディレクトリID
 
         EditColumns();

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -466,7 +466,7 @@ Gtk::TreeViewColumn* EditTreeView::create_column( const int ypad )
     col->pack_start( *m_ren_text, true );
     col->add_attribute( *m_ren_text, "text", EDITCOL_NAME );
     col->add_attribute( *m_ren_text, "underline", EDITCOL_UNDERLINE );
-    col->add_attribute( *m_ren_text, "foreground_gdk", EDITCOL_FGCOLOR );
+    col->add_attribute( *m_ren_text, "foreground_rgba", EDITCOL_FGCOLOR );
     col->set_sizing( Gtk::TREE_VIEW_COLUMN_FIXED );
 
     // 実際の描画時に偶数行に色を塗る


### PR DESCRIPTION
GTK4で削除される`Gtk::Color`のかわりに`Gtk::RGBA`を使います。

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

<details>
<summary>コンパイラのレポート</summary>

```
../src/bbslist/columns.cpp:26:107: error: invalid use of incomplete type 'class Gdk::Color'
   26 |     if( type == TYPE_COMMENT ) row[ m_fgcolor ] = Gdk::Color( CONFIG::get_color( COLOR_CHAR_BBS_COMMENT ) );
      |                                                                                                           ^
../src/bbslist/bbslistviewbase.cpp:617:121: error: invalid use of incomplete type 'class Gdk::Color'
  617 |         if( type == TYPE_COMMENT ) row[ m_columns.m_fgcolor ] = Gdk::Color( CONFIG::get_color( COLOR_CHAR_BBS_COMMENT ) );
      |                                                                                                                         ^
../src/image/imageareaicon.cpp:170:104: error: invalid use of incomplete type 'class Gdk::Color'
  170 |         m_pixbuf_loading->fill( MISC::color_to_int( Gdk::Color( CONFIG::get_color( COLOR_IMG_LOADING ) ) ) );
      |                                                                                                        ^
../src/image/imageareaicon.cpp:171:96: error: invalid use of incomplete type 'class Gdk::Color'
  171 |         m_pixbuf_err->fill( MISC::color_to_int( Gdk::Color( CONFIG::get_color( COLOR_IMG_ERR ) ) ) );
      |                                                                                                ^
../src/jdlib/miscgtk.cpp:21:16: error: invalid use of incomplete type 'const class Gdk::Color'
   21 |     l_rgb[0] = color.get_red();
      |                ^~~~~
../src/jdlib/miscgtk.cpp:22:16: error: invalid use of incomplete type 'const class Gdk::Color'
   22 |     l_rgb[1] = color.get_green();
      |                ^~~~~
../src/jdlib/miscgtk.cpp:23:16: error: invalid use of incomplete type 'const class Gdk::Color'
   23 |     l_rgb[2] = color.get_blue();
      |                ^~~~~
../src/jdlib/miscgtk.cpp:102:19: error: invalid use of incomplete type 'const class Gdk::Color'
  102 |     guint32 red = color.get_red() >> 8;
      |                   ^~~~~
../src/jdlib/miscgtk.cpp:103:21: error: invalid use of incomplete type 'const class Gdk::Color'
  103 |     guint32 green = color.get_green() >> 8;
      |                     ^~~~~
../src/jdlib/miscgtk.cpp:104:20: error: invalid use of incomplete type 'const class Gdk::Color'
  104 |     guint32 blue = color.get_blue() >> 8;
      |                    ^~~~~
../src/core.cpp:1679:31: error: variable 'Gdk::Color color' has initializer but incomplete type
 1679 |     Gdk::Color color( CONFIG::get_color( id ) );
      |                               ^~~~~~~~~
../src/fontcolorpref.cpp:457:74: error: invalid use of incomplete type 'class Gdk::Color'
  457 |         sel->set_current_color( Gdk::Color( CONFIG::get_color( colorid ) ) );
      |                                                                          ^
../src/fontcolorpref.cpp:457:74: error: invalid use of incomplete type 'class Gdk::Color'
  457 |         sel->set_current_color( Gdk::Color( CONFIG::get_color( colorid ) ) );
      |                                                                          ^
../src/core.cpp:1679:31: error: variable 'Gdk::Color color' has initializer but incomplete type
 1679 |     Gdk::Color color( CONFIG::get_color( id ) );
      |                               ^~~~~~~~~
```
</details>

関連のissue: #229 
