### PR TITLE
Use i18n text instead of Gtk::Stock::OPEN for button label

### DIFF
--- a/src/skeleton/filediag.h
+++ b/src/skeleton/filediag.h
@@ -5,6 +5,7 @@
 #ifndef _FILEDIAG_H
 #define _FILEDIAG_H
 
+#include <glib/gi18n.h>
 #include <gtkmm.h>
 
 #include "command.h"
@@ -23,7 +24,9 @@ namespace SKELETON
 
             add_button( g_dgettext( GTK_DOMAIN, "_Cancel" ), Gtk::RESPONSE_CANCEL );
 
-            if( m_action == Gtk::FILE_CHOOSER_ACTION_OPEN ) add_button( Gtk::Stock::OPEN, Gtk::RESPONSE_ACCEPT );
+            if( m_action == Gtk::FILE_CHOOSER_ACTION_OPEN ) {
+                add_button( g_dgettext( GTK_DOMAIN, "Stock label\x04_Open" ), Gtk::RESPONSE_ACCEPT );
+            }
             else add_button( Gtk::Stock::SAVE, Gtk::RESPONSE_ACCEPT );
 
             set_default_response( Gtk::RESPONSE_ACCEPT );

--- a/src/skeleton/prefdiag.cpp
+++ b/src/skeleton/prefdiag.cpp
@@ -32,7 +32,7 @@ PrefDiag::PrefDiag( Gtk::Window* parent, const std::string& url, const bool add_
         ->signal_clicked().connect( sigc::mem_fun(*this, &PrefDiag::slot_cancel_clicked ) );
     }
 
-    if( add_open ) m_bt_ok = add_button( Gtk::Stock::OPEN, Gtk::RESPONSE_OK );
+    if( add_open ) m_bt_ok = add_button( g_dgettext( GTK_DOMAIN, "Stock label\x04_Open" ), Gtk::RESPONSE_OK );
     else m_bt_ok = add_button( g_dgettext( GTK_DOMAIN, "_OK" ), Gtk::RESPONSE_OK );
 
     m_bt_ok->signal_clicked().connect( sigc::mem_fun(*this, &PrefDiag::slot_ok_clicked ) );


### PR DESCRIPTION
GTK4で廃止される`Gtk::Stock::OPEN`をi18n対応テキストに置き換えます。

Gtk::Stockからラベルに変更する参考文献:
https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html
https://stackoverflow.com/questions/36805505/gtk-stock-is-deprecated-whats-the-alternative/36811163#36811163
https://gitlab.gnome.org/GNOME/gtk/blob/3.24.20/gtk/deprecated/gtkstock.c#L422

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/skeleton/filediag.h:26:78: error: 'Gtk::Stock' has not been declared
   26 |             if( m_action == Gtk::FILE_CHOOSER_ACTION_OPEN ) add_button( Gtk::Stock::OPEN, Gtk::RESPONSE_ACCEPT );
      |                                                                              ^~~~~
../src/skeleton/prefdiag.cpp:30:47: error: 'Gtk::Stock' has not been declared
   30 |     if( add_open ) m_bt_ok = add_button( Gtk::Stock::OPEN, Gtk::RESPONSE_OK );
      |                                               ^~~~~
```

関連のissue: #229, #482 
