### PR TITLE
MessageViewBase: Fix member initialization

### DIFF
--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -62,18 +62,10 @@ enum
 
 
 MessageViewBase::MessageViewBase( const std::string& url )
-    : SKELETON::View( url ),
-      m_post( nullptr ),
-      m_preview( nullptr ),
-      m_entry_name( CORE::COMP_NAME ),
-      m_entry_mail( CORE::COMP_MAIL ),
-      m_text_message( nullptr ),
-      m_enable_focus( true ),
-      m_lng_str_enc( 0 ),
-      m_counter( 0 ),
-      m_text_changed( false ),
-      m_over_lines( false ),
-      m_over_lng( false )
+    : SKELETON::View( url )
+    , m_entry_name( CORE::COMP_NAME )
+    , m_entry_mail( CORE::COMP_MAIL )
+    , m_enable_focus( true )
 {
 #ifdef _DEBUG
     std::cout << "MessageViewBase::MessageViewBase " << get_url() << std::endl;

--- a/src/message/messageviewbase.h
+++ b/src/message/messageviewbase.h
@@ -30,10 +30,10 @@ namespace MESSAGE
 
     class MessageViewBase : public SKELETON::View
     {
-        Post* m_post;
+        Post* m_post{};
 
         Gtk::Notebook m_notebook;
-        SKELETON::View* m_preview;
+        SKELETON::View* m_preview{};
         Gtk::VBox m_msgview;
 
         SKELETON::JDToolbar m_toolbar_name_mail;
@@ -52,7 +52,7 @@ namespace MESSAGE
         SKELETON::CompletionEntry m_entry_name;
         SKELETON::CompletionEntry m_entry_mail;
 
-        SKELETON::EditView* m_text_message;
+        SKELETON::EditView* m_text_message{};
 
         bool m_enable_focus;
 
@@ -60,17 +60,17 @@ namespace MESSAGE
         JDLIB::Iconv* m_iconv;
         int m_max_line;
         int m_max_str;
-        int m_lng_str_enc;
+        int m_lng_str_enc{};
         int m_lng_iconv;
 
         // 経過時間表示用
-        int m_counter;
+        int m_counter{};
         std::string m_str_pass;
 
-        bool m_text_changed;
+        bool m_text_changed{};
 
-        bool m_over_lines;
-        bool m_over_lng;
+        bool m_over_lines{};
+        bool m_over_lng{};
 
       public:
 


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581