### PR TITLE
Fix posting to 2ch

### DIFF
--- a/src/dbtree/article2ch.cpp
+++ b/src/dbtree/article2ch.cpp
@@ -35,9 +35,15 @@ std::string Article2ch::create_write_message( const std::string& name, const std
     const std::string charset = DBTREE::board_charset( get_url() );
 
     std::stringstream ss_post;
-    ss_post.clear();
-    ss_post << "bbs="      << DBTREE::board_id( get_url() )
-            << "&key="     << get_key();
+    ss_post << "FROM=" << MISC::charset_url_encode( name, charset )
+            << "&mail=" << MISC::charset_url_encode( mail, charset )
+            << "&MESSAGE=" << MISC::charset_url_encode( msg, charset )
+            << "&bbs=" << DBTREE::board_id( get_url() )
+            << "&key=" << get_key()
+            << "&time=" << get_time_modified()
+            << "&submit=" << MISC::charset_url_encode( "書き込む", charset )
+            // XXX: ブラウザの種類に関係なく含めて問題ないか？
+            << "&oekaki_thread1=";
 
     // キーワード( hana=mogera や suka=pontan など )
     const std::string keyword = DBTREE::board_keyword_for_write( get_url() );
@@ -49,15 +55,12 @@ std::string Article2ch::create_write_message( const std::string& name, const std
                 ss_post << "&sid=" << MISC::url_encode( sid.c_str(), sid.length() );
     }
 
-    ss_post << "&time="    << get_time_modified()
-            << "&submit="  << MISC::charset_url_encode( "書き込む", charset )
-            << "&FROM="    << MISC::charset_url_encode( name, charset )
-            << "&mail="    << MISC::charset_url_encode( mail, charset )
-            << "&MESSAGE=" << MISC::charset_url_encode( msg, charset );
-
 #ifdef _DEBUG
     std::cout << "Article2chCompati::create_write_message " << ss_post.str() << std::endl;
 #endif
+
+    // 書き込みメッセージを作成したらキーワードはリセットする
+    DBTREE::board_set_keyword_for_write( get_url(), std::string{} );
 
     return ss_post.str();
 }

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -181,9 +181,9 @@ std::string Board2ch::cookie_for_post() const
 }
 
 
-std::string Board2ch::get_write_referer()
+std::string Board2ch::get_write_referer( const std::string& url )
 {
-    return Board2chCompati::get_write_referer();
+    return url_readcgi( url, 0, 0 );
 }
 
 

--- a/src/dbtree/board2ch.h
+++ b/src/dbtree/board2ch.h
@@ -51,7 +51,7 @@ namespace DBTREE
         std::string cookie_for_post() const override;
 
         // 書き込み時のリファラ
-        std::string get_write_referer() override;
+        std::string get_write_referer( const std::string& url ) override;
 
         // フロントページのダウンロード
         void download_front() override;

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -87,25 +87,26 @@ bool Board2chCompati::is_valid( const std::string& filename )
 }
 
 
-std::string Board2chCompati::analyze_keyword_impl( const std::string& html )
+std::string Board2chCompati::analyze_keyword_impl( const std::string& html, bool full_parse )
 {
     std::string keyword;
 
     std::vector<MISC::FormDatum> data = MISC::parse_html_form_data( html );
     for( MISC::FormDatum& d : data ) {
 
-        // 除外する name の判定
-        // 2ch の仕様が変わったら項目を追加すること
         const std::string lowname = MISC::tolower_str( d.name );
-        if( lowname == "subject"
-            || lowname == "from"
-            || lowname == "mail"
-            || lowname == "message"
-            || lowname == "bbs"
-            || lowname == "time"
-            || lowname == "key"
-            || lowname == "submit" ) continue;
-
+        if( ! full_parse ) {
+            // 除外する name の判定
+            // 2ch の仕様が変わったら項目を追加すること
+            if( lowname == "subject"
+                || lowname == "from"
+                || lowname == "mail"
+                || lowname == "message"
+                || lowname == "bbs"
+                || lowname == "time"
+                || lowname == "key"
+                || lowname == "submit" ) continue;
+        }
         if( lowname == "message" ) {
             // アンカー記号(>>)などがエスケープされる(&gt;&gt;)ため
             // 一度HTMLエスケープされた文字をデコードする
@@ -135,7 +136,8 @@ void Board2chCompati::analyze_keyword_for_write( const std::string& html )
     std::cout << html << std::endl << "--------------------\n";
 #endif
 
-    std::string keyword = analyze_keyword_impl( html );
+    constexpr bool full_parse{ false };
+    std::string keyword = analyze_keyword_impl( html, full_parse );
     set_keyword_for_write( keyword );
 }
 
@@ -152,7 +154,8 @@ void Board2chCompati::analyze_keyword_for_newarticle( const std::string& html )
     std::size_t i = html.rfind( "<form" );
     if( i == std::string::npos ) i = 0;
 
-    std::string keyword = analyze_keyword_impl( html.substr( i ) );
+    constexpr bool full_parse{ false };
+    std::string keyword = analyze_keyword_impl( html.substr( i ), full_parse );
     set_keyword_for_newarticle( keyword );
 }
 

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -91,6 +91,16 @@ std::string Board2chCompati::analyze_keyword_impl( const std::string& html, bool
 {
     std::string keyword;
 
+    // form要素から action属性(送信先URLのパス) を取得する
+    const std::string path = MISC::parse_html_form_action( html );
+    // action属性が見つかったら m_path_subbbscgi に設定する
+    if( ! path.empty() ) {
+#ifdef _DEBUG
+        std::cout << "Board2chCompati::analyze_keyword_impl update subbbscgi path = " << path << std::endl;
+#endif
+        set_path_subbbscgi( path );
+    }
+
     std::vector<MISC::FormDatum> data = MISC::parse_html_form_data( html );
     for( MISC::FormDatum& d : data ) {
 

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -160,6 +160,19 @@ void Board2chCompati::analyze_keyword_for_newarticle( const std::string& html )
 }
 
 
+// 確認画面のHTMLから書き込み、スレ立て時に使うフォームデータを取得する
+std::string Board2chCompati::parse_form_data( const std::string& html )
+{
+#ifdef _DEBUG
+    std::cout << "Board2chCompati::parse_form_data\n";
+    std::cout << html << std::endl << "--------------------\n";
+#endif
+
+    constexpr bool full_parse{ true };
+    return analyze_keyword_impl( html, full_parse );
+}
+
+
 // 新スレ作成時の書き込みメッセージ作成
 std::string Board2chCompati::create_newarticle_message( const std::string& subject,
                                                        const std::string& name, const std::string& mail, const std::string& msg )

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -31,6 +31,9 @@ namespace DBTREE
         // スレ立て時に必要なキーワードをフロントページのhtmlから解析する
         void analyze_keyword_for_newarticle( const std::string& html ) override;
 
+        // 確認画面のHTMLから書き込み、スレ立て時に使うフォームデータを取得する
+        std::string parse_form_data( const std::string& html ) override;
+
         // 新スレ作成用のメッセージ変換
         std::string create_newarticle_message( const std::string& subject, const std::string& name,
                                                const std::string& mail, const std::string& msg ) override;

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -66,7 +66,7 @@ namespace DBTREE
         int get_abone_number_global() override;
 
         // htmlからキーワードを解析する
-        std::string analyze_keyword_impl( const std::string& html );
+        std::string analyze_keyword_impl( const std::string& html, bool full_parse );
     };
 }
 

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -353,9 +353,9 @@ namespace DBTREE
         virtual void analyze_keyword_for_newarticle( const std::string& html ) {}
 
         // 書き込み時のリファラ
-        virtual std::string get_write_referer(){ return url_boardbase(); }
+        virtual std::string get_write_referer( const std::string& url ){ return url_boardbase(); }
         // スレ立て時のリファラ
-        virtual std::string get_newarticle_referer() { return url_boardbase(); }
+        virtual std::string get_newarticle_referer( const std::string& url ) { return url_boardbase(); }
 
         // basic認証
         const std::string& get_basicauth() const { return m_basicauth; }

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -352,6 +352,9 @@ namespace DBTREE
         // スレ立て時に必要なキーワードをフロントページのhtmlから解析する
         virtual void analyze_keyword_for_newarticle( const std::string& html ) {}
 
+        // 確認画面のHTMLから書き込み、スレ立て時に使うフォームデータを取得する
+        virtual std::string parse_form_data( const std::string& html ) { return {}; }
+
         // 書き込み時のリファラ
         virtual std::string get_write_referer( const std::string& url ){ return url_boardbase(); }
         // スレ立て時のリファラ

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -354,6 +354,8 @@ namespace DBTREE
 
         // 書き込み時のリファラ
         virtual std::string get_write_referer(){ return url_boardbase(); }
+        // スレ立て時のリファラ
+        virtual std::string get_newarticle_referer() { return url_boardbase(); }
 
         // basic認証
         const std::string& get_basicauth() const { return m_basicauth; }

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -1116,13 +1116,13 @@ std::string DBTREE::create_newarticle_message( const std::string& url, const std
 
 std::string DBTREE::get_write_referer( const std::string& url )
 {
-    return DBTREE::get_board( url )->get_write_referer();
+    return DBTREE::get_board( url )->get_write_referer( url );
 }
 
 
 std::string DBTREE::get_newarticle_referer( const std::string& url )
 {
-    return DBTREE::get_board( url )->get_newarticle_referer();
+    return DBTREE::get_board( url )->get_newarticle_referer( url );
 }
 
 

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -362,6 +362,12 @@ void DBTREE::board_analyze_keyword_for_newarticle( const std::string& url, const
 }
 
 
+std::string DBTREE::board_parse_form_data( const std::string& url, const std::string& html )
+{
+    return DBTREE::get_board( url )->parse_form_data( html );
+}
+
+
 std::string DBTREE::board_basicauth( const std::string& url )
 {
     return DBTREE::get_board( url )->get_basicauth();

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -1120,6 +1120,12 @@ std::string DBTREE::get_write_referer( const std::string& url )
 }
 
 
+std::string DBTREE::get_newarticle_referer( const std::string& url )
+{
+    return DBTREE::get_board( url )->get_newarticle_referer();
+}
+
+
 // キャッシュ削除
 void DBTREE::delete_article( const std::string& url, const bool cache_only )
 {

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -304,6 +304,8 @@ namespace DBTREE
 
     // 書き込み時のリファラ
     std::string get_write_referer( const std::string& url );
+    // スレ立て時のリファラ
+    std::string get_newarticle_referer( const std::string& url );
 
     // あぼーん関係
 

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -114,6 +114,7 @@ namespace DBTREE
     std::string board_keyword_for_newarticle( const std::string& url );
     void board_set_keyword_for_newarticle( const std::string& url, const std::string& keyword );
     void board_analyze_keyword_for_newarticle( const std::string& url, const std::string& html );
+    std::string board_parse_form_data( const std::string& url, const std::string& html );
     std::string board_basicauth( const std::string& url );
     std::string board_ext( const std::string& url );
     int board_status( const std::string& url );

--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -507,6 +507,7 @@ bool Loader::run( SKELETON::Loadable* cb, const LOADERDATA& data_in )
     m_data.byte_readfrom = data_in.byte_readfrom;    
     m_data.contenttype = data_in.contenttype;
     m_data.agent = data_in.agent;
+    m_data.origin = data_in.origin;
     m_data.referer = data_in.referer;
     m_data.cookie_for_request = data_in.cookie_for_request;
     m_data.timeout = MAX( TIMEOUT_MIN, data_in.timeout );
@@ -1144,6 +1145,7 @@ std::string Loader::create_msg_send()
     msg << "Host: " << m_data.host << "\r\n";
     if( ! m_data.contenttype.empty() ) msg << "Content-Type: " << m_data.contenttype << "\r\n";
     if( ! m_data.agent.empty() ) msg << "User-Agent: " << m_data.agent << "\r\n";
+    if( ! m_data.origin.empty() ) msg << "Origin: " << m_data.origin << "\r\n";
     if( ! m_data.referer.empty() ) msg << "Referer: " << m_data.referer << "\r\n";
 
     // basic認証

--- a/src/jdlib/loaderdata.cpp
+++ b/src/jdlib/loaderdata.cpp
@@ -41,6 +41,7 @@ void LOADERDATA::init()
     basicauth_proxy.clear();
 
     agent.clear();
+    origin.clear();
     referer.clear();
     ex_field.clear();
             

--- a/src/jdlib/loaderdata.h
+++ b/src/jdlib/loaderdata.h
@@ -38,6 +38,7 @@ namespace JDLIB
         std::string basicauth_proxy; // proxy 認証
 
         std::string agent;
+        std::string origin;
         std::string referer;
         std::string ex_field;  // 送信時にヘッダに追加するフィールド
         std::string str_header;

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1953,3 +1953,25 @@ std::vector<MISC::FormDatum> MISC::parse_html_form_data( const std::string& html
     }
     return data;
 }
+
+
+// HTMLのform要素から action属性(送信先URLのパス) を取得する
+// 2ch互換板に特化して実装しているため他の掲示板で期待した結果を返す保証はない
+// 詳細は実装やテストコードを参照
+//
+std::string MISC::parse_html_form_action( const std::string& html )
+{
+    const char pattern[] = R"(<form +method=("POST"|POST)[^>]* action="(\.\.)?(/test/(sub)?bbs\.cgi(\?[^"]*)?))";
+    JDLIB::Regex regex;
+    constexpr std::size_t offset = 0;
+    constexpr bool icase = true; // 大文字小文字区別しない
+    constexpr bool newline = false;  // . に改行をマッチさせる
+    constexpr bool usemigemo = false;
+    constexpr bool wchar = false;
+
+    std::string path;
+    if( regex.exec( pattern, html, offset, icase, newline, usemigemo, wchar ) ) {
+        path = regex.str( 3 );
+    }
+    return path;
+}

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -43,6 +43,15 @@ namespace MISC
          WINtoUNIX
      };
 
+     // parse_html_form_data() の戻り値
+     struct FormDatum
+     {
+         std::string name;
+         std::string value;
+
+         bool operator==( const FormDatum& rhs ) const { return name == rhs.name && value == rhs.value; }
+     };
+
     // str を "\n" ごとに区切ってlistにして出力
     std::list< std::string > get_lines( const std::string& str );
 
@@ -275,6 +284,9 @@ namespace MISC
     // selfの先頭部分がstartsと等しいか（ヌル終端文字列バージョン）
     // Unicode正規化は行わなずバイト列として比較する
     bool starts_with( const char* self, const char* starts );
+
+    // HTMLからform要素を解析してinput,textarea要素の名前と値を返す
+    std::vector<FormDatum> parse_html_form_data( const std::string& html );
 }
 
 

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -287,6 +287,11 @@ namespace MISC
 
     // HTMLからform要素を解析してinput,textarea要素の名前と値を返す
     std::vector<FormDatum> parse_html_form_data( const std::string& html );
+
+    // HTMLのform要素から action属性(送信先URLのパス) を取得する
+    // 2ch互換板に特化して実装しているため他の掲示板で期待した結果を返す保証はない
+    // 詳細は実装やテストコードを参照
+    std::string parse_html_form_action( const std::string& html );
 }
 
 

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -438,6 +438,8 @@ void Post::receive_finish()
         std::string msg_body = DBTREE::board_parse_form_data( m_url, m_return_html );
         if( ! msg_body.empty() ) m_msg = std::move( msg_body );
 
+        // subbbs.cgi にポスト先を変更してもう一回ポスト
+        m_subbbs = true;
         ++m_count; // 永久ループ防止
         post_msg();
 

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -189,6 +189,10 @@ void Post::post_msg()
 
     data.agent = DBTREE::get_agent_w( m_url );
     data.referer = m_count < 1 ? m_post_strategy->get_referer( m_url ) : m_post_strategy->url_bbscgi( m_url );
+    // WebブラウザのUAならOriginを含める
+    if( data.agent.compare( 0, 11, "Mozilla/5.0" ) == 0 ) {
+        data.origin = MISC::get_hostname( m_url );
+    }
     data.str_post = m_msg;
     data.host_proxy = DBTREE::get_proxy_host_w( m_url );
     data.port_proxy = DBTREE::get_proxy_port_w( m_url );
@@ -203,6 +207,7 @@ void Post::post_msg()
               << "url = " << data.url << std::endl
               << "contenttype = " << data.contenttype << std::endl
               << "agent = " << data.agent << std::endl
+              << "origin = " << data.origin << std::endl
               << "referer = " << data.referer << std::endl
               << "cookie = " << data.cookie_for_request << std::endl
               << "proxy = " << data.host_proxy << ":" << data.port_proxy << std::endl

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -43,6 +43,8 @@ struct WriteStrategy : public MESSAGE::PostStrategy
     }
     std::string get_keyword( const std::string& url ) override { return DBTREE::board_keyword_for_write( url ); }
 
+    std::string get_referer( const std::string& url ) const override { return DBTREE::get_write_referer( url ); }
+
 } s_write_strategy;
 
 
@@ -59,6 +61,8 @@ struct NewArticleStrategy : public MESSAGE::PostStrategy
         DBTREE::board_analyze_keyword_for_newarticle( url, html );
     }
     std::string get_keyword( const std::string& url ) override { return DBTREE::board_keyword_for_newarticle( url ); }
+
+    std::string get_referer( const std::string& url ) const override { return DBTREE::get_newarticle_referer( url ); }
 
 } s_new_article_strategy;
 
@@ -196,7 +200,7 @@ void Post::post_msg()
     data.contenttype = "application/x-www-form-urlencoded";
 
     data.agent = DBTREE::get_agent_w( m_url );
-    data.referer = DBTREE::get_write_referer( m_url );
+    data.referer = m_count < 1 ? m_post_strategy->get_referer( m_url ) : m_post_strategy->url_bbscgi( m_url );
     data.str_post = m_msg;
     data.host_proxy = DBTREE::get_proxy_host_w( m_url );
     data.port_proxy = DBTREE::get_proxy_port_w( m_url );

--- a/src/message/post.h
+++ b/src/message/post.h
@@ -27,8 +27,6 @@ namespace MESSAGE
         virtual ~PostStrategy() noexcept = default;
         virtual std::string url_bbscgi( const std::string& url ) = 0; // 1回目の投稿先
         virtual std::string url_subbbscgi( const std::string& url ) = 0; // 2回目の投稿先
-        virtual void analyze_keyword( const std::string& url, const std::string& html ) = 0; // キーワードを解析
-        virtual std::string get_keyword( const std::string& url ) = 0; // キーワードをゲット
         virtual std::string get_referer( const std::string& url ) const = 0; // リファラを取得
     };
 

--- a/src/message/post.h
+++ b/src/message/post.h
@@ -29,6 +29,7 @@ namespace MESSAGE
         virtual std::string url_subbbscgi( const std::string& url ) = 0; // 2回目の投稿先
         virtual void analyze_keyword( const std::string& url, const std::string& html ) = 0; // キーワードを解析
         virtual std::string get_keyword( const std::string& url ) = 0; // キーワードをゲット
+        virtual std::string get_referer( const std::string& url ) const = 0; // リファラを取得
     };
 
     class Post : public SKELETON::Loadable

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -683,4 +683,90 @@ TEST_F(MISC_ParseHtmlFormData, textarea_empty_value_by_double_quotes)
     EXPECT_EQ( result, expect );
 }
 
+
+class MISC_ParseHtmlFormActionTest : public ::testing::Test {};
+
+TEST_F(MISC_ParseHtmlFormActionTest, empty_html)
+{
+    std::string result = MISC::parse_html_form_action( std::string{} );
+    EXPECT_EQ( result, std::string{} );
+}
+
+TEST_F(MISC_ParseHtmlFormActionTest, unquote_post)
+{
+    const std::string html = R"(<form method=POST action="/test/bbs.cgi">")";
+    std::string result = MISC::parse_html_form_action( html );
+    EXPECT_EQ( result, "/test/bbs.cgi" );
+}
+
+TEST_F(MISC_ParseHtmlFormActionTest, quote_post)
+{
+    const std::string html = R"(<form method="POST" action="/test/bbs.cgi">")";
+    std::string result = MISC::parse_html_form_action( html );
+    EXPECT_EQ( result, "/test/bbs.cgi" );
+}
+
+TEST_F(MISC_ParseHtmlFormActionTest, subbbscgi)
+{
+    const std::string html = R"(<form method="POST" action="/test/subbbs.cgi">")";
+    std::string result = MISC::parse_html_form_action( html );
+    EXPECT_EQ( result, "/test/subbbs.cgi" );
+}
+
+TEST_F(MISC_ParseHtmlFormActionTest, with_parameter)
+{
+    const std::string html = R"(<form method="POST" action="/test/bbs.cgi?foo=bar">")";
+    std::string result = MISC::parse_html_form_action( html );
+    EXPECT_EQ( result, "/test/bbs.cgi?foo=bar" );
+}
+
+TEST_F(MISC_ParseHtmlFormActionTest, ignore_attributes)
+{
+    const std::string html = R"(<form method="POST" accept-charset="Shift_JIS" action="/test/bbs.cgi">")";
+    std::string result = MISC::parse_html_form_action( html );
+    EXPECT_EQ( result, "/test/bbs.cgi" );
+}
+
+TEST_F(MISC_ParseHtmlFormActionTest, relative_path_an_upper_order)
+{
+    const std::string html = R"(<form method="POST" action="../test/bbs.cgi">")";
+    std::string result = MISC::parse_html_form_action( html );
+    EXPECT_EQ( result, "/test/bbs.cgi" );
+}
+
+TEST_F(MISC_ParseHtmlFormActionTest, relative_path_double_upper_orders)
+{
+    const std::string html = R"(<form method="POST" action="../../test/bbs.cgi">")";
+    std::string result = MISC::parse_html_form_action( html );
+    EXPECT_EQ( result, std::string{} );
+}
+
+TEST_F(MISC_ParseHtmlFormActionTest, relative_path_middle_upper_order)
+{
+    const std::string html = R"(<form method="POST" action="/test/../bbs.cgi">")";
+    std::string result = MISC::parse_html_form_action( html );
+    EXPECT_EQ( result, std::string{} );
+}
+
+TEST_F(MISC_ParseHtmlFormActionTest, absolute_path_without_scheme)
+{
+    const std::string html = R"(<form method="POST" action="//example.test/test/bbs.cgi">")";
+    std::string result = MISC::parse_html_form_action( html );
+    EXPECT_EQ( result, std::string{} );
+}
+
+TEST_F(MISC_ParseHtmlFormActionTest, http_url)
+{
+    const std::string html = R"(<form method="POST" action="http://example.test/test/bbs.cgi">")";
+    std::string result = MISC::parse_html_form_action( html );
+    EXPECT_EQ( result, std::string{} );
+}
+
+TEST_F(MISC_ParseHtmlFormActionTest, https_url)
+{
+    const std::string html = R"(<form method="POST" action="https://example.test/test/bbs.cgi">")";
+    std::string result = MISC::parse_html_form_action( html );
+    EXPECT_EQ( result, std::string{} );
+}
+
 } // namespace

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -542,4 +542,145 @@ TEST_F(MISC_StartsWith, null_terminated_string)
     EXPECT_FALSE( MISC::starts_with( "hello", "helloworld" ) );
 }
 
+
+class MISC_ParseHtmlFormData : public ::testing::Test {};
+
+TEST_F(MISC_ParseHtmlFormData, empty_html)
+{
+    auto result = MISC::parse_html_form_data( std::string{} );
+    EXPECT_TRUE( result.empty() );
+}
+
+TEST_F(MISC_ParseHtmlFormData, hidden_datum)
+{
+    auto result = MISC::parse_html_form_data( "<input type=hidden name=FOO value=100>" );
+    decltype(result) expect{ { "FOO", "100" } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, hidden_datum_uppercase)
+{
+    auto result = MISC::parse_html_form_data( "<INPUT TYPE=hidden NAME=FOO VALUE=100>" );
+    decltype(result) expect{ { "FOO", "100" } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, hidden_datum_with_double_quotes)
+{
+    auto result = MISC::parse_html_form_data( R"(<input type="hidden" name="FOO" value="100">)" );
+    decltype(result) expect{ { "FOO", "100" } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, submit_datum)
+{
+    auto result = MISC::parse_html_form_data( "<input type=submit value=書き込む name=submit>" );
+    decltype(result) expect{ { "submit", "書き込む" } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, submit_datum_with_double_quotes)
+{
+    auto result = MISC::parse_html_form_data( R"(<input type="submit" value="書き込む" name="submit">)" );
+    decltype(result) expect{ { "submit", "書き込む" } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, textarea_datum)
+{
+    auto result = MISC::parse_html_form_data( "<textarea name=MESSAGE>あかさたな</textarea>" );
+    decltype(result) expect{ { "MESSAGE", "あかさたな" } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, textarea_have_tag)
+{
+    auto result = MISC::parse_html_form_data( "<textarea name=MESSAGE>あか<br>さたな</textarea>" );
+    decltype(result) expect{ { "MESSAGE", "あか<br>さたな" } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, textarea_datum_uppercase)
+{
+    auto result = MISC::parse_html_form_data( "<TEXTAREA NAME=MESSAGE>あかさたな</TEXTAREA>" );
+    decltype(result) expect{ { "MESSAGE", "あかさたな" } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, textarea_datum_with_double_quotes)
+{
+    auto result = MISC::parse_html_form_data( R"(<textarea name="MESSAGE">"あかさたな"</textarea>)" );
+    decltype(result) expect{ { "MESSAGE", "あかさたな" } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, multi_data_1)
+{
+    auto result = MISC::parse_html_form_data( R"(<textarea name="MESSAGE">"あかさたな"</textarea>)"
+                                              "<input type=submit value=書き込む name=submit>"
+                                              R"(<input type="hidden" name="FOO" value="100">)" );
+    decltype(result) expect{ { "MESSAGE", "あかさたな" }, { "submit", "書き込む" }, { "FOO", "100" } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, multi_data_2)
+{
+    auto result = MISC::parse_html_form_data( "<input type=submit value=書き込む name=submit>"
+                                              R"(<input type="hidden" name="FOO" value="100">)"
+                                              R"(<textarea name="MESSAGE">"あかさたな"</textarea>)" );
+    decltype(result) expect{ { "submit", "書き込む" }, { "FOO", "100" }, { "MESSAGE", "あかさたな" } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, multi_data_3)
+{
+    auto result = MISC::parse_html_form_data( R"(<input type="hidden" name="FOO" value="100">)"
+                                              R"(<textarea name="MESSAGE">"あかさたな"</textarea>)"
+                                              "<input type=submit value=書き込む name=submit>" );
+    decltype(result) expect{ { "FOO", "100" }, { "MESSAGE", "あかさたな" }, { "submit", "書き込む" } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, hidden_empty_name_by_double_quotes)
+{
+    auto result = MISC::parse_html_form_data( R"(<input type="hidden" name="" value="100">)" );
+    decltype(result) expect{ { std::string{}, "100" } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, hidden_empty_value_by_double_quotes)
+{
+    auto result = MISC::parse_html_form_data( R"(<input type="hidden" name=FOO value="">)" );
+    decltype(result) expect{ { "FOO", std::string{} } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, submit_empty_name_by_double_quotes)
+{
+    auto result = MISC::parse_html_form_data( R"(<input type="submit" value=書き込む name="">)" );
+    decltype(result) expect{ { std::string{}, "書き込む" } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, submit_empty_value_by_double_quotes)
+{
+    auto result = MISC::parse_html_form_data( R"(<input type="submit" value="" name=submit>)" );
+    decltype(result) expect{ { "submit", std::string{} } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, textarea_empty_name_by_double_quotes)
+{
+    auto result = MISC::parse_html_form_data( R"(<textarea name="">あかさたな</textarea>)" );
+    decltype(result) expect{ { std::string{}, "あかさたな" } };
+    EXPECT_EQ( result, expect );
+}
+
+TEST_F(MISC_ParseHtmlFormData, textarea_empty_value_by_double_quotes)
+{
+    auto result = MISC::parse_html_form_data( R"(<textarea name="MESSAGE"></textarea>)" );
+    decltype(result) expect{ { "MESSAGE", std::string{} } };
+    EXPECT_EQ( result, expect );
+}
+
 } // namespace


### PR DESCRIPTION
2ch互換板への書き込みを修正します。
[2020年8月中旬くらい][res103]から特定の掲示板への書き込みでエラーが出て失敗することがありました。
詳細は上記スレッドを参照してください。

[res103]: https://mao.5ch.net/test/read.cgi/linux/1594134444/103

### 変更点

- 投稿確認画面が出たときはフォームのデータを使って再度投稿するように変更します。
- 投稿確認後の2回目のHTTPリクエストに使うURLは上記解析で取得したURLがあればそれを使います。
- HTTPヘッダーRefererやOriginの設定を調整します。
- その他細かい変更はコミットメッセージを見てください。

