### PR TITLE
Use Gtk::GestureMultiPress instead of Gtk::Button::signal_pressed/released

### DIFF
--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -59,10 +59,12 @@ ImageAdmin::ImageAdmin( const std::string& url )
     m_left.set_focus_on_click( false );
     m_right.set_focus_on_click( false );
 
-    m_left.signal_pressed().connect( sigc::mem_fun( *this, &ImageAdmin::slot_press_left ) );
-    m_right.signal_pressed().connect( sigc::mem_fun( *this, &ImageAdmin::slot_press_right ) );
-    m_left.signal_released().connect( sigc::mem_fun( *this, &ImageAdmin::slot_release_left ) );
-    m_right.signal_released().connect( sigc::mem_fun( *this, &ImageAdmin::slot_release_right ) );
+    m_gesture_press_left = Gtk::GestureMultiPress::create( m_left );
+    m_gesture_press_right = Gtk::GestureMultiPress::create( m_right );
+    m_gesture_press_left->signal_pressed().connect( sigc::mem_fun( *this, &ImageAdmin::slot_press_left ) );
+    m_gesture_press_right->signal_pressed().connect( sigc::mem_fun( *this, &ImageAdmin::slot_press_right ) );
+    m_gesture_press_left->signal_released().connect( sigc::mem_fun( *this, &ImageAdmin::slot_release_left ) );
+    m_gesture_press_right->signal_released().connect( sigc::mem_fun( *this, &ImageAdmin::slot_release_right ) );
 
     // マウスホイールによる画像ビューのタブ切り替えを設定する
     m_tab.add_events( Gdk::SCROLL_MASK );
@@ -991,7 +993,7 @@ void ImageAdmin::scroll_tab( int scroll )
 
 
 //左押した
-void ImageAdmin::slot_press_left()
+void ImageAdmin::slot_press_left( int, double, double )
 {
     m_scroll = SCROLL_LEFT;
     m_counter_scroll = 0;
@@ -999,7 +1001,7 @@ void ImageAdmin::slot_press_left()
 }
 
 //右押した
-void ImageAdmin::slot_press_right()
+void ImageAdmin::slot_press_right( int, double, double )
 {
     m_scroll = SCROLL_RIGHT;
     m_counter_scroll = 0;
@@ -1008,13 +1010,13 @@ void ImageAdmin::slot_press_right()
 
 
 //左離した
-void ImageAdmin::slot_release_left()
+void ImageAdmin::slot_release_left( int, double, double )
 {
     m_scroll = SCROLL_NO;
 }
 
 // 右離した
-void ImageAdmin::slot_release_right()
+void ImageAdmin::slot_release_right( int, double, double )
 {
     m_scroll = SCROLL_NO;
 }

--- a/src/image/imageadmin.h
+++ b/src/image/imageadmin.h
@@ -35,6 +35,9 @@ namespace IMAGE
 
         double m_smooth_dy{ 0.0 }; // GDK_SCROLL_SMOOTH のスクロール変化量
 
+        Glib::RefPtr<Gtk::GestureMultiPress> m_gesture_press_left;
+        Glib::RefPtr<Gtk::GestureMultiPress> m_gesture_press_right;
+
       public:
 
         explicit ImageAdmin( const std::string& url );
@@ -115,10 +118,10 @@ namespace IMAGE
         void scroll_tab( int scroll );
 
         // スクロールボタン
-        void slot_press_left();
-        void slot_press_right();
-        void slot_release_left();
-        void slot_release_right();
+        void slot_press_left( int, double, double );
+        void slot_press_right( int, double, double );
+        void slot_release_left( int, double, double );
+        void slot_release_right( int, double, double );
         // マウスホイールによるタブ切り替え
         bool slot_scroll_event( GdkEventScroll* event );
 


### PR DESCRIPTION
GTK4で廃止される`Gtk::Button`の`pressed/released`シグナルハンドラのかわりに`Gtk::GestureMultiPress`を使います。

非推奨のシンボルを無効化するマクロ
```
-DGDK_DISABLE_DEPRECATED
-DGTK_DISABLE_DEPRECATED
-DGDKMM_DISABLE_DEPRECATED
-DGTKMM_DISABLE_DEPRECATED
-DGIOMM_DISABLE_DEPRECATED
-DGLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/image/imageadmin.cpp:62:12: error: 'class Gtk::Button' has no member named 'signal_pressed'; did you mean 'on_pressed'?
   62 |     m_left.signal_pressed().connect( sigc::mem_fun( *this, &ImageAdmin::slot_press_left ) );
      |            ^~~~~~~~~~~~~~
      |            on_pressed
../src/image/imageadmin.cpp:63:13: error: 'class Gtk::Button' has no member named 'signal_pressed'; did you mean 'on_pressed'?
   63 |     m_right.signal_pressed().connect( sigc::mem_fun( *this, &ImageAdmin::slot_press_right ) );
      |             ^~~~~~~~~~~~~~
      |             on_pressed
../src/image/imageadmin.cpp:64:12: error: 'class Gtk::Button' has no member named 'signal_released'; did you mean 'on_released'?
   64 |     m_left.signal_released().connect( sigc::mem_fun( *this, &ImageAdmin::slot_release_left ) );
      |            ^~~~~~~~~~~~~~~
      |            on_released
../src/image/imageadmin.cpp:65:13: error: 'class Gtk::Button' has no member named 'signal_released'; did you mean 'on_released'?
   65 |     m_right.signal_released().connect( sigc::mem_fun( *this, &ImageAdmin::slot_release_right ) );
      |             ^~~~~~~~~~~~~~~
      |             on_released
```

関連のissue: #229 
