### PR TITLE
Board2chCompati: Cut html source for analyzing form data

### DIFF
--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -165,7 +165,11 @@ void Board2chCompati::analyze_keyword_for_newarticle( const std::string& html )
     std::cout << html << std::endl << "--------------------\n";
 #endif
 
-    std::string keyword = analyze_keyword_impl( html );
+    // XXX: スレ立てフォームはページの最後にあると決め打ちしている
+    std::size_t i = html.rfind( "<form" );
+    if( i == std::string::npos ) i = 0;
+
+    std::string keyword = analyze_keyword_impl( html.substr( i ) );
     set_keyword_for_newarticle( keyword );
 }
 


### PR DESCRIPTION
2ch互換板スレ立てに利用するフォームデータの解析に渡すHTMLソースから使用しない部分をカットします。

#### 実装の詳細
スレ立てのフォームはwebページの最後にあると決め打ちしている