### PR TITLE
Implement loading local rule and settings for JBBS

### DIFF
--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -427,6 +427,17 @@ std::string Board2chCompati::localrule()
 }
 
 
+//
+// SETTING.TXTのURL
+//
+// (例) "http://hoge.2ch.net/hogeboard/SETTING.TXT"
+//
+std::string Board2chCompati::url_settingtxt()
+{
+    return url_boardbase() + DBTREE::kSettingTxt;
+}
+
+
 std::string Board2chCompati::settingtxt()
 {
     if( m_settingloader ){

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -47,6 +47,9 @@ namespace DBTREE
         // ローカルルール
         std::string localrule() override;
 
+        // SETTING.TXT のURL
+        std::string url_settingtxt() override;
+
         // SETTING.TXT 
         std::string settingtxt() override;
         std::string default_noname() override;

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -239,6 +239,10 @@ namespace DBTREE
         // クッキーの更新 (クッキーをセットした時に実行)
         virtual void update_hap(){}
 
+        // subject.txt の URLを取得
+        // (例) "http://hoge.2ch.net/hogeboard/subject.txt"
+        std::string url_subject();
+
       public:
 
         BoardBase( const std::string& root, const std::string& path_board, const std::string& name );
@@ -375,9 +379,9 @@ namespace DBTREE
         // "http://www.hoge2ch.net/test/read.cgi/hogeboard/12345/12-15"
         virtual std::string url_readcgi( const std::string& url, int num_from, int num_to );
 
-        // subject.txt の URLを取得
-        // (例) "http://www.hoge2ch.net/hogeboard/subject.txt"
-        std::string url_subject();
+        // SETTING.TXT の URLを取得
+        // (例) "http://hoge.2ch.net/hogeboard/SETTING.TXT"
+        virtual std::string url_settingtxt() { return {}; }
 
         // ルートアドレス
         // (例) "http://www.hoge2ch.net/hogeboard/" なら "http://www.hoge2ch.net/"

--- a/src/dbtree/boardjbbs.h
+++ b/src/dbtree/boardjbbs.h
@@ -9,14 +9,23 @@
 
 #include "boardbase.h"
 
+#include <memory>
+
+
 namespace DBTREE
 {
+    class RuleLoader;
+    class SettingLoader;
+
     class BoardJBBS : public BoardBase
     {
+        std::unique_ptr<RuleLoader> m_ruleloader;
+        std::unique_ptr<SettingLoader> m_settingloader;
+
       public:
 
         BoardJBBS( const std::string& root, const std::string& path_board,const std::string& name );
-        ~BoardJBBS() noexcept = default;
+        ~BoardJBBS() noexcept;
 
         std::string url_datpath() override;
 
@@ -30,12 +39,25 @@ namespace DBTREE
         // 新スレ作成用のsubbbscgi のURL
         std::string url_subbbscgi_new() override;
 
+        // ローカルルール
+        std::string localrule() override;
+
+        // SETTING.TXT
+        std::string settingtxt() override;
+        std::string default_noname() override;
+
+        // SETTING.TXT のURL
+        std::string url_settingtxt() override;
+
       private:
 
         bool is_valid( const std::string& filename ) override;
         ArticleBase* append_article( const std::string& datbase, const std::string& id, const bool cached ) override;
         void parse_subject( const char* str_subject_txt ) override;
         void regist_article( const bool is_online ) override;
+
+        void load_rule_setting() override;
+        void download_rule_setting() override;
     };
 }
 

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -102,6 +102,12 @@ std::string DBTREE::url_readcgi( const std::string& url, int num_from, int num_t
 }
 
 
+std::string DBTREE::url_settingtxt( const std::string& url )
+{
+    return DBTREE::get_board( url )->url_settingtxt();
+}
+
+
 std::string DBTREE::url_bbscgibase( const std::string& url )
 {
     return DBTREE::get_board( url )->url_bbscgibase();

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -51,6 +51,8 @@ namespace DBTREE
     // read.cgi型のurlに変換
     std::string url_readcgi( const std::string& url, int num_from, int num_to );
 
+    std::string url_settingtxt( const std::string& url );
+
     std::string url_bbscgibase( const std::string& url );
     std::string url_subbbscgibase( const std::string& url );
     std::string url_bbscgi( const std::string& url );

--- a/src/dbtree/ruleloader.cpp
+++ b/src/dbtree/ruleloader.cpp
@@ -17,9 +17,10 @@
 
 using namespace DBTREE;
 
-RuleLoader::RuleLoader( const std::string& url_boadbase )
-    : SKELETON::TextLoader(),
-      m_url_boadbase( url_boadbase )
+RuleLoader::RuleLoader( const std::string& url_boadbase, const char* override_charset )
+    : SKELETON::TextLoader()
+    , m_url_boadbase( url_boadbase )
+    , m_override_charset{ override_charset }
 {
 #ifdef _DEBUG
     std::cout << "RuleLoader::RuleLoader : " << RuleLoader::get_url() << std::endl;
@@ -51,7 +52,7 @@ std::string RuleLoader::get_path()
 
 std::string RuleLoader::get_charset()
 {
-    return DBTREE::board_charset( m_url_boadbase );
+    return m_override_charset ? m_override_charset : DBTREE::board_charset( m_url_boadbase );
 }
 
 

--- a/src/dbtree/ruleloader.h
+++ b/src/dbtree/ruleloader.h
@@ -20,10 +20,13 @@ namespace DBTREE
     class RuleLoader : public SKELETON::TextLoader
     {
         std::string m_url_boadbase;
+        // スレ本文とエンコーディングが異なる板があるため指定可能にする
+        // 文字列の寿命は呼び出し元が責任を持つこと
+        const char* m_override_charset;
 
       public:
 
-        explicit RuleLoader( const std::string& url_boardbase );
+        explicit RuleLoader( const std::string& url_boardbase, const char* override_charset = nullptr );
         ~RuleLoader();
 
       protected:

--- a/src/dbtree/settingloader.cpp
+++ b/src/dbtree/settingloader.cpp
@@ -13,7 +13,6 @@
 
 #include "cache.h"
 
-#define SETTING_TXT "SETTING.TXT"
 
 using namespace DBTREE;
 
@@ -41,13 +40,13 @@ SettingLoader::~SettingLoader()
 
 std::string SettingLoader::get_url()
 {
-    return m_url_boadbase + SETTING_TXT;
+    return DBTREE::url_settingtxt( m_url_boadbase );
 }
 
 
 std::string SettingLoader::get_path()
 {
-    return CACHE::path_board_root( m_url_boadbase ) + SETTING_TXT;
+    return CACHE::path_board_root( m_url_boadbase ) + DBTREE::kSettingTxt;
 }
 
 

--- a/src/dbtree/settingloader.h
+++ b/src/dbtree/settingloader.h
@@ -17,6 +17,9 @@ namespace JDLIB
 
 namespace DBTREE
 {
+    // 板設定のファイル名
+    constexpr const char kSettingTxt[] = "SETTING.TXT";
+
     class SettingLoader : public SKELETON::TextLoader
     {
         std::string m_url_boadbase;


### PR DESCRIPTION
したらば掲示板のローカルルールとSETTING.TXTの読み込みを実装します。
読み込んだ板設定からデフォルト名無しを設定します。

したらばのAPI
http://blog.livedoor.jp/bbsnews/archives/51024405.html
