### PR TITLE
Use Gtk::Dialog::get_content_area() instead of get_vbox() part3

### DIFF
--- a/src/privacypref.h
+++ b/src/privacypref.h
@@ -71,8 +71,8 @@ namespace CORE
             m_hbox_selectall.pack_start( m_bt_selectall, Gtk::PACK_SHRINK );
             m_vbox.pack_start( m_hbox_selectall, Gtk::PACK_SHRINK );
 
-            get_vbox()->set_spacing( 8 );
-            get_vbox()->pack_start( m_vbox, Gtk::PACK_SHRINK );
+            get_content_area()->set_spacing( 8 );
+            get_content_area()->pack_start( m_vbox, Gtk::PACK_SHRINK );
 
             set_title( "プライバシー情報の消去" );
             show_all_children();

--- a/src/proxypref.h
+++ b/src/proxypref.h
@@ -136,11 +136,11 @@ namespace CORE
             set_activate_entry( m_frame_data.entry_host );
             set_activate_entry( m_frame_data.entry_port );
 
-            get_vbox()->set_spacing( 4 );
-            get_vbox()->pack_start( m_label );
-            get_vbox()->pack_start( m_frame_2ch );
-            get_vbox()->pack_start( m_frame_2ch_w );
-            get_vbox()->pack_start( m_frame_data );
+            get_content_area()->set_spacing( 4 );
+            get_content_area()->pack_start( m_label );
+            get_content_area()->pack_start( m_frame_2ch );
+            get_content_area()->pack_start( m_frame_2ch_w );
+            get_content_area()->pack_start( m_frame_data );
 
             set_title( "プロキシ設定" );
             show_all_children();

--- a/src/setupwizard.cpp
+++ b/src/setupwizard.cpp
@@ -294,7 +294,7 @@ SetupWizard::SetupWizard()
     m_notebook.set_show_tabs( false );
     m_sigc_switch_page = m_notebook.signal_switch_page().connect( sigc::mem_fun( *this, &SetupWizard::slot_switch_page ) );
 
-    get_vbox()->pack_start( m_notebook, Gtk::PACK_EXPAND_PADDING, SPACING_SIZE );
+    get_content_area()->pack_start( m_notebook, Gtk::PACK_EXPAND_PADDING, SPACING_SIZE );
 
     show_all_children();
 }

--- a/src/skeleton/aboutdiag.cpp
+++ b/src/skeleton/aboutdiag.cpp
@@ -130,7 +130,7 @@ void AboutDiag::init()
     m_hbuttonbox_environment.pack_start( m_button_copy_environment, Gtk::PACK_SHRINK );
     m_vbox_environment.pack_start( m_hbuttonbox_environment, Gtk::PACK_SHRINK );
 
-    get_vbox()->pack_start( m_notebook, Gtk::PACK_EXPAND_WIDGET, MARGIN );
+    get_content_area()->pack_start( m_notebook, Gtk::PACK_EXPAND_WIDGET, MARGIN );
 
     show_all_children();
 

--- a/src/skeleton/detaildiag.cpp
+++ b/src/skeleton/detaildiag.cpp
@@ -32,7 +32,7 @@ DetailDiag::DetailDiag( Gtk::Window* parent, const std::string& url,
     m_notebook.append_page( *m_detail, tab_detail );
     m_notebook.signal_switch_page().connect( sigc::mem_fun( *this, &DetailDiag::slot_switch_page ) );
 
-    get_vbox()->pack_start( m_notebook );
+    get_content_area()->pack_start( m_notebook );
 
     show_all_children();
     grab_ok();

--- a/src/skeleton/editviewdialog.h
+++ b/src/skeleton/editviewdialog.h
@@ -22,7 +22,7 @@ namespace SKELETON
             m_edit.set_editable( editable );
 
             add_button( Gtk::Stock::OK, Gtk::RESPONSE_OK );
-            get_vbox()->pack_start( m_edit  );
+            get_content_area()->pack_start( m_edit );
             set_title( title );
             show_all_children();
 

--- a/src/skeleton/msgdiag.cpp
+++ b/src/skeleton/msgdiag.cpp
@@ -153,7 +153,7 @@ MsgCheckDiag::MsgCheckDiag( Gtk::Window* parent,
                 
     Gtk::HBox* hbox = Gtk::manage( new Gtk::HBox );
     hbox->pack_start( m_chkbutton, Gtk::PACK_EXPAND_WIDGET, mrg );
-    get_vbox()->pack_start( *hbox, Gtk::PACK_SHRINK );
+    get_content_area()->pack_start( *hbox, Gtk::PACK_SHRINK );
 
     Gtk::Button* button = nullptr;
 

--- a/src/skeleton/selectitempref.cpp
+++ b/src/skeleton/selectitempref.cpp
@@ -124,8 +124,8 @@ void SelectItemPref::pack_widgets()
 
     m_hbox.pack_start( m_scroll_hidden, Gtk::PACK_EXPAND_WIDGET );
 
-    get_vbox()->set_spacing( 8 );
-    get_vbox()->pack_start( m_hbox );
+    get_content_area()->set_spacing( 8 );
+    get_content_area()->pack_start( m_hbox );
 
     show_all_children();
 }

--- a/src/usrcmdmanager.cpp
+++ b/src/usrcmdmanager.cpp
@@ -58,8 +58,8 @@ public:
         m_vbox.pack_start( m_label, Gtk::PACK_SHRINK );
         m_vbox.pack_start( m_entry, Gtk::PACK_SHRINK );
 
-        get_vbox()->set_spacing( 8 );
-        get_vbox()->pack_start( m_vbox );
+        get_content_area()->set_spacing( 8 );
+        get_content_area()->pack_start( m_vbox );
 
         set_title( "テキスト入力" );
         show_all_children();

--- a/src/usrcmdpref.cpp
+++ b/src/usrcmdpref.cpp
@@ -46,8 +46,8 @@ UsrCmdDiag::UsrCmdDiag( Gtk::Window* parent, const Glib::ustring& name, const Gl
     m_vbox.pack_start( m_hbox_cmd, Gtk::PACK_SHRINK );
     m_vbox.pack_start( m_entry_cmd, Gtk::PACK_SHRINK );
 
-    get_vbox()->set_spacing( 8 );
-    get_vbox()->pack_start( m_vbox );
+    get_content_area()->set_spacing( 8 );
+    get_content_area()->pack_start( m_vbox );
 
     set_activate_entry( m_entry_name );
     set_activate_entry( m_entry_cmd );
@@ -87,12 +87,12 @@ UsrCmdPref::UsrCmdPref( Gtk::Window* parent, const std::string& url )
     m_scrollwin.set_policy( Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS );
     m_scrollwin.set_size_request( 640, 400 );
 
-    get_vbox()->set_spacing( 8 );
-    get_vbox()->pack_start( m_label, Gtk::PACK_SHRINK );
-    get_vbox()->pack_start( m_scrollwin );
+    get_content_area()->set_spacing( 8 );
+    get_content_area()->pack_start( m_label, Gtk::PACK_SHRINK );
+    get_content_area()->pack_start( m_scrollwin );
 
     m_ckbt_hide_usrcmd.set_active( CONFIG::get_hide_usrcmd() );
-    get_vbox()->pack_start( m_ckbt_hide_usrcmd, Gtk::PACK_SHRINK );
+    get_content_area()->pack_start( m_ckbt_hide_usrcmd, Gtk::PACK_SHRINK );
 
     // ポップアップメニュー
     m_action_group = Gtk::ActionGroup::create();


### PR DESCRIPTION
GTK4で廃止される`Gtk::Dialog::get_vbox()`のかわりに`Gtk::Dialog::get_content_area()`を使います。

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/privacypref.h:74:13: error: 'get_vbox' was not declared in this scope; did you mean 'm_vbox'?
   74 |             get_vbox()->set_spacing( 8 );
      |             ^~~~~~~~
      |             m_vbox
../src/proxypref.h:139:13: error: 'get_vbox' was not declared in this scope
  139 |             get_vbox()->set_spacing( 4 );
      |             ^~~~~~~~
../src/setupwizard.cpp:297:5: error: 'get_vbox' was not declared in this scope
  297 |     get_vbox()->pack_start( m_notebook, Gtk::PACK_EXPAND_PADDING, SPACING_SIZE );
      |     ^~~~~~~~
../src/skeleton/aboutdiag.cpp:133:5: error: 'get_vbox' was not declared in this scope
  133 |     get_vbox()->pack_start( m_notebook, Gtk::PACK_EXPAND_WIDGET, MARGIN );
      |     ^~~~~~~~
../src/skeleton/detaildiag.cpp:35:5: error: 'get_vbox' was not declared in this scope
   35 |     get_vbox()->pack_start( m_notebook );
      |     ^~~~~~~~
../src/skeleton/editviewdialog.h:25:13: error: 'get_vbox' was not declared in this scope
   25 |             get_vbox()->pack_start( m_edit  );
      |             ^~~~~~~~
../src/skeleton/msgdiag.cpp:156:5: error: 'get_vbox' was not declared in this scope
  156 |     get_vbox()->pack_start( *hbox, Gtk::PACK_SHRINK );
      |     ^~~~~~~~
../src/skeleton/selectitempref.cpp:127:5: error: 'get_vbox' was not declared in this scope; did you mean 'm_vbox'?
  127 |     get_vbox()->set_spacing( 8 );
      |     ^~~~~~~~
      |     m_vbox
../src/usrcmdmanager.cpp:61:9: error: 'get_vbox' was not declared in this scope; did you mean 'm_vbox'?
   61 |         get_vbox()->set_spacing( 8 );
      |         ^~~~~~~~
      |         m_vbox
../src/usrcmdpref.cpp:49:5: error: 'get_vbox' was not declared in this scope; did you mean 'm_vbox'?
   49 |     get_vbox()->set_spacing( 8 );
      |     ^~~~~~~~
      |     m_vbox
../src/usrcmdpref.cpp:90:5: error: 'get_vbox' was not declared in this scope
   90 |     get_vbox()->set_spacing( 8 );
      |     ^~~~~~~~
```

関連のissue: #229 
