### PR TITLE
PopupWin: Use Gdk::Seat instead of Gdk::DeviceManager

### DIFF
--- a/src/skeleton/popupwin.cpp
+++ b/src/skeleton/popupwin.cpp
@@ -44,11 +44,10 @@ PopupWin::~PopupWin()
 void PopupWin::slot_resize_popup()
 {
     if( ! m_view ) return;
-    
+
     // マウス座標
     int x_mouse, y_mouse;
-    // TODO: Use Gdk::Display::get_default_seat() instead of get_device_manager() (since 3.20)
-    Gdk::Display::get_default()->get_device_manager()->get_client_pointer()->get_position( x_mouse, y_mouse );
+    Gdk::Display::get_default()->get_default_seat()->get_pointer()->get_position( x_mouse, y_mouse );
 
     // クライアントのサイズを取得
     const int width_client = m_view->width_client();


### PR DESCRIPTION
GTK4で廃止される[`Gdk::DeviceManager`][1]のかわりに`Gdk::Seat`を使います。

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/skeleton/popupwin.cpp:51:34: error: 'class Gdk::Display' has no member named 'get_device_manager'
51 |     Gdk::Display::get_default()->get_device_manager()->get_client_pointer()->get_position( x_mouse, y_mouse );
  |                                  ^~~~~~~~~~~~~~~~~~
```

[1]: https://developer.gnome.org/gdk3/stable/GdkDisplay.html#gdk-display-get-device-manager

関連のissue: #443
