### PR TITLE
Use boardbase URL instead of subject.txt URL for identifier

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -1567,7 +1567,8 @@ void ArticleViewBase::slot_setup_abone()
 
 void ArticleViewBase::slot_setup_abone_board()
 {
-    SKELETON::PrefDiag* pref =  CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_BOARD, DBTREE::url_subject( m_url_article ), "show_abone_article" );
+    SKELETON::PrefDiag* pref = CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_BOARD,
+                                                      DBTREE::url_boardbase( m_url_article ), "show_abone_article" );
     pref->run();
     delete pref;
 }
@@ -2337,12 +2338,12 @@ void ArticleViewBase::slot_on_url( const std::string& url, const std::string& im
         std::string num_str;
 
         const std::string url_dat = DBTREE::url_dat( url, num_from, num_to, num_str );
-        const std::string url_subject = DBTREE::url_subject( url );
+        const std::string boardbase = DBTREE::url_boardbase( url );
 
 #ifdef _DEBUG
         std::cout << "ArticleViewBase::slot_on_url " << url << std::endl;
         std::cout << "url_dat = " << url_dat << std::endl;
-        std::cout << "url_subject = " << url_subject << std::endl;
+        std::cout << "boardbase = " << boardbase << std::endl;
         std::cout << "num_from = " << num_from << std::endl;
         std::cout << "num_to = " << num_to << std::endl;
         std::cout << "num = " << num_str << std::endl;
@@ -2360,7 +2361,7 @@ void ArticleViewBase::slot_on_url( const std::string& url, const std::string& im
         }
 
         // 板
-        else if( ! url_subject.empty() ){
+        else if( ! boardbase.empty() ){
 
             std::string tmpstr = DBTREE::board_name( url );
             args.arg1 = "[ " + tmpstr + " ] ";
@@ -3447,7 +3448,7 @@ void ArticleViewBase::slot_search_cachelocal()
 
     if( query.empty() ) return;
 
-    const std::string url = DBTREE::url_subject( m_url_article );
+    const std::string url = DBTREE::url_boardbase( m_url_article );
 
 #ifdef _DEBUG
     std::cout << "ArticleViewBase::slot_search_cachelocal " << url << std::endl
@@ -3465,7 +3466,7 @@ void ArticleViewBase::slot_search_next()
 {
     if( m_article->empty() ) return;
 
-    CORE::core_set_command( "open_board_next", DBTREE::url_subject( m_url_article ) , m_url_article );
+    CORE::core_set_command( "open_board_next", DBTREE::url_boardbase( m_url_article ), m_url_article );
 }
 
 

--- a/src/article/articleviewsearch.cpp
+++ b/src/article/articleviewsearch.cpp
@@ -290,7 +290,7 @@ void ArticleViewSearch::relayout()
 
                 // 板名表示
                 if( m_searchmode == CORE::SEARCHMODE_ALLLOG || m_searchmode == CORE::SEARCHMODE_TITLE  )
-                    comment << "[ <a href=\"" << DBTREE::url_subject( (*it).url_readcgi ) << "\">" << (*it).boardname << "</a> ] ";
+                    comment << "[ <a href=\"" << DBTREE::url_boardbase( (*it).url_readcgi ) << "\">" << (*it).boardname << "</a> ] ";
 
                 comment << "<a href=\"" << (*it).url_readcgi << "\">" << MISC::html_escape( (*it).subject ) << "</a>";
 

--- a/src/article/preference.cpp
+++ b/src/article/preference.cpp
@@ -273,5 +273,5 @@ void Preferences::slot_clear_post_history()
     CORE::core_set_command( "redraw_article" );
 
     // BoardViewの行を更新
-    CORE::core_set_command( "update_board_item", DBTREE::url_subject( get_url() ), DBTREE::article_id( get_url() ) );
+    CORE::core_set_command( "update_board_item", DBTREE::url_boardbase( get_url() ), DBTREE::article_id( get_url() ) );
 }

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -1697,7 +1697,7 @@ void BBSListViewBase::check_update_dir( const bool root, const bool open )
 
         if( type == TYPE_THREAD || type == TYPE_THREAD_UPDATE ) CORE::get_checkupdate_manager()->push_back( DBTREE::url_dat( url ), open );
         else if( CONFIG::get_check_update_board() && ( type == TYPE_BOARD || type == TYPE_BOARD_UPDATE ) )
-            CORE::get_checkupdate_manager()->push_back( DBTREE::url_subject( url ), open );
+            CORE::get_checkupdate_manager()->push_back( DBTREE::url_boardbase( url ), open );
 
     }
 
@@ -1798,7 +1798,8 @@ void BBSListViewBase::slot_preferences_board()
     if( m_path_selected.empty() ) return;
     std::string url = path2url( m_path_selected );
 
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_BOARD, DBTREE::url_subject( url ) );
+    SKELETON::PrefDiag* pref = CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_BOARD,
+                                                      DBTREE::url_boardbase( url ) );
     pref->run();
     delete pref;
 }
@@ -1890,7 +1891,7 @@ bool BBSListViewBase::open_row( Gtk::TreePath& path, const bool tab )
 
         case TYPE_BOARD:
         case TYPE_BOARD_UPDATE:
-            CORE::core_set_command( "open_board", DBTREE::url_subject( url ), str_tab, str_mode );
+            CORE::core_set_command( "open_board", DBTREE::url_boardbase( url ), str_tab, str_mode );
             break;
 
         case TYPE_THREAD_OLD:
@@ -1974,7 +1975,7 @@ void BBSListViewBase::open_selected_rows()
 
             case TYPE_BOARD:
             case TYPE_BOARD_UPDATE:
-                url = DBTREE::url_subject( url );
+                url = DBTREE::url_boardbase( url );
                 if( !list_url_board.empty() ) list_url_board += " ";
                 list_url_board += url;
                 break;
@@ -2018,7 +2019,7 @@ void BBSListViewBase::checkupdate_selected_rows( const bool open )
 
         if( type == TYPE_THREAD || type == TYPE_THREAD_UPDATE ) CORE::get_checkupdate_manager()->push_back( DBTREE::url_dat( url ), open );
         else if( CONFIG::get_check_update_board() && ( type == TYPE_BOARD || type == TYPE_BOARD_UPDATE ) )
-            CORE::get_checkupdate_manager()->push_back( DBTREE::url_subject( url ), open );
+            CORE::get_checkupdate_manager()->push_back( DBTREE::url_boardbase( url ), open );
     }
 }
 

--- a/src/board/boardadmin.cpp
+++ b/src/board/boardadmin.cpp
@@ -122,8 +122,7 @@ void BoardAdmin::restore( const bool only_locked )
         COMMAND_ARGS command_arg = url_to_openarg( *it_url, true, lock );
 
         // 板がDBに登録されていない場合は表示しない
-        if( command_arg.url != URL_ALLLOG && command_arg.arg4 != "SIDEBAR"
-            && DBTREE::url_boardbase( command_arg.url ).empty() ){
+        if( command_arg.url.empty() && command_arg.arg4 != "SIDEBAR" ){
             MISC::ERRMSG(  *it_url + " is not registered" );
             list_switchhistory.remove( *it_url );
             continue;
@@ -162,7 +161,7 @@ COMMAND_ARGS BoardAdmin::url_to_openarg( const std::string& url, const bool tab,
     // 次スレ検索
     if( regex.exec( std::string( "(.*)" ) + NEXT_SIGN + ARTICLE_SIGN + "(.*)", url, offset, icase, newline, usemigemo, wchar )){
 
-        command_arg.url = regex.str( 1 );
+        command_arg.url = DBTREE::url_boardbase( regex.str( 1 ) );
 
         command_arg.arg4 = "NEXT";
         command_arg.arg5 = regex.str( 2 ); // 前スレのアドレス
@@ -179,7 +178,7 @@ COMMAND_ARGS BoardAdmin::url_to_openarg( const std::string& url, const bool tab,
     // ログ一覧
     else if( regex.exec( std::string( "(.*)" ) + LOG_SIGN, url, offset, icase, newline, usemigemo, wchar )){
 
-        command_arg.url = regex.str( 1 );
+        command_arg.url = DBTREE::url_boardbase( regex.str( 1 ) );
 
         command_arg.arg4 = "LOG";
     }
@@ -187,7 +186,7 @@ COMMAND_ARGS BoardAdmin::url_to_openarg( const std::string& url, const bool tab,
     // サイドバー
     else if( regex.exec( std::string( "(.*)" ) + SIDEBAR_SIGN + "(.*)", url, offset, icase, newline, usemigemo, wchar )){
 
-        command_arg.url = regex.str( 1 );
+        command_arg.url = DBTREE::url_boardbase( regex.str( 1 ) );
 
         command_arg.arg4 = "SIDEBAR";
         command_arg.arg5 = regex.str( 2 ); // ディレクトリID
@@ -196,7 +195,7 @@ COMMAND_ARGS BoardAdmin::url_to_openarg( const std::string& url, const bool tab,
     // スレビュー
     else{
 
-        command_arg.url = url;
+        command_arg.url = DBTREE::url_boardbase( url );
 
         command_arg.arg4 = "MAIN";
     }

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -125,8 +125,8 @@ BoardViewBase::BoardViewBase( const std::string& url, const bool show_col_board 
     // 次スレ検索ビューのようにURLの途中に http が入っている場合は取り除く
     size_t pos = url.rfind( "http://" );
     if( pos == std::string::npos || pos == 0 ) pos = url.rfind( "https://" );
-    if( pos != std::string::npos && pos != 0 ) m_url_board = DBTREE::url_subject( url.substr( 0, pos ) );
-    else m_url_board = DBTREE::url_subject( url );
+    if( pos != std::string::npos && pos != 0 ) m_url_board = DBTREE::url_boardbase( url.substr( 0, pos ) );
+    else m_url_board = DBTREE::url_boardbase( url );
 
     m_scrwin.add( m_treeview );
     m_scrwin.set_policy( Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS );
@@ -237,7 +237,7 @@ int BoardViewBase::get_icon( const std::string& iconname ) const
 //
 std::string BoardViewBase::url_for_copy() const
 {
-    return DBTREE::url_boardbase( get_url_board() );
+    return get_url_board();
 }
 
 
@@ -1334,6 +1334,8 @@ void BoardViewBase::update_status()
 //
 void BoardViewBase::select_item( const std::string& url )
 {
+    if( m_url_board != DBTREE::url_boardbase( url ) ) return;
+
     const Gtk::TreeModel::Row row = get_row_from_url( url );
     if( row ){
         Gtk::TreePath path = GET_PATH( row );
@@ -1749,7 +1751,7 @@ Gtk::Menu* BoardViewBase::get_popupmenu( const std::string& url )
 //
 // 特定の行だけの表示内容更新
 //
-// url : subject.txt のアドレス
+// url : boardbase アドレス
 // id : DAT の ID(拡張子付き), empty なら全ての行の表示内容を更新する
 //
 void BoardViewBase::update_item( const std::string& url, const std::string& id )
@@ -2550,7 +2552,7 @@ std::string BoardViewBase::path2url_board( const Gtk::TreePath& path )
 {
     if( ! get_url_board().empty() ) return get_url_board();
     if( path.empty() ) return std::string();
-    return DBTREE::url_subject( path2daturl( path ) );
+    return DBTREE::url_boardbase( path2daturl( path ) );
 }
 
 
@@ -2929,7 +2931,7 @@ void BoardViewBase::slot_search_next()
     if( m_path_selected.empty() ) return;
     const std::string url = path2daturl( m_path_selected );
 
-    CORE::core_set_command( "open_board_next", DBTREE::url_subject( url ) , url );
+    CORE::core_set_command( "open_board_next", DBTREE::url_boardbase( url ), url );
 }
 
 

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -405,7 +405,7 @@ void Preferences::slot_clear_post_history()
     DBTREE::board_clear_all_post_history( get_url() );
 
     // スレ一覧とスレビューの表示更新
-    CORE::core_set_command( "update_board", DBTREE::url_subject( get_url() ) );
+    CORE::core_set_command( "update_board", DBTREE::url_boardbase( get_url() ) );
     CORE::core_set_command( "redraw_article" );
 }
 

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1496,17 +1496,17 @@ void Core::slot_activate_menubar()
 
     // 開いている板のログ検索
     act = m_action_group->get_action( "SearchCacheBoard" );
-    if( BOARD::get_admin()->empty() || DBTREE::url_subject( BOARD::get_admin()->get_current_url() ).empty() ) act->set_sensitive( false );
+    if( BOARD::get_admin()->empty() || DBTREE::url_boardbase( BOARD::get_admin()->get_current_url() ).empty() ) act->set_sensitive( false );
     else act->set_sensitive( true );
 
     // 開いている板のログ一覧表示
     act = m_action_group->get_action( "ShowCacheBoard" );
-    if( BOARD::get_admin()->empty() || DBTREE::url_subject( BOARD::get_admin()->get_current_url() ).empty() ) act->set_sensitive( false );
+    if( BOARD::get_admin()->empty() || DBTREE::url_boardbase( BOARD::get_admin()->get_current_url() ).empty() ) act->set_sensitive( false );
     else act->set_sensitive( true );
 
     // スレ一覧のプロパティ
     act = m_action_group->get_action( "BoardPref" );
-    if( BOARD::get_admin()->empty() || DBTREE::url_subject( BOARD::get_admin()->get_current_url() ).empty() ) act->set_sensitive( false );
+    if( BOARD::get_admin()->empty() || DBTREE::url_boardbase( BOARD::get_admin()->get_current_url() ).empty() ) act->set_sensitive( false );
     else act->set_sensitive( true );
     
     // スレのプロパティ
@@ -3219,7 +3219,7 @@ void Core::exec_command()
         int num_from, num_to;
         std::string num_str;
         const std::string url_dat = DBTREE::url_dat( command.url, num_from, num_to, num_str );
-        const std::string url_subject = DBTREE::url_subject( command.url );
+        const std::string boardbase = DBTREE::url_boardbase( command.url );
        
         // datの場合ビューで開く
         if( ! url_dat.empty() ){
@@ -3259,13 +3259,13 @@ void Core::exec_command()
         }
 
         // 掲示板のベースURLの場合
-        else if( ! url_subject.empty() ){
+        else if( ! boardbase.empty() ){
 
 #ifdef _DEBUG
-            std::cout << "exec : open_board url = " << url_subject << std::endl;
+            std::cout << "exec : open_board url = " << boardbase << std::endl;
 #endif
 
-            CORE::core_set_command( "open_board" , url_subject, "true" );
+            CORE::core_set_command( "open_board", boardbase, "true" );
         }
 
         // その他
@@ -4241,10 +4241,10 @@ void Core::import_dat( const std::string& url_board, const std::vector< std::str
 {
     if( ! list_files.size() ) return;
 
-    const std::string url_subject = DBTREE::url_subject( url_board );
+    const std::string boardbase = DBTREE::url_boardbase( url_board );
 
 #ifdef _DEBUG
-    std::cout << "Core::import_dat url = " << url_subject << std::endl;
+    std::cout << "Core::import_dat url = " << boardbase << std::endl;
 #endif
 
     CORE::DATA_INFO_LIST list_info;
@@ -4257,7 +4257,7 @@ void Core::import_dat( const std::string& url_board, const std::vector< std::str
         std::cout << filename << std::endl;
 #endif
 
-        std::string url = DBTREE::board_import_dat( url_subject, filename );
+        std::string url = DBTREE::board_import_dat( boardbase, filename );
         if( ! url.empty() ){
             info.url = url;
             list_info.push_back( info );
@@ -4266,10 +4266,10 @@ void Core::import_dat( const std::string& url_board, const std::vector< std::str
 
     if( list_info.size() ){
 
-        CORE::core_set_command( "open_board" , url_subject, "true" , "auto" );
+        CORE::core_set_command( "open_board", boardbase, "true", "auto" );
 
         CORE::SBUF_set_list( list_info );
-        BOARD::get_admin()->set_command( "draw_bg_articles", url_subject );
+        BOARD::get_admin()->set_command( "draw_bg_articles", boardbase );
     }
 }
 

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -548,7 +548,7 @@ void ArticleBase::update_writetime()
         m_save_info = true;
 
         // BoardViewの行を更新
-        CORE::core_set_command( "update_board_item", DBTREE::url_subject( m_url ), m_id );
+        CORE::core_set_command( "update_board_item", DBTREE::url_boardbase( m_url ), m_id );
     }
 
     // 板の書き込み時間を更新
@@ -574,7 +574,7 @@ void ArticleBase::set_bookmarked_thread( const bool bookmarked )
     save_info( true );
 
     // BoardViewの行を更新
-    CORE::core_set_command( "update_board_item", DBTREE::url_subject( m_url ), m_id );
+    CORE::core_set_command( "update_board_item", DBTREE::url_boardbase( m_url ), m_id );
 }
 
 
@@ -1343,7 +1343,7 @@ void ArticleBase::slot_load_finished()
             DBTREE::board_show_updateicon( m_url, true );
 
             // スレ一覧の ! 行のアイコンを更新マークにする
-            CORE::core_set_command( "update_board_item", DBTREE::url_subject( m_url ), m_id );
+            CORE::core_set_command( "update_board_item", DBTREE::url_boardbase( m_url ), m_id );
         }
 
         // code と modified を戻しておく
@@ -1525,7 +1525,7 @@ void ArticleBase::slot_load_finished()
 #endif
 
     // 対応するBoardビューの行を更新
-    CORE::core_set_command( "update_board_item", DBTREE::url_subject( m_url ), m_id );
+    CORE::core_set_command( "update_board_item", DBTREE::url_boardbase( m_url ), m_id );
     
     // articleビューに終了を知らせる
     CORE::core_set_command( "update_article", m_url );
@@ -1743,7 +1743,7 @@ void ArticleBase::delete_cache( const bool cache_only )
     if( CACHE::file_exists( path_dat ) == CACHE::EXIST_FILE ) unlink( to_locale_cstr( path_dat ) );
 
     // BoardViewの行を更新
-    CORE::core_set_command( "update_board_item", DBTREE::url_subject( m_url ), m_id );
+    CORE::core_set_command( "update_board_item", DBTREE::url_boardbase( m_url ), m_id );
 
     // サイドバーのアイコン表示を戻す
     CORE::core_set_command( "toggle_sidebar_articleicon", m_url );

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -375,7 +375,7 @@ void BoardBase::send_update_board()
     // "update_board" コマンドの後に"update_board_item"を送ると
     // ローディングが終了しているため行を二回更新してしまうので注意
     // 詳しくは BoardViewBase::update_item() を参照
-    CORE::core_set_command( "update_board_item", url_subject(),
+    CORE::core_set_command( "update_board_item", url_boardbase(),
                             std::string() // IDとして空文字を送る
         );
 
@@ -997,7 +997,7 @@ ArticleBase* BoardBase::get_article_fromURL( const std::string& url )
 void BoardBase::download_subject( const std::string& url_update_view, const bool read_from_cache )
 {
 #ifdef _DEBUG
-    std::cout << "BoardBase::download_subject " << url_subject() << std::endl
+    std::cout << "BoardBase::download_subject " << url_boardbase() << std::endl
               << "url_update_view = " << url_update_view << std::endl
               << "read_from_cache = " << read_from_cache << std::endl
               << "empty = " << empty() << std::endl
@@ -1160,7 +1160,7 @@ void BoardBase::receive_finish()
             if( DBTREE::move_board( url_boardbase(), location() ) ) {
                 // 再読み込み
                 const std::string str_tab = "false";
-                CORE::core_set_command( "open_board", url_subject(), str_tab );
+                CORE::core_set_command( "open_board", url_boardbase(), str_tab );
             }
         }
         // HTMLの埋め込みスクリプトで移動を指示された場合
@@ -1209,7 +1209,7 @@ void BoardBase::receive_finish()
 
                         // 再読み込み
                         const std::string str_tab = "false";
-                        CORE::core_set_command( "open_board", url_subject(), str_tab );
+                        CORE::core_set_command( "open_board", url_boardbase(), str_tab );
                     }
                 }
             }
@@ -1696,7 +1696,7 @@ void BoardBase::update_abone_thread( const bool redraw )
     const bool online = SESSION::is_online();
     SESSION::set_online( false );
 
-    download_subject( ( redraw ? url_subject() : std::string() ), false );
+    download_subject( ( redraw ? url_boardbase() : std::string() ), false );
 
     SESSION::set_online( online );
 }
@@ -1871,7 +1871,7 @@ void BoardBase::search_cache( std::vector< DBTREE::ArticleBase* >& list_article,
     )
 {
 #ifdef _DEBUG
-    std::cout << "BoardBase::search_cache " << url_subject() << std::endl;
+    std::cout << "BoardBase::search_cache " << url_boardbase() << std::endl;
 #endif
 
     if( empty() ) return;
@@ -2330,7 +2330,7 @@ void BoardBase::show_updateicon( const bool update )
             m_status |= STATUS_UPDATE;
 
             // スレ一覧のタブのアイコン表示を更新
-            CORE::core_set_command( "toggle_board_icon", url_subject() );
+            CORE::core_set_command( "toggle_board_icon", url_boardbase() );
 
             // サイドバーのアイコン表示を更新
             CORE::core_set_command( "toggle_sidebar_boardicon", url_datbase() );
@@ -2350,7 +2350,7 @@ void BoardBase::show_updateicon( const bool update )
 
             // サイドバーのアイコン表示を戻す
             // スレ一覧のタブのアイコンはBoardViewがロード終了時に自動的に戻す
-            CORE::core_set_command( "toggle_sidebar_boardicon", url_subject() );
+            CORE::core_set_command( "toggle_sidebar_boardicon", url_boardbase() );
 
             save_info();
         }

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -60,11 +60,6 @@ DBTREE::ArticleBase* DBTREE::get_article( const std::string& url )
 
 //////////////////////////////////////
 
-std::string DBTREE::url_subject( const std::string& url )
-{
-    return DBTREE::get_board( url )->url_subject();
-}
-
 
 std::string DBTREE::url_root( const std::string& url )
 {

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -37,7 +37,7 @@ namespace DBTREE
     ArticleBase* get_article( const std::string& url );
 
     // urlの変換関係
-    std::string url_subject( const std::string& url ); // 板の subject.txt の URL
+    std::string url_subject( const std::string& url ) = delete; // 板の subject.txt の URL
     std::string url_root( const std::string& url );
     std::string url_boardbase( const std::string& url );
     std::string url_datbase( const std::string& url );

--- a/src/history/historysubmenu.cpp
+++ b/src/history/historysubmenu.cpp
@@ -156,7 +156,7 @@ bool HistorySubMenu::open_history( const int i )
 
             case TYPE_BOARD:
                 
-                CORE::core_set_command( "open_board" , DBTREE::url_subject( info_list[ i ].url ), tab, mode );
+                CORE::core_set_command( "open_board", DBTREE::url_boardbase( info_list[ i ].url ), tab, mode );
                 ret = true;
                 break;
 

--- a/src/menuslots.cpp
+++ b/src/menuslots.cpp
@@ -1137,7 +1137,7 @@ void Core::slot_search_cache()
 //
 void Core::slot_show_cache_board()
 {
-    const std::string url = DBTREE::url_subject( BOARD::get_admin()->get_current_url() );
+    const std::string url = DBTREE::url_boardbase( BOARD::get_admin()->get_current_url() );
     if( ! url.empty() ) CORE::core_set_command( "open_board_showlog", url );
 }
 
@@ -1265,7 +1265,7 @@ void Core::slot_create_vboard()
 //
 void Core::slot_show_bbs()
 {
-    CORE::core_set_command( "open_board" , DBTREE::url_subject( ENVIRONMENT::get_jdbbs() ), "newtab" );
+    CORE::core_set_command( "open_board", DBTREE::url_boardbase( ENVIRONMENT::get_jdbbs() ), "newtab" );
 }
 
 
@@ -1274,7 +1274,7 @@ void Core::slot_show_bbs()
 //
 void Core::slot_show_old2ch()
 {
-    CORE::core_set_command( "open_board" , DBTREE::url_subject( ENVIRONMENT::get_jd2chlog() ), "newtab" );
+    CORE::core_set_command( "open_board", DBTREE::url_boardbase( ENVIRONMENT::get_jd2chlog() ), "newtab" );
 }
 
 

--- a/src/message/messageview.cpp
+++ b/src/message/messageview.cpp
@@ -207,5 +207,5 @@ void MessageViewNew::write_impl( const std::string& msg )
 
 void MessageViewNew::reload()
 {
-    CORE::core_set_command( "open_board", DBTREE::url_subject( get_url() ), "true" );
+    CORE::core_set_command( "open_board", DBTREE::url_boardbase( get_url() ), "true" );
 }

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -656,7 +656,7 @@ void ToolBar::slot_open_board()
 {
     if( ! m_enable_slot ) return;
 
-    CORE::core_set_command( "open_board", DBTREE::url_subject( get_url() ), "true",
+    CORE::core_set_command( "open_board", DBTREE::url_boardbase( get_url() ), "true",
                             "auto" // オートモードで開く
         );
 }
@@ -670,9 +670,11 @@ void ToolBar::slot_menu_board( int i )
 
     // ToolBar::get_button_board()で作成したメニューの順番に内容を合わせる
     if( i == 0 ) slot_open_board();
-    else if( i == 1 ) CORE::core_set_command( "open_board", DBTREE::url_subject( get_url() ), "true" );
-    else if( i == 3 ) pref = CORE::PrefDiagFactory( CORE::get_mainwindow(), CORE::PREFDIAG_BOARD, DBTREE::url_subject( get_url() ), "show_localrule" );
-    else if( i == 4 ) pref = CORE::PrefDiagFactory( CORE::get_mainwindow(), CORE::PREFDIAG_BOARD, DBTREE::url_subject( get_url() )  );
+    else if( i == 1 ) CORE::core_set_command( "open_board", DBTREE::url_boardbase( get_url() ), "true" );
+    else if( i == 3 ) pref = CORE::PrefDiagFactory( CORE::get_mainwindow(), CORE::PREFDIAG_BOARD,
+                                                    DBTREE::url_boardbase( get_url() ), "show_localrule" );
+    else if( i == 4 ) pref = CORE::PrefDiagFactory( CORE::get_mainwindow(), CORE::PREFDIAG_BOARD,
+                                                    DBTREE::url_boardbase( get_url() )  );
 
     if( pref ){
         pref->run();

--- a/src/updatemanager.cpp
+++ b/src/updatemanager.cpp
@@ -104,7 +104,7 @@ void CheckUpdate_Manager::push_back( const std::string& url, const bool open )
     int num_from, num_to;
     std::string num_str;
     const std::string url_dat = DBTREE::url_dat( url, num_from, num_to, num_str );
-    const std::string url_subject = DBTREE::url_subject( url );
+    const std::string boardbase = DBTREE::url_boardbase( url );
 
     // スレ
     if( ! url_dat.empty() ){
@@ -116,10 +116,10 @@ void CheckUpdate_Manager::push_back( const std::string& url, const bool open )
     }
 
     // 板
-    else if( ! url_subject.empty() ){
+    else if( ! boardbase.empty() ){
 #ifdef _DEBUG
         std::cout << "type = board\n"
-                  << url_subject << std::endl;
+                  << boardbase << std::endl;
 #endif
         urllist = DBTREE::board_get_check_update_articles( url );
     }
@@ -173,7 +173,7 @@ void CheckUpdate_Manager::pop_front()
                 int num_from, num_to;
                 std::string num_str;
                 const std::string url_dat = DBTREE::url_dat( url, num_from, num_to, num_str );
-                const std::string url_subject = DBTREE::url_subject( url );
+                const std::string boardbase = DBTREE::url_boardbase( url );
 
                 // スレ
                 if( ! url_dat.empty() ){
@@ -182,7 +182,7 @@ void CheckUpdate_Manager::pop_front()
                 }
 
                 // 板
-                else if( ! url_subject.empty() ){
+                else if( ! boardbase.empty() ){
 
                     if( DBTREE::board_status( url ) & STATUS_UPDATE ) urls_board += url + " ";
                 }


### PR DESCRIPTION
`CORE::PrefDiagFactory()`や`CORE::core_set_command()`などに使う板の識別子をsubject.txtのURLから板のURLへ変更します。
`DBTREE::url_subject()`は呼び出すコードが無くなるため削除します。
