### PR TITLE
Use GIConv instead of the underlying iconv implementation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,16 +37,12 @@ case "${host_os}" in
    AC_DEFINE(NO_TIMEGM, , [no timegm])
    ;;
  darwin*)
-   AC_DEFUN([AM_ICONV], [])
    AC_DEFINE(USE_MKTIME, , [use mktime])
    ;;
 dnl linux*|gnu*|*-gnu
  *)
-   AC_DEFUN([AM_ICONV], [])
    ;;
 esac
-
-AM_ICONV
 
 
 dnl ---------------------------------------------------

--- a/meson.build
+++ b/meson.build
@@ -98,15 +98,6 @@ if cpp_compiler.has_header('crypt.h')
   conf.set('HAVE_CRYPT_H', 1)
 endif
 
-# iconv
-if cpp_compiler.has_function('iconv_open')
-  iconv_dep = dependency('', required : false)
-elif cpp_compiler.has_header_symbol('iconv.h', 'iconv_open')
-  iconv_dep = cpp_compiler.find_library('iconv')
-else
-  error('iconv fucntion not found')
-endif
-
 # socket
 if cpp_compiler.has_header('sys/socket.h')
   socket_dep = dependency('', required : false)

--- a/src/jdlib/jdiconv.h
+++ b/src/jdlib/jdiconv.h
@@ -3,8 +3,10 @@
 #ifndef _JDICONV_H
 #define _JDICONV_H
 
-#include <iconv.h>
 #include <string>
+
+#include <gmodule.h> // GIConv
+
 
 // iconv の内部で確保するバッファサイズ(バイト)
 //  BUF_SIZE_ICONV_IN を超える入力は扱えないので注意
@@ -18,7 +20,7 @@ namespace JDLIB
 {
     class Iconv
     {
-        iconv_t m_cd;
+        GIConv m_cd; // iconv実装は環境で違いがあるためGlibのラッパーAPIを利用する
 
         size_t m_byte_left_in{};
         char* m_buf_in{};

--- a/src/meson.build
+++ b/src/meson.build
@@ -80,7 +80,6 @@ jdim_deps = [
   crypt_dep,
   gtkmm_dep,
   ice_dep,
-  iconv_dep,
   migemo_dep,
   regex_dep,
   sm_dep,


### PR DESCRIPTION
Fix #470 

BSD系プラットフォームでは2種類のiconv関数が使われています。(標準Cライブラリ[dragonfly][1], [freebsd][2], [netbsd][3] と [GNU libiconv][4])
そのためビルド時にどちらのiconvを使うか設定しないとリンクエラーが起こる場合があります。
そこでGlibが提供する[ラッパーAPI][5]を利用して依存関係の問題を回避します。

[1]: https://man.dragonflybsd.org/?command=iconvctl&section=3
[2]: https://www.freebsd.org/cgi/man.cgi?query=iconv&sektion=3
[3]: https://man.netbsd.org/iconv.3
[4]: https://www.gnu.org/software/libiconv/
[5]: https://developer.gnome.org/glib/stable/glib-Character-Set-Conversion.html
