### PR TITLE
Remove unused MsgDiag::add_default_button(const Gtk::StockID&, const int)

### DIFF
--- a/src/skeleton/msgdiag.cpp
+++ b/src/skeleton/msgdiag.cpp
@@ -49,13 +49,6 @@ MsgDiag::MsgDiag( Gtk::Window* parent,
 MsgDiag::~MsgDiag() noexcept = default;
 
 
-void MsgDiag::add_default_button( const Gtk::StockID& stock_id, const int id )
-{
-    Gtk::Button* button = Gtk::manage( new Gtk::Button( stock_id ) );
-    add_default_button( button, id );
-}
-
-
 void MsgDiag::add_default_button( const Glib::ustring& label, const int id )
 {
     Gtk::Button* button = Gtk::manage( new Gtk::Button( label, true ) );

--- a/src/skeleton/msgdiag.h
+++ b/src/skeleton/msgdiag.h
@@ -35,7 +35,6 @@ namespace SKELETON
 
         ~MsgDiag() noexcept;
 
-        void add_default_button( const Gtk::StockID& stock_id, const int id );
         void add_default_button( const Glib::ustring& label, const int id );
         void add_default_button( Gtk::Widget* button, const int id );
 


### PR DESCRIPTION
GTK4で廃止される`Gtk::StockID`を使う関数オーバーロードを削除します。

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/skeleton/msgdiag.cpp:52:66: error: no matching function for call to 'Gtk::Button::Button(const Gtk::StockID&)'
   52 |     Gtk::Button* button = Gtk::manage( new Gtk::Button( stock_id ) );
      |                                                                  ^
```

関連のissue: #229 