### PR TITLE
Remove travis-ci badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # JDim - 2ch browser for linux
 
-[![Build Status](https://travis-ci.com/JDimproved/JDim.svg?branch=master)](https://travis-ci.com/JDimproved/JDim)
 ![GitHub Actions CI](https://github.com/JDimproved/JDim/workflows/CI/badge.svg)
 [![Snap Store](https://snapcraft.io/jdim/badge.svg)](https://snapcraft.io/jdim)
 


### PR DESCRIPTION
利用を休止したためtravis-ciのビルド結果を表示するバッジをREADME.mdから外します。