### PR TITLE
Loader: Fix member initialization

### DIFF
--- a/src/skeleton/loadable.cpp
+++ b/src/skeleton/loadable.cpp
@@ -13,8 +13,6 @@
 using namespace SKELETON;
 
 Loadable::Loadable()
-    : m_loader( nullptr ),
-      m_low_priority( false )
 {
     clear_load_data();
 }

--- a/src/skeleton/loadable.h
+++ b/src/skeleton/loadable.h
@@ -61,9 +61,9 @@ namespace SKELETON
 {
     class Loadable : public Dispatchable
     {
-        JDLIB::Loader* m_loader;
+        JDLIB::Loader* m_loader{};
 
-        bool m_low_priority; 
+        bool m_low_priority{};
 
         // ローダからコピーしたデータ
         int m_code;


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581