### PR TITLE
Use icon theme instead of Gtk::Arrow

### DIFF
--- a/src/skeleton/menubutton.cpp
+++ b/src/skeleton/menubutton.cpp
@@ -21,14 +21,14 @@ enum
 
 
 MenuButton::MenuButton( const bool show_arrow, Gtk::Widget& label )
-    : m_label( nullptr ), m_arrow( nullptr )
+    : m_label( nullptr )
 {
     setup( show_arrow, &label );
 }
 
 
 MenuButton::MenuButton( const bool show_arrow, const int id )
-    : m_label( nullptr ), m_arrow( nullptr )
+    : m_label( nullptr )
 {
     setup( show_arrow, Gtk::manage( new Gtk::Image( ICON::get_icon( id ) ) ), Gtk::PACK_SHRINK );
 }
@@ -49,7 +49,8 @@ void MenuButton::setup( const bool show_arrow, Gtk::Widget* label, Gtk::PackOpti
     if( m_label ) hbox->pack_start( *m_label, options, padding );
 
     if( show_arrow ){
-        m_arrow = Gtk::manage( new Gtk::Arrow( Gtk::ARROW_DOWN, Gtk::SHADOW_NONE ) );
+        m_arrow = Gtk::manage( new Gtk::Image() );
+        m_arrow->set_from_icon_name( "pan-down-symbolic", Gtk::ICON_SIZE_SMALL_TOOLBAR );
         hbox->pack_start( *m_arrow, Gtk::PACK_SHRINK );
     }
     else m_enable_sig_clicked = false;

--- a/src/skeleton/menubutton.h
+++ b/src/skeleton/menubutton.h
@@ -25,7 +25,7 @@ namespace SKELETON
         std::vector< Gtk::MenuItem* > m_menuitems;
         Gtk::Widget* m_label;
 
-        Gtk::Arrow* m_arrow;
+        Gtk::Image* m_arrow{};
 
         bool m_on_arrow;
         bool m_enable_sig_clicked;

--- a/src/skeleton/tabswitchbutton.cpp
+++ b/src/skeleton/tabswitchbutton.cpp
@@ -14,6 +14,7 @@ TabSwitchButton::TabSwitchButton( DragableNoteBook* )
 {
     set_border_width( 0 );
 
+    m_arrow.set_from_icon_name( "pan-down-symbolic", Gtk::ICON_SIZE_SMALL_TOOLBAR );
     m_button.add( m_arrow );
     m_button.show_all_children();
     m_button.set_relief( Gtk::RELIEF_NONE );

--- a/src/skeleton/tabswitchbutton.h
+++ b/src/skeleton/tabswitchbutton.h
@@ -17,7 +17,7 @@ namespace SKELETON
     {
         Gtk::VBox m_vbox;
         Gtk::Button m_button;
-        Gtk::Arrow m_arrow{ Gtk::ARROW_DOWN, Gtk::SHADOW_NONE };
+        Gtk::Image m_arrow;
 
         bool m_shown = false;
 


### PR DESCRIPTION
GTK4で廃止される`Gtk::Arrow`のかわりにアイコンテーマを使います。

[GtkArrowのリファレンス][gtkarrow]より
> GtkArrow has been deprecated; you can simply use a GtkImage with a suitable icon name, such as "pan-down-symbolic".

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/skeleton/tabswitchbutton.h:20:14: error: 'Arrow' in namespace 'Gtk' does not name a type
   20 |         Gtk::Arrow m_arrow{ Gtk::ARROW_DOWN, Gtk::SHADOW_NONE };
      |              ^~~~~
../src/skeleton/menubutton.h:28:14: error: 'Arrow' in namespace 'Gtk' does not name a type
   28 |         Gtk::Arrow* m_arrow;
      |              ^~~~~
```

関連のissue: #229 

[gtkarrow]: https://developer.gnome.org/gtk3/stable/GtkArrow.html
