### PR TITLE
Use i18n text instead of Gtk::Stock::REMOVE for button label

### DIFF
--- a/src/message/messageview.cpp
+++ b/src/message/messageview.cpp
@@ -79,7 +79,7 @@ std::string MessageViewMain::create_message()
 
             mdiag.set_title( "確認" );
             mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Cancel" ), Gtk::RESPONSE_CANCEL );
-            mdiag.add_button( Gtk::Stock::REMOVE, Gtk::RESPONSE_DELETE_EVENT );
+            mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Remove" ), Gtk::RESPONSE_DELETE_EVENT );
             mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Yes" ), Gtk::RESPONSE_YES );
 
             switch( mdiag.run() )


### PR DESCRIPTION
GTK4で廃止される`Gtk::Stock::REMOVE`をi18n対応テキストに置き換えます。
修正箇所はコメントアウトされていますが一連の修正に合わせて変更します。

Gtk::Stockからラベルに変更する参考文献
https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html
https://stackoverflow.com/questions/36805505/gtk-stock-is-deprecated-whats-the-alternative/36811163#36811163

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

関連のissue: #229, #482 
