### PR TITLE
Use i18n text instead of Gtk::Stock::CLOSE for button label

### DIFF
--- a/src/skeleton/aboutdiag.cpp
+++ b/src/skeleton/aboutdiag.cpp
@@ -13,6 +13,9 @@
 #include "icons/iconmanager.h"
 #include "jdlib/miscgtk.h"
 
+#include <glib/gi18n.h>
+
+
 using namespace SKELETON;
 
 enum
@@ -28,7 +31,7 @@ AboutDiag::AboutDiag( const Glib::ustring& title )
     set_transient_for( *CORE::get_mainwindow() );
     set_resizable( false );
 
-    Gtk::Button* button = add_button( Gtk::Stock::CLOSE, Gtk::RESPONSE_CLOSE );
+    Gtk::Button* button = add_button( g_dgettext( GTK_DOMAIN, "_Close" ), Gtk::RESPONSE_CLOSE );
     button->signal_clicked().connect( sigc::mem_fun( *this, &AboutDiag::slot_close_clicked ) );
 
     set_default_response( Gtk::RESPONSE_CLOSE );


### PR DESCRIPTION
GTK4で廃止される`Gtk::Stock::CLOSE`をi18n対応テキストに置き換えます。

Gtk::Stockからラベルに変更する参考文献
https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html
https://stackoverflow.com/questions/36805505/gtk-stock-is-deprecated-whats-the-alternative/36811163#36811163

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/skeleton/aboutdiag.cpp:31:44: error: 'Gtk::Stock' has not been declared
   31 |     Gtk::Button* button = add_button( Gtk::Stock::CLOSE, Gtk::RESPONSE_CLOSE );
      |                                            ^~~~~
```

関連のissue: #229, #482 
