### PR TITLE
Fix compiler warning for unused const variable

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -44,7 +44,6 @@
 
 
 constexpr size_t SECTION_NUM = 5;
-constexpr size_t LNG_RES = 16;
 constexpr int LNG_ID = 256;
 constexpr size_t LNG_LINK = 256;
 constexpr size_t MAX_ANCINFO = 64;


### PR DESCRIPTION
コンパイラ(clang11)が警告した未使用の定数を削除します。

clang11のレポート
```
../src/dbtree/nodetreebase.cpp:47:18: warning: unused variable 'LNG_RES' [-Wunused-const-variable]
constexpr size_t LNG_RES = 16;
                 ^
```