### PR TITLE
setupwizard: Use Gtk::Grid instead of Gtk::Table

### DIFF
--- a/src/setupwizard.cpp
+++ b/src/setupwizard.cpp
@@ -143,15 +143,17 @@ PageFont::PageFont() : Gtk::VBox(),
     m_table.set_row_spacing( 4 );
     m_table.set_column_spacing( 4 );
     m_table.set_hexpand( true );
-    m_table.attach( m_label_res, 0, 0 );
-    m_table.attach( m_label_mail, 0, 1 );
-    m_table.attach( m_label_popup, 0, 2 );
-    m_table.attach( m_label_tree, 0, 3 );
+    constexpr int width = 1;
+    constexpr int height = 1;
+    m_table.attach( m_label_res, 0, 0, width, height );
+    m_table.attach( m_label_mail, 0, 1, width, height );
+    m_table.attach( m_label_popup, 0, 2, width, height );
+    m_table.attach( m_label_tree, 0, 3, width, height );
 
-    m_table.attach( m_font_res, 1, 0 );
-    m_table.attach( m_font_mail, 1, 1 );
-    m_table.attach( m_font_popup, 1, 2 );
-    m_table.attach( m_font_tree, 1, 3 );
+    m_table.attach( m_font_res, 1, 0, width, height );
+    m_table.attach( m_font_mail, 1, 1, width, height );
+    m_table.attach( m_font_popup, 1, 2, width, height );
+    m_table.attach( m_font_tree, 1, 3, width, height );
 
     set_spacing( SPACING_SIZE );
     pack_start( m_hbox_label, Gtk::PACK_SHRINK );

--- a/src/setupwizard.cpp
+++ b/src/setupwizard.cpp
@@ -106,11 +106,10 @@ void PageNet::slot_setup_browser()
 
 PageFont::PageFont() : Gtk::VBox(),
                        m_label( "３/５．フォントの設定をします", Gtk::ALIGN_START ),
-                       m_table( 2, 4 ),
-                       m_label_res( "スレ(_T)", Gtk::ALIGN_START, Gtk::ALIGN_START, true ),
-                       m_label_mail( "メール(_U)", Gtk::ALIGN_START, Gtk::ALIGN_START, true ),
-                       m_label_popup( "ポップアップ(_P)", Gtk::ALIGN_START, Gtk::ALIGN_START, true ),
-                       m_label_tree( "板／スレ一覧(_O)", Gtk::ALIGN_START, Gtk::ALIGN_START,  true ),
+                       m_label_res( "スレ(_T)", Gtk::ALIGN_START, Gtk::ALIGN_CENTER, true ),
+                       m_label_mail( "メール(_U)", Gtk::ALIGN_START, Gtk::ALIGN_CENTER, true ),
+                       m_label_popup( "ポップアップ(_P)", Gtk::ALIGN_START, Gtk::ALIGN_CENTER, true ),
+                       m_label_tree( "板／スレ一覧(_O)", Gtk::ALIGN_START, Gtk::ALIGN_CENTER, true ),
                        m_font_res( "スレフォント" ),
                        m_font_mail( "メール欄フォント" ),
                        m_font_popup( "ポップアップフォント" ),
@@ -136,16 +135,23 @@ PageFont::PageFont() : Gtk::VBox(),
     m_font_popup.signal_font_set().connect( sigc::mem_fun( *this, &PageFont::slot_font_popup ) );
     m_font_tree.signal_font_set().connect( sigc::mem_fun( *this, &PageFont::slot_font_tree ) );
 
-    m_table.set_spacings( 4 );
-    m_table.attach( m_label_res, 0, 1, 0, 1, Gtk::FILL, Gtk::SHRINK );
-    m_table.attach( m_label_mail, 0, 1, 1, 2, Gtk::FILL, Gtk::SHRINK );
-    m_table.attach( m_label_popup, 0, 1, 2, 3, Gtk::FILL, Gtk::SHRINK );
-    m_table.attach( m_label_tree, 0, 1, 3, 4, Gtk::FILL, Gtk::SHRINK );
+    m_font_res.set_hexpand( true );
+    m_font_mail.set_hexpand( true );
+    m_font_popup.set_hexpand( true );
+    m_font_tree.set_hexpand( true );
 
-    m_table.attach( m_font_res, 1, 2, 0, 1, Gtk::FILL | Gtk::EXPAND, Gtk::SHRINK );
-    m_table.attach( m_font_mail, 1, 2, 1, 2, Gtk::FILL | Gtk::EXPAND, Gtk::SHRINK );
-    m_table.attach( m_font_popup, 1, 2, 2, 3, Gtk::FILL | Gtk::EXPAND, Gtk::SHRINK );
-    m_table.attach( m_font_tree, 1, 2, 3, 4, Gtk::FILL | Gtk::EXPAND, Gtk::SHRINK );
+    m_table.set_row_spacing( 4 );
+    m_table.set_column_spacing( 4 );
+    m_table.set_hexpand( true );
+    m_table.attach( m_label_res, 0, 0 );
+    m_table.attach( m_label_mail, 0, 1 );
+    m_table.attach( m_label_popup, 0, 2 );
+    m_table.attach( m_label_tree, 0, 3 );
+
+    m_table.attach( m_font_res, 1, 0 );
+    m_table.attach( m_font_mail, 1, 1 );
+    m_table.attach( m_font_popup, 1, 2 );
+    m_table.attach( m_font_tree, 1, 3 );
 
     set_spacing( SPACING_SIZE );
     pack_start( m_hbox_label, Gtk::PACK_SHRINK );

--- a/src/setupwizard.h
+++ b/src/setupwizard.h
@@ -70,7 +70,7 @@ namespace CORE
         Gtk::Image m_icon;
         Gtk::Label m_label;
 
-        Gtk::Table m_table;
+        Gtk::Grid m_table;
 
         Gtk::Label m_label_res;
         Gtk::Label m_label_mail;


### PR DESCRIPTION
GTK4で廃止される`Gtk::Table`のかわりに`Gtk::Grid`を使います。

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/setupwizard.h:73:14: error: 'Table' in namespace 'Gtk' does not name a type
   73 |         Gtk::Table m_table;
      |              ^~~~~
```

関連のissue: #229 
