### PR TITLE
Remove deprecated build option --with-regex=posix

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -106,23 +106,18 @@
        gprofによるプロファイリングを行う。コンパイルオプションに -pg が付き、JDimを実行すると
        gmon.out が出来るのでgprof./jdgmon.out で解析できる。CPUの最適化は効かなくなるので注意する。
 
-    --with-regex=[posix|oniguruma|glib]
+    --with-regex=oniguruma|glib
 
        使用する正規表現ライブラリを設定する。
        デフォルトでは Glib Regex(GRegex) を使用する。(v0.4.0+から変更)
 
-    --with-regex=posix
-
-       非推奨: かわりに --with-regex=glib を使用してください。
-
     --with-regex=oniguruma
 
-       POSIX regex のかわりに鬼車を使用する。
+       GRegex のかわりに鬼車を使用する。
        鬼車はBSDライセンスなのでJDimをバイナリ配布する場合には注意すること(ライセンスはGPLになる)。
 
     --with-regex=glib
 
-       POSIX regex のかわりに GRegex を使用する。
        Perl互換の正規表現なので、従来の POSIX 拡張の正規表現から設定変更が必要になる場合がある。
        (v0.3.0+から追加)
 

--- a/configure.ac
+++ b/configure.ac
@@ -149,16 +149,14 @@ dnl 正規表現ライブラリ
 dnl
 AC_MSG_CHECKING(for --with-regex)
 AC_ARG_WITH(regex,
-AC_HELP_STRING([--with-regex=@<:@posix|oniguruma|glib@:>@],
+AC_HELP_STRING([--with-regex=oniguruma|glib],
                [use regular expression library @<:@default=glib@:>@]),
 [], [with_regex=glib])
 AC_MSG_RESULT($with_regex)
 
 AS_IF(
   [test "x$with_regex" = xposix],
-  [AC_CHECK_HEADERS([regex.h], , [AC_MSG_ERROR([regex.h not found])])
-   AC_CHECK_LIB([regex], [regexec])
-   AC_MSG_WARN([--with-regex=posix is deprecated. Use --with-regex=glib instead.])],
+  [AC_MSG_ERROR([--with-regex=posix has been removed. Use --with-regex=glib instead.])],
 
   [test "x$with_regex" = xoniguruma],
   [PKG_CHECK_MODULES(ONIG, [oniguruma])

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -120,21 +120,18 @@ configure のかわりに [meson] を使ってビルドする方法は [GitHub][
     <code>gprof  ./jdim  gmon.out</code> で解析できる。CPUの最適化は効かなくなるので注意する。
   </dd>
 
-  <dt>--with-regex=[posix|oniguruma|glib]</dt>
+  <dt>--with-regex=oniguruma|glib</dt>
   <dd>
     使用する正規表現ライブラリを設定する。
     デフォルトでは Glib Regex(GRegex) を使用する。<small>(v0.4.0+から変更)</small>
   </dd>
-  <dt>--with-regex=posix</dt>
-  <dd><strong>非推奨</strong>: かわりに <code>--with-regex=glib</code> を使用してください。</dd>
   <dt>--with-regex=oniguruma</dt>
   <dd>
-    POSIX regex のかわりに鬼車を使用する。
+    GRegex のかわりに鬼車を使用する。
     鬼車はBSDライセンスなのでJDimをバイナリ配布する場合には注意すること(ライセンスはGPLになる)。
   </dd>
   <dt>--with-regex=glib</dt>
   <dd>
-    POSIX regex のかわりに GRegex を使用する。
     Perl互換の正規表現なので、従来の POSIX 拡張の正規表現から設定変更が必要になる場合がある。
     <small>(v0.3.0+から追加)</small>
   </dd>

--- a/meson.build
+++ b/meson.build
@@ -127,12 +127,7 @@ endif
 
 # 正規表現ライブラリ
 regex_opt = get_option('regex')
-if regex_opt == 'posix'
-  configure_args += '\'--with-regex=posix\''
-  regex_dep = dependency('', required : false)
-  conf.set('HAVE_REGEX_H', 1)
-  warning('--with-regex=posix is deprecated. Use --with-regex=glib instead.')
-elif regex_opt == 'oniguruma'
+if regex_opt == 'oniguruma'
   regex_dep = dependency('oniguruma')
   if not cpp_compiler.has_header('onigposix.h')
     error('onigposix.h not found')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,6 @@ option('migemo', type : 'feature', value : 'disabled', description : 'Use text s
 option('migemodict', type : 'string', value : '', description : 'Default path for migemo dictionary file')
 option('native', type : 'feature', value : 'disabled', description : 'Optimize to your machine')
 option('pangolayout', type : 'feature', value : 'disabled', description : 'Render text by PangoLayout')
-option('regex', type : 'combo', choices : ['posix', 'oniguruma', 'glib'], value : 'glib', description : 'Regex library to use')
+option('regex', type : 'combo', choices : ['oniguruma', 'glib'], value : 'glib', description : 'Regex library to use')
 option('sessionlib', type : 'combo', choices : ['xsmp', 'no'], value : 'xsmp', description : 'Use Session Management Protocol')
 option('tls', type : 'combo', choices : ['gnutls', 'openssl'], value : 'gnutls', description : 'SSL/TLS library to use')

--- a/src/jdlib/jdregex.cpp
+++ b/src/jdlib/jdregex.cpp
@@ -172,9 +172,6 @@ std::string RegexPattern::errstr() const
         case REG_EBRACK: errmsg = "リストオペレータ [] が閉じていません。"; break;
         case REG_ECOLLATE: errmsg = "照合順序の要素として有効ではありません。"; break;
         case REG_ECTYPE: errmsg = "未知のキャラクタークラス名です。"; break;
-#ifdef HAVE_REGEX_H
-        case REG_EEND: errmsg = "未定義エラー。POSIX.2 には定義されていません。"; break;
-#endif
         case REG_EESCAPE: errmsg = "正規表現がバックスラッシュで終っています。"; break;
         case REG_EPAREN: errmsg = "グループオペレータ () が閉じていません。"; break;
         case REG_ERANGE: errmsg = "無効な範囲オペレータを使用しています。"; break;

--- a/src/jdlib/jdregex.h
+++ b/src/jdlib/jdregex.h
@@ -12,13 +12,11 @@
 
 #if defined(HAVE_ONIGPOSIX_H)
 #include <onigposix.h>
-#elif defined(HAVE_REGEX_H)
-#include <regex.h>
 #else
 #include <glib.h>
 #endif
 
-#if defined(HAVE_ONIGPOSIX_H) || defined(HAVE_REGEX_H)
+#if defined(HAVE_ONIGPOSIX_H)
 #define POSIX_STYLE_REGEX_API 1
 #endif
 

--- a/src/replacestrmanager.cpp
+++ b/src/replacestrmanager.cpp
@@ -80,13 +80,11 @@ ReplaceStr_Manager::ReplaceStr_Manager()
         ReplaceStrCondition condition{};
         list_append( REPLACETARGET_MESSAGE, condition, "ダブルクリックすると編集出来ます",
                      "(この項目は削除して構いません)" );
-#ifndef HAVE_REGEX_H
         condition.regex = true;
         list_append( REPLACETARGET_MESSAGE, condition, "(?<!t)ps://([[:alnum:]]+)", "https://\\1" );
         list_append( REPLACETARGET_MESSAGE, condition,
                      "(?<!ps://)i\\.imgur\\.com/([[:alnum:]]{7})\\.(jpe?g|gif|png)",
                      "https://i.imgur.com/\\1.\\2" );
-#endif
     }
 }
 


### PR DESCRIPTION
廃止予定の正規表現ライブラリのビルドオプション`--with-regex=posix`を削除します。
削除されたオプションは指定するとエラーになり./configureが失敗します。

関連のissue: #521