### PR TITLE
Use i18n text instead of Gtk::Stock::OK for button label

### DIFF
--- a/src/skeleton/editviewdialog.h
+++ b/src/skeleton/editviewdialog.h
@@ -3,6 +3,7 @@
 #ifndef _EDITVIEWDIALOG_H
 #define _EDITVIEWDIALOG_H
 
+#include <glib/gi18n.h>
 #include <gtkmm.h>
 
 #include "editview.h"
@@ -21,7 +22,7 @@ namespace SKELETON
             m_edit.set_text( str );
             m_edit.set_editable( editable );
 
-            add_button( Gtk::Stock::OK, Gtk::RESPONSE_OK );
+            add_button( g_dgettext( GTK_DOMAIN, "_OK" ), Gtk::RESPONSE_OK );
             get_content_area()->pack_start( m_edit );
             set_title( title );
             show_all_children();

--- a/src/skeleton/msgdiag.cpp
+++ b/src/skeleton/msgdiag.cpp
@@ -157,18 +157,14 @@ MsgCheckDiag::MsgCheckDiag( Gtk::Window* parent,
     hbox->pack_start( m_chkbutton, Gtk::PACK_EXPAND_WIDGET, mrg );
     get_content_area()->pack_start( *hbox, Gtk::PACK_SHRINK );
 
-    Gtk::Button* button = nullptr;
-
     if( buttons == Gtk::BUTTONS_OK ){
 
-        button = Gtk::manage( new Gtk::Button( Gtk::Stock::OK ) );
-        add_default_button( button, Gtk::RESPONSE_OK );
+        add_default_button( g_dgettext( GTK_DOMAIN, "_OK" ), Gtk::RESPONSE_OK );
     }
     else if( buttons == Gtk::BUTTONS_OK_CANCEL ){
         add_button( g_dgettext( GTK_DOMAIN, "_No" ), Gtk::RESPONSE_CANCEL );
 
-        button = Gtk::manage( new Gtk::Button( Gtk::Stock::OK ) );
-        add_default_button( button, Gtk::RESPONSE_OK );
+        add_default_button( g_dgettext( GTK_DOMAIN, "_OK" ), Gtk::RESPONSE_OK );
     }
     else if( buttons == Gtk::BUTTONS_YES_NO ){
 

--- a/src/skeleton/prefdiag.cpp
+++ b/src/skeleton/prefdiag.cpp
@@ -11,6 +11,9 @@
 #include "dispatchmanager.h"
 #include "global.h"
 
+#include <glib/gi18n.h>
+
+
 using namespace SKELETON;
 
 PrefDiag::PrefDiag( Gtk::Window* parent, const std::string& url, const bool add_cancel, const bool add_apply, const bool add_open )
@@ -28,7 +31,7 @@ PrefDiag::PrefDiag( Gtk::Window* parent, const std::string& url, const bool add_
     }
 
     if( add_open ) m_bt_ok = add_button( Gtk::Stock::OPEN, Gtk::RESPONSE_OK );
-    else m_bt_ok = add_button( Gtk::Stock::OK, Gtk::RESPONSE_OK );
+    else m_bt_ok = add_button( g_dgettext( GTK_DOMAIN, "_OK" ), Gtk::RESPONSE_OK );
 
     m_bt_ok->signal_clicked().connect( sigc::mem_fun(*this, &PrefDiag::slot_ok_clicked ) );
 


### PR DESCRIPTION
GTK4で廃止される`Gtk::Stock::OK`をi18n対応テキストに置き換えます。

Gtk::Stockからラベルに変更する参考文献:
https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html
https://stackoverflow.com/questions/36805505/gtk-stock-is-deprecated-whats-the-alternative/36811163#36811163

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/skeleton/editviewdialog.h:24:30: error: 'Gtk::Stock' has not been declared
   24 |             add_button( Gtk::Stock::OK, Gtk::RESPONSE_OK );
      |                              ^~~~~
../src/skeleton/msgdiag.cpp:162:53: error: 'Gtk::Stock' has not been declared
  162 |         button = Gtk::manage( new Gtk::Button( Gtk::Stock::OK ) );
      |                                                     ^~~~~
../src/skeleton/msgdiag.cpp:168:53: error: 'Gtk::Stock' has not been declared
  168 |         button = Gtk::manage( new Gtk::Button( Gtk::Stock::OK ) );
      |                                                     ^~~~~
../src/skeleton/prefdiag.cpp:31:37: error: 'Gtk::Stock' has not been declared
   31 |     else m_bt_ok = add_button( Gtk::Stock::OK, Gtk::RESPONSE_OK );
      |                                     ^~~~~
```

関連のissue: #229, #482 