### PR TITLE
Update compiler requirement to clang-5.0 since version 0.5.0

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -25,7 +25,7 @@
   ・autoconf
   ・autoconf-archive
   ・automake
-  ・g++ 5 以上、または clang++ 3.3 以上 ( 将来のリリースで g++ 6 以上、または clang++ 4.0 以上になる )
+  ・g++ 5 以上、または clang++ 3.3 以上 ( 将来のリリースで g++ 6 以上、または clang++ 5.0 以上になる )
   ・gnutls
   ・gtkmm
   ・libtool

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -39,7 +39,7 @@ layout: default
 - autoconf
 - autoconf-archive
 - automake
-- g++ 5 以上、または clang++ 3.3 以上 ( 将来のリリースで g++ 6 以上、または clang++ 4.0 以上になる )
+- g++ 5 以上、または clang++ 3.3 以上 ( 将来のリリースで g++ 6 以上、または clang++ 5.0 以上になる )
 - gnutls
 - gtkmm
 - libtool


### PR DESCRIPTION
プロジェクトで使うテスト環境ではclang-4.0を利用する[ビルドが失敗][1]するためv0.5.0リリース後のコンパイラ要件をclang-5.0にします。
gcc-6は変更ありません。

[1]: https://github.com/ma8ma/JDim/pull/52#issuecomment-731599869