### PR TITLE
meson: Add build_tests option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -182,12 +182,17 @@ endif
 
 
 # googletestが見つからない場合はテストはしない
-# ディストロのパッケージとmeson wrapに対応
-gtest_main_dep = dependency('gtest',
-                            main : true,
-                            fallback : ['gtest', 'gtest_main_dep'],
-                            required : false)
-
+build_tests_opt = get_option('build_tests')
+if not build_tests_opt.disabled()
+  # ディストロのパッケージとmeson wrapに対応
+  gtest_main_dep = dependency('gtest',
+                              main : true,
+                              fallback : ['gtest', 'gtest_main_dep'],
+                              required : build_tests_opt)
+  build_tests = gtest_main_dep.found()
+else
+  build_tests = false
+endif
 
 #
 # オプションの機能
@@ -253,7 +258,9 @@ endif
 
 
 subdir('src')
-subdir('test', if_found : gtest_main_dep)
+if build_tests
+  subdir('test', if_found : gtest_main_dep)
+endif
 
 
 #

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 option('alsa', type : 'feature', value : 'disabled', description : 'Use sound effects')
+option('build_tests', type : 'feature', value : 'auto', description : 'Build tests if gtest is found')
 option('compat_cache_dir', type : 'feature', value : 'enabled', description : 'Use compatible cache directory')
 option('gprof', type : 'feature', value : 'disabled', description : 'Output profile information for gprof')
 option('migemo', type : 'feature', value : 'disabled', description : 'Use text search by romaji')


### PR DESCRIPTION
mesonの構成にテストプログラムのビルドをオプトアウトするビルドオプション`build_tests`を追加します。
これまではテストライブラリを見つけるとテストプログラムをビルドする設定だったのでテストが不要なときは余計に時間がかかっていました。