### PR TITLE
Fix compiler warning for null possibility

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -5398,7 +5398,10 @@ void DrawAreaBase::slot_swipe( double velocity_x, double velocity_y )
 gboolean DrawAreaBase::deceleration_tick_cb( GtkWidget* cwidget, GdkFrameClock* clock, gpointer )
 {
     Gtk::Widget* const widget = Glib::wrap( cwidget );
-    return dynamic_cast< DrawAreaBase* >( widget )->deceleration_tick_impl( clock );
+    if( auto area = dynamic_cast<DrawAreaBase*>( widget ) ) {
+        return area->deceleration_tick_impl( clock );
+    }
+    return G_SOURCE_REMOVE;
 }
 
 gboolean DrawAreaBase::deceleration_tick_impl( GdkFrameClock* clock )

--- a/src/skeleton/menubutton.cpp
+++ b/src/skeleton/menubutton.cpp
@@ -123,7 +123,9 @@ void MenuButton::append_menu( std::vector< std::string >& items )
         }
         else{
             item = m_menuitems[ i ];
-            dynamic_cast< Gtk::Label* >( item->get_child() )->set_text( MISC::cut_str( items[ i ], MENU_MAX_LNG ) );
+            if( auto label = dynamic_cast<Gtk::Label*>( item->get_child() ) ) {
+                label->set_text( MISC::cut_str( items[i], MENU_MAX_LNG ) );
+            }
         }
 
         if( item ) m_popupmenu->append( *item );


### PR DESCRIPTION
Fixes #506

コンパイラ(gcc11)が警告したnullの可能性がある箇所を修正します。

gcc11のログ
```
menubutton.cpp:126:115: warning: 'this' pointer null [-Wnonnull]
  126 |             dynamic_cast< Gtk::Label* >( item->get_child() )->set_text( MISC::cut_str( items[ i ], MENU_MAX_LNG ) );
      |                                                                                                                   ^
drawareabase.cpp:5405:83: warning: 'this' pointer null [-Wnonnull]
 5405 |     return dynamic_cast< DrawAreaBase* >( widget )->deceleration_tick_impl( clock );
      |                                                                                   ^
```