### PR TITLE
Fix argument order for JDLIB::Iconv constructor

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -2387,17 +2387,17 @@ void ArticleViewBase::slot_on_url( const std::string& url, const std::string& im
             {
                 case MISC::CHARCODE_EUC_JP:
 
-                    status_url = MISC::Iconv( tmp, "EUC-JP", "UTF-8" );
+                    status_url = MISC::Iconv( tmp, "UTF-8", "EUC-JP" );
                     break;
 
                 case MISC::CHARCODE_JIS:
 
-                    status_url = MISC::Iconv( tmp, "ISO-2022-JP", "UTF-8" );
+                    status_url = MISC::Iconv( tmp, "UTF-8", "ISO-2022-JP" );
                     break;
 
                 case MISC::CHARCODE_SJIS:
 
-                    status_url = MISC::Iconv( tmp, "MS932", "UTF-8" );
+                    status_url = MISC::Iconv( tmp, "UTF-8", "MS932" );
                     break;
 
                 case MISC::CHARCODE_ASCII:

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -109,7 +109,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
         str_cookies = "クッキー:\n未取得\n";
     }
     else {
-        str_cookies = "クッキー:\n" + MISC::Iconv( temp_cookies, DBTREE::board_charset( get_url() ), "UTF-8" ) + "\n";
+        str_cookies = "クッキー:\n" + MISC::Iconv( temp_cookies, "UTF-8", DBTREE::board_charset( get_url() ) ) + "\n";
     }
 
     std::string keyword = DBTREE::board_keyword_for_write( get_url() );

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1094,7 +1094,7 @@ void BoardBase::receive_data( const char* data, size_t size )
     if( m_rawdata_left.capacity() < SIZE_OF_RAWDATA ) {
         m_rawdata_left.reserve( SIZE_OF_RAWDATA );
     }
-    if( ! m_iconv ) m_iconv = new JDLIB::Iconv( m_charset, "UTF-8" );
+    if( ! m_iconv ) m_iconv = new JDLIB::Iconv( "UTF-8", m_charset );
 
     m_rawdata_left.append( data, size );
 
@@ -1879,7 +1879,7 @@ void BoardBase::search_cache( std::vector< DBTREE::ArticleBase* >& list_article,
     if( m_hash_article->size() == 0 ) return;
 
     const bool append_all = query.empty();
-    const std::string query_local = MISC::Iconv( query, "UTF-8", get_charset() );
+    const std::string query_local = MISC::Iconv( query, get_charset(), "UTF-8" );
     const std::list< std::string > list_query = MISC::split_line( query_local );
 
     const std::string path_board_root = CACHE::path_board_root_fast( url_boardbase() );

--- a/src/dbtree/nodetree2chcompati.cpp
+++ b/src/dbtree/nodetree2chcompati.cpp
@@ -69,7 +69,7 @@ void NodeTree2chCompati::init_loading()
 
     // iconv 初期化
     std::string charset = DBTREE::board_charset( get_url() );
-    if( ! m_iconv ) m_iconv = new JDLIB::Iconv( charset, "UTF-8" );
+    if( ! m_iconv ) m_iconv = new JDLIB::Iconv( "UTF-8", charset );
 }
 
 

--- a/src/dbtree/nodetreejbbs.cpp
+++ b/src/dbtree/nodetreejbbs.cpp
@@ -79,7 +79,7 @@ void NodeTreeJBBS::init_loading()
 
     // iconv 初期化
     std::string charset = DBTREE::board_charset( get_url() );
-    if( ! m_iconv ) m_iconv = new JDLIB::Iconv( charset, "UTF-8" );
+    if( ! m_iconv ) m_iconv = new JDLIB::Iconv( "UTF-8", charset );
 
     if( m_decoded_lines.capacity() < BUF_SIZE_ICONV_OUT ) {
         m_decoded_lines.reserve( BUF_SIZE_ICONV_OUT );

--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -93,7 +93,7 @@ void NodeTreeMachi::init_loading()
 
     // iconv 初期化
     std::string charset = DBTREE::board_charset( get_url() );
-    if( ! m_iconv ) m_iconv = new JDLIB::Iconv( charset, "UTF-8" );
+    if( ! m_iconv ) m_iconv = new JDLIB::Iconv( "UTF-8", charset );
 
     m_buffer_for_200.clear();
 
@@ -201,7 +201,7 @@ char* NodeTreeMachi::process_raw_lines( char* rawlines )
                 if( m_regex->exec( reg_subject, line, offset, icase, newline, usemigemo, wchar ) ){
 
                     const std::string charset = DBTREE::board_charset( get_url() );
-                    m_subject_machi = MISC::Iconv( m_regex->str( 1 ), charset, "UTF-8" );
+                    m_subject_machi = MISC::Iconv( m_regex->str( 1 ), "UTF-8", charset );
 #ifdef _DEBUG
                     std::cout << "NodeTreeMachi::process_raw_lines\n";
                     std::cout << "subject = " << m_subject_machi << std::endl;

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -405,7 +405,7 @@ void Root::receive_finish()
     }
 
     // 文字コードを変換してXML作成
-    JDLIB::Iconv* libiconv = new JDLIB::Iconv( "MS932", "UTF-8" );
+    JDLIB::Iconv* libiconv = new JDLIB::Iconv( "UTF-8", "MS932" );
     int byte_out;
     const char* rawdata_utf8 = libiconv->convert( &*m_rawdata.begin(), m_rawdata.size(),  byte_out );
     bbsmenu2xml( rawdata_utf8 );

--- a/src/jdlib/jdiconv.cpp
+++ b/src/jdlib/jdiconv.cpp
@@ -16,7 +16,7 @@
 
 using namespace JDLIB;
 
-Iconv::Iconv( const std::string& coding_from, const std::string& coding_to )
+Iconv::Iconv( const std::string& coding_to, const std::string& coding_from )
     : m_coding_from( coding_from )
 {
 #ifdef _DEBUG

--- a/src/jdlib/jdiconv.h
+++ b/src/jdlib/jdiconv.h
@@ -32,7 +32,7 @@ namespace JDLIB
 
     public:
         
-        Iconv( const std::string& coding_from, const std::string& coding_to );
+        Iconv( const std::string& coding_to, const std::string& coding_from );
         ~Iconv();
 
         const char* convert( char* str_in, int size_in, int& size_out );

--- a/src/jdlib/misctrip.cpp
+++ b/src/jdlib/misctrip.cpp
@@ -244,7 +244,7 @@ std::string MISC::get_trip( const std::string& str, const std::string& charset )
     if( str.empty() ) return std::string();
 
     // str の文字コードを UTF-8 から charset に変更して key に代入する
-    std::string key = MISC::Iconv( str, "UTF-8", charset );
+    std::string key = MISC::Iconv( str, charset, "UTF-8" );
 
     std::string trip;
 

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1126,7 +1126,7 @@ std::string MISC::charset_url_encode( const std::string& str, const std::string&
 {
     if( charset.empty() || charset == "UTF-8" ) return MISC::url_encode( str.c_str(), str.length() );
 
-    const std::string str_enc = MISC::Iconv( str, "UTF-8", charset );
+    const std::string str_enc = MISC::Iconv( str, charset, "UTF-8" );
     return  MISC::url_encode( str_enc.c_str(), str_enc.length() );
 }
 
@@ -1204,13 +1204,13 @@ std::string MISC::base64( const std::string& str )
 //
 // 遅いので連続的な処理が必要な時は使わないこと
 //
-std::string MISC::Iconv( const std::string& str, const std::string& coding_from, const std::string& coding_to )
+std::string MISC::Iconv( const std::string& str, const std::string& coding_to, const std::string& coding_from )
 {
     if( coding_from == coding_to ) return str;
 
     std::string str_bk = str;
 
-    JDLIB::Iconv* libiconv = new JDLIB::Iconv( coding_from, coding_to );
+    JDLIB::Iconv* libiconv = new JDLIB::Iconv( coding_to, coding_from );
     int byte_out;
 
     std::string str_enc = libiconv->convert( &*str_bk.begin(), str_bk.size(), byte_out );

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -192,7 +192,7 @@ namespace MISC
 
     // 文字コードを coding_from から coding_to に変換
     // 遅いので連続的な処理が必要な時は使わないこと
-    std::string Iconv( const std::string& str, const std::string& coding_from, const std::string& coding_to );
+    std::string Iconv( const std::string& str, const std::string& coding_to, const std::string& coding_from );
 
     // 「&#数字;」形式の数字参照文字列の中の「数字」部分の文字列長
     //

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -85,7 +85,7 @@ MessageViewBase::MessageViewBase( const std::string& url )
     m_max_line = DBTREE::line_number( get_url() ) * 2;
     m_max_str = DBTREE::message_count( get_url() );
 
-    m_iconv = new JDLIB::Iconv( "UTF-8", DBTREE::board_charset( get_url() ) );;
+    m_iconv = new JDLIB::Iconv( DBTREE::board_charset( get_url() ), "UTF-8" );;
 
     m_lng_iconv = m_max_str * 3;
     if( ! m_lng_iconv ) m_lng_iconv = MAX_STR_ICONV;

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -243,7 +243,7 @@ void Post::receive_finish()
 #endif
 
     std::string charset = DBTREE::board_charset( m_url );
-    JDLIB::Iconv* libiconv = new JDLIB::Iconv( charset, "UTF-8" );
+    JDLIB::Iconv* libiconv = new JDLIB::Iconv( "UTF-8", charset );
     int byte_out;
     m_return_html = libiconv->convert( &*m_rawdata.begin(), m_rawdata.size(), byte_out );
     delete libiconv;

--- a/src/skeleton/textloader.cpp
+++ b/src/skeleton/textloader.cpp
@@ -172,7 +172,7 @@ void TextLoader::receive_finish()
     set_str_code( std::string() );
 
     // UTF-8に変換しておく
-    JDLIB::Iconv* libiconv = new JDLIB::Iconv( get_charset(), "UTF-8" );
+    JDLIB::Iconv* libiconv = new JDLIB::Iconv( "UTF-8", get_charset() );
     int byte_out;
     m_data = libiconv->convert( &*m_rawdata.begin(), m_rawdata.size(),  byte_out );
     delete libiconv;


### PR DESCRIPTION
[JDLIB::Iconvクラス][jdlib]はiconv APIのラッパーですがエンコーディングを指定する引数が基底のライブラリと逆順になっています。

API | 順序
--- | ---
iconv API | `iconv_open(to_code, from_code)`
JDLIB::Iconv | `JDLIB:Iconv(from_code, to_code)`

[POSIX][2008][のAPI][susv2]や[Glibの][glib][ラッパーAPI][glibmm]はすべて`(to_code, from_code)`の順序です。
jdimの実装だけ逆順なのは紛らわしいため基底のライブラリの順序に修正します。

[jdlib]: https://github.com/JDimproved/JDim/blob/5a8e66f3d0/src/jdlib/jdiconv.h#L33
[2008]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/iconv_open.html "POSIX-1.2008"
[susv2]: https://pubs.opengroup.org/onlinepubs/7908799/xsh/iconv_open.html "SUSv2"
[glib]: https://developer.gnome.org/glib/stable/glib-Character-Set-Conversion.html "glib"
[glibmm]: https://developer.gnome.org/glibmm/stable/classGlib_1_1IConv.html "glibmm"
