### PR TITLE
Remove obsolete gtk codes for less than version 3.22

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -775,7 +775,6 @@ void DrawAreaBase::redraw_view()
 
     configure_impl();
 
-#if GTKMM_CHECK_VERSION(3,20,0)
     // 実行時の警告を修正する
     // Gtk-WARNING **: HH:MM:SS.sss: Drawing a gadget with negative dimensions. Did you forget to allocate a size?
     // (node tab owner gtkmm__GtkNotebook)
@@ -790,13 +789,8 @@ void DrawAreaBase::redraw_view()
               << std::endl;
 #endif
     if( alloc_view.get_x() < 0 || alloc_view.get_y() < 0 ) return;
-#endif
 
     m_view.queue_draw();
-#if !GTKMM_CHECK_VERSION(3,22,0)
-    // 廃止予定の関数を呼び出すとスクロールバーの挙動がおかしくなるため省略する
-    if( m_window ) m_window->process_updates( false );
-#endif
 }
 
 // 強制再描画
@@ -1743,10 +1737,6 @@ bool DrawAreaBase::draw_screen( const int y, const int height )
     // expose イベント経由で exec_draw_screen() を呼び出す
     // gtk2.18以降は expose イベント内で描画処理しないと正しく描画されない様なので注意
     m_view.queue_draw();
-#if !GTKMM_CHECK_VERSION(3,22,0)
-    m_window->process_updates( false );
-#endif
-
     return true;
 }
 

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -238,19 +238,14 @@ void MessageViewBase::init_color()
             const auto bg = Gdk::RGBA( CONFIG::get_color( COLOR_BACK_MESSAGE ) ).to_string();
             const auto sel_fg = Gdk::RGBA( CONFIG::get_color( COLOR_CHAR_MESSAGE_SELECTION ) ).to_string();
             const auto sel_bg = Gdk::RGBA( CONFIG::get_color( COLOR_BACK_MESSAGE_SELECTION ) ).to_string();
-#if GTKMM_CHECK_VERSION(3,20,0)
-            constexpr const char* const caret_prop = u8"caret-color";
-#else
-            constexpr const char* const caret_prop = u8"-GtkWidget-cursor-color";
-#endif
             m_text_message->update_style( Glib::ustring::compose(
                 u8R"(
-                    .%1, .%1 text { color: %2; background-color: %3; %4: %2; }
+                    .%1, .%1 text { color: %2; background-color: %3; caret-color: %2; }
                     .%1:selected, .%1:selected:focus,
                     .%1 text:selected, .%1 text:selected:focus,
-                    .%1 text selection, .%1 text selection:focus { color: %5; background-color: %6; }
+                    .%1 text selection, .%1 text selection:focus { color: %4; background-color: %5; }
                 )",
-                classname, fg, bg, caret_prop, sel_fg, sel_bg ) );
+                classname, fg, bg, sel_fg, sel_bg ) );
         }
     }
 }


### PR DESCRIPTION
GTKのバージョン要件の変更(3.22以上)により使われなくなったコードを削除します。

関連のissue: #443, #566