### PR TITLE
Get rid of calling deprecated Gtk::TreeView::set_rules_hint()

### DIFF
--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -45,7 +45,6 @@ DragTreeView::DragTreeView( const std::string& url, const std::string& dndtarget
 #endif
 
     set_enable_search( false );
-    set_rules_hint( CONFIG::get_use_tree_gtkrc() );
     add_events( Gdk::LEAVE_NOTIFY_MASK );
 
     auto context = get_style_context();

--- a/src/skeleton/selectitempref.cpp
+++ b/src/skeleton/selectitempref.cpp
@@ -48,7 +48,6 @@ void SelectItemPref::pack_widgets()
     // 同一カラムにアイコンと項目名の両方を表示するので、手動で列を作成する
 
     // 表示項目リスト
-    m_tree_shown.set_rules_hint( CONFIG::get_use_tree_gtkrc() );
     m_tree_shown.get_selection()->set_mode( Gtk::SELECTION_MULTIPLE );
     m_tree_shown.signal_focus_in_event().connect( sigc::mem_fun( *this, &SelectItemPref::slot_focus_in_shown ) );
     m_store_shown = Gtk::ListStore::create( m_columns_shown );
@@ -88,7 +87,6 @@ void SelectItemPref::pack_widgets()
 
 
     // 非表示項目リスト
-    m_tree_hidden.set_rules_hint( CONFIG::get_use_tree_gtkrc() );
     m_tree_hidden.get_selection()->set_mode( Gtk::SELECTION_MULTIPLE );
     m_tree_hidden.signal_focus_in_event().connect( sigc::mem_fun( *this, &SelectItemPref::slot_focus_in_hidden ) );
     m_store_hidden = Gtk::ListStore::create( m_columns_hidden );


### PR DESCRIPTION
GTK4で廃止される[`Gtk::TreeView::set_rules_hint()`][1]の呼び出しを取り除きます。
`Gtk::TreeView`の背景縞模様はGTKテーマが制御する問題となったためアプリケーション側の設定は非推奨になりました。

[1]: https://developer.gnome.org/gtk3/stable/GtkTreeView.html#gtk-tree-view-set-rules-hint

関連のissue: #443
