### PR TITLE
meson: Fall back requirement to version 0.49.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -46,7 +46,7 @@
 project('jdim', 'cpp',
         version : '0.4.0',
         license : 'GPL2',
-        meson_version : '>= 0.49.2',
+        meson_version : '>= 0.49.0',
         default_options : ['warning_level=3', 'cpp_std=c++11'])
 
 # 追加コンパイルオプション


### PR DESCRIPTION
Debian Stretchは[backportsリポジトリ][bpo]でmeson __0.49.0__ が利用できます。
JDimはmesonのバージョン要件を __0.49.2__ に設定していますがstretch-backportsとはマイナーバージョンの差です。
互換性に影響がないので要件を修正してbackportsのmesonを利用したビルドができるようにします。

[bpo]: https://packages.debian.org/source/stretch-backports/meson