### PR TITLE
Use named icons instead of Gtk::Stock::GO_(FORWARD|BACK) for button

### DIFF
--- a/src/skeleton/selectitempref.cpp
+++ b/src/skeleton/selectitempref.cpp
@@ -24,11 +24,12 @@ SelectItemPref::SelectItemPref( Gtk::Window* parent, const std::string& url )
       m_button_up( Gtk::Stock::GO_UP ),
       m_button_down( Gtk::Stock::GO_DOWN ),
       m_button_bottom( Gtk::Stock::GOTO_BOTTOM ),
-      m_button_delete( Gtk::Stock::GO_FORWARD, std::string(), Gtk::ICON_SIZE_BUTTON ),
-      m_button_add( Gtk::Stock::GO_BACK, std::string(), Gtk::ICON_SIZE_BUTTON ),
       m_button_default( g_dgettext( GTK_DOMAIN, "Stock label\x04_Revert" ), true )
 {
     m_list_default_data.clear();
+
+    m_button_delete.set_image_from_icon_name( "go-next" );
+    m_button_add.set_image_from_icon_name( "go-previous" );
 
     pack_widgets();
 }

--- a/src/skeleton/selectitempref.h
+++ b/src/skeleton/selectitempref.h
@@ -52,8 +52,8 @@ namespace SKELETON
         Gtk::Button m_button_bottom;
         Gtk::VButtonBox m_vbuttonbox_v;
         // ボタン(横移動)
-        SKELETON::ImgButton m_button_delete;
-        SKELETON::ImgButton m_button_add;
+        Gtk::Button m_button_delete;
+        Gtk::Button m_button_add;
         Gtk::VButtonBox m_vbuttonbox_h;
         // ボタン(アクション)
         Gtk::Button m_button_default;


### PR DESCRIPTION
GTK4で廃止される`Gtk::Stock::GO_(FORWARD|BACK)`をアイコンテーマに置き換えます。

Gtk::Stockからラベルに変更する参考文献
https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html
https://stackoverflow.com/questions/36805505/gtk-stock-is-deprecated-whats-the-alternative/36811163#36811163

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/skeleton/selectitempref.cpp:24:29: error: 'Gtk::Stock' has not been declared
   24 |       m_button_delete( Gtk::Stock::GO_FORWARD, std::string(), Gtk::ICON_SIZE_BUTTON ),
      |                             ^~~~~
../src/skeleton/selectitempref.cpp:25:26: error: 'Gtk::Stock' has not been declared
   25 |       m_button_add( Gtk::Stock::GO_BACK, std::string(), Gtk::ICON_SIZE_BUTTON ),
      |                          ^~~~~
```

関連のissue: #229, #482 
