### PR TITLE
Use i18n text instead of Gtk::Stock::YES for button label

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,7 @@ dnl
 dnl 追加コンパイルオプション
 dnl -Wextraで有効になる-Wunused-parameterは修正方法の検討が必要なので暫定的に無効
 CXXFLAGS="-ggdb -Wall -Wextra -Wno-unused-parameter -pedantic $CXXFLAGS"
+CPPFLAGS="-DGTK_DOMAIN='\"gtk30\"' $CPPFLAGS"
 
 dnl ---------------------------------------------------
 dnl ---------------------------------------------------

--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,7 @@ project('jdim', 'cpp',
 
 # 追加コンパイルオプション
 add_project_arguments('-DHAVE_CONFIG_H=1', language : 'cpp')
+add_project_arguments('-DGTK_DOMAIN="gtk30"', language : 'cpp')
 # -Wextraで有効になる-Wunused-parameterは修正方法の検討が必要なので暫定的に無効
 add_project_arguments('-Wno-unused-parameter', language : 'cpp')
 

--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -50,6 +50,8 @@
 
 #include "icons/iconmanager.h"
 
+#include <glib/gi18n.h>
+
 #include <sstream>
 #include <cstring>
 
@@ -1124,7 +1126,7 @@ bool ArticleViewBase::operate_view( const int control )
                                           "今後表示しない(常に削除)(_D)",
                                           Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_NONE );
             mdiag.add_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
-            mdiag.add_default_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
+            mdiag.add_default_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
 
             Gtk::Button *button = mdiag.add_button( "スレ再取得(_R)", Gtk::RESPONSE_YES + 100 );
             Gtk::Image image( Gtk::Stock::REFRESH, Gtk::ICON_SIZE_BUTTON );

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -45,6 +45,8 @@
 #include "dndmanager.h"
 #include "sign.h"
 
+#include <glib/gi18n.h>
+
 
 enum
 {
@@ -2629,7 +2631,7 @@ void BBSListViewBase::replace_thread( const std::string& url, const std::string&
                             );
 
                         mdiag.add_default_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
-                        mdiag.add_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
+                        mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
                         mdiag.add_button( "新スレをお気に入りに追加(_F)", Gtk::RESPONSE_CANCEL );
 
                         mdiag.set_title( "お気に入り更新" );

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -19,6 +19,7 @@
 
 #include "dbtree/interface.h"
 
+#include <glib/gi18n.h>
 #include <gtkmm.h>
 
 #include <fstream>
@@ -1043,7 +1044,7 @@ std::string CACHE::open_save_diag( Gtk::Window* parent, const std::string& dir, 
         SKELETON::MsgDiag mdiag( parent, "ファイルが存在します。ファイル名を変更して保存しますか？", 
                                  false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_NONE );
         mdiag.add_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
-        mdiag.add_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
+        mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
         mdiag.add_button( "上書き", Gtk::RESPONSE_YES + 100 );
 
         int ret = mdiag.run();

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -27,6 +27,7 @@
 #include "session.h"
 #include "updatemanager.h"
 
+#include <glib/gi18n.h>
 #include <sstream>
 
 
@@ -1660,7 +1661,7 @@ void ArticleBase::delete_cache( const bool cache_only )
                                                   Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_NONE );
 
                     mdiag.add_button( "スレ削除中止(_C)", Gtk::RESPONSE_CANCEL );
-                    mdiag.add_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
+                    mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
                     Gtk::Button button( Gtk::Stock::NO );
                     mdiag.add_default_button( &button, Gtk::RESPONSE_NO );
 

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -28,6 +28,8 @@
 #include "session.h"
 #include "boardcolumnsid.h"
 
+#include <glib/gi18n.h>
+
 #include <sstream>
 #include <cstring>
 
@@ -1644,7 +1646,7 @@ void BoardBase::remove_old_abone_thread()
                                       Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_NONE );
 
         mdiag.add_default_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
-        mdiag.add_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
+        mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
 
         const int ret = mdiag.run();
 

--- a/src/message/messageview.cpp
+++ b/src/message/messageview.cpp
@@ -18,6 +18,8 @@
 #include "command.h"
 #include "session.h"
 
+#include <glib/gi18n.h>
+
 #include <sstream>
 
 using namespace MESSAGE;
@@ -78,7 +80,7 @@ std::string MessageViewMain::create_message()
             mdiag.set_title( "確認" );
             mdiag.add_button( Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL );
             mdiag.add_button( Gtk::Stock::REMOVE, Gtk::RESPONSE_DELETE_EVENT );
-            mdiag.add_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
+            mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
 
             switch( mdiag.run() )
             {
@@ -105,7 +107,7 @@ std::string MessageViewMain::create_message()
 
         mdiag.set_title( "！！！誤爆注意！！！" );
         mdiag.add_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
-        mdiag.add_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
+        mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
         mdiag.add_button( "スレを開く", Gtk::RESPONSE_YES + 100 );
 
         int ret = mdiag.run();

--- a/src/skeleton/msgdiag.cpp
+++ b/src/skeleton/msgdiag.cpp
@@ -10,6 +10,8 @@
 #include "dispatchmanager.h"
 #include "global.h"
 
+#include <glib/gi18n.h>
+
 
 using namespace SKELETON;
 
@@ -56,7 +58,7 @@ void MsgDiag::add_default_button( const Gtk::StockID& stock_id, const int id )
 
 void MsgDiag::add_default_button( const Glib::ustring& label, const int id )
 {
-    Gtk::Button* button = Gtk::manage( new Gtk::Button( label ) );
+    Gtk::Button* button = Gtk::manage( new Gtk::Button( label, true ) );
     add_default_button( button, id );
 }
 
@@ -175,14 +177,13 @@ MsgCheckDiag::MsgCheckDiag( Gtk::Window* parent,
             button = Gtk::manage( new Gtk::Button( Gtk::Stock::NO ) );
             add_default_button( button, Gtk::RESPONSE_NO );
 
-            add_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
+            add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
         }
         else{
 
             add_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
 
-            button = Gtk::manage( new Gtk::Button( Gtk::Stock::YES ) );
-            add_default_button( button, Gtk::RESPONSE_YES );
+            add_default_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
         }
     }
 
@@ -202,7 +203,7 @@ MsgOverwriteDiag::MsgOverwriteDiag( Gtk::Window* parent )
                          false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_NONE )
 {
     add_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
-    add_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
+    add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
     add_button( "上書き", OVERWRITE_YES );
     add_button( "すべていいえ", OVERWRITE_NO_ALL );
     add_button( "すべて上書き", OVERWRITE_YES_ALL );


### PR DESCRIPTION
GTK4で廃止される`Gtk::Stock::YES`をi18n対応テキストに置き換えます。

### 実装
GTK3用のgettextパッケージを利用して日本語テキストを表示します。

GTK3用gettextパッケージ名のマクロ定義をコンパイラーの引数に追加します。
現時点ではパッケージ名として文字列リテラル("gtk30")をgettext APIの引数に直接指定することは可能です。
しかし将来のGTK4対応で変更が必要になるためマクロを使います。

### Gtk::Stockからラベルに変更する参考文献
https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html
https://stackoverflow.com/questions/36805505/gtk-stock-is-deprecated-whats-the-alternative/36811163#36811163

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/article/articleviewbase.cpp:1127:44: error: 'Gtk::Stock' has not been declared
1127 |             mdiag.add_default_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
  |                                            ^~~~~
../src/bbslist/bbslistviewbase.cpp:2632:48: error: 'Gtk::Stock' has not been declared
2632 |                         mdiag.add_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
  |                                                ^~~~~
../src/cache.cpp:1075:32: error: 'Gtk::Stock' has not been declared
1075 |         mdiag.add_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
  |                                ^~~~~
../src/dbtree/articlebase.cpp:1663:44: error: 'Gtk::Stock' has not been declared
1663 |                     mdiag.add_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
  |                                            ^~~~~
../src/dbtree/boardbase.cpp:1653:32: error: 'Gtk::Stock' has not been declared
1653 |         mdiag.add_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
  |                                ^~~~~
../src/message/messageview.cpp:108:32: error: 'Gtk::Stock' has not been declared
108 |         mdiag.add_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
  |                                ^~~~~
../src/skeleton/msgdiag.cpp:178:30: error: 'Gtk::Stock' has not been declared
178 |             add_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
  |                              ^~~~~
../src/skeleton/msgdiag.cpp:184:57: error: 'Gtk::Stock' has not been declared
184 |             button = Gtk::manage( new Gtk::Button( Gtk::Stock::YES ) );
  |                                                         ^~~~~
../src/skeleton/msgdiag.cpp:205:22: error: 'Gtk::Stock' has not been declared
205 |     add_button( Gtk::Stock::YES, Gtk::RESPONSE_YES );
  |                      ^~~~~
```

関連のissue: #229, #482 