### PR TITLE
Root: Use std::find_if() instead of range based for statement

### DIFF
--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -184,18 +184,17 @@ BoardBase* Root::get_board( const std::string& url, const int count )
     }
 
     // サーチ
-    for( BoardBase* board : m_list_board ) {
+    auto it_board = std::find_if( m_list_board.begin(), m_list_board.end(),
+                                  [&url]( const BoardBase* b ) { return b->equal( url ); } );
+    if( it_board != m_list_board.end() ) {
 
-        if( board->equal( url ) ){
-
-            board->read_info(); // 板情報の取得( 詳しくはBoardBase::read_info()をみること )
-            m_get_board = board;
+        m_get_board = *it_board;
+        m_get_board->read_info(); // 板情報の取得( 詳しくはBoardBase::read_info()をみること )
 
 #ifdef _SHOW_GETBOARD
             std::cout << "found\n";
 #endif
-            return board;
-        }
+        return m_get_board;;
     }
 
     // 見つからなかった


### PR DESCRIPTION
`std::find_if()`が使えるとcppcheckに指摘されたためループ文を修正します。

cppcheckのレポート
```
src/dbtree/root.cpp:189:34: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
        if( board->equal( url ) ){
                                 ^
```