### PR TITLE
Use __has_include() instead of config macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,8 +97,6 @@ dnl
 dnl any other POSIX systems
 dnl
 
-AC_CHECK_HEADERS([sys/utsname.h])
-
 AC_CHECK_HEADERS([socket.h])
 AC_CHECK_LIB(socket,socket)
 

--- a/configure.ac
+++ b/configure.ac
@@ -255,7 +255,6 @@ case "${host_os}" in
     [test "x$with_alsa" = xyes],
     [PKG_CHECK_MODULES(ALSA, [alsa >= 1.0])
      AC_DEFINE(USE_ALSA, , [use alsa])
-     AC_CHECK_HEADERS([alsa/asoundlib.h])
      AC_SUBST(ALSA_CFLAGS)
      AC_SUBST(ALSA_LIBS)]
   )

--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,6 @@ AC_SUBST(GTKMM_LIBS)
 dnl
 dnl crypt
 dnl
-AC_CHECK_HEADERS([crypt.h])
 AC_CHECK_LIB(crypt,crypt)
 
 

--- a/meson.build
+++ b/meson.build
@@ -103,11 +103,6 @@ else
   socket_dep = cpp_compiler.find_library('socket')
 endif
 
-# utsname
-if cpp_compiler.has_header('sys/utsname.h')
-  conf.set('HAVE_SYS_UTSNAME_H', 1)
-endif
-
 
 #
 # オプションのパッケージ

--- a/meson.build
+++ b/meson.build
@@ -92,9 +92,6 @@ endif
 if not crypt_dep.found()
   crypt_dep = dependency('libxcrypt')
 endif
-if cpp_compiler.has_header('crypt.h')
-  conf.set('HAVE_CRYPT_H', 1)
-endif
 
 # socket
 if cpp_compiler.has_header('sys/socket.h')

--- a/meson.build
+++ b/meson.build
@@ -161,9 +161,6 @@ endif
 alsa_dep = dependency('alsa', version : '>= 1.0.0', required : get_option('alsa'))
 if alsa_dep.found()
   conf.set('USE_ALSA', 1)
-  if cpp_compiler.has_header('alsa/asoundlib.h')
-    conf.set('HAVE_ALSA_ASOUNDLIB_H', 1)
-  endif
   configure_args += '\'--with-alsa\''
 endif
 

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -15,7 +15,8 @@
 
 #include "gtkmm.h"
 
-#ifdef HAVE_SYS_UTSNAME_H
+#if __has_include(<sys/utsname.h>)
+#define HAVE_SYS_UTSNAME_H
 #include <sys/utsname.h> // uname()
 #endif
 

--- a/src/jdlib/misctrip.cpp
+++ b/src/jdlib/misctrip.cpp
@@ -26,7 +26,7 @@
 #include <gnutls/crypto.h>
 #endif
 
-#ifdef HAVE_CRYPT_H
+#if __has_include(<crypt.h>)
 #include <crypt.h>
 #endif
 

--- a/src/sound/playsound.cpp
+++ b/src/sound/playsound.cpp
@@ -10,7 +10,7 @@
 #include "jdlib/miscmsg.h"
 
 #include <string>
-#ifdef HAVE_ALSA_ASOUNDLIB_H
+#if __has_include(<alsa/asoundlib.h>)
 #include <alsa/asoundlib.h>
 #else
 #include <asoundlib.h>


### PR DESCRIPTION
ビルド構成時のヘッダーファイル検査を[`__has_include()`][1]で置き換えます。

- `<alsa/asoundlib.h>`
- `<crypt.h>`
- `<sys/utsname.h>`

[1]: https://cpprefjp.github.io/lang/cpp17/has_include.html