### PR TITLE
DrawAreaBase: Fix warning while closing thread view

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -5433,7 +5433,7 @@ gboolean DrawAreaBase::deceleration_tick_impl( GdkFrameClock* clock )
 
 void DrawAreaBase::cancel_deceleration()
 {
-    if( m_deceleration.id ) {
+    if( m_deceleration.id && GTK_IS_WIDGET( this->gobj() ) ) {
         gtk_widget_remove_tick_callback( GTK_WIDGET( this->gobj() ), m_deceleration.id );
         m_deceleration.id = 0;
     }


### PR DESCRIPTION
スレビューをタッチスクリーン操作のスワイプで慣性スクロールしているときにタブを閉じるとコンソールにエラーメッセージが表示されるため修正します。

実行時のレポート (環境変数`GTK_TEST_TOUCHSCREEN=1`で確認)
```
(jdim:1024608): Gtk-CRITICAL **: 21:54:08.801: gtk_widget_remove_tick_callback: assertion 'GTK_IS_WIDGET (widget)' failed
```