### PR TITLE
Deprecate posix regex option

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -110,6 +110,10 @@
        使用する正規表現ライブラリを設定する。
        デフォルトでは Glib Regex(GRegex) を使用する。(v0.4.0+から変更)
 
+    --with-regex=posix
+
+       非推奨: かわりに --with-regex=glib を使用してください。
+
     --with-regex=oniguruma
 
        POSIX regex のかわりに鬼車を使用する。

--- a/configure.ac
+++ b/configure.ac
@@ -179,7 +179,8 @@ AC_MSG_RESULT($with_regex)
 AS_IF(
   [test "x$with_regex" = xposix],
   [AC_CHECK_HEADERS([regex.h], , [AC_MSG_ERROR([regex.h not found])])
-   AC_CHECK_LIB([regex], [regexec])],
+   AC_CHECK_LIB([regex], [regexec])
+   AC_MSG_WARN([--with-regex=posix is deprecated. Use --with-regex=glib instead.])],
 
   [test "x$with_regex" = xpcre],
   [AC_MSG_ERROR([--with-regex=pcre has been removed. Use --with-regex=glib instead.])],

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -125,6 +125,8 @@ configure のかわりに [meson] を使ってビルドする方法は [GitHub][
     使用する正規表現ライブラリを設定する。
     デフォルトでは Glib Regex(GRegex) を使用する。<small>(v0.4.0+から変更)</small>
   </dd>
+  <dt>--with-regex=posix</dt>
+  <dd><strong>非推奨</strong>: かわりに <code>--with-regex=glib</code> を使用してください。</dd>
   <dt>--with-regex=oniguruma</dt>
   <dd>
     POSIX regex のかわりに鬼車を使用する。

--- a/meson.build
+++ b/meson.build
@@ -135,6 +135,7 @@ if regex_opt == 'posix'
   configure_args += '\'--with-regex=posix\''
   regex_dep = dependency('', required : false)
   conf.set('HAVE_REGEX_H', 1)
+  warning('--with-regex=posix is deprecated. Use --with-regex=glib instead.')
 elif regex_opt == 'oniguruma'
   regex_dep = dependency('oniguruma')
   if not cpp_compiler.has_header('onigposix.h')


### PR DESCRIPTION
正規表現ライブラリPOSIX regexのサポートを廃止予定にします。
POSIXは幅広い環境で利用できる利点がありますが、PCRE系の正規表現と比べると機能が少なく動作確認の手間がかかります。
デフォルトオプションのGRegexはPCRE系の構文でありJDimが動作する環境なら利用できるためライブラリを整理してメンテナンスの負担を削減します。

関連のissue: #521 