### PR TITLE
Change default regex library to Glib Regex

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -103,7 +103,8 @@
 
     --with-regex=[posix|oniguruma|glib]
 
-       使用する正規表現ライブラリを設定する。デフォルトでは POSIX regex を使用する。
+       使用する正規表現ライブラリを設定する。
+       デフォルトでは Glib Regex(GRegex) を使用する。(v0.4.0+から変更)
 
     --with-regex=oniguruma
 

--- a/configure.ac
+++ b/configure.ac
@@ -213,8 +213,8 @@ dnl
 AC_MSG_CHECKING(for --with-regex)
 AC_ARG_WITH(regex,
 AC_HELP_STRING([--with-regex=@<:@posix|oniguruma|glib@:>@],
-               [use regular expression library @<:@default=posix@:>@]),
-[], [with_regex=posix])
+               [use regular expression library @<:@default=glib@:>@]),
+[], [with_regex=glib])
 AC_MSG_RESULT($with_regex)
 
 AS_IF(

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -116,7 +116,10 @@ configure のかわりに [meson] を使ってビルドする方法は [GitHub][
   </dd>
 
   <dt>--with-regex=[posix|oniguruma|glib]</dt>
-  <dd>使用する正規表現ライブラリを設定する。デフォルトでは POSIX regex を使用する。</dd>
+  <dd>
+    使用する正規表現ライブラリを設定する。
+    デフォルトでは Glib Regex(GRegex) を使用する。<small>(v0.4.0+から変更)</small>
+  </dd>
   <dt>--with-regex=oniguruma</dt>
   <dd>
     POSIX regex のかわりに鬼車を使用する。

--- a/meson.build
+++ b/meson.build
@@ -140,6 +140,7 @@ endif
 # 正規表現ライブラリ
 regex_opt = get_option('regex')
 if regex_opt == 'posix'
+  configure_args += '\'--with-regex=posix\''
   regex_dep = dependency('', required : false)
   conf.set('HAVE_REGEX_H', 1)
 elif regex_opt == 'oniguruma'
@@ -150,7 +151,6 @@ elif regex_opt == 'oniguruma'
   conf.set('HAVE_ONIGPOSIX_H', 1)
   configure_args += '\'--with-regex=oniguruma\''
 elif regex_opt == 'glib'
-  configure_args += '\'--with-regex=glib\''
   regex_dep = dependency('glib-2.0', version : '>= 2.14.0')
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,6 +5,6 @@ option('migemo', type : 'feature', value : 'disabled', description : 'Use text s
 option('migemodict', type : 'string', value : '', description : 'Default path for migemo dictionary file')
 option('native', type : 'feature', value : 'disabled', description : 'Optimize to your machine')
 option('pangolayout', type : 'feature', value : 'disabled', description : 'Render text by PangoLayout')
-option('regex', type : 'combo', choices : ['posix', 'oniguruma', 'glib'], value : 'posix', description : 'Regex library to use')
+option('regex', type : 'combo', choices : ['posix', 'oniguruma', 'glib'], value : 'glib', description : 'Regex library to use')
 option('sessionlib', type : 'combo', choices : ['xsmp', 'no'], value : 'xsmp', description : 'Use Session Management Protocol')
 option('tls', type : 'combo', choices : ['gnutls', 'openssl'], value : 'gnutls', description : 'SSL/TLS library to use')


### PR DESCRIPTION
Fix #444

デフォルトの正規表現ライブラリをPOSIX regexからGlib Regex(GRegex)に変更します。
また、mesonを利用したときはglibではなくposixを指定したときにビルドオプションを表示するように変更します。

#### 互換性に関する注意
GRegexはPerl互換の正規表現なので、従来のPOSIX拡張の正規表現から設定変更が必要になる場合があります。