### PR TITLE
Fix documents for meson command example

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -54,7 +54,7 @@
 * ビルド方法( meson の場合 )
 
     1. meson builddir
-    2. meson compile -C builddir
+    2. meson compile -C builddir ( 又は ninja -C builddir )
     3. 起動は ./builddir/src/jdim
 
     mesonのビルドオプション

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -71,7 +71,7 @@ configure のかわりに [meson] を使ってビルドする方法は [GitHub][
 ### ビルド方法( meson の場合 )
 
 1. `meson builddir`
-2. `meson compile -C builddir`
+2. `meson compile -C builddir` ( 又は `ninja -C builddir` )
 3. 起動は `./builddir/src/jdim`
 
 #### mesonのビルドオプション

--- a/meson.build
+++ b/meson.build
@@ -9,14 +9,14 @@
 # Fedora
 #   ディストロのパッケージをインストールする
 #   ```
-#   dnf install git libtool meson ninja-build
+#   dnf install git libtool meson
 #   dnf install gnutls-devel gtkmm30-devel libSM-devel
 #   ```
 #
 # Debian Buster, Ubuntu 20.04
 #   ディストロのパッケージをインストールする
 #   ```
-#   sudo apt install build-essential git libtool meson ninja-build
+#   sudo apt install build-essential git libtool meson
 #   sudo apt install libgnutls28-dev libgtkmm-3.0-dev libltdl-dev
 #   ```
 #
@@ -38,7 +38,8 @@
 #   ninja
 #   ```
 # Tips
-#   - JDimのビルドオプションは `meson configure` で確認できる
+#   - JDimのビルドオプションは `meson configure` を実行してProject optionsの段落を確認する
+#     または meson_options.txt を見る
 #   - ビルドオプションは `meson builddir -Dregex=glib` のように指定する
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 


### PR DESCRIPTION
ドキュメントに記載したmesonのコマンド例は新しいバージョン(>= 0.54.0)でないと使えないサブコマンド([compile])を使用していたため古いバージョンでも利用できる例を追加します。

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1597722999/561

[compile]: https://mesonbuild.com/Commands.html#compile