### PR TITLE
Migrate cpp_std to c++17

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,8 @@ Pull requestは`master`ブランチに対してお願いいたします。
 
 #### :pencil: C++ソースコードを修正するときの注意
 
-* C++11の機能を使う。迷ったときは[C++ Core Guidelines][isocpp]を参考にする。
+* C++14の機能を使う。迷ったときは[C++ Core Guidelines][isocpp]を参考にする。
+* C++17の機能はgcc-6が[サポート][support] [\[1\]][lang] [\[2\]][lib]していれば使ってもよい。(メンテナーと相談)
 * コーディングスタイルは周囲のコードになるべく合わせる。
 * ソースコードを修正したときはビルド可能なことチェックする。
 * 修正前よりコンパイル時警告を増やさないように気をつける。
@@ -68,3 +69,6 @@ Pull requestは`master`ブランチに対してお願いいたします。
 [docs-readme]: https://github.com/JDimproved/JDim/tree/master/docs/README.md
 [test-readme]: https://github.com/JDimproved/JDim/tree/master/test/README.md
 [isocpp]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines
+[support]: https://en.cppreference.com/w/Template:cpp/compiler_support/17
+[lang]: https://gcc.gnu.org/projects/cxx-status.html#cxx17
+[lib]: https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html#status.iso.2017

--- a/INSTALL
+++ b/INSTALL
@@ -25,7 +25,7 @@
   ・autoconf
   ・autoconf-archive
   ・automake
-  ・g++ 5 以上、または clang++ 3.3 以上 ( 将来のリリースで g++ 6 以上、または clang++ 5.0 以上になる )
+  ・g++ 6 以上、または clang++ 5.0 以上
   ・gnutls
   ・gtkmm
   ・libtool

--- a/README.md
+++ b/README.md
@@ -143,14 +143,15 @@ yay -S jdim-git
   gcc -Q -c -march=native --help=target -o /dev/null | grep "march\|mtune\|mcpu"
   ```
 
-* **configureチェック中に `AX_CXX_COMPILE_STDCXX_11(noext, mandatory)` に関連したエラーがでた場合**
+* **configureチェック中に `AX_CXX_COMPILE_STDCXX(17, noext, mandatory)` に関連したエラーがでた場合**
 
   ubuntuでは `autoconf-archive` をインストールして `autoreconf -i` からやり直してみてください。
   パッケージが見つからないまたはエラーが消えない場合は以下の手順を試してみてください。
+  または`./configure`のかわりにMesonを利用してビルドする方法があります。([GitHub][dis556]を参照)
 
-  1. `configure.ac` の `AX_CXX_COMPILE_STDCXX_11([noext], [mandatory])` の行を削除する。
+  1. `configure.ac` の `AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])` の行を削除する。
   2. `autoreconf -i` で `configure` を作りconfigureチェックをやり直す。
-  3. `make CXXFLAGS+="-std=c++11"` でビルドする。
+  3. `make CXXFLAGS+="-std=c++1z"` でビルドする。
 
   もしこれで駄目な場合はgccのversionが古すぎるので、
   gccのバージョンアップをするか、ディストリをバージョンアップしてください。

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AC_PROG_LIBTOOL
 AC_PROG_MKDIR_P
 AC_LANG_CPLUSPLUS
 
-AX_CXX_COMPILE_STDCXX_11([noext], [mandatory])
+AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
 
 dnl
 dnl buildinfo.h

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -39,7 +39,7 @@ layout: default
 - autoconf
 - autoconf-archive
 - automake
-- g++ 5 以上、または clang++ 3.3 以上 ( 将来のリリースで g++ 6 以上、または clang++ 5.0 以上になる )
+- g++ 6 以上、または clang++ 5.0 以上
 - gnutls
 - gtkmm
 - libtool

--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,7 @@ project('jdim', 'cpp',
         version : '0.5.0',
         license : 'GPL2',
         meson_version : '>= 0.49.0',
-        default_options : ['warning_level=3', 'cpp_std=c++11'])
+        default_options : ['warning_level=3', 'cpp_std=c++1z'])
 
 # 追加コンパイルオプション
 add_project_arguments('-DHAVE_CONFIG_H=1', language : 'cpp')


### PR DESCRIPTION
使用するC++標準規格をC++17に更新します。
合わせてドキュメントのコンパイラ要件やエラー回避のtipsも更新します。

コントリビュートガイドを更新しC++14を利用するように案内します。
さらにC++17の機能についてgcc-6の実装を条件に利用可能とします。

関連のissue: #527