### PR TITLE
Use Gdk::Window::get_device_position() instead of Gtk::Widget::get_pointer()

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -1011,9 +1011,7 @@ void ArticleViewBase::warp_pointer_to_popup()
         const int mrg = 32;
 
         int x, y;
-        get_pointer( x, y );
-
-        m_popup_win->get_pointer( x, y );
+        MISC::get_pointer_at_window( m_popup_win->get_window(), x, y );
 
         if( x < mrg ) x = mrg;
         else if( x > m_popup_win->get_width() - mrg ) x = m_popup_win->get_width() - mrg;

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -15,9 +15,10 @@
 #include "font.h"
 #include "embeddedimage.h"
 
-#include "jdlib/miscutil.h"
-#include "jdlib/miscmsg.h"
 #include "jdlib/jdregex.h"
+#include "jdlib/miscgtk.h"
+#include "jdlib/miscmsg.h"
+#include "jdlib/miscutil.h"
 
 #include "dbtree/articlebase.h"
 #include "dbtree/node.h"
@@ -3154,7 +3155,7 @@ void DrawAreaBase::exec_scroll()
         {
             // 現在のポインタの位置取得
             int x_point, y_point;
-            m_view.get_pointer( x_point, y_point );
+            MISC::get_pointer_at_window( m_view.get_window(), x_point, y_point );
             double dy = m_scrollinfo.y - y_point;
 
             if( dy >= 0 && ! m_scrollinfo.enable_up ) dy = 0;

--- a/src/jdlib/miscgtk.cpp
+++ b/src/jdlib/miscgtk.cpp
@@ -158,3 +158,12 @@ void MISC::CopyClipboard( const std::string& str )
     clip->set_text( str );
 }
 
+
+// ウインドウの左上隅を基準としたマウスポインターの座標を取得
+Glib::RefPtr<Gdk::Window> MISC::get_pointer_at_window( const Glib::RefPtr<Gdk::Window>& window, int& x, int& y )
+{
+    assert( window );
+    Gdk::ModifierType unused;
+    const auto device = Gdk::Display::get_default()->get_default_seat()->get_pointer();
+    return window->get_device_position( device, x, y, unused );
+}

--- a/src/jdlib/miscgtk.h
+++ b/src/jdlib/miscgtk.h
@@ -39,6 +39,9 @@ namespace MISC
 
     // str をクリップボードにコピー
     void CopyClipboard( const std::string& str );
+
+    // ウィジェット左上隅を基準としたマウスポインターの座標を取得
+    Glib::RefPtr<Gdk::Window> get_pointer_at_window( const Glib::RefPtr<Gdk::Window>& window, int& x, int& y );
 }
 
 #endif

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -9,10 +9,9 @@
 #include "msgdiag.h"
 #include "undobuffer.h"
 
-#include "dbtree/interface.h"
-
 #include "config/globalconf.h"
-
+#include "dbtree/interface.h"
+#include "jdlib/miscgtk.h"
 #include "xml/document.h"
 
 #include "sharedbuffer.h"
@@ -231,7 +230,7 @@ void EditTreeView::clock_in()
                 const int step = (int)adjust->get_step_increment() / 2;
                 int val = -1;
                 int x,y;
-                get_pointer( x, y );
+                MISC::get_pointer_at_window( get_window(), x, y );
 
                 if( y < step * 2 ){
                     val = MAX( 0, (int)adjust->get_value() - step );

--- a/src/skeleton/tabnote.cpp
+++ b/src/skeleton/tabnote.cpp
@@ -10,6 +10,7 @@
 #include "tablabel.h"
 
 #include "config/globalconf.h"
+#include "jdlib/miscgtk.h"
 
 #include "session.h"
 #include "dndmanager.h"
@@ -164,7 +165,7 @@ int TabNotebook::get_page_under_mouse()
 {
     int x, y;
     Gdk::Rectangle rect = get_allocation();
-    get_pointer( x, y );
+    MISC::get_pointer_at_window( get_window(), x, y );
     x += rect.get_x();
     y += rect.get_y();
 

--- a/src/skeleton/treeviewbase.cpp
+++ b/src/skeleton/treeviewbase.cpp
@@ -5,6 +5,9 @@
 
 #include "treeviewbase.h"
 
+#include "jdlib/miscgtk.h"
+
+
 using namespace SKELETON;
 
 
@@ -79,7 +82,7 @@ Gtk::TreeModel::Path JDTreeViewBase::get_path_under_xy( int x, int y )
 Gtk::TreeModel::Path JDTreeViewBase::get_path_under_mouse()
 {
     int x, y;
-    get_pointer( x, y );
+    MISC::get_pointer_at_window( get_window(), x, y );
     return get_path_under_xy( x, y );
 }
 
@@ -96,7 +99,7 @@ void JDTreeViewBase::get_cell_xy_wh( int& cell_x, int& cell_y, int& cell_w, int&
     int x, y;
     Gdk::Rectangle rect;
 
-    get_pointer( x, y );
+    MISC::get_pointer_at_window( get_window(), x, y );
     get_path_at_pos( x, y, path, column, cell_x, cell_y );
     if( column ) {
         int o_x, o_y;

--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -6,9 +6,9 @@
 #include "admin.h"
 #include "view.h"
 
-#include "history/historymanager.h"
-
 #include "config/globalconf.h"
+#include "history/historymanager.h"
+#include "jdlib/miscgtk.h"
 
 #include "global.h"
 #include "session.h"
@@ -172,7 +172,7 @@ bool View::is_mouse_on_view()
     bool ret = false;
 
     int x,y;
-    get_pointer( x, y );
+    MISC::get_pointer_at_window( get_window(), x, y );
     if( x < get_width() && x >= 0 && y < get_height() && y >= 0 ) ret = true;
 
 #ifdef _DEBUG


### PR DESCRIPTION
GTK4で廃止される[`Gtk::Widget::get_pointer()`][1]のかわりに`Gdk::Window::get_device_position()`を使います。

参考
https://stackoverflow.com/questions/24844489/how-to-use-gdk-device-get-position

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

コンパイラのレポート
```
../src/article/articleviewbase.cpp:1012:9: error: 'get_pointer' was not declared in this scope; did you mean 'gpointer'?
1012 |         get_pointer( x, y );
  |         ^~~~~~~~~~~
  |         gpointer
../src/article/articleviewbase.cpp:1014:22: error: 'class SKELETON::PopupWin' has no member named 'get_pointer'
1014 |         m_popup_win->get_pointer( x, y );
  |                      ^~~~~~~~~~~
../src/article/drawareabase.cpp:3188:20: error: 'class Gtk::DrawingArea' has no member named 'get_pointer'
3188 |             m_view.get_pointer( x_point, y_point );
  |                    ^~~~~~~~~~~
../src/skeleton/edittreeview.cpp:234:17: error: 'get_pointer' was not declared in this scope; did you mean 'gpointer'?
234 |                 get_pointer( x, y );
  |                 ^~~~~~~~~~~
  |                 gpointer
../src/skeleton/tabnote.cpp:168:5: error: 'get_pointer' was not declared in this scope; did you mean 'gpointer'?
168 |     get_pointer( x, y );
  |     ^~~~~~~~~~~
  |     gpointer
../src/skeleton/treeviewbase.cpp:82:5: error: 'get_pointer' was not declared in this scope; did you mean 'gpointer'?
82 |     get_pointer( x, y );
  |     ^~~~~~~~~~~
  |     gpointer
../src/skeleton/treeviewbase.cpp:99:5: error: 'get_pointer' was not declared in this scope; did you mean 'gpointer'?
99 |     get_pointer( x, y );
  |     ^~~~~~~~~~~
  |     gpointer
../src/skeleton/view.cpp:175:5: error: 'get_pointer' was not declared in this scope; did you mean 'gpointer'?
175 |     get_pointer( x, y );
  |     ^~~~~~~~~~~
  |     gpointer
```

[1]: https://developer.gnome.org/gtkmm/3.24/classGtk_1_1Widget.html#a9f27636d0f3d3be136e890ac198c50c2
