### PR TITLE
Root: Fix null pointer redundant check

### DIFF
--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -405,9 +405,9 @@ void Root::receive_finish()
     }
 
     // 文字コードを変換してXML作成
-    JDLIB::Iconv* libiconv = new JDLIB::Iconv( "UTF-8", "MS932" );
+    JDLIB::Iconv libiconv{ "UTF-8", "MS932" };
     int byte_out;
-    const char* rawdata_utf8 = libiconv->convert( &*m_rawdata.begin(), m_rawdata.size(),  byte_out );
+    const std::string rawdata_utf8 = libiconv.convert( &*m_rawdata.begin(), m_rawdata.size(),  byte_out );
     bbsmenu2xml( rawdata_utf8 );
 
     if( m_xml_document.hasChildNodes() )
@@ -419,7 +419,6 @@ void Root::receive_finish()
         CORE::core_set_command( "update_bbslist" );
     }
 
-    if( libiconv ) delete libiconv;
     clear();
 }
 


### PR DESCRIPTION
ヌルポインタをデリファレンスする可能性があるとcppcheck 2.1に指摘されたため変数定義を修正します。

cppcheckのレポート
```
src/dbtree/root.cpp:410:32: warning: Either the condition 'if(libiconv)' is redundant or there is possible null pointer dereference: libiconv. [nullPointerRedundantCheck]
    const char* rawdata_utf8 = libiconv->convert( &*m_rawdata.begin(), m_rawdata.size(),  byte_out );
                               ^
src/dbtree/root.cpp:422:7: note: Assuming that condition 'if(libiconv)' is not redundant
    if( libiconv ) delete libiconv;
      ^
src/dbtree/root.cpp:410:32: note: Null pointer dereference
    const char* rawdata_utf8 = libiconv->convert( &*m_rawdata.begin(), m_rawdata.size(),  byte_out );
                               ^
```