### PR TITLE
Bump version to 0.5.0-beta

### DIFF
--- a/docs/manual/2020.md
+++ b/docs/manual/2020.md
@@ -10,6 +10,68 @@ layout: default
 
 <a name="0.5.0-unreleased"></a>
 ### [0.5.0-unreleased](https://github.com/JDimproved/JDim/compare/1fee8b4327...master) (unreleased)
+- Bump version to 0.5.0-beta
+  ([#540](https://github.com/JDimproved/JDim/pull/540))
+- Modify dialog message for multiple start
+  ([#539](https://github.com/JDimproved/JDim/pull/539))
+- board: Fix cache filename checking
+  ([#538](https://github.com/JDimproved/JDim/pull/538))
+- `NodeTreeBase`, `DragTreeView`: Fix member initialization
+  ([#537](https://github.com/JDimproved/JDim/pull/537))
+- `NodeTreeBase`: Fix out of bounds error
+  ([#536](https://github.com/JDimproved/JDim/pull/536))
+- Revert "Use `Gtk::ColorChooserDialog` instead of `Gtk::ColorSelectionDialog`"
+  ([#535](https://github.com/JDimproved/JDim/pull/535))
+- Update compiler requirement to clang-5.0 since version 0.5.0
+  ([#533](https://github.com/JDimproved/JDim/pull/533))
+- Implement replacing string feature for thread
+  ([#532](https://github.com/JDimproved/JDim/pull/532))
+- meson: Update support to provisional
+  ([#531](https://github.com/JDimproved/JDim/pull/531))
+- `NodeTreeBase`: Update DAT parsing to try the old format if failure
+  ([#530](https://github.com/JDimproved/JDim/pull/530))
+- Improve regex class
+  ([#529](https://github.com/JDimproved/JDim/pull/529))
+- Deprecate posix regex option
+  ([#528](https://github.com/JDimproved/JDim/pull/528))
+- Implement loading local rule and settings for JBBS
+  ([#526](https://github.com/JDimproved/JDim/pull/526))
+- `BBSListViewBase`: Get URL from `TreeView` instead of `DBTREE` interfaces
+  ([#525](https://github.com/JDimproved/JDim/pull/525))
+- Use boardbase URL instead of subject.txt URL for identifier
+  ([#524](https://github.com/JDimproved/JDim/pull/524))
+- meson: Fall back requirement to version 0.49.0
+  ([#523](https://github.com/JDimproved/JDim/pull/523))
+- `TabLabel`: Fix null pointer check for debug print
+  ([#522](https://github.com/JDimproved/JDim/pull/522))
+- meson: Add summary for build configuration
+  ([#520](https://github.com/JDimproved/JDim/pull/520))
+- meson: Add `build_tests` option
+  ([#519](https://github.com/JDimproved/JDim/pull/519))
+- `Loader`: Fix typo for error message
+  ([#518](https://github.com/JDimproved/JDim/pull/518))
+- setupwizard: Use `Gtk::Grid` instead of `Gtk::VBox` for `PageEnd`
+  ([#517](https://github.com/JDimproved/JDim/pull/517))
+- setupwizard: Use `Gtk::Grid` instead of `Gtk::VBox` for `PagePane`
+  ([#516](https://github.com/JDimproved/JDim/pull/516))
+- setupwizard: Fix setting mnemonic widget for `PageFont`
+  ([#515](https://github.com/JDimproved/JDim/pull/515))
+- setupwizard: Use `Gtk::Grid` instead of `Gtk::VBox` for `PageFont`
+  ([#514](https://github.com/JDimproved/JDim/pull/514))
+- setupwizard: Set parent window to pref dialogs for `PageNet`
+  ([#513](https://github.com/JDimproved/JDim/pull/513))
+- setupwizard: Use `Gtk::Grid` instead of `Gtk::VBox` for `PageNet`
+  ([#512](https://github.com/JDimproved/JDim/pull/512))
+- setupwizard: Use `Gtk::Grid` instead of `Gtk::VBox` for `PageStart`
+  ([#511](https://github.com/JDimproved/JDim/pull/511))
+- Remove unused `ImgButton` class
+  ([#510](https://github.com/JDimproved/JDim/pull/510))
+- Remove unused `ImgToggleButton` class
+  ([#509](https://github.com/JDimproved/JDim/pull/509))
+- Remove unused `MsgDiag::add_default_button(const Gtk::StockID&, const int)`
+  ([#508](https://github.com/JDimproved/JDim/pull/508))
+- manual: Update histories
+  ([#507](https://github.com/JDimproved/JDim/pull/507))
 - `Root`: Fix null pointer redundant check
   ([#505](https://github.com/JDimproved/JDim/pull/505))
 - miscutil: Fix known condition true/false

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -15,10 +15,10 @@
 // SEE ALSO: ENVIRONMENT::get_jdversion()
 
 #define MAJORVERSION 0
-#define MINORVERSION 4
+#define MINORVERSION 5
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20201003"
-#define JDTAG     ""
+#define JDDATE_FALLBACK    "20201212"
+#define JDTAG     "beta"
 
 //---------------------------------
 


### PR DESCRIPTION
機能フリーズ期間に入るためバージョン番号をベータ版に更新します。

関連のissue: #474 
