### PR TITLE
Use i18n text instead of Gtk::Stock::(ADD|DELETE) for button label

### DIFF
--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -15,6 +15,8 @@
 
 #include "colorid.h"
 
+#include <glib/gi18n.h>
+
 
 using namespace CONTROL;
 
@@ -269,8 +271,8 @@ MouseKeyDiag::MouseKeyDiag( Gtk::Window* parent, const std::string& url,
       m_controlmode( CONTROL::get_mode( m_id ) ),
       m_single( false ),
       m_label( "編集したい" + target + "設定をダブルクリックして下さい。" ),
-      m_button_delete( Gtk::Stock::DELETE ),
-      m_button_add( Gtk::Stock::ADD ),
+      m_button_delete( g_dgettext( GTK_DOMAIN, "Stock label\x04_Delete" ), true ),
+      m_button_add( g_dgettext( GTK_DOMAIN, "Stock label\x04_Add" ), true ),
       m_button_reset( "デフォルト" )
 {
     m_liststore = Gtk::ListStore::create( m_columns );

--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -17,6 +17,9 @@
 #include "command.h"
 #include "environment.h"
 
+#include <glib/gi18n.h>
+
+
 using namespace CORE;
 
 LinkFilterDiag::LinkFilterDiag( Gtk::Window* parent, const std::string& url, const std::string& cmd )
@@ -67,8 +70,8 @@ LinkFilterPref::LinkFilterPref( Gtk::Window* parent, const std::string& url )
       m_button_up( Gtk::Stock::GO_UP ),
       m_button_down( Gtk::Stock::GO_DOWN ),
       m_button_bottom( Gtk::Stock::GOTO_BOTTOM ),
-      m_button_delete( Gtk::Stock::DELETE ),
-      m_button_add( Gtk::Stock::ADD )
+      m_button_delete( g_dgettext( GTK_DOMAIN, "Stock label\x04_Delete" ), true ),
+      m_button_add( g_dgettext( GTK_DOMAIN, "Stock label\x04_Add" ), true )
 {
     m_button_top.signal_clicked().connect( sigc::mem_fun( *this, &LinkFilterPref::slot_top ) );
     m_button_up.signal_clicked().connect( sigc::mem_fun( *this, &LinkFilterPref::slot_up ) );


### PR DESCRIPTION
GTK4で廃止される`Gtk::Stock::(ADD|DELETE)`をi18n対応テキストに置き換えます。

Gtk::Stockからラベルに変更する参考文献
https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html
https://stackoverflow.com/questions/36805505/gtk-stock-is-deprecated-whats-the-alternative/36811163#36811163
https://gitlab.gnome.org/GNOME/gtk/blob/3.24.20/gtk/deprecated/gtkstock.c#L346

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/control/mousekeypref.cpp:272:29: error: 'Gtk::Stock' has not been declared
  272 |       m_button_delete( Gtk::Stock::DELETE ),
      |                             ^~~~~
../src/control/mousekeypref.cpp:273:26: error: 'Gtk::Stock' has not been declared
  273 |       m_button_add( Gtk::Stock::ADD ),
      |                          ^~~~~
../src/linkfilterpref.cpp:70:29: error: 'Gtk::Stock' has not been declared
   70 |       m_button_delete( Gtk::Stock::DELETE ),
      |                             ^~~~~
../src/linkfilterpref.cpp:71:26: error: 'Gtk::Stock' has not been declared
   71 |       m_button_add( Gtk::Stock::ADD )
      |                          ^~~~~
```

関連のissue: #229, #482 
