### PR TITLE
Fix button label text without language pack

### DIFF
--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -271,8 +271,8 @@ MouseKeyDiag::MouseKeyDiag( Gtk::Window* parent, const std::string& url,
       m_controlmode( CONTROL::get_mode( m_id ) ),
       m_single( false ),
       m_label( "編集したい" + target + "設定をダブルクリックして下さい。" ),
-      m_button_delete( g_dgettext( GTK_DOMAIN, "Stock label\x04_Delete" ), true ),
-      m_button_add( g_dgettext( GTK_DOMAIN, "Stock label\x04_Add" ), true ),
+      m_button_delete( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Delete", 12 ), true ),
+      m_button_add( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Add", 12 ), true ),
       m_button_reset( "デフォルト" )
 {
     m_liststore = Gtk::ListStore::create( m_columns );

--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -66,12 +66,12 @@ void LinkFilterDiag::slot_show_manual()
 LinkFilterPref::LinkFilterPref( Gtk::Window* parent, const std::string& url )
     : SKELETON::PrefDiag( parent, url )
     , m_label( "追加ボタンを押すとフィルタ設定を追加出来ます。編集するにはダブルクリックします。" )
-    , m_button_top( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Top" ), true )
-    , m_button_up( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Up" ), true )
-    , m_button_down( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Down" ), true )
-    , m_button_bottom( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Bottom" ), true )
-    , m_button_delete( g_dgettext( GTK_DOMAIN, "Stock label\x04_Delete" ), true )
-    , m_button_add( g_dgettext( GTK_DOMAIN, "Stock label\x04_Add" ), true )
+    , m_button_top( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Top", 24 ), true )
+    , m_button_up( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Up", 24 ), true )
+    , m_button_down( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Down", 24 ), true )
+    , m_button_bottom( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Bottom", 24 ), true )
+    , m_button_delete( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Delete", 12 ), true )
+    , m_button_add( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Add", 12 ), true )
 {
     m_button_top.set_image_from_icon_name( "go-top" );
     m_button_up.set_image_from_icon_name( "go-up" );

--- a/src/message/messageadmin.cpp
+++ b/src/message/messageadmin.cpp
@@ -381,7 +381,7 @@ bool MessageAdmin::delete_message( SKELETON::View * view )
 
     mdiag.add_button( "保存せずに閉じる(_Q)", Gtk::RESPONSE_NO );
     mdiag.add_button( g_dgettext( GTK_DOMAIN, "_Cancel" ), Gtk::RESPONSE_CANCEL );
-    mdiag.add_default_button( g_dgettext( GTK_DOMAIN, "Stock label\x04_Save" ), Gtk::RESPONSE_YES );
+    mdiag.add_default_button( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Save", 12 ), Gtk::RESPONSE_YES );
 
     int ret = mdiag.run();
     mdiag.hide();

--- a/src/replacestrpref.cpp
+++ b/src/replacestrpref.cpp
@@ -122,12 +122,12 @@ ReplaceStrPref::ReplaceStrPref( Gtk::Window* parent, const std::string& url )
     , m_check_chref( "対象の置換前に文字参照をデコード(_E)", true )
     , m_chref( REPLACETARGET_MAX )
     , m_store( REPLACETARGET_MAX )
-    , m_button_top( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Top" ), true )
-    , m_button_up( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Up" ), true )
-    , m_button_down( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Down" ), true )
-    , m_button_bottom( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Bottom" ), true )
-    , m_button_delete( g_dgettext( GTK_DOMAIN, "Stock label\x04_Delete" ), true )
-    , m_button_add( g_dgettext( GTK_DOMAIN, "Stock label\x04_Add" ), true )
+    , m_button_top( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Top", 24 ), true )
+    , m_button_up( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Up", 24 ), true )
+    , m_button_down( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Down", 24 ), true )
+    , m_button_bottom( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Bottom", 24 ), true )
+    , m_button_delete( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Delete", 12 ), true )
+    , m_button_add( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Add", 12 ), true )
     , m_vbuttonbox{ Gtk::ORIENTATION_VERTICAL }
 {
     m_button_top.set_image_from_icon_name( "go-top" );

--- a/src/skeleton/filediag.h
+++ b/src/skeleton/filediag.h
@@ -25,9 +25,9 @@ namespace SKELETON
             add_button( g_dgettext( GTK_DOMAIN, "_Cancel" ), Gtk::RESPONSE_CANCEL );
 
             if( m_action == Gtk::FILE_CHOOSER_ACTION_OPEN ) {
-                add_button( g_dgettext( GTK_DOMAIN, "Stock label\x04_Open" ), Gtk::RESPONSE_ACCEPT );
+                add_button( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Open", 12 ), Gtk::RESPONSE_ACCEPT );
             }
-            else add_button( g_dgettext( GTK_DOMAIN, "Stock label\x04_Save" ), Gtk::RESPONSE_ACCEPT );
+            else add_button( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Save", 12 ), Gtk::RESPONSE_ACCEPT );
 
             set_default_response( Gtk::RESPONSE_ACCEPT );
         }

--- a/src/skeleton/prefdiag.cpp
+++ b/src/skeleton/prefdiag.cpp
@@ -32,7 +32,7 @@ PrefDiag::PrefDiag( Gtk::Window* parent, const std::string& url, const bool add_
         ->signal_clicked().connect( sigc::mem_fun(*this, &PrefDiag::slot_cancel_clicked ) );
     }
 
-    if( add_open ) m_bt_ok = add_button( g_dgettext( GTK_DOMAIN, "Stock label\x04_Open" ), Gtk::RESPONSE_OK );
+    if( add_open ) m_bt_ok = add_button( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Open", 12 ), Gtk::RESPONSE_OK );
     else m_bt_ok = add_button( g_dgettext( GTK_DOMAIN, "_OK" ), Gtk::RESPONSE_OK );
 
     m_bt_ok->signal_clicked().connect( sigc::mem_fun(*this, &PrefDiag::slot_ok_clicked ) );

--- a/src/skeleton/selectitempref.cpp
+++ b/src/skeleton/selectitempref.cpp
@@ -20,11 +20,11 @@ using namespace SKELETON;
 
 SelectItemPref::SelectItemPref( Gtk::Window* parent, const std::string& url )
     : SKELETON::PrefDiag( parent, url, true, true )
-    , m_button_top( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Top" ), true )
-    , m_button_up( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Up" ), true )
-    , m_button_down( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Down" ), true )
-    , m_button_bottom( g_dgettext( GTK_DOMAIN, "Stock label, navigation\x04_Bottom" ), true )
-    , m_button_default( g_dgettext( GTK_DOMAIN, "Stock label\x04_Revert" ), true )
+    , m_button_top( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Top", 24 ), true )
+    , m_button_up( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Up", 24 ), true )
+    , m_button_down( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Down", 24 ), true )
+    , m_button_bottom( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Bottom", 24 ), true )
+    , m_button_default( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Revert", 12 ), true )
 {
     m_list_default_data.clear();
 


### PR DESCRIPTION
以前の修正で廃止予定の`GtkStock`をi18n対応テキストに置き換えましたが言語パックがインストールされていない環境では正常に表示されない状態でした。
そのため利用するgettext APIを変更して修正します。

#### スクリーンショット(バグの一部)
![20201218-jdim-stocklabel-bug](https://user-images.githubusercontent.com/15698961/102684136-5e619080-4219-11eb-9432-2b036dd76d03.png)
