### PR TITLE
miscutil: Fix known condition true/false

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1344,7 +1344,8 @@ static int sanitize_numeric_character_reference( int raw_point )
     else if( raw_point <= 0x0008 // Control character
             || raw_point == 0x000B // Control character (Vertical tab)
             || ( 0x000D <= raw_point && raw_point <= 0x001F ) // Control character
-            || ( 0xFDD0 <= raw_point && raw_point <= 0xFDEF ) // Noncharacters
+            || ( 0xFDD0 <= raw_point // && raw_point <= 0xFDEF の境界は上でチェックしているので不要
+                ) // Noncharacters
             ) {
         parse_error = true;
     }


### PR DESCRIPTION
既に条件が判明している比較があるとcppcheck 2.1に指摘されたため条件文を修正します。

cppcheckのレポート
```
src/jdlib/miscutil.cpp:1347:51: style: Condition 'raw_point<=0xFDEF' is always true [knownConditionTrueFalse]
            || ( 0xFDD0 <= raw_point && raw_point <= 0xFDEF ) // Noncharacters
                                                  ^
src/jdlib/miscutil.cpp:1334:21: note: Assuming that condition '0xFDEF<raw_point' is not redundant
    else if( 0xFDEF < raw_point ) return raw_point;
                    ^
src/jdlib/miscutil.cpp:1347:51: note: Condition 'raw_point<=0xFDEF' is always true
            || ( 0xFDD0 <= raw_point && raw_point <= 0xFDEF ) // Noncharacters
                                                  ^
```