### PR TITLE
Use i18n text instead of Gtk::Stock::REVERT_TO_SAVED for button label

### DIFF
--- a/src/skeleton/selectitempref.cpp
+++ b/src/skeleton/selectitempref.cpp
@@ -11,6 +11,9 @@
 #include "global.h"
 #include "session.h"
 
+#include <glib/gi18n.h>
+
+
 using namespace SKELETON;
 
 #define ROW_COLOR "WhiteSmoke"
@@ -23,7 +26,7 @@ SelectItemPref::SelectItemPref( Gtk::Window* parent, const std::string& url )
       m_button_bottom( Gtk::Stock::GOTO_BOTTOM ),
       m_button_delete( Gtk::Stock::GO_FORWARD, std::string(), Gtk::ICON_SIZE_BUTTON ),
       m_button_add( Gtk::Stock::GO_BACK, std::string(), Gtk::ICON_SIZE_BUTTON ),
-      m_button_default( Gtk::Stock::REVERT_TO_SAVED )
+      m_button_default( g_dgettext( GTK_DOMAIN, "Stock label\x04_Revert" ), true )
 {
     m_list_default_data.clear();
 


### PR DESCRIPTION
GTK4で廃止される`Gtk::Stock::REVERT_TO_SAVED`をi18n対応テキストに置き換えます。

Gtk::Stockからラベルに変更する参考文献
https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html
https://stackoverflow.com/questions/36805505/gtk-stock-is-deprecated-whats-the-alternative/36811163#36811163
https://gitlab.gnome.org/GNOME/gtk/blob/3.24.20/gtk/deprecated/gtkstock.c#L441

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/skeleton/selectitempref.cpp:26:30: error: 'Gtk::Stock' has not been declared
   26 |       m_button_default( Gtk::Stock::REVERT_TO_SAVED )
      |                              ^~~~~
```

関連のissue: #229, #482 
