### PR TITLE
miscutil: Fix return dangling pointer

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1693,10 +1693,9 @@ std::string MISC::getenv_limited( const char *name, const size_t size )
 {
     if( ! name || ! getenv( name ) ) return std::string();
 
-    std::vector< char > env( size + 1, '\0' );
-    strncpy( env.data(), getenv( name ), size );
-
-    return env.data();
+    std::string env = getenv( name );
+    if( env.size() > size ) env.resize( size );
+    return env;
 }
 
 


### PR DESCRIPTION
ダングリングポインタを関数から返しているとcppcheck 2.1に指摘されたため戻り値を修正します。

cppcheckのレポート
```
src/jdlib/miscutil.cpp:1699:20: error: Returning object that points to local variable 'env' that will be invalid when returning. [returnDanglingLifetime]
    return env.data();
                   ^
src/jdlib/miscutil.cpp:1699:12: note: Pointer to container is created here.
    return env.data();
           ^
src/jdlib/miscutil.cpp:1696:25: note: Variable created here.
    std::vector< char > env( size + 1, '\0' );
                        ^
src/jdlib/miscutil.cpp:1699:20: note: Returning object that points to local variable 'env' that will be invalid when returning.
    return env.data();
                   ^
```