### PR TITLE
ImageAdmin: Fix null pointer redundant check

### DIFF
--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -656,9 +656,8 @@ void ImageAdmin::close_left_views( const std::string& url )
     set_command( "set_imgtab_operating", "", "true" );
 
     for( auto&& widget : m_iconbox.get_children() ) {
-        auto view = dynamic_cast< SKELETON::View* >( widget );
-        if( view->get_url() == url ) break;
-        if( view ) {
+        if( auto view{ dynamic_cast<SKELETON::View*>( widget ) } ) {
+            if( view->get_url() == url ) break;
             set_command( "close_view", view->get_url() );
         }
     }


### PR DESCRIPTION
ヌルポインタをデリファレンスする可能性があるとcppcheck 2.1に指摘されたため条件文を修正します。

cppcheckのレポート
```
src/image/imageadmin.cpp:660:13: warning: Either the condition 'if(view)' is redundant or there is possible null pointer dereference: view. [nullPointerRedundantCheck]
        if( view->get_url() == url ) break;
            ^
src/image/imageadmin.cpp:661:11: note: Assuming that condition 'if(view)' is not redundant
        if( view ) {
          ^
src/image/imageadmin.cpp:660:13: note: Null pointer dereference
        if( view->get_url() == url ) break;
            ^
```