### PR TITLE
Use Gtk::Dialog::get_content_area() instead of get_vbox() part1

### DIFF
--- a/src/article/preference.cpp
+++ b/src/article/preference.cpp
@@ -200,7 +200,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     const int page_abone = 1;
     m_notebook.append_page( m_notebook_abone, "あぼ〜ん設定" );
 
-    get_vbox()->pack_start( m_notebook );
+    get_content_area()->pack_start( m_notebook );
     set_title( "「" + DBTREE::article_subject( get_url() ) + "」のプロパティ" );
     resize( 600, 400 );
     show_all_children();

--- a/src/bbslist/addetcdialog.cpp
+++ b/src/bbslist/addetcdialog.cpp
@@ -32,10 +32,10 @@ AddEtcDialog::AddEtcDialog( const bool move, const std::string& url, const std::
     m_frame.set_label( "BASIC認証" );
     m_frame.add( m_vbox );
 
-    get_vbox()->set_spacing( 8 );
-    get_vbox()->pack_start( m_entry_name );
-    get_vbox()->pack_start( m_entry_url );
-    get_vbox()->pack_start( m_frame );
+    get_content_area()->set_spacing( 8 );
+    get_content_area()->pack_start( m_entry_name );
+    get_content_area()->pack_start( m_entry_url );
+    get_content_area()->pack_start( m_frame );
 
     set_activate_entry( m_entry_name );
     set_activate_entry( m_entry_url );

--- a/src/bbslist/selectdialog.cpp
+++ b/src/bbslist/selectdialog.cpp
@@ -85,8 +85,8 @@ SelectListDialog::SelectListDialog( Gtk::Window* parent, const std::string& url,
 #endif 
     m_combo_dirs.set_active( active_row );
 
-    get_vbox()->pack_start( m_label_name, Gtk::PACK_SHRINK );
-    get_vbox()->pack_start( m_hbox_dirs, Gtk::PACK_SHRINK );
+    get_content_area()->pack_start( m_label_name, Gtk::PACK_SHRINK );
+    get_content_area()->pack_start( m_hbox_dirs, Gtk::PACK_SHRINK );
     m_bt_show_tree.signal_clicked().connect( sigc::mem_fun( this, &SelectListDialog::slot_show_tree ) );
 
     set_title( "お気に入り追加先選択" );
@@ -146,7 +146,7 @@ void SelectListDialog::slot_show_tree()
             m_selectview->copy_treestore( m_treestore );
             m_selectview->sig_close_dialog().connect( sigc::mem_fun(*this, &SelectListDialog::hide ) );
 
-            get_vbox()->pack_start(* m_selectview );
+            get_content_area()->pack_start( *m_selectview );
             m_selectview->set_size_request( -1, SELECTDIAG_TREEHEIGHT );
             m_selectview->focus_view();
             show_all_children();
@@ -154,7 +154,7 @@ void SelectListDialog::slot_show_tree()
 
     }
     else if( m_selectview ){
-        get_vbox()->remove( *m_selectview );
+        get_content_area()->remove( *m_selectview );
         resize( get_width(), 1 );
         delete m_selectview;
         m_selectview = nullptr;

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -357,7 +357,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     m_notebook.append_page( m_edit_settingtxt, "SETTING.TXT" );
     m_notebook.signal_switch_page().connect( sigc::mem_fun( *this, &Preferences::slot_switch_page ) );
 
-    get_vbox()->pack_start( m_notebook );
+    get_content_area()->pack_start( m_notebook );
     set_title( "「" + DBTREE::board_name( get_url() ) + "」のプロパティ" );
     resize( 600, 400 );
     show_all_children();

--- a/src/browserpref.h
+++ b/src/browserpref.h
@@ -67,8 +67,8 @@ namespace CORE
             m_vbox.pack_start( m_combo, Gtk::PACK_EXPAND_WIDGET, 0 );
             m_vbox.pack_start( m_frame, Gtk::PACK_EXPAND_WIDGET, mrg );
 
-            get_vbox()->set_spacing( 0 );
-            get_vbox()->pack_start( m_vbox );
+            get_content_area()->set_spacing( 0 );
+            get_content_area()->pack_start( m_vbox );
 
             set_activate_entry( m_entry_browser );
 

--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -70,9 +70,9 @@ void AboutConfig::pack_widgets()
     m_scrollwin.add( m_treeview );
     m_scrollwin.set_policy( Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS );
 
-    get_vbox()->set_spacing( 8 );
-    get_vbox()->pack_start( m_label, Gtk::PACK_SHRINK );
-    get_vbox()->pack_start( m_scrollwin );
+    get_content_area()->set_spacing( 8 );
+    get_content_area()->pack_start( m_label, Gtk::PACK_SHRINK );
+    get_content_area()->pack_start( m_scrollwin );
 
     set_title( "about:config 高度な設定" );
     set_default_size_ratio( 0.666 );

--- a/src/config/aboutconfigdiag.cpp
+++ b/src/config/aboutconfigdiag.cpp
@@ -19,8 +19,8 @@ AboutConfigDiagStr::AboutConfigDiagStr( Gtk::Window* parent, std::string* value,
     m_button_default.signal_clicked().connect( sigc::mem_fun( *this, &AboutConfigDiagStr::slot_default ) );
     m_hbox.pack_start( m_button_default, Gtk::PACK_SHRINK );
 
-    get_vbox()->set_spacing( 8 );
-    get_vbox()->pack_start( m_hbox );
+    get_content_area()->set_spacing( 8 );
+    get_content_area()->pack_start( m_hbox );
 
     set_activate_entry( m_entry );
 
@@ -56,8 +56,8 @@ AboutConfigDiagInt::AboutConfigDiagInt( Gtk::Window* parent, int* value, const i
     m_button_default.signal_clicked().connect( sigc::mem_fun( *this, &AboutConfigDiagInt::slot_default ) );
     m_hbox.pack_start( m_button_default, Gtk::PACK_SHRINK );
 
-    get_vbox()->set_spacing( 8 );
-    get_vbox()->pack_start( m_hbox );
+    get_content_area()->set_spacing( 8 );
+    get_content_area()->pack_start( m_hbox );
 
     set_activate_entry( m_entry );
 
@@ -98,8 +98,8 @@ AboutConfigDiagBool::AboutConfigDiagBool( Gtk::Window* parent, bool* value, cons
     m_hbox.pack_start( m_button_default, Gtk::PACK_SHRINK );
 
 
-    get_vbox()->set_spacing( 8 );
-    get_vbox()->pack_start( m_hbox );
+    get_content_area()->set_spacing( 8 );
+    get_content_area()->pack_start( m_hbox );
 
     set_title( "真偽値設定" );
     show_all_children();


### PR DESCRIPTION
GTK4で廃止される`Gtk::Dialog::get_vbox()`のかわりに`Gtk::Dialog::get_content_area()`を使います。

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/article/preference.cpp:203:5: error: 'get_vbox' was not declared in this scope
  203 |     get_vbox()->pack_start( m_notebook );
      |     ^~~~~~~~
../src/bbslist/addetcdialog.cpp:35:5: error: 'get_vbox' was not declared in this scope; did you mean 'm_vbox'?
   35 |     get_vbox()->set_spacing( 8 );
      |     ^~~~~~~~
      |     m_vbox
../src/bbslist/selectdialog.cpp:88:5: error: 'get_vbox' was not declared in this scope
   88 |     get_vbox()->pack_start( m_label_name, Gtk::PACK_SHRINK );
      |     ^~~~~~~~
../src/bbslist/selectdialog.cpp:149:13: error: 'get_vbox' was not declared in this scope
  149 |             get_vbox()->pack_start(* m_selectview );
      |             ^~~~~~~~
../src/bbslist/selectdialog.cpp:157:9: error: 'get_vbox' was not declared in this scope
  157 |         get_vbox()->remove( *m_selectview );
      |         ^~~~~~~~
../src/board/preference.cpp:360:5: error: 'get_vbox' was not declared in this scope; did you mean 'm_vbox'?
  360 |     get_vbox()->pack_start( m_notebook );
      |     ^~~~~~~~
      |     m_vbox
../src/browserpref.h:70:13: error: 'get_vbox' was not declared in this scope; did you mean 'm_vbox'?
   70 |             get_vbox()->set_spacing( 0 );
      |             ^~~~~~~~
      |             m_vbox
../src/config/aboutconfig.cpp:73:5: error: 'get_vbox' was not declared in this scope
   73 |     get_vbox()->set_spacing( 8 );
      |     ^~~~~~~~
../src/config/aboutconfigdiag.cpp:22:5: error: 'get_vbox' was not declared in this scope
   22 |     get_vbox()->set_spacing( 8 );
      |     ^~~~~~~~
../src/config/aboutconfigdiag.cpp:59:5: error: 'get_vbox' was not declared in this scope
   59 |     get_vbox()->set_spacing( 8 );
      |     ^~~~~~~~
../src/config/aboutconfigdiag.cpp:101:5: error: 'get_vbox' was not declared in this scope
  101 |     get_vbox()->set_spacing( 8 );
      |     ^~~~~~~~
```

関連のissue: #229 