### PR TITLE
Use i18n text instead of Gtk::Stock::CANCEL for button label

### DIFF
--- a/src/dbimg/delimgcachediag.cpp
+++ b/src/dbimg/delimgcachediag.cpp
@@ -16,6 +16,8 @@
 #include "jdlib/miscutil.h"
 #include "jdlib/miscmsg.h"
 
+#include <glib/gi18n.h>
+
 #include <sys/time.h>
 
 
@@ -25,7 +27,7 @@ using namespace DBIMG;
 DelImgCacheDiag::DelImgCacheDiag()
     : m_label( "画像キャッシュ削除中・・・\n\nしばらくお待ち下さい" )
 {
-    add_button( Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL )
+    add_button( g_dgettext( GTK_DOMAIN, "_Cancel" ), Gtk::RESPONSE_CANCEL )
     ->signal_clicked().connect( sigc::mem_fun(*this, &DelImgCacheDiag::slot_cancel_clicked ) );
 
     set_title( "JDim 画像キャッシュ削除中" );

--- a/src/message/messageadmin.cpp
+++ b/src/message/messageadmin.cpp
@@ -380,7 +380,7 @@ bool MessageAdmin::delete_message( SKELETON::View * view )
                                   Gtk::MESSAGE_WARNING, Gtk::BUTTONS_NONE );
 
     mdiag.add_button( "保存せずに閉じる(_Q)", Gtk::RESPONSE_NO );
-    mdiag.add_button( Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL );
+    mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Cancel" ), Gtk::RESPONSE_CANCEL );
     Gtk::Button button( Gtk::Stock::SAVE );
     mdiag.add_default_button( &button, Gtk::RESPONSE_YES );
 

--- a/src/message/messageview.cpp
+++ b/src/message/messageview.cpp
@@ -78,7 +78,7 @@ std::string MessageViewMain::create_message()
                                      false, Gtk::MESSAGE_WARNING, Gtk::BUTTONS_NONE );
 
             mdiag.set_title( "確認" );
-            mdiag.add_button( Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL );
+            mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Cancel" ), Gtk::RESPONSE_CANCEL );
             mdiag.add_button( Gtk::Stock::REMOVE, Gtk::RESPONSE_DELETE_EVENT );
             mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
 

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -2721,7 +2721,7 @@ bool Admin::back_forward_viewhistory( const std::string& url, const bool back, c
                                          false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_NONE );
                 mdiag.add_button( "タブを開く(_T)", Gtk::RESPONSE_YES );
                 if( enable_next ) mdiag.add_button( "次を開く(_N)", Gtk::RESPONSE_NO );
-                mdiag.add_button( Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL );
+                mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Cancel" ), Gtk::RESPONSE_CANCEL );
 
                 int ret = mdiag.run();
                 mdiag.hide();

--- a/src/skeleton/filediag.h
+++ b/src/skeleton/filediag.h
@@ -21,7 +21,7 @@ namespace SKELETON
         // ボタン追加 + saveボタンをデフォルトボタンにセット
         void add_buttons(){
 
-            add_button( Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL );
+            add_button( g_dgettext( GTK_DOMAIN, "_Cancel" ), Gtk::RESPONSE_CANCEL );
 
             if( m_action == Gtk::FILE_CHOOSER_ACTION_OPEN ) add_button( Gtk::Stock::OPEN, Gtk::RESPONSE_ACCEPT );
             else add_button( Gtk::Stock::SAVE, Gtk::RESPONSE_ACCEPT );

--- a/src/skeleton/prefdiag.cpp
+++ b/src/skeleton/prefdiag.cpp
@@ -26,7 +26,7 @@ PrefDiag::PrefDiag( Gtk::Window* parent, const std::string& url, const bool add_
     }
 
     if( add_cancel ){
-        add_button( Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL )
+        add_button( g_dgettext( GTK_DOMAIN, "_Cancel" ), Gtk::RESPONSE_CANCEL )
         ->signal_clicked().connect( sigc::mem_fun(*this, &PrefDiag::slot_cancel_clicked ) );
     }
 


### PR DESCRIPTION
GTK4で廃止される`Gtk::Stock::CANCEL`をi18n対応テキストに置き換えます。

Gtk::Stockからラベルに変更する参考文献:
https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html
https://stackoverflow.com/questions/36805505/gtk-stock-is-deprecated-whats-the-alternative/36811163#36811163

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/dbimg/delimgcachediag.cpp:28:22: error: 'Gtk::Stock' has not been declared
   28 |     add_button( Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL )
      |                      ^~~~~
../src/message/messageadmin.cpp:383:28: error: 'Gtk::Stock' has not been declared
  383 |     mdiag.add_button( Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL );
      |                            ^~~~~
../src/skeleton/admin.cpp:2724:40: error: 'Gtk::Stock' has not been declared
 2724 |                 mdiag.add_button( Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL );
      |                                        ^~~~~
../src/skeleton/filediag.h:24:30: error: 'Gtk::Stock' has not been declared
   24 |             add_button( Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL );
      |                              ^~~~~
../src/skeleton/prefdiag.cpp:26:26: error: 'Gtk::Stock' has not been declared
   26 |         add_button( Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL )
      |                          ^~~~~
```

関連のissue: #229, #482 
