### PR TITLE
NodeTreeBase, DragTreeView: Fix member initialization

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -80,17 +80,10 @@ using namespace DBTREE;
 
 
 NodeTreeBase::NodeTreeBase( const std::string& url, const std::string& modified )
-    : SKELETON::Loadable(),
-      m_url( url ),
-      m_lng_dat( 0 ),
-      m_resume ( RESUME_NO ),
-      m_resume_cached( false ),
-      m_broken( false ),
-      m_heap( SIZE_OF_HEAP ),
-      m_check_update( false ),
-      m_check_write( false ),
-      m_loading_newthread( false ),
-      m_fout ( nullptr )
+    : SKELETON::Loadable()
+    , m_url( url )
+    , m_resume( RESUME_NO )
+    , m_heap( SIZE_OF_HEAP )
 {
     set_date_modified( modified );
 

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -49,24 +49,24 @@ namespace DBTREE
         std::string m_default_noname;
 
         // コード変換前の生データのサイズ ( byte )
-        size_t m_lng_dat; 
+        std::size_t m_lng_dat{};
 
         // レジュームのモード
         int m_resume;
 
         // レジューム時のチェック用
-        bool m_resume_cached;
+        bool m_resume_cached{};
         // 生データの先頭から RESUME_CHKSIZE バイト分を入れる
         char m_resume_head[ RESUME_CHKSIZE ];
 
         // レジューム中にスキップした生データサイズ
-        size_t m_resume_lng;
+        std::size_t m_resume_lng{};
 
         // 現在処理中のヘッダ番号( つまりロード中でないなら総レス数になる )
         int m_id_header; 
 
         // サーバー側であぼーんがあったりしてスレが壊れている
-        bool m_broken;  
+        bool m_broken{};
 
         JDLIB::HEAP m_heap;
         std::vector< NODE* > m_vec_header;  // レスのヘッダのポインタの配列
@@ -94,11 +94,11 @@ namespace DBTREE
         std::list< std::string > m_list_abone_word_global; // あぼーんする文字列(全体)
         std::list< JDLIB::RegexPattern > m_list_abone_regex_global; // あぼーんする正規表現(全体)
         std::unordered_set< int > m_abone_reses; // レスあぼーん情報
-        bool m_abone_transparent; // 透明あぼーん
-        bool m_abone_chain; // 連鎖あぼーん
-        bool m_abone_age; // age ているレスはあぼーん
-        bool m_abone_board; // 板レベルでのあぼーんを有効にする
-        bool m_abone_global; // 全体レベルでのあぼーんを有効にする
+        bool m_abone_transparent{}; // 透明あぼーん
+        bool m_abone_chain{}; // 連鎖あぼーん
+        bool m_abone_age{}; // age ているレスはあぼーん
+        bool m_abone_board{}; // 板レベルでのあぼーんを有効にする
+        bool m_abone_global{}; // 全体レベルでのあぼーんを有効にする
 
         // 自分が書き込んだレスか
         std::unordered_set< int > m_posts;
@@ -114,15 +114,15 @@ namespace DBTREE
         std::string m_buffer_lines;
         std::string m_parsed_text; // HTMLパーサに使うバッファ
         std::string m_buffer_write; // 書き込みチェック用バッファ
-        bool m_check_update; // HEADによる更新チェックのみ
-        bool m_check_write; // 自分の書き込みかチェックする
-        bool m_loading_newthread; // 新スレ読み込み中
-        
+        bool m_check_update{}; // HEADによる更新チェックのみ
+        bool m_check_write{}; // 自分の書き込みかチェックする
+        bool m_loading_newthread{}; // 新スレ読み込み中
+
         // キャッシュ保存用ファイルハンドラ
-        FILE *m_fout;
-        
+        FILE* m_fout{};
+
         // パース用雑用変数
-        NODE* m_node_previous;
+        NODE* m_node_previous{};
 
         // AA判定用
         JDLIB::RegexPattern m_aa_regex;

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -36,13 +36,9 @@ constexpr const char* DragTreeView::s_css_classname;
 
 DragTreeView::DragTreeView( const std::string& url, const std::string& dndtarget,
     const bool use_usr_fontcolor, const std::string& fontname, const int colorid_text, const int colorid_bg, const int colorid_bg_even )
-    : JDTreeViewBase(),
-      m_url( url ),
-      m_dndtarget( dndtarget ),
-      m_dragging( false ),
-      m_use_bg_even( false ),
-      m_popup_win( nullptr ),
-      m_popup_shown( false )
+    : JDTreeViewBase()
+    , m_url( url )
+    , m_dndtarget( dndtarget )
 {
 #ifdef _DEBUG
     std::cout << "DragTreeView::DragTreeView\n";

--- a/src/skeleton/dragtreeview.h
+++ b/src/skeleton/dragtreeview.h
@@ -31,10 +31,10 @@ namespace SKELETON
         std::string m_url;
         std::string m_dndtarget;
 
-        bool m_dragging;  // ドラッグ中
+        bool m_dragging{}; // ドラッグ中
 
         // 範囲選択に使用
-        bool m_selection_canceled; // 範囲選択を解除したときにsig_button_release()を発行しないようにする
+        bool m_selection_canceled{}; // 範囲選択を解除したときにsig_button_release()を発行しないようにする
         Gtk::TreeModel::Path m_path_dragstart;
         Gtk::TreeModel::Path m_path_dragpre;
 
@@ -42,15 +42,15 @@ namespace SKELETON
         Glib::RefPtr< Gtk::CssProvider > m_provider = Gtk::CssProvider::create();
 
         // 色
-        bool m_use_bg_even;
+        bool m_use_bg_even{};
         Gdk::RGBA m_color_text;
         Gdk::RGBA m_color_bg;
         Gdk::RGBA m_color_bg_even;
 
         // ポップアップウィンドウ用
-        PopupWin* m_popup_win;
+        PopupWin* m_popup_win{};
         std::string m_pre_popup_url;
-        bool m_popup_shown;
+        bool m_popup_shown{};
         
         // 入力コントローラ
         CONTROL::Control m_control;


### PR DESCRIPTION
コンパイラの未定義動作を検出するオプション(`-fsanitize=undefined`)で未初期化変数の使用を見つけたため修正します。

エラーログ
```
../src/dbtree/nodetreebase.cpp:3160:11: runtime error: load of value 93, which is not a valid value for type 'bool'
../src/dbtree/nodetreebase.cpp:3186:37: runtime error: load of value 92, which is not a valid value for type 'bool'
../src/dbtree/nodetreebase.cpp:3187:38: runtime error: load of value 92, which is not a valid value for type 'bool'
../src/dbtree/nodetreebase.cpp:3189:38: runtime error: load of value 85, which is not a valid value for type 'bool'
../src/dbtree/nodetreebase.cpp:3190:39: runtime error: load of value 85, which is not a valid value for type 'bool'
../src/dbtree/nodetreebase.cpp:3287:10: runtime error: load of value 109, which is not a valid value for type 'bool'
../src/skeleton/dragtreeview.cpp:331:13: runtime error: load of value 235, which is not a valid value for type 'bool'
```