### PR TITLE
board: Fix cache filename checking

### DIFF
--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -18,8 +18,10 @@
 #include "httpcode.h"
 #include "global.h"
 
-#include <sstream>
+#include <algorithm>
 #include <cstring>
+#include <iterator>
+#include <sstream>
 
 using namespace DBTREE;
 
@@ -75,15 +77,12 @@ Board2chCompati::~Board2chCompati()
 //
 bool Board2chCompati::is_valid( const std::string& filename )
 {
-    if( filename.find( get_ext() ) == std::string::npos ) return false;
-    if( filename.length() - filename.rfind( get_ext() ) != get_ext().length() ) return false;
+    const std::string& ext = get_ext();
+    if( filename.size() <= ext.size() ) return false;
+    if( filename.compare( filename.size() - ext.size(), ext.size(), ext ) != 0 ) return false;
 
-    size_t dig, n;
-    MISC::str_to_uint( filename.c_str(), dig, n );
-    if( dig != n ) return false;
-    if( dig == 0 ) return false;
-        
-    return true;
+    return std::all_of( filename.cbegin(), std::prev( filename.cend(), ext.size() ),
+                        []( char c ) { return '0' <= c && c <= '9'; } );
 }
 
 

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -18,8 +18,9 @@
 #include "global.h"
 #include "httpcode.h"
 
-#include <sstream>
+#include <algorithm>
 #include <cstring>
+#include <sstream>
 
 using namespace DBTREE;
 
@@ -58,12 +59,8 @@ bool BoardJBBS::is_valid( const std::string& filename )
 {
     if( filename.length() != 10 ) return false;
 
-    size_t dig, n;
-    MISC::str_to_uint( filename.c_str(), dig, n );
-    if( dig != n ) return false;
-    if( dig != 10 ) return false;
-        
-    return true;
+    return std::all_of( filename.cbegin(), filename.cend(),
+                        []( char c ) { return '0' <= c && c <= '9'; } );
 }
 
 

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -16,8 +16,9 @@
 
 #include "global.h"
 
-#include <sstream>
+#include <algorithm>
 #include <cstring>
+#include <sstream>
 
 using namespace DBTREE;
 
@@ -61,12 +62,8 @@ bool BoardMachi::is_valid( const std::string& filename )
 {
     if( filename.length() != 10 ) return false;
 
-    size_t dig, n;
-    MISC::str_to_uint( filename.c_str(), dig, n );
-    if( dig != n ) return false;
-    if( dig != 10 ) return false;
-        
-    return true;
+    return std::all_of( filename.cbegin(), filename.cend(),
+                        []( char c ) { return '0' <= c && c <= '9'; } );
 }
 
 


### PR DESCRIPTION
- したらばとまちBBSのキャッシュのファイル名チェックを修正してシンプルにします。
- 2ch互換板のキャッシュのファイル名チェックを修正してシンプルにします。
  コンパイラの未定義動作を検出するオプション(`-fsanitize=undefined`)で符号付き整数のオーバーフローを見つけたため修正します。
  
  エラーログ
  ```
  ../src/jdlib/miscutil.cpp:551:22: runtime error: signed integer overflow: 924222222 * 10 cannot be represented in type 'int'
  ```

