### PR TITLE
Use i18n text instead of Gtk::Stock::SAVE for button label

### DIFF
--- a/src/message/messageadmin.cpp
+++ b/src/message/messageadmin.cpp
@@ -381,8 +381,7 @@ bool MessageAdmin::delete_message( SKELETON::View * view )
 
     mdiag.add_button( "保存せずに閉じる(_Q)", Gtk::RESPONSE_NO );
     mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Cancel" ), Gtk::RESPONSE_CANCEL );
-    Gtk::Button button( Gtk::Stock::SAVE );
-    mdiag.add_default_button( &button, Gtk::RESPONSE_YES );
+    mdiag.add_default_button( g_dgettext( GTK_DOMAIN, "Stock label\x04_Save" ), Gtk::RESPONSE_YES );
 
     int ret = mdiag.run();
     mdiag.hide();

--- a/src/skeleton/filediag.h
+++ b/src/skeleton/filediag.h
@@ -27,7 +27,7 @@ namespace SKELETON
             if( m_action == Gtk::FILE_CHOOSER_ACTION_OPEN ) {
                 add_button( g_dgettext( GTK_DOMAIN, "Stock label\x04_Open" ), Gtk::RESPONSE_ACCEPT );
             }
-            else add_button( Gtk::Stock::SAVE, Gtk::RESPONSE_ACCEPT );
+            else add_button( g_dgettext( GTK_DOMAIN, "Stock label\x04_Save" ), Gtk::RESPONSE_ACCEPT );
 
             set_default_response( Gtk::RESPONSE_ACCEPT );
         }


### PR DESCRIPTION
GTK4で廃止される`Gtk::Stock::SAVE`をi18n対応テキストに置き換えます。

Gtk::Stockからラベルに変更する参考文献
https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html
https://stackoverflow.com/questions/36805505/gtk-stock-is-deprecated-whats-the-alternative/36811163#36811163
https://gitlab.gnome.org/GNOME/gtk/blob/3.24.20/gtk/deprecated/gtkstock.c#L442

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/message/messageadmin.cpp:384:30: error: 'Gtk::Stock' has not been declared
  384 |     Gtk::Button button( Gtk::Stock::SAVE );
      |                              ^~~~~
../src/skeleton/filediag.h:27:35: error: 'Gtk::Stock' has not been declared
   27 |             else add_button( Gtk::Stock::SAVE, Gtk::RESPONSE_ACCEPT );
      |                                   ^~~~~
```

関連のissue: #229, #482 
