### PR TITLE
Use Gtk::Paned instead of Gtk::VPaned

### DIFF
--- a/src/skeleton/vpaned.cpp
+++ b/src/skeleton/vpaned.cpp
@@ -9,8 +9,8 @@ using namespace SKELETON;
 
 
 JDVPaned::JDVPaned( const int fixmode )
-    : Gtk::VPaned(),
-      m_pctrl( *this, fixmode )
+    : Gtk::Paned( Gtk::ORIENTATION_VERTICAL )
+    , m_pctrl( *this, fixmode )
 {}
 
 
@@ -19,7 +19,7 @@ JDVPaned::~JDVPaned() noexcept = default;
 
 void JDVPaned::on_realize()
 {
-    Gtk::VPaned::on_realize();
+    Gtk::Paned::on_realize();
     m_pctrl.update_position();
 }
 
@@ -27,31 +27,31 @@ void JDVPaned::on_realize()
 bool JDVPaned::on_button_press_event( GdkEventButton* event )
 {
     m_pctrl.button_press_event( event );
-    return Gtk::VPaned::on_button_press_event( event );
+    return Gtk::Paned::on_button_press_event( event );
 }
 
 
 bool JDVPaned::on_button_release_event( GdkEventButton* event )
 {
     m_pctrl.button_release_event( event );
-    return Gtk::VPaned::on_button_release_event( event );
+    return Gtk::Paned::on_button_release_event( event );
 }
     
 
 bool JDVPaned::on_motion_notify_event( GdkEventMotion* event )
 {
     m_pctrl.motion_notify_event( event );
-    return Gtk::VPaned::on_motion_notify_event( event );
+    return Gtk::Paned::on_motion_notify_event( event );
 }
 
 bool JDVPaned::on_enter_notify_event( GdkEventCrossing* event )
 {
     m_pctrl.enter_notify_event( event );
-    return Gtk::VPaned::on_enter_notify_event( event );
+    return Gtk::Paned::on_enter_notify_event( event );
 }
 
 bool JDVPaned::on_leave_notify_event( GdkEventCrossing* event )
 {
     m_pctrl.leave_notify_event( event );
-    return Gtk::VPaned::on_leave_notify_event( event );
+    return Gtk::Paned::on_leave_notify_event( event );
 }

--- a/src/skeleton/vpaned.h
+++ b/src/skeleton/vpaned.h
@@ -12,7 +12,7 @@
 
 namespace SKELETON
 {
-    class JDVPaned : public Gtk::VPaned
+    class JDVPaned : public Gtk::Paned
     {
         VPaneControl m_pctrl;
 


### PR DESCRIPTION
GTK4で廃止される`Gtk::VPaned`のかわりに`Gtk::Paned`を使います。

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

<details>
<summary>コンパイラのレポート</summary>

```
../src/skeleton/vpaned.h:16:5: error: expected class-name before '{' token
   16 |     {
      |     ^
../src/skeleton/vpaned.h:28:14: error: 'void SKELETON::JDVPaned::on_realize()' marked 'override', but does not override
   28 |         void on_realize() override;
      |              ^~~~~~~~~~
../src/skeleton/vpaned.h:29:14: error: 'bool SKELETON::JDVPaned::on_button_press_event(GdkEventButton*)' marked 'override', but does not override
   29 |         bool on_button_press_event( GdkEventButton* event ) override;
      |              ^~~~~~~~~~~~~~~~~~~~~
../src/skeleton/vpaned.h:30:14: error: 'bool SKELETON::JDVPaned::on_button_release_event(GdkEventButton*)' marked 'override', but does not override
   30 |         bool on_button_release_event( GdkEventButton* event ) override;
      |              ^~~~~~~~~~~~~~~~~~~~~~~
../src/skeleton/vpaned.h:31:14: error: 'bool SKELETON::JDVPaned::on_motion_notify_event(GdkEventMotion*)' marked 'override', but does not override
   31 |         bool on_motion_notify_event( GdkEventMotion* event ) override;
      |              ^~~~~~~~~~~~~~~~~~~~~~
../src/skeleton/vpaned.h:32:14: error: 'bool SKELETON::JDVPaned::on_enter_notify_event(GdkEventCrossing*)' marked 'override', but does not override
   32 |         bool on_enter_notify_event( GdkEventCrossing* event ) override;
      |              ^~~~~~~~~~~~~~~~~~~~~
../src/skeleton/vpaned.h:33:14: error: 'bool SKELETON::JDVPaned::on_leave_notify_event(GdkEventCrossing*)' marked 'override', but does not override
   33 |         bool on_leave_notify_event( GdkEventCrossing* event ) override;
      |              ^~~~~~~~~~~~~~~~~~~~~
../src/skeleton/vpaned.cpp: In constructor 'SKELETON::JDVPaned::JDVPaned(int)':
../src/skeleton/vpaned.cpp:12:18: error: expected class-name before '(' token
   12 |     : Gtk::VPaned(),
      |                  ^
../src/skeleton/vpaned.cpp:12:18: error: use of deleted function 'SKELETON::VPaneControl::VPaneControl()'
In file included from ../src/skeleton/vpaned.h:11,
                 from ../src/skeleton/vpaned.cpp:6:
../src/skeleton/panecontrol.h:120:11: note: 'SKELETON::VPaneControl::VPaneControl()' is implicitly deleted because the default definition would be ill-formed:
  120 |     class VPaneControl : public PaneControl
      |           ^~~~~~~~~~~~
../src/skeleton/panecontrol.h:120:11: error: no matching function for call to 'SKELETON::PaneControl::PaneControl()'
../src/skeleton/panecontrol.h:58:9: note: candidate: 'SKELETON::PaneControl::PaneControl(Gtk::Paned&, int)'
   58 |         PaneControl( Gtk::Paned& paned, int fixmode );
      |         ^~~~~~~~~~~
../src/skeleton/panecontrol.h:58:9: note:   candidate expects 2 arguments, 0 provided
../src/skeleton/panecontrol.h:39:11: note: candidate: 'SKELETON::PaneControl::PaneControl(const SKELETON::PaneControl&)'
   39 |     class PaneControl
      |           ^~~~~~~~~~~
../src/skeleton/panecontrol.h:39:11: note:   candidate expects 1 argument, 0 provided
../src/skeleton/vpaned.cpp:12:18: error: expected '{' before '(' token
   12 |     : Gtk::VPaned(),
      |                  ^
../src/skeleton/vpaned.cpp: At global scope:
../src/skeleton/vpaned.cpp:12:19: error: expected unqualified-id before ')' token
   12 |     : Gtk::VPaned(),
      |                   ^
../src/skeleton/vpaned.cpp:13:14: error: expected constructor, destructor, or type conversion before '(' token
   13 |       m_pctrl( *this, fixmode )
      |              ^
../src/skeleton/vpaned.cpp: In member function 'void SKELETON::JDVPaned::on_realize()':
../src/skeleton/vpaned.cpp:22:10: error: 'Gtk::VPaned' has not been declared
   22 |     Gtk::VPaned::on_realize();
      |          ^~~~~~
../src/skeleton/vpaned.cpp: In member function 'bool SKELETON::JDVPaned::on_button_press_event(GdkEventButton*)':
../src/skeleton/vpaned.cpp:30:17: error: 'Gtk::VPaned' has not been declared
   30 |     return Gtk::VPaned::on_button_press_event( event );
      |                 ^~~~~~
../src/skeleton/vpaned.cpp: In member function 'bool SKELETON::JDVPaned::on_button_release_event(GdkEventButton*)':
../src/skeleton/vpaned.cpp:37:17: error: 'Gtk::VPaned' has not been declared
   37 |     return Gtk::VPaned::on_button_release_event( event );
      |                 ^~~~~~
../src/skeleton/vpaned.cpp: In member function 'bool SKELETON::JDVPaned::on_motion_notify_event(GdkEventMotion*)':
../src/skeleton/vpaned.cpp:44:17: error: 'Gtk::VPaned' has not been declared
   44 |     return Gtk::VPaned::on_motion_notify_event( event );
      |                 ^~~~~~
../src/skeleton/vpaned.cpp: In member function 'bool SKELETON::JDVPaned::on_enter_notify_event(GdkEventCrossing*)':
../src/skeleton/vpaned.cpp:50:17: error: 'Gtk::VPaned' has not been declared
   50 |     return Gtk::VPaned::on_enter_notify_event( event );
      |                 ^~~~~~
../src/skeleton/vpaned.cpp: In member function 'bool SKELETON::JDVPaned::on_leave_notify_event(GdkEventCrossing*)':
../src/skeleton/vpaned.cpp:56:17: error: 'Gtk::VPaned' has not been declared
   56 |     return Gtk::VPaned::on_leave_notify_event( event );
      |                 ^~~~~~
```
</details>

関連のissue: #229
