### PR TITLE
Use Gtk::Label::set_xalign() instead of Gtk::Misc::set_alignment()

### DIFF
--- a/src/article/preference.cpp
+++ b/src/article/preference.cpp
@@ -121,7 +121,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
 
     if( CONFIG::get_abone_transparent() || CONFIG::get_abone_chain() ){
         m_label_abone.set_text( "チェック出来ない場合は設定メニューから「デフォルトで透明/連鎖あぼ〜ん」を解除して下さい" );
-        m_label_abone.set_alignment( Gtk::ALIGN_START, Gtk::ALIGN_CENTER );
+        m_label_abone.set_xalign( 0 );
         m_vbox_abone.pack_start( m_label_abone, Gtk::PACK_SHRINK );
     }
 

--- a/src/bbslist/toolbar.cpp
+++ b/src/bbslist/toolbar.cpp
@@ -35,7 +35,7 @@ BBSListToolBar::BBSListToolBar() :
 {
     m_button_toggle.get_button()->set_tooltip_arrow( "ページ切り替え\n\nマウスホイール回転でも切り替え可能" );
 
-    m_label.set_alignment( Gtk::ALIGN_START );
+    m_label.set_xalign( 0 );
     m_label.set_ellipsize( Pango::ELLIPSIZE_END );
     std::vector< std::string > menu;
     menu.push_back( ITEM_NAME_BBSLISTVIEW );

--- a/src/browserpref.h
+++ b/src/browserpref.h
@@ -60,7 +60,7 @@ namespace CORE
             m_hbox.add( m_entry_browser );
             m_frame.set_label( "ブラウザ起動コマンド" );
             m_frame.add( m_hbox );
-            m_label_notice.set_alignment( Gtk::ALIGN_START, Gtk::ALIGN_CENTER );
+            m_label_notice.set_xalign( 0 );
 
             m_vbox.set_border_width( mrg );
             m_vbox.pack_start( m_label_notice, Gtk::PACK_EXPAND_WIDGET, mrg );

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -426,8 +426,8 @@ void MessageViewBase::set_mail()
 void MessageViewBase::pack_widget()
 {
     // 書き込みビュー
-    m_label_name.set_alignment( Gtk::ALIGN_START, Gtk::ALIGN_CENTER );
-    m_label_mail.set_alignment( Gtk::ALIGN_START, Gtk::ALIGN_CENTER );
+    m_label_name.set_xalign( 0 );
+    m_label_mail.set_xalign( 0 );
     m_label_name.set_text( " 名前 " );
     m_label_mail.set_text( " メール " );
 

--- a/src/skeleton/label_entry.cpp
+++ b/src/skeleton/label_entry.cpp
@@ -18,7 +18,7 @@ LabelEntry::LabelEntry( const bool editable, const std::string& label, const std
     pack_start( m_label, Gtk::PACK_SHRINK );
 
     m_info.set_size_request( 0, 0 );
-    m_info.set_alignment( Gtk::ALIGN_START );
+    m_info.set_xalign( 0 );
     m_info.set_selectable( true );
     m_info.set_ellipsize( Pango::ELLIPSIZE_END );
 

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -300,7 +300,7 @@ Gtk::ToolItem* ToolBar::get_label()
         m_label = Gtk::manage( new Gtk::Label );
 
         m_label->set_ellipsize( Pango::ELLIPSIZE_END );
-        m_label->set_alignment( Gtk::ALIGN_START );
+        m_label->set_xalign( 0 );
         m_label->set_selectable( true );
 
         m_ebox_label->add( *m_label );
@@ -631,7 +631,7 @@ Gtk::ToolItem* ToolBar::get_button_board()
     if( ! m_button_board ){
 
         m_label_board = Gtk::manage( new Gtk::Label );
-        m_label_board->set_alignment( Gtk::ALIGN_START );
+        m_label_board->set_xalign( 0 );
 
         m_button_board = Gtk::manage( new SKELETON::ToolMenuButton( CONTROL::get_label( CONTROL::OpenParentBoard ), false, true, *m_label_board ) );
 

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -58,7 +58,7 @@ JDWindow::JDWindow( const bool fold_when_focusout, const bool need_mginfo )
 {
     // ステータスバー
     m_label_stat.set_size_request( 0, -1 );
-    m_label_stat.set_alignment( Gtk::ALIGN_START );
+    m_label_stat.set_xalign( 0 );
     m_label_stat.set_selectable( true );
     m_label_stat.set_single_line_mode( true );
     m_label_stat.set_ellipsize( Pango::ELLIPSIZE_END );
@@ -74,7 +74,7 @@ JDWindow::JDWindow( const bool fold_when_focusout, const bool need_mginfo )
     }
 
     m_mginfo.set_width_chars( MGINFO_CHARS );
-    m_mginfo.set_alignment( Gtk::ALIGN_START );
+    m_mginfo.set_xalign( 0 );
 
     m_statbar.show_all_children();
 


### PR DESCRIPTION
GTK4で廃止される`Gtk::Misc::set_alignment()`のかわりに`Gtk::Label::set_xalign()`を使います。

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

<details>
<summary>コンパイラのレポート</summary>

```
../src/article/preference.cpp:124:23: error: 'class Gtk::Label' has no member named 'set_alignment'; did you mean 'set_lines'?
  124 |         m_label_abone.set_alignment( Gtk::ALIGN_START, Gtk::ALIGN_CENTER );
      |                       ^~~~~~~~~~~~~
      |                       set_lines
../src/bbslist/toolbar.cpp:38:13: error: 'class Gtk::Label' has no member named 'set_alignment'; did you mean 'set_lines'?
   38 |     m_label.set_alignment( Gtk::ALIGN_START );
      |             ^~~~~~~~~~~~~
      |             set_lines
../src/message/messageviewbase.cpp:429:18: error: 'class Gtk::Label' has no member named 'set_alignment'; did you mean 'set_lines'?
  429 |     m_label_name.set_alignment( Gtk::ALIGN_START, Gtk::ALIGN_CENTER );
      |                  ^~~~~~~~~~~~~
      |                  set_lines
../src/message/messageviewbase.cpp:430:18: error: 'class Gtk::Label' has no member named 'set_alignment'; did you mean 'set_lines'?
  430 |     m_label_mail.set_alignment( Gtk::ALIGN_START, Gtk::ALIGN_CENTER );
      |                  ^~~~~~~~~~~~~
      |                  set_lines
../src/skeleton/label_entry.cpp:21:12: error: 'class Gtk::Label' has no member named 'set_alignment'; did you mean 'set_lines'?
   21 |     m_info.set_alignment( Gtk::ALIGN_START );
      |            ^~~~~~~~~~~~~
      |            set_lines
../src/skeleton/toolbar.cpp:303:18: error: 'class Gtk::Label' has no member named 'set_alignment'; did you mean 'set_lines'?
  303 |         m_label->set_alignment( Gtk::ALIGN_START );
      |                  ^~~~~~~~~~~~~
      |                  set_lines
../src/skeleton/toolbar.cpp:633:24: error: 'class Gtk::Label' has no member named 'set_alignment'; did you mean 'set_lines'?
  633 |         m_label_board->set_alignment( Gtk::ALIGN_START );
      |                        ^~~~~~~~~~~~~
      |                        set_lines
../src/skeleton/window.cpp:61:18: error: 'class Gtk::Label' has no member named 'set_alignment'; did you mean 'set_lines'?
   61 |     m_label_stat.set_alignment( Gtk::ALIGN_START );
      |                  ^~~~~~~~~~~~~
      |                  set_lines
../src/skeleton/window.cpp:77:14: error: 'class Gtk::Label' has no member named 'set_alignment'; did you mean 'set_lines'?
   77 |     m_mginfo.set_alignment( Gtk::ALIGN_START );
      |              ^~~~~~~~~~~~~
      |              set_lines
../src/browserpref.h:63:28: error: 'class Gtk::Label' has no member named 'set_alignment'; did you mean 'set_lines'?
   63 |             m_label_notice.set_alignment( Gtk::ALIGN_START, Gtk::ALIGN_CENTER );
      |                            ^~~~~~~~~~~~~
      |                            set_lines
```
</details>

関連のissue: #229 
