### PR TITLE
Change size setting for dialog box to use child natural size

### DIFF
--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -69,6 +69,8 @@ void AboutConfig::pack_widgets()
 
     m_scrollwin.add( m_treeview );
     m_scrollwin.set_policy( Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS );
+    m_scrollwin.set_propagate_natural_height( true );
+    m_scrollwin.set_propagate_natural_width( true );
 
     get_content_area()->set_spacing( 8 );
     get_content_area()->pack_start( m_label, Gtk::PACK_SHRINK );

--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -75,7 +75,6 @@ void AboutConfig::pack_widgets()
     get_content_area()->pack_start( m_scrollwin );
 
     set_title( "about:config 高度な設定" );
-    set_default_size_ratio( 0.666 );
     show_all_children();
 
     append_rows();

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -526,7 +526,9 @@ MouseKeyPref::MouseKeyPref( Gtk::Window* parent, const std::string& url, const s
     if( cell ) column->set_cell_data_func( *cell, sigc::mem_fun( *this, &MouseKeyPref::slot_cell_data ) );
 
     m_scrollwin.add( m_treeview );
-    m_scrollwin.set_policy( Gtk::POLICY_NEVER, Gtk::POLICY_ALWAYS );
+    m_scrollwin.set_policy( Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS );
+    m_scrollwin.set_propagate_natural_height( true );
+    m_scrollwin.set_propagate_natural_width( true );
 
     m_button_reset.signal_clicked().connect( sigc::mem_fun( *this, &MouseKeyPref::slot_reset ) );
     m_hbox.pack_start( m_button_reset, Gtk::PACK_SHRINK );

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -536,7 +536,6 @@ MouseKeyPref::MouseKeyPref( Gtk::Window* parent, const std::string& url, const s
     get_content_area()->pack_start( m_scrollwin );
     get_content_area()->pack_start( m_hbox, Gtk::PACK_SHRINK );
 
-    set_default_size_ratio( 0.666 );
     show_all_children();
     set_title( target + "設定" );
 }

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -195,6 +195,7 @@ void FontColorPref::pack_widget()
     m_treeview_color.get_selection()->set_mode( Gtk::SELECTION_MULTIPLE );
     m_treeview_color.signal_row_activated().connect( sigc::mem_fun( *this, &FontColorPref::slot_row_activated ) );
     m_scrollwin_color.add( m_treeview_color );
+    m_scrollwin_color.set_min_content_height( 180 );
     m_scrollwin_color.set_policy( Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS );
     m_vbox_color.pack_start( m_scrollwin_color, Gtk::PACK_EXPAND_WIDGET );
 

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -103,7 +103,6 @@ FontColorPref::FontColorPref( Gtk::Window* parent, const std::string& url )
     m_fontbutton.set_tooltip_text( m_tooltips_font[ 0 ] );
 
     set_title( "フォントと色の詳細設定" );
-    set_default_size_ratio( 0.5 );
     show_all_children();
 }
 

--- a/src/skeleton/prefdiag.cpp
+++ b/src/skeleton/prefdiag.cpp
@@ -101,16 +101,6 @@ int PrefDiag::run(){
 }
 
 
-// ダイアログのサイズをデフォルトのスクリーンに対する比率で設定する
-void PrefDiag::set_default_size_ratio( double ratio )
-{
-    const auto screen = Gdk::Screen::get_default();
-    const int width = static_cast< int >( screen->get_width() * ratio );
-    const int height = static_cast< int >( screen->get_height() * ratio );
-    Gtk::Dialog::set_default_size( width, height );
-}
-
-
 // タイマーのslot関数
 bool PrefDiag::slot_timeout( int timer_number )
 {

--- a/src/skeleton/prefdiag.h
+++ b/src/skeleton/prefdiag.h
@@ -5,8 +5,6 @@
 #ifndef _PREFDIAG_H
 #define _PREFDIAG_H
 
-#include "gtkmmversion.h"
-
 #include <gtkmm.h>
 
 #include "jdlib/timeout.h"
@@ -47,8 +45,6 @@ namespace SKELETON
         virtual void slot_ok_clicked(){}
         virtual void slot_cancel_clicked(){}
         virtual void slot_apply_clicked(){}
-
-        void set_default_size_ratio( double ratio );
 
       private:
 


### PR DESCRIPTION
GTKのAPIが更新され複数モニターがある環境が前提となったためスクリーンの長さをもとにウインドウサイズを求める方法は不適当になりました。
そのためダイアログのウインドウサイズを子要素の自然な長さから設定するように変更します。

This reverts commit c6d57f203e79dd8c7e65f94f4a3233c4b7f1a760.
GTK4で廃止される`Gdk::Screen::get_width/height()`を利用する関数を削除します。

コンパイラのレポート (非推奨のシンボルを無効化)
```
../src/skeleton/prefdiag.cpp:103:51: error: 'class Gdk::Screen' has no member named 'get_width'
103 |     const int width = static_cast< int >( screen->get_width() * ratio );
  |                                                   ^~~~~~~~~
../src/skeleton/prefdiag.cpp:104:52: error: 'class Gdk::Screen' has no member named 'get_height'
104 |     const int height = static_cast< int >( screen->get_height() * ratio );
  |                                                    ^~~~~~~~~~
```
