### PR TITLE
Use cursor name instead of Gdk::CursorType

### DIFF
--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -210,7 +210,7 @@ namespace ARTICLE
         bool m_r_drugging{}; // 右ドラッグ中
         std::string m_link_current; // 現在マウスポインタの下にあるリンクの文字列
         LAYOUT* m_layout_current{}; // 現在マウスポインタの下にあるlayoutノード(下が空白ならnullptr)
-        Gdk::CursorType m_cursor_type; // カーソルの形状
+        Glib::ustring m_cursor_type; // カーソルの形状
 
         // 入力コントローラ
         CONTROL::Control m_control;
@@ -460,10 +460,10 @@ namespace ARTICLE
         bool motion_mouse();
 
         // 現在のポインターの下のノードからカーソルのタイプを決定する
-        Gdk::CursorType get_cursor_type();
+        Glib::ustring get_cursor_type();
 
         // カーソルの形状の変更
-        void change_cursor( const Gdk::CursorType type );
+        void change_cursor( const Glib::ustring& cursor_type );
 
         // スクロールマーカの描画
         void draw_marker();


### PR DESCRIPTION
GTK4で削除される`Gdk::CursorType`のかわりに[カーソルテーマの名前][name]を使います。
カーソル名の入力ミスを予防するため文字列リテラルを直接指定するかわりに定数を使います。

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/article/drawareabase.cpp:5226:70: error: no matching function for call to 'Gdk::Cursor::create(Gdk::CursorType&)'
 5226 |             m_window->set_cursor( Gdk::Cursor::create( m_cursor_type ) );
      |                                                                      ^
```

関連のissue: #229

[name]: https://developer.gnome.org/gdk3/stable/gdk3-Cursors.html#gdk-cursor-new-from-name