### PR TITLE
Use i18n text instead of Gtk::Stock::NO for button label

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -1125,7 +1125,7 @@ bool ArticleViewBase::operate_view( const int control )
                                           "ログを削除しますか？\n\n「スレ再取得」を押すと\nあぼ〜んなどのスレ情報を削除せずにスレを再取得します。",
                                           "今後表示しない(常に削除)(_D)",
                                           Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_NONE );
-            mdiag.add_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
+            mdiag.add_button( g_dgettext( GTK_DOMAIN, "_No" ), Gtk::RESPONSE_NO );
             mdiag.add_default_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
 
             Gtk::Button *button = mdiag.add_button( "スレ再取得(_R)", Gtk::RESPONSE_YES + 100 );

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -2630,7 +2630,7 @@ void BBSListViewBase::replace_thread( const std::string& url, const std::string&
                                                       Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_NONE
                             );
 
-                        mdiag.add_default_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
+                        mdiag.add_default_button( g_dgettext( GTK_DOMAIN, "_No" ), Gtk::RESPONSE_NO );
                         mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
                         mdiag.add_button( "新スレをお気に入りに追加(_F)", Gtk::RESPONSE_CANCEL );
 

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -1043,7 +1043,7 @@ std::string CACHE::open_save_diag( Gtk::Window* parent, const std::string& dir, 
 
         SKELETON::MsgDiag mdiag( parent, "ファイルが存在します。ファイル名を変更して保存しますか？", 
                                  false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_NONE );
-        mdiag.add_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
+        mdiag.add_button( g_dgettext( GTK_DOMAIN, "_No" ), Gtk::RESPONSE_NO );
         mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
         mdiag.add_button( "上書き", Gtk::RESPONSE_YES + 100 );
 

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -1662,8 +1662,7 @@ void ArticleBase::delete_cache( const bool cache_only )
 
                     mdiag.add_button( "スレ削除中止(_C)", Gtk::RESPONSE_CANCEL );
                     mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
-                    Gtk::Button button( Gtk::Stock::NO );
-                    mdiag.add_default_button( &button, Gtk::RESPONSE_NO );
+                    mdiag.add_default_button( g_dgettext( GTK_DOMAIN, "_No" ), Gtk::RESPONSE_NO );
 
                     const int ret = mdiag.run();
                     if( ret == Gtk::RESPONSE_CANCEL ) return;

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1645,7 +1645,7 @@ void BoardBase::remove_old_abone_thread()
                                       "今後表示しない(_D)",
                                       Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_NONE );
 
-        mdiag.add_default_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
+        mdiag.add_default_button( g_dgettext( GTK_DOMAIN, "_No" ), Gtk::RESPONSE_NO );
         mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
 
         const int ret = mdiag.run();

--- a/src/message/messageview.cpp
+++ b/src/message/messageview.cpp
@@ -106,7 +106,7 @@ std::string MessageViewMain::create_message()
                                  false, Gtk::MESSAGE_WARNING, Gtk::BUTTONS_NONE );
 
         mdiag.set_title( "！！！誤爆注意！！！" );
-        mdiag.add_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
+        mdiag.add_button( g_dgettext( GTK_DOMAIN, "_No" ), Gtk::RESPONSE_NO );
         mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
         mdiag.add_button( "スレを開く", Gtk::RESPONSE_YES + 100 );
 

--- a/src/skeleton/msgdiag.cpp
+++ b/src/skeleton/msgdiag.cpp
@@ -165,7 +165,7 @@ MsgCheckDiag::MsgCheckDiag( Gtk::Window* parent,
         add_default_button( button, Gtk::RESPONSE_OK );
     }
     else if( buttons == Gtk::BUTTONS_OK_CANCEL ){
-        add_button( Gtk::Stock::NO, Gtk::RESPONSE_CANCEL );
+        add_button( g_dgettext( GTK_DOMAIN, "_No" ), Gtk::RESPONSE_CANCEL );
 
         button = Gtk::manage( new Gtk::Button( Gtk::Stock::OK ) );
         add_default_button( button, Gtk::RESPONSE_OK );
@@ -174,14 +174,13 @@ MsgCheckDiag::MsgCheckDiag( Gtk::Window* parent,
 
         if( default_response == Gtk::RESPONSE_NO ){
 
-            button = Gtk::manage( new Gtk::Button( Gtk::Stock::NO ) );
-            add_default_button( button, Gtk::RESPONSE_NO );
+            add_default_button( g_dgettext( GTK_DOMAIN, "_No" ), Gtk::RESPONSE_NO );
 
             add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
         }
         else{
 
-            add_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
+            add_button( g_dgettext( GTK_DOMAIN, "_No" ), Gtk::RESPONSE_NO );
 
             add_default_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
         }
@@ -202,7 +201,7 @@ MsgOverwriteDiag::MsgOverwriteDiag( Gtk::Window* parent )
     : SKELETON::MsgDiag( parent, "ファイルが存在します。ファイル名を変更して保存しますか？", 
                          false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_NONE )
 {
-    add_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
+    add_button( g_dgettext( GTK_DOMAIN, "_No" ), Gtk::RESPONSE_NO );
     add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
     add_button( "上書き", OVERWRITE_YES );
     add_button( "すべていいえ", OVERWRITE_NO_ALL );


### PR DESCRIPTION
GTK4で廃止される`Gtk::Stock::NO`をi18n対応テキストに置き換えます。

Gtk::Stockからラベルに変更する参考文献:
https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html
https://stackoverflow.com/questions/36805505/gtk-stock-is-deprecated-whats-the-alternative/36811163#36811163

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/article/articleviewbase.cpp:1126:36: error: 'Gtk::Stock' has not been declared
 1126 |             mdiag.add_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
      |                                    ^~~~~
../src/bbslist/bbslistviewbase.cpp:2631:56: error: 'Gtk::Stock' has not been declared
 2631 |                         mdiag.add_default_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
      |                                                        ^~~~~
../src/cache.cpp:1074:32: error: 'Gtk::Stock' has not been declared
 1074 |         mdiag.add_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
      |                                ^~~~~
../src/dbtree/articlebase.cpp:1664:46: error: 'Gtk::Stock' has not been declared
 1664 |                     Gtk::Button button( Gtk::Stock::NO );
      |                                              ^~~~~
../src/dbtree/boardbase.cpp:1652:40: error: 'Gtk::Stock' has not been declared
 1652 |         mdiag.add_default_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
      |                                        ^~~~~
../src/message/messageview.cpp:107:32: error: 'Gtk::Stock' has not been declared
  107 |         mdiag.add_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
      |                                ^~~~~
../src/skeleton/msgdiag.cpp:166:26: error: 'Gtk::Stock' has not been declared
  166 |         add_button( Gtk::Stock::NO, Gtk::RESPONSE_CANCEL );
      |                          ^~~~~
../src/skeleton/msgdiag.cpp:175:57: error: 'Gtk::Stock' has not been declared
  175 |             button = Gtk::manage( new Gtk::Button( Gtk::Stock::NO ) );
      |                                                         ^~~~~
../src/skeleton/msgdiag.cpp:182:30: error: 'Gtk::Stock' has not been declared
  182 |             add_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
      |                              ^~~~~
../src/skeleton/msgdiag.cpp:204:22: error: 'Gtk::Stock' has not been declared
  204 |     add_button( Gtk::Stock::NO, Gtk::RESPONSE_NO );
      |                      ^~~~~
```

関連のissue: #229, #482 