### PR TITLE
Use i18n text instead of Gtk::Stock::APPLY for button label

### DIFF
--- a/src/skeleton/prefdiag.cpp
+++ b/src/skeleton/prefdiag.cpp
@@ -17,7 +17,9 @@
 using namespace SKELETON;
 
 PrefDiag::PrefDiag( Gtk::Window* parent, const std::string& url, const bool add_cancel, const bool add_apply, const bool add_open )
-    : Gtk::Dialog(), m_url( url ), m_bt_ok( nullptr ), m_bt_apply( Gtk::Stock::APPLY )
+    : Gtk::Dialog()
+    , m_url( url )
+    , m_bt_apply( g_dgettext( GTK_DOMAIN, "_Apply" ), true )
 {
     if( add_apply ){
         m_bt_apply.signal_clicked().connect( sigc::mem_fun(*this, &PrefDiag::slot_apply_clicked ) );

--- a/src/skeleton/prefdiag.h
+++ b/src/skeleton/prefdiag.h
@@ -19,7 +19,7 @@ namespace SKELETON
     {
         std::string m_url;
 
-        Gtk::Button* m_bt_ok;
+        Gtk::Button* m_bt_ok{};
         Gtk::Button m_bt_apply;
 
         std::unique_ptr<JDLIB::Timeout> m_conn_timer;


### PR DESCRIPTION
GTK4で廃止される`Gtk::Stock::APPLY`をi18n対応テキストに置き換えます。

Gtk::Stockからラベルに変更する参考文献
https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html
https://stackoverflow.com/questions/36805505/gtk-stock-is-deprecated-whats-the-alternative/36811163#36811163

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/skeleton/prefdiag.cpp:17:73: error: 'Gtk::Stock' has not been declared
   17 |     : Gtk::Dialog(), m_url( url ), m_bt_ok( nullptr ), m_bt_apply( Gtk::Stock::APPLY )
      |                                                                         ^~~~~
```

関連のissue: #229, #482 