### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,50 @@ matrix:
             - zlib1g-dev
             - libgnutls28-dev
             - libonig-dev
+    # Adding jobs for ppc64le architecture
+    - name: "CONFIG_ARG=\"--with-tls=gnutls --with-regex=posix --with-migemo\""
+      os: linux
+      compiler: gcc
+      arch: ppc64le
+      env: CONFIG_ARG="--with-tls=gnutls --with-regex=posix --with-migemo"
+      addons:
+        apt:
+          update: true
+          packages:
+            - autoconf-archive
+            - libgtkmm-3.0-dev
+            - zlib1g-dev
+            - libgnutls28-dev
+            - libmigemo-dev
+    - name: "CONFIG_ARG=\"--with-tls=openssl --with-regex=glib --with-alsa --with-compat-cache-dir\""
+      os: linux
+      arch: ppc64le
+      compiler: gcc
+      env: CONFIG_ARG="--with-tls=openssl --with-regex=glib --with-alsa --with-compat-cache-dir"
+      addons:
+        apt:
+          update: true
+          packages:
+            - autoconf-archive
+            - libgtkmm-3.0-dev
+            - zlib1g-dev
+            - libssl-dev
+            - libasound2-dev
+
+    - name: "CONFIG_ARG=\"--with-tls=gnutls --with-regex=oniguruma --with-sessionlib=no --with-pangolayout\""
+      os: linux
+      compiler: gcc
+      arch: ppc64le
+      env: CONFIG_ARG="--with-tls=gnutls --with-regex=oniguruma --with-sessionlib=no --with-pangolayout"
+      addons:
+        apt:
+          update: true
+          packages:
+            - autoconf-archive
+            - libgtkmm-3.0-dev
+            - zlib1g-dev
+            - libgnutls28-dev
+            - libonig-dev
 
 install:
   - travis_retry git clone --depth 1 --branch master https://github.com/google/googletest.git test/googletest


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/JDim/builds/191681515

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj
