### PR TITLE
Use Gtk::ColorChooserDialog instead of Gtk::ColorSelectionDialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,10 +276,13 @@ WaylandやXWaylandではX11限定の機能を使うことができないため�
 * 32bit OSの古いMATE環境（バージョン[1.10][mate-1-10]から[1.16][mate-1-16]？）でJDim GTK3版を実行したとき
   スレビューの上に別のウインドウを重ねて移動させると残像でスレビュー内のみ描画が乱れる。
   スレビューをスクロール等させて再描画すると直る。([背景事情][mate-background])
+* KDE plasma(X11?)環境では色選択ダイアログのカラーピッカーで色を抜き出すことができない。
+  ([関連の問題？][kwin-colorpicker] - KDEのieeue)
 
 [mate-1-10]: https://mate-desktop.org/blog/2015-06-11-mate-1-10-released/ "GTK3の実験的なサポート追加"
 [mate-1-16]: https://mate-desktop.org/blog/2016-09-21-mate-1-16-released/ "GTK3に移行途中"
 [mate-background]: https://github.com/JDimproved/JDim/commit/ffbce60ede#commitcomment-40911816 "別の不具合が再発する"
+[kwin-colorpicker]: https://bugs.kde.org/show_bug.cgi?id=407226
 
 
 ## JDとの互換性

--- a/docs/manual/start.md
+++ b/docs/manual/start.md
@@ -144,10 +144,13 @@ WaylandやXWaylandではX11限定の機能を使うことができないため�
 * 32bit OSの古いMATE環境（バージョン[1.10][mate-1-10]から[1.16][mate-1-16]？）でJDim GTK3版を実行したとき
   スレビューの上に別のウインドウを重ねて移動させると残像でスレビュー内のみ描画が乱れる。
   スレビューをスクロール等させて再描画すると直る。([背景事情][mate-background])
+* KDE plasma(X11?)環境では色選択ダイアログのカラーピッカーで色を抜き出すことができない。
+  ([関連の問題？][kwin-colorpicker] - KDEのieeue)
 
 [mate-1-10]: https://mate-desktop.org/blog/2015-06-11-mate-1-10-released/ "GTK3の実験的なサポート追加"
 [mate-1-16]: https://mate-desktop.org/blog/2016-09-21-mate-1-16-released/ "GTK3に移行途中"
 [mate-background]: https://github.com/JDimproved/JDim/commit/ffbce60ede#commitcomment-40911816 "別の不具合が再発する"
+[kwin-colorpicker]: https://bugs.kde.org/show_bug.cgi?id=407226
 
 
 <a name="compatibility"></a>

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1678,12 +1678,12 @@ bool Core::open_color_diag( std::string title, int id )
 {
     Gdk::RGBA color( CONFIG::get_color( id ) );
 
-    Gtk::ColorSelectionDialog diag( title );
-    diag.get_color_selection()->set_current_rgba( color );
+    Gtk::ColorChooserDialog diag( title );
+    diag.set_use_alpha( false );
+    diag.set_rgba( color );
     diag.set_transient_for( *CORE::get_mainwindow() );
     if( diag.run() == Gtk::RESPONSE_OK ){
-        Gtk::ColorSelection* sel = diag.get_color_selection();
-        CONFIG::set_color( id, MISC::color_to_str( sel->get_current_rgba() ) );
+        CONFIG::set_color( id, MISC::color_to_str( diag.get_rgba() ) );
         return true;
     }
 

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -451,11 +451,11 @@ void FontColorPref::slot_change_color()
         if( colorid == COLOR_NONE ) return;
     }
 
-    Gtk::ColorSelectionDialog colordiag;
+    Gtk::ColorChooserDialog colordiag;
     if( colorid != COLOR_NONE ) {
-        Gtk::ColorSelection* sel = colordiag.get_color_selection();
-        sel->set_current_rgba( Gdk::RGBA( CONFIG::get_color( colorid ) ) );
+        colordiag.set_rgba( Gdk::RGBA( CONFIG::get_color( colorid ) ) );
     }
+    colordiag.set_use_alpha( false );
     colordiag.set_transient_for( *CORE::get_mainwindow() );
     const int ret = colordiag.run();
 
@@ -468,8 +468,7 @@ void FontColorPref::slot_change_color()
 
             colorid = row[ m_columns_color.m_col_colorid ];
             if( colorid != COLOR_NONE ) {
-                Gtk::ColorSelection* sel = colordiag.get_color_selection();
-                CONFIG::set_color( colorid, MISC::color_to_str( sel->get_current_rgba() ) );
+                CONFIG::set_color( colorid, MISC::color_to_str( colordiag.get_rgba() ) );
             }
         }
     }


### PR DESCRIPTION
Fix #469 

GTK4で廃止される`Gtk::ColorSelectionDialog`のかわりに`Gtk::ColorChooserDialog`を使います。

JDimの関数や設定が対応してないためalphaチャンネルは無効にしてあります。

#### 既知の問題
KDE plasma(X11?)環境では色選択ダイアログのカラーピッカーで色を抜き出すことができない。([関連の問題？][bugs])

[bugs]: https://bugs.kde.org/show_bug.cgi?id=407226

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/core.cpp:1681:10: error: 'ColorSelectionDialog' is not a member of 'Gtk'
 1681 |     Gtk::ColorSelectionDialog diag( title );
      |          ^~~~~~~~~~~~~~~~~~~~
../src/core.cpp:1682:5: error: 'diag' was not declared in this scope
 1682 |     diag.get_color_selection()->set_current_color( color );
      |     ^~~~
../src/core.cpp:1685:14: error: 'ColorSelection' is not a member of 'Gtk'
 1685 |         Gtk::ColorSelection* sel = diag.get_color_selection();
      |              ^~~~~~~~~~~~~~
../src/core.cpp:1685:30: error: 'sel' was not declared in this scope
 1685 |         Gtk::ColorSelection* sel = diag.get_color_selection();
      |                              ^~~
../src/fontcolorpref.cpp:454:10: error: 'ColorSelectionDialog' is not a member of 'Gtk'
  454 |     Gtk::ColorSelectionDialog colordiag;
      |          ^~~~~~~~~~~~~~~~~~~~
../src/fontcolorpref.cpp:456:14: error: 'ColorSelection' is not a member of 'Gtk'
  456 |         Gtk::ColorSelection* sel = colordiag.get_color_selection();
      |              ^~~~~~~~~~~~~~
../src/fontcolorpref.cpp:456:30: error: 'sel' was not declared in this scope
  456 |         Gtk::ColorSelection* sel = colordiag.get_color_selection();
      |                              ^~~
../src/fontcolorpref.cpp:456:36: error: 'colordiag' was not declared in this scope; did you mean 'colorid'?
  456 |         Gtk::ColorSelection* sel = colordiag.get_color_selection();
      |                                    ^~~~~~~~~
      |                                    colorid
../src/fontcolorpref.cpp:471:22: error: 'ColorSelection' is not a member of 'Gtk'
  471 |                 Gtk::ColorSelection* sel = colordiag.get_color_selection();
      |                      ^~~~~~~~~~~~~~
../src/fontcolorpref.cpp:471:38: error: 'sel' was not declared in this scope
  471 |                 Gtk::ColorSelection* sel = colordiag.get_color_selection();
      |                                      ^~~
```

関連のissue: #229 
