### PR TITLE
metadata: Fix AppStream component-ID to lowercase

### DIFF
--- a/jdim.metainfo.xml
+++ b/jdim.metainfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2019 JDimproved project -->
 <component type="desktop-application">
-  <id>com.github.jdimproved.JDim</id>
+  <id>com.github.jdimproved.jdim</id>
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-2.0</project_license>
   <name>JDim</name>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,7 +59,7 @@ parts:
 apps:
   jdim:
     command: bin/jdim
-    common-id: com.github.jdimproved.JDim
+    common-id: com.github.jdimproved.jdim
     desktop: share/applications/jdim.desktop
     extensions: [gnome-3-34]
     plugs:


### PR DESCRIPTION
ディストリビューション共通のメタデータとして設定したAppStreamコンポーネントIDを[freedesktop.orgが推奨する形式][*]（大文字を使わない）に修正します。

[*]: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-id-generic

> Additionally, even though uppercase letters are permitted in a component-ID, it is strongly encouraged to only use lowercase letters for the ID.

修正前のファイルをappstreamcliで検証した結果
```
I: com.github.jdimproved.JDim:4: cid-contains-uppercase-letter com.github.jdimproved.JDim

Validation was successful: infos: 1
```