### PR TITLE
Use Gtk::Paned instead of Gtk::HPaned

### DIFF
--- a/src/skeleton/hpaned.cpp
+++ b/src/skeleton/hpaned.cpp
@@ -9,8 +9,8 @@ using namespace SKELETON;
 
 
 JDHPaned::JDHPaned( const int fixmode )
-    : Gtk::HPaned(),
-      m_pctrl( *this, fixmode )
+    : Gtk::Paned( Gtk::ORIENTATION_HORIZONTAL )
+    , m_pctrl( *this, fixmode )
 {}
 
 
@@ -19,7 +19,7 @@ JDHPaned::~JDHPaned() noexcept = default;
 
 void JDHPaned::on_realize()
 {
-    Gtk::HPaned::on_realize();
+    Gtk::Paned::on_realize();
     m_pctrl.update_position();
 }
 
@@ -27,32 +27,32 @@ void JDHPaned::on_realize()
 bool JDHPaned::on_button_press_event( GdkEventButton* event )
 {
     m_pctrl.button_press_event( event );
-    return Gtk::HPaned::on_button_press_event( event );
+    return Gtk::Paned::on_button_press_event( event );
 }
 
 
 bool JDHPaned::on_button_release_event( GdkEventButton* event )
 {
     m_pctrl.button_release_event( event );   
-    return Gtk::HPaned::on_button_release_event( event );
+    return Gtk::Paned::on_button_release_event( event );
 }
 
 
 bool JDHPaned::on_motion_notify_event( GdkEventMotion* event )
 {
     m_pctrl.motion_notify_event( event );
-    return Gtk::HPaned::on_motion_notify_event( event );
+    return Gtk::Paned::on_motion_notify_event( event );
 }
 
 
 bool JDHPaned::on_enter_notify_event( GdkEventCrossing* event )
 {
     m_pctrl.enter_notify_event( event );
-    return Gtk::HPaned::on_enter_notify_event( event );
+    return Gtk::Paned::on_enter_notify_event( event );
 }
 
 bool JDHPaned::on_leave_notify_event( GdkEventCrossing* event )
 {
     m_pctrl.leave_notify_event( event );
-    return Gtk::HPaned::on_leave_notify_event( event );
+    return Gtk::Paned::on_leave_notify_event( event );
 }

--- a/src/skeleton/hpaned.h
+++ b/src/skeleton/hpaned.h
@@ -12,7 +12,7 @@
 
 namespace SKELETON
 {
-    class JDHPaned : public Gtk::HPaned
+    class JDHPaned : public Gtk::Paned
     {
         HPaneControl m_pctrl;
 


### PR DESCRIPTION
GTK4で廃止される`Gtk::HPaned`のかわりに`Gtk::Paned`を使います。

非推奨のシンボルを無効化するマクロ
```
-DGDK_DISABLE_DEPRECATED
-DGTK_DISABLE_DEPRECATED
-DGDKMM_DISABLE_DEPRECATED
-DGTKMM_DISABLE_DEPRECATED
-DGIOMM_DISABLE_DEPRECATED
-DGLIBMM_DISABLE_DEPRECATED
```

<details>
<summary>コンパイラのレポート</summary>

```
../src/skeleton/hpaned.h:16:5: error: expected class-name before '{' token
   16 |     {
      |     ^
../src/skeleton/hpaned.h:28:14: error: 'void SKELETON::JDHPaned::on_realize()' marked 'override', but does not override
   28 |         void on_realize() override;
      |              ^~~~~~~~~~
../src/skeleton/hpaned.h:29:14: error: 'bool SKELETON::JDHPaned::on_button_press_event(GdkEventButton*)' marked 'override', but does not override
   29 |         bool on_button_press_event( GdkEventButton* event ) override;
      |              ^~~~~~~~~~~~~~~~~~~~~
../src/skeleton/hpaned.h:30:14: error: 'bool SKELETON::JDHPaned::on_button_release_event(GdkEventButton*)' marked 'override', but does not override
   30 |         bool on_button_release_event( GdkEventButton* event ) override;
      |              ^~~~~~~~~~~~~~~~~~~~~~~
../src/skeleton/hpaned.h:31:14: error: 'bool SKELETON::JDHPaned::on_motion_notify_event(GdkEventMotion*)' marked 'override', but does not override
   31 |         bool on_motion_notify_event( GdkEventMotion* event ) override;
      |              ^~~~~~~~~~~~~~~~~~~~~~
../src/skeleton/hpaned.h:32:14: error: 'bool SKELETON::JDHPaned::on_enter_notify_event(GdkEventCrossing*)' marked 'override', but does not override
   32 |         bool on_enter_notify_event( GdkEventCrossing* event ) override;
      |              ^~~~~~~~~~~~~~~~~~~~~
../src/skeleton/hpaned.h:33:14: error: 'bool SKELETON::JDHPaned::on_leave_notify_event(GdkEventCrossing*)' marked 'override', but does not override
   33 |         bool on_leave_notify_event( GdkEventCrossing* event ) override;
      |              ^~~~~~~~~~~~~~~~~~~~~
../src/skeleton/hpaned.cpp: In constructor 'SKELETON::JDHPaned::JDHPaned(int)':
../src/skeleton/hpaned.cpp:12:18: error: expected class-name before '(' token
   12 |     : Gtk::HPaned(),
      |                  ^
../src/skeleton/hpaned.cpp:12:18: error: use of deleted function 'SKELETON::HPaneControl::HPaneControl()'
In file included from ../src/skeleton/hpaned.h:11,
                 from ../src/skeleton/hpaned.cpp:6:
../src/skeleton/panecontrol.h:98:11: note: 'SKELETON::HPaneControl::HPaneControl()' is implicitly deleted because the default definition would be ill-formed:
   98 |     class HPaneControl : public PaneControl
      |           ^~~~~~~~~~~~
../src/skeleton/panecontrol.h:98:11: error: no matching function for call to 'SKELETON::PaneControl::PaneControl()'
../src/skeleton/panecontrol.h:58:9: note: candidate: 'SKELETON::PaneControl::PaneControl(Gtk::Paned&, int)'
   58 |         PaneControl( Gtk::Paned& paned, int fixmode );
      |         ^~~~~~~~~~~
../src/skeleton/panecontrol.h:58:9: note:   candidate expects 2 arguments, 0 provided
../src/skeleton/panecontrol.h:39:11: note: candidate: 'SKELETON::PaneControl::PaneControl(const SKELETON::PaneControl&)'
   39 |     class PaneControl
      |           ^~~~~~~~~~~
../src/skeleton/panecontrol.h:39:11: note:   candidate expects 1 argument, 0 provided
../src/skeleton/hpaned.cpp:12:18: error: expected '{' before '(' token
   12 |     : Gtk::HPaned(),
      |                  ^
../src/skeleton/hpaned.cpp: At global scope:
../src/skeleton/hpaned.cpp:12:19: error: expected unqualified-id before ')' token
   12 |     : Gtk::HPaned(),
      |                   ^
../src/skeleton/hpaned.cpp:13:14: error: expected constructor, destructor, or type conversion before '(' token
   13 |       m_pctrl( *this, fixmode )
      |              ^
../src/skeleton/hpaned.cpp: In member function 'void SKELETON::JDHPaned::on_realize()':
../src/skeleton/hpaned.cpp:22:10: error: 'Gtk::HPaned' has not been declared
   22 |     Gtk::HPaned::on_realize();
      |          ^~~~~~
../src/skeleton/hpaned.cpp: In member function 'bool SKELETON::JDHPaned::on_button_press_event(GdkEventButton*)':
../src/skeleton/hpaned.cpp:30:17: error: 'Gtk::HPaned' has not been declared
   30 |     return Gtk::HPaned::on_button_press_event( event );
      |                 ^~~~~~
../src/skeleton/hpaned.cpp: In member function 'bool SKELETON::JDHPaned::on_button_release_event(GdkEventButton*)':
../src/skeleton/hpaned.cpp:37:17: error: 'Gtk::HPaned' has not been declared
   37 |     return Gtk::HPaned::on_button_release_event( event );
      |                 ^~~~~~
../src/skeleton/hpaned.cpp: In member function 'bool SKELETON::JDHPaned::on_motion_notify_event(GdkEventMotion*)':
../src/skeleton/hpaned.cpp:44:17: error: 'Gtk::HPaned' has not been declared
   44 |     return Gtk::HPaned::on_motion_notify_event( event );
      |                 ^~~~~~
../src/skeleton/hpaned.cpp: In member function 'bool SKELETON::JDHPaned::on_enter_notify_event(GdkEventCrossing*)':
../src/skeleton/hpaned.cpp:51:17: error: 'Gtk::HPaned' has not been declared
   51 |     return Gtk::HPaned::on_enter_notify_event( event );
      |                 ^~~~~~
../src/skeleton/hpaned.cpp: In member function 'bool SKELETON::JDHPaned::on_leave_notify_event(GdkEventCrossing*)':
../src/skeleton/hpaned.cpp:57:17: error: 'Gtk::HPaned' has not been declared
   57 |     return Gtk::HPaned::on_leave_notify_event( event );
      |                 ^~~~~~
```
</details>

関連のissue: #229 
