### PR TITLE
Use Gtk::Widget::property_margin() instead of Gtk::Misc::set_padding()

### DIFF
--- a/src/skeleton/detaildiag.cpp
+++ b/src/skeleton/detaildiag.cpp
@@ -21,7 +21,7 @@ DetailDiag::DetailDiag( Gtk::Window* parent, const std::string& url,
 {
     m_message.set_width_chars( 60 );
     m_message.set_line_wrap( true );
-    m_message.set_padding( 8, 8 );
+    m_message.property_margin() = 8;
     m_message.set_selectable( true );
     m_message.property_can_focus() = false;
 


### PR DESCRIPTION
GTK4で廃止される`Gtk::Misc::set_padding()`のかわりに`Gtk::Widget::property_margin()`を使います。

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/skeleton/detaildiag.cpp:24:15: error: 'class Gtk::Label' has no member named 'set_padding'
   24 |     m_message.set_padding( 8, 8 );
      |               ^~~~~~~~~~~
```

関連のissue: #229 
