### PR TITLE
DrawAreaBase: Remove deprecated Gtk::Widget::signal_visibility_notify_event()

### DIFF
--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -134,11 +134,6 @@ namespace ARTICLE
         bool m_enable_draw;
         DRAWINFO m_drawinfo{};
 
-        // 高速スクロール描画実行
-        // DrawingAreaの領域が全て表示されているときは Gdk::Window::scroll() を使ってスクロール
-        // 一部が隠れている時はバックスクリーン内でスクロール処理してバックスクリーン全体をウィンドウにコピーする
-        bool m_scroll_window; 
-
         // キャレット情報
         CARET_POSITION m_caret_pos;           // 現在のキャレットの位置(クリックやドラッグすると移動)
         CARET_POSITION m_caret_pos_pre;       // 移動前のキャレットの位置(選択範囲の描画などで使用する)
@@ -483,7 +478,6 @@ namespace ARTICLE
         bool slot_draw( const Cairo::RefPtr< Cairo::Context >& cr );
         bool slot_scroll_event( GdkEventScroll* event );
         bool slot_leave_notify_event( GdkEventCrossing* event );
-        bool slot_visibility_notify_event( GdkEventVisibility* event );
         void slot_realize();
 
         bool slot_button_press_event( GdkEventButton* event );


### PR DESCRIPTION
GTK4で廃止される`Gtk::Widget::signal_visibility_notify_event()`を整理します。

#### developer.gnome.org より[引用][visi]
> GtkWidget::visibility-notify-event has been deprecated since version 3.12 and should not be used in newly-written code.
> Modern composited windowing systems with pervasive transparency make it impossible to track the visibility of a window reliably, so this signal can not be guaranteed to provide useful information.

#### 非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

#### コンパイラのレポート
```
../src/article/drawareabase.cpp:187:12: error: 'class Gtk::DrawingArea' has no member named 'signal_visibility_notify_event'; did you mean 'on_visibility_notify_event'?
  187 |     m_view.signal_visibility_notify_event().connect( sigc::mem_fun(*this, &DrawAreaBase::slot_visibility_notify_event ) );
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |            on_visibility_notify_event
```

関連のissue: #229 

[visi]: https://developer.gnome.org/gtk3/stable/GtkWidget.html#GtkWidget-visibility-notify-event