### PR TITLE
Use Gtk::Widget::set_[hv]align() instead of Gtk::Misc::set_alignment()

### DIFF
--- a/src/image/imageareabase.cpp
+++ b/src/image/imageareabase.cpp
@@ -65,7 +65,8 @@ ImageAreaBase::ImageAreaBase( const std::string& url, const int interptype )
     if( interptype == 1 ) m_interptype = Gdk::INTERP_BILINEAR;
     else if( interptype >= 2 ) m_interptype = Gdk::INTERP_HYPER;
 
-    set_alignment( Gtk::ALIGN_CENTER, Gtk::ALIGN_CENTER );
+    set_halign( Gtk::ALIGN_CENTER );
+    set_valign( Gtk::ALIGN_CENTER );
 }
 
 


### PR DESCRIPTION
GTK4で廃止される`Gtk::Misc::set_alignment()`のかわりに`Gtk::Widget::set_[hv]align()`を使います。

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/image/imageareabase.cpp:68:5: error: 'set_alignment' was not declared in this scope; did you mean 'set_halign'?
   68 |     set_alignment( Gtk::ALIGN_CENTER, Gtk::ALIGN_CENTER );
      |     ^~~~~~~~~~~~~
      |     set_halign
```

関連のissue: #229 
