### PR TITLE
Fix updating thread title for replacing favorite

### DIFF
--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -2631,7 +2631,7 @@ void BBSListViewBase::replace_thread( const std::string& url, const std::string&
 #ifdef _DEBUG
                         std::cout << "name_row = " << ustr_name << std::endl;
 #endif
-                        if( ustr_name.raw() == name_old ){
+                        if( MISC::remove_space( ustr_name ) == name_old ){
 #ifdef _DEBUG
                             std::cout << "replace name\n";
 #endif


### PR DESCRIPTION
お気に入りにPartスレッドを登録しているときスレビュー内のURLから次スレ(次のPart)を開く、または前スレからスレ情報を引き継ぐとお気に入りに登録されたスレッドの更新が可能です。
しかし、更新を行ってもスレタイだけ前スレのまま変わらないことがありましたので処理を修正します。

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1609398982/200

#### バグの再現
スレタイの末尾に空白が含まれているとスレタイが更新されませんでした。
状況の再現が難しいためissueは省略します。
