### PR TITLE
Fix posting to JD support BBS

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1941,6 +1941,7 @@ std::vector<MISC::FormDatum> MISC::parse_html_form_data( const std::string& html
 std::string MISC::parse_html_form_action( const std::string& html )
 {
     const char pattern[] = R"(<form +method=("POST"|POST)[^>]* action="(\.\.)?(/test/(sub)?bbs\.cgi(\?[^"]*)?))";
+    const char pattern_same_hierarchy[] = R"(<form +method=("POST"|POST)[^>]* action="\.(/(sub)?bbs\.cgi(\?[^"]*)?))";
     JDLIB::Regex regex;
     constexpr std::size_t offset = 0;
     constexpr bool icase = true; // 大文字小文字区別しない
@@ -1951,6 +1952,9 @@ std::string MISC::parse_html_form_action( const std::string& html )
     std::string path;
     if( regex.exec( pattern, html, offset, icase, newline, usemigemo, wchar ) ) {
         path = regex.str( 3 );
+    }
+    else if( regex.exec( pattern_same_hierarchy, html, offset, icase, newline, usemigemo, wchar ) ) {
+        path = "/test" + regex.str( 2 );
     }
     return path;
 }

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -734,6 +734,17 @@ TEST_F(MISC_ParseHtmlFormActionTest, relative_path_an_upper_order)
     EXPECT_EQ( result, "/test/bbs.cgi" );
 }
 
+TEST_F(MISC_ParseHtmlFormActionTest, relative_path_same_hierarchy)
+{
+    std::string html = R"(<form method="POST" action="./bbs.cgi">")";
+    std::string result = MISC::parse_html_form_action( html );
+    EXPECT_EQ( result, "/test/bbs.cgi" );
+
+    html = R"(<form method="POST" action="./subbbs.cgi">")";
+    result = MISC::parse_html_form_action( html );
+    EXPECT_EQ( result, "/test/subbbs.cgi" );
+}
+
 TEST_F(MISC_ParseHtmlFormActionTest, relative_path_double_upper_orders)
 {
     const std::string html = R"(<form method="POST" action="../../test/bbs.cgi">")";


### PR DESCRIPTION
コミット 3db07d3d97e43601bd6c871ad12038c0c8ee200f より後でJDサポート掲示板への書き込みが失敗する不具合を修正します。

上記コミットから書き込み確認で再POSTするURLを解析しますがサポート掲示板はパターンが異なっていたため失敗していました。