### PR TITLE
ArticleAdmin: Fix member initialization

### DIFF
--- a/src/article/articleadmin.cpp
+++ b/src/article/articleadmin.cpp
@@ -53,7 +53,7 @@ void ARTICLE::delete_admin()
 using namespace ARTICLE;
 
 ArticleAdmin::ArticleAdmin( const std::string& url )
-    : SKELETON::Admin( url ), m_toolbar( nullptr ), m_toolbarsimple( nullptr ), m_search_toolbar( nullptr )
+    : SKELETON::Admin( url )
 {
     set_use_viewhistory( true );
     set_use_switchhistory( true );

--- a/src/article/articleadmin.h
+++ b/src/article/articleadmin.h
@@ -36,9 +36,9 @@ namespace ARTICLE
 
     class ArticleAdmin : public SKELETON::Admin
     {
-        ArticleToolBar* m_toolbar;
-        ArticleToolBarSimple* m_toolbarsimple;
-        SearchToolBar* m_search_toolbar;
+        ArticleToolBar* m_toolbar{};
+        ArticleToolBarSimple* m_toolbarsimple{};
+        SearchToolBar* m_search_toolbar{};
 
         std::unique_ptr<JDLIB::Timeout> m_conn_timer;
 


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 
