### PR TITLE
Remove obsolete configure options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -145,21 +145,6 @@ AS_IF(
 
 
 dnl
-dnl checking oniguruma (removed)
-dnl
-AC_ARG_WITH(oniguruma,
-AS_HELP_STRING([--with-oniguruma], [NO LONGER AVAILABLE. use --with-regex=oniguruma]),
-[AC_MSG_ERROR([--with-oniguruma has been removed. Use --with-regex=oniguruma instead.])])
-
-dnl
-dnl checking PCRE (removed)
-dnl
-AC_ARG_WITH(pcre,
-AS_HELP_STRING([--with-pcre], [NO LONGER AVAILABLE. use --with-regex=glib]),
-[AC_MSG_ERROR([--with-pcre has been removed. Use --with-regex=glib instead.])])
-
-
-dnl
 dnl 正規表現ライブラリ
 dnl
 AC_MSG_CHECKING(for --with-regex)
@@ -174,9 +159,6 @@ AS_IF(
   [AC_CHECK_HEADERS([regex.h], , [AC_MSG_ERROR([regex.h not found])])
    AC_CHECK_LIB([regex], [regexec])
    AC_MSG_WARN([--with-regex=posix is deprecated. Use --with-regex=glib instead.])],
-
-  [test "x$with_regex" = xpcre],
-  [AC_MSG_ERROR([--with-regex=pcre has been removed. Use --with-regex=glib instead.])],
 
   [test "x$with_regex" = xoniguruma],
   [PKG_CHECK_MODULES(ONIG, [oniguruma])

--- a/configure.ac
+++ b/configure.ac
@@ -175,13 +175,6 @@ AS_IF(
 
 
 dnl
-dnl checking OpenSSL (removed)
-dnl
-AC_ARG_WITH(openssl,
-AS_HELP_STRING([--with-openssl], [NO LONGER AVAILABLE. use --with-tls=openssl]),
-[AC_MSG_ERROR([--with-openssl has been removed. Use --with-tls=openssl instead.])])
-
-dnl
 dnl TLS
 dnl
 AC_MSG_CHECKING(for --with-tls)

--- a/configure.ac
+++ b/configure.ac
@@ -297,22 +297,6 @@ esac
 
 
 dnl
-dnl thread (removed)
-dnl
-AC_ARG_WITH(gthread,
-AS_HELP_STRING([--with-gthread], [NO LONGER AVAILABLE]),
-[AC_MSG_ERROR([thread library options have been removed. see https://github.com/JDimproved/JDim/issues/228])])
-
-AC_ARG_WITH(stdthread,
-AS_HELP_STRING([--with-stdthread], [NO LONGER AVAILABLE]),
-[AC_MSG_ERROR([thread library options have been removed. see https://github.com/JDimproved/JDim/issues/228])])
-
-AC_ARG_WITH(thread,
-AC_HELP_STRING([--with-thread=@<:@posix|glib|std@:>@], [NO LONGER AVAILABLE]),
-[AC_MSG_ERROR([thread library options have been removed. see https://github.com/JDimproved/JDim/issues/228])])
-
-
-dnl
 dnl checking pangolayout
 dnl
 AC_MSG_CHECKING(for --with-pangolayout)

--- a/configure.ac
+++ b/configure.ac
@@ -70,10 +70,6 @@ dnl
 dnl
 dnl gtkmm
 dnl
-AC_ARG_WITH(gtkmm3,
-[AS_HELP_STRING([--with-gtkmm3], [NO LONGER AVAILABLE. gtkmm3 is now default.])],
-[AC_MSG_ERROR([gtkmm3 is now default. see https://github.com/JDimproved/JDim/issues/229])])
-
 PKG_CHECK_MODULES(GTKMM, [gtkmm-3.0 >= 3.22.0])
 AC_SUBST(GTKMM_CFLAGS)
 AC_SUBST(GTKMM_LIBS)


### PR DESCRIPTION
廃止されたスレッドライブラリを選択するconfigureオプションを削除します。
削除されたオプションは指定しても無視されてエラーは出なくなります。

- `--with-gthread`
- `--with-stdthred`
- `--with-thread=posix|glib|std`
- `--with-gtkmm3`
- `--with-oniguruma`
- `--with-pcre`
- `--with-regex=pcre`
- `--with-openssl`

関連のissue: #228, #229, #361