### PR TITLE
snapcraft: Get rid of libsigc++-2.0 from stage-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,9 +44,6 @@ parts:
       - git
       - libgnutls28-dev
       - libsigc++-2.0-dev
-    stage-packages:
-      # base or gnome-3-34 extension do not include the follow package:
-      - libsigc++-2.0-0v5
     override-build: |
       set -eu
       snapcraftctl build


### PR DESCRIPTION
snapcraftのgnome-3-34-1804スタックが更新され[libsigc++を同梱する][1]ようになりました。
Snapパッケージの[stableチャンネル][2]にも反映されましたのでjdimに同梱していたパッケージを取り除きます。
開発用パッケージ(-dev)に変更はないためbuild-packagesの設定は維持します。

[1]: https://gitlab.gnome.org/Community/Ubuntu/gnome-sdk/-/merge_requests/21
[2]: https://snapcraft.io/gnome-3-34-1804