### PR TITLE
Use Gtk::Dialog::get_content_area() instead of get_vbox() part2

### DIFF
--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -38,7 +38,7 @@ InputDiag::InputDiag( Gtk::Window* parent, const std::string& url,
     set_title( CONTROL::get_label( m_id ) + " ( " + CONTROL::get_mode_label( m_controlmode ) + " )" );
     resize( 400, 400 );
 
-    get_vbox()->pack_start( m_label );
+    get_content_area()->pack_start( m_label );
 
     show_all_children();
 }
@@ -298,9 +298,9 @@ MouseKeyDiag::MouseKeyDiag( Gtk::Window* parent, const std::string& url,
     m_hbox.pack_start( m_scrollwin, Gtk::PACK_EXPAND_WIDGET );
     m_hbox.pack_start( m_vbuttonbox, Gtk::PACK_SHRINK );
 
-    get_vbox()->set_spacing( 8 );
-    get_vbox()->pack_start( m_label, Gtk::PACK_SHRINK );
-    get_vbox()->pack_start( m_hbox );
+    get_content_area()->set_spacing( 8 );
+    get_content_area()->pack_start( m_label, Gtk::PACK_SHRINK );
+    get_content_area()->pack_start( m_hbox );
 
     show_all_children();
     set_title( CONTROL::get_label( m_id ) + " ( " + CONTROL::get_mode_label( m_controlmode ) + " )" );
@@ -529,10 +529,10 @@ MouseKeyPref::MouseKeyPref( Gtk::Window* parent, const std::string& url, const s
     m_button_reset.signal_clicked().connect( sigc::mem_fun( *this, &MouseKeyPref::slot_reset ) );
     m_hbox.pack_start( m_button_reset, Gtk::PACK_SHRINK );
 
-    get_vbox()->set_spacing( 8 );
-    get_vbox()->pack_start( m_label, Gtk::PACK_SHRINK );
-    get_vbox()->pack_start( m_scrollwin );
-    get_vbox()->pack_start( m_hbox, Gtk::PACK_SHRINK );
+    get_content_area()->set_spacing( 8 );
+    get_content_area()->pack_start( m_label, Gtk::PACK_SHRINK );
+    get_content_area()->pack_start( m_scrollwin );
+    get_content_area()->pack_start( m_hbox, Gtk::PACK_SHRINK );
 
     set_default_size_ratio( 0.666 );
     show_all_children();

--- a/src/dbimg/delimgcachediag.cpp
+++ b/src/dbimg/delimgcachediag.cpp
@@ -31,9 +31,9 @@ DelImgCacheDiag::DelImgCacheDiag()
     set_title( "JDim 画像キャッシュ削除中" );
 
     const int mrg = 8;
-    get_vbox()->set_spacing( mrg );
+    get_content_area()->set_spacing( mrg );
     set_border_width( mrg );
-    get_vbox()->pack_start( m_label, Gtk::PACK_SHRINK );
+    get_content_area()->pack_start( m_label, Gtk::PACK_SHRINK );
     show_all_children();
 }
 

--- a/src/dbimg/delimgdiag.h
+++ b/src/dbimg/delimgdiag.h
@@ -107,9 +107,9 @@ namespace DBIMG
         SKELETON::PrefDiag( parent, url )
         {
 
-            get_vbox()->set_spacing( 8 );
-            get_vbox()->pack_start( m_frame_cache );
-            get_vbox()->pack_start( m_frame_abone );
+            get_content_area()->set_spacing( 8 );
+            get_content_area()->pack_start( m_frame_cache );
+            get_content_area()->pack_start( m_frame_abone );
 
             set_activate_entry( m_frame_cache.get_spin() );
             set_activate_entry( m_frame_abone.get_spin() );

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -238,8 +238,8 @@ void FontColorPref::pack_widget()
     m_notebook.append_page( m_vbox_color, "色の設定" );    
 
     // 全体
-    get_vbox()->pack_start( m_notebook );
-    get_vbox()->set_spacing( mrg );
+    get_content_area()->pack_start( m_notebook );
+    get_content_area()->set_spacing( mrg );
     set_border_width( mrg );
 }
 

--- a/src/globalabonepref.h
+++ b/src/globalabonepref.h
@@ -70,7 +70,7 @@ namespace CORE
             m_notebook.append_page( m_edit_word, "NG ワード" );
             m_notebook.append_page( m_edit_regex, "NG 正規表現" );
 
-            get_vbox()->pack_start( m_notebook );
+            get_content_area()->pack_start( m_notebook );
             set_title( "全体あぼ〜ん設定" );
             resize( 600, 400 );
             show_all_children();

--- a/src/globalabonethreadpref.h
+++ b/src/globalabonethreadpref.h
@@ -113,7 +113,7 @@ namespace CORE
             m_notebook.append_page( m_edit_word, "NG ワード" );
             m_notebook.append_page( m_edit_regex, "NG 正規表現" );
 
-            get_vbox()->pack_start( m_notebook );
+            get_content_area()->pack_start( m_notebook );
             set_title( "全体スレあぼ〜ん設定" );
             resize( 600, 400 );
             show_all_children();

--- a/src/image/preference.cpp
+++ b/src/image/preference.cpp
@@ -73,7 +73,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url )
     m_vbox_info.pack_end( m_check_protect, Gtk::PACK_SHRINK );
 
     set_title( "画像のプロパティ" );
-    get_vbox()->pack_start( m_vbox_info );
+    get_content_area()->pack_start( m_vbox_info );
     resize( 600, 400 );
     show_all_children();
 }

--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -44,8 +44,8 @@ LinkFilterDiag::LinkFilterDiag( Gtk::Window* parent, const std::string& url, con
     set_activate_entry( m_entry_url );
     set_activate_entry( m_entry_cmd );
 
-    get_vbox()->set_spacing( 8 );
-    get_vbox()->pack_start( m_vbox );
+    get_content_area()->set_spacing( 8 );
+    get_content_area()->pack_start( m_vbox );
 
     set_title( "フィルタ設定" );
     show_all_children();
@@ -110,9 +110,9 @@ LinkFilterPref::LinkFilterPref( Gtk::Window* parent, const std::string& url )
     m_hbox.pack_start( m_scrollwin, Gtk::PACK_EXPAND_WIDGET );
     m_hbox.pack_start( m_vbuttonbox, Gtk::PACK_SHRINK );
 
-    get_vbox()->set_spacing( 8 );
-    get_vbox()->pack_start( m_label, Gtk::PACK_SHRINK );
-    get_vbox()->pack_start( m_hbox );
+    get_content_area()->set_spacing( 8 );
+    get_content_area()->pack_start( m_label, Gtk::PACK_SHRINK );
+    get_content_area()->pack_start( m_hbox );
 
     show_all_children();
     set_title( "リンクフィルタ設定" );

--- a/src/livepref.cpp
+++ b/src/livepref.cpp
@@ -63,9 +63,9 @@ LivePref::LivePref( Gtk::Window* parent, const std::string& url )
     m_vbox.pack_start( m_bt_reset, Gtk::PACK_SHRINK );
     m_vbox.set_border_width( mrg );
 
-    get_vbox()->set_spacing( mrg );
-    get_vbox()->pack_start( m_label_inst, Gtk::PACK_SHRINK );
-    get_vbox()->pack_start( m_vbox, Gtk::PACK_SHRINK );
+    get_content_area()->set_spacing( mrg );
+    get_content_area()->pack_start( m_label_inst, Gtk::PACK_SHRINK );
+    get_content_area()->pack_start( m_vbox, Gtk::PACK_SHRINK );
 
     set_title( "実況設定" );
     show_all_children();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -538,7 +538,7 @@ int main( int argc, char **argv )
                                                                 false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
 
             Gtk::CheckButton chk_button( "今後表示しない" );
-            mdiag->get_vbox()->pack_start( chk_button, Gtk::PACK_SHRINK );
+            mdiag->get_content_area()->pack_start( chk_button, Gtk::PACK_SHRINK );
             chk_button.show();
 
             const int ret = mdiag->run();

--- a/src/message/confirmdiag.cpp
+++ b/src/message/confirmdiag.cpp
@@ -23,7 +23,7 @@ ConfirmDiag::ConfirmDiag( const std::string& url, const std::string& message )
     const int mrg = 16;
     Gtk::HBox* hbox = Gtk::manage( new Gtk::HBox );
     hbox->pack_start( m_chkbutton, Gtk::PACK_EXPAND_WIDGET, mrg );
-    get_vbox()->pack_start( *hbox, Gtk::PACK_SHRINK );
+    get_content_area()->pack_start( *hbox, Gtk::PACK_SHRINK );
 
     set_title( "投稿確認" );
     show_all_children();

--- a/src/openurldiag.cpp
+++ b/src/openurldiag.cpp
@@ -15,7 +15,7 @@ OpenURLDialog::OpenURLDialog( const std::string& url )
     m_label_url.set_text( url );
     set_activate_entry( m_label_url );
 
-    get_vbox()->pack_start( m_label_url, Gtk::PACK_SHRINK );
+    get_content_area()->pack_start( m_label_url, Gtk::PACK_SHRINK );
 
     set_title( "URLを開く" );
     resize( 600, 1 );

--- a/src/passwdpref.h
+++ b/src/passwdpref.h
@@ -127,7 +127,7 @@ namespace CORE
 
             m_notebook.append_page( m_frame_2ch, "2ch" );
             m_notebook.append_page( m_frame_be, "BE" );
-            get_vbox()->pack_start( m_notebook );
+            get_content_area()->pack_start( m_notebook );
 
             set_title( "パスワード設定" );
             show_all_children();


### PR DESCRIPTION
GTK4で廃止される`Gtk::Dialog::get_vbox()`のかわりに`Gtk::Dialog::get_content_area()`を使います。

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/control/mousekeypref.cpp:41:5: error: 'get_vbox' was not declared in this scope
   41 |     get_vbox()->pack_start( m_label );
      |     ^~~~~~~~
../src/control/mousekeypref.cpp:301:5: error: 'get_vbox' was not declared in this scope
  301 |     get_vbox()->set_spacing( 8 );
      |     ^~~~~~~~
../src/control/mousekeypref.cpp:532:5: error: 'get_vbox' was not declared in this scope
  532 |     get_vbox()->set_spacing( 8 );
      |     ^~~~~~~~
../src/dbimg/delimgcachediag.cpp:34:5: error: 'get_vbox' was not declared in this scope
   34 |     get_vbox()->set_spacing( mrg );
      |     ^~~~~~~~
../src/dbimg/delimgdiag.h:110:13: error: 'get_vbox' was not declared in this scope
  110 |             get_vbox()->set_spacing( 8 );
      |             ^~~~~~~~
../src/fontcolorpref.cpp:241:5: error: 'get_vbox' was not declared in this scope
  241 |     get_vbox()->pack_start( m_notebook );
      |     ^~~~~~~~
../src/globalabonepref.h:73:13: error: 'get_vbox' was not declared in this scope
   73 |             get_vbox()->pack_start( m_notebook );
      |             ^~~~~~~~
../src/globalabonethreadpref.h:116:13: error: 'get_vbox' was not declared in this scope
  116 |             get_vbox()->pack_start( m_notebook );
      |             ^~~~~~~~
../src/image/preference.cpp:76:5: error: 'get_vbox' was not declared in this scope
   76 |     get_vbox()->pack_start( m_vbox_info );
      |     ^~~~~~~~
../src/linkfilterpref.cpp:47:5: error: 'get_vbox' was not declared in this scope; did you mean 'm_vbox'?
   47 |     get_vbox()->set_spacing( 8 );
      |     ^~~~~~~~
      |     m_vbox
../src/linkfilterpref.cpp:113:5: error: 'get_vbox' was not declared in this scope
  113 |     get_vbox()->set_spacing( 8 );
      |     ^~~~~~~~
../src/livepref.cpp:66:5: error: 'get_vbox' was not declared in this scope; did you mean 'm_vbox'?
   66 |     get_vbox()->set_spacing( mrg );
      |     ^~~~~~~~
      |     m_vbox
../src/main.cpp:549:20: error: 'class Gtk::MessageDialog' has no member named 'get_vbox'
  549 |             mdiag->get_vbox()->pack_start( chk_button, Gtk::PACK_SHRINK );
      |                    ^~~~~~~~
../src/message/confirmdiag.cpp:26:5: error: 'get_vbox' was not declared in this scope
   26 |     get_vbox()->pack_start( *hbox, Gtk::PACK_SHRINK );
      |     ^~~~~~~~
../src/openurldiag.cpp:18:5: error: 'get_vbox' was not declared in this scope
   18 |     get_vbox()->pack_start( m_label_url, Gtk::PACK_SHRINK );
      |     ^~~~~~~~
../src/passwdpref.h:130:13: error: 'get_vbox' was not declared in this scope
  130 |             get_vbox()->pack_start( m_notebook );
      |             ^~~~~~~~
```

関連のissue: #229 
