### PR TITLE
Use i18n text and nemed icon instead of Gtk::Stock for buttons

### DIFF
--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -64,15 +64,20 @@ void LinkFilterDiag::slot_show_manual()
 
 
 LinkFilterPref::LinkFilterPref( Gtk::Window* parent, const std::string& url )
-    : SKELETON::PrefDiag( parent, url ),
-      m_label( "追加ボタンを押すとフィルタ設定を追加出来ます。編集するにはダブルクリックします。" ),
-      m_button_top( Gtk::Stock::GOTO_TOP ),
-      m_button_up( Gtk::Stock::GO_UP ),
-      m_button_down( Gtk::Stock::GO_DOWN ),
-      m_button_bottom( Gtk::Stock::GOTO_BOTTOM ),
-      m_button_delete( g_dgettext( GTK_DOMAIN, "Stock label\x04_Delete" ), true ),
-      m_button_add( g_dgettext( GTK_DOMAIN, "Stock label\x04_Add" ), true )
+    : SKELETON::PrefDiag( parent, url )
+    , m_label( "追加ボタンを押すとフィルタ設定を追加出来ます。編集するにはダブルクリックします。" )
+    , m_button_top( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Top" ), true )
+    , m_button_up( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Up" ), true )
+    , m_button_down( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Down" ), true )
+    , m_button_bottom( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Bottom" ), true )
+    , m_button_delete( g_dgettext( GTK_DOMAIN, "Stock label\x04_Delete" ), true )
+    , m_button_add( g_dgettext( GTK_DOMAIN, "Stock label\x04_Add" ), true )
 {
+    m_button_top.set_image_from_icon_name( "go-top" );
+    m_button_up.set_image_from_icon_name( "go-up" );
+    m_button_down.set_image_from_icon_name( "go-down" );
+    m_button_bottom.set_image_from_icon_name( "go-bottom" );
+
     m_button_top.signal_clicked().connect( sigc::mem_fun( *this, &LinkFilterPref::slot_top ) );
     m_button_up.signal_clicked().connect( sigc::mem_fun( *this, &LinkFilterPref::slot_up ) );
     m_button_down.signal_clicked().connect( sigc::mem_fun( *this, &LinkFilterPref::slot_down ) );

--- a/src/skeleton/selectitempref.cpp
+++ b/src/skeleton/selectitempref.cpp
@@ -19,14 +19,19 @@ using namespace SKELETON;
 #define ROW_COLOR "WhiteSmoke"
 
 SelectItemPref::SelectItemPref( Gtk::Window* parent, const std::string& url )
-    : SKELETON::PrefDiag( parent, url, true, true ),
-      m_button_top( Gtk::Stock::GOTO_TOP ),
-      m_button_up( Gtk::Stock::GO_UP ),
-      m_button_down( Gtk::Stock::GO_DOWN ),
-      m_button_bottom( Gtk::Stock::GOTO_BOTTOM ),
-      m_button_default( g_dgettext( GTK_DOMAIN, "Stock label\x04_Revert" ), true )
+    : SKELETON::PrefDiag( parent, url, true, true )
+    , m_button_top( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Top" ), true )
+    , m_button_up( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Up" ), true )
+    , m_button_down( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Down" ), true )
+    , m_button_bottom( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Bottom" ), true )
+    , m_button_default( g_dgettext( GTK_DOMAIN, "Stock label\x04_Revert" ), true )
 {
     m_list_default_data.clear();
+
+    m_button_top.set_image_from_icon_name( "go-top" );
+    m_button_up.set_image_from_icon_name( "go-up" );
+    m_button_down.set_image_from_icon_name( "go-down" );
+    m_button_bottom.set_image_from_icon_name( "go-bottom" );
 
     m_button_delete.set_image_from_icon_name( "go-next" );
     m_button_add.set_image_from_icon_name( "go-previous" );


### PR DESCRIPTION
GTK4で廃止される`Gtk::Stock`をi18n対応テキストとアイコンテーマに置き換えます。
ナビゲージョンのアイコンは表示したほうが分かりやすいと判断したため残しておきます。

Gtk::Stockからラベルに変更する参考文献
https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html
https://stackoverflow.com/questions/36805505/gtk-stock-is-deprecated-whats-the-alternative/36811163#36811163
https://gitlab.gnome.org/GNOME/gtk/blob/3.24.20/gtk/deprecated/gtkstock.c

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/linkfilterpref.cpp:66:26: error: 'Gtk::Stock' has not been declared
   66 |       m_button_top( Gtk::Stock::GOTO_TOP ),
      |                          ^~~~~
../src/linkfilterpref.cpp:67:25: error: 'Gtk::Stock' has not been declared
   67 |       m_button_up( Gtk::Stock::GO_UP ),
      |                         ^~~~~
../src/linkfilterpref.cpp:68:27: error: 'Gtk::Stock' has not been declared
   68 |       m_button_down( Gtk::Stock::GO_DOWN ),
      |                           ^~~~~
../src/linkfilterpref.cpp:69:29: error: 'Gtk::Stock' has not been declared
   69 |       m_button_bottom( Gtk::Stock::GOTO_BOTTOM ),
      |                             ^~~~~
../src/skeleton/selectitempref.cpp:20:26: error: 'Gtk::Stock' has not been declared
   20 |       m_button_top( Gtk::Stock::GOTO_TOP ),
      |                          ^~~~~
../src/skeleton/selectitempref.cpp:21:25: error: 'Gtk::Stock' has not been declared
   21 |       m_button_up( Gtk::Stock::GO_UP ),
      |                         ^~~~~
../src/skeleton/selectitempref.cpp:22:27: error: 'Gtk::Stock' has not been declared
   22 |       m_button_down( Gtk::Stock::GO_DOWN ),
      |                           ^~~~~
../src/skeleton/selectitempref.cpp:23:29: error: 'Gtk::Stock' has not been declared
   23 |       m_button_bottom( Gtk::Stock::GOTO_BOTTOM ),
      |                             ^~~~~
```

関連のissue: #229, #482 
