### PR TITLE
ArticleViewSearch: Fix member initialization

### DIFF
--- a/src/article/articleviewsearch.cpp
+++ b/src/article/articleviewsearch.cpp
@@ -28,13 +28,8 @@ using namespace ARTICLE;
 
 // ログやスレタイ検索抽出ビュー
 ArticleViewSearch::ArticleViewSearch( const std::string& url, const bool exec_search )
-    : ArticleViewBase( url, "dummy" ),
-      m_mode_or( false ),
-      m_enable_bm( false ),
-      m_bm( false ),
-      m_loading( false ),
-      m_search_executed( false ),
-      m_escaped( false )
+    : ArticleViewBase( url, "dummy" )
+    , m_searchmode{ CORE::SEARCHMODE_LOG } // set_toolbar_from_url() で検索モードを設定する
 {
     set_id_toolbar( TOOLBAR_SEARCH );
     set_writeable( false );

--- a/src/article/articleviewsearch.h
+++ b/src/article/articleviewsearch.h
@@ -18,13 +18,13 @@ namespace ARTICLE
         std::string m_url_title;
         std::string m_url_board;
         int m_searchmode; // searchmanager.hで定義した検索モード
-        bool m_mode_or;
-        bool m_enable_bm;
-        bool m_bm;
+        bool m_mode_or{};
+        bool m_enable_bm{};
+        bool m_bm{};
         std::list< CORE::SEARCHDATA > m_list_searchdata;
-        bool m_loading;
-        bool m_search_executed;
-        bool m_escaped;
+        bool m_loading{};
+        bool m_search_executed{};
+        bool m_escaped{};
         bool m_cancel_reload;
 
       public:


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 
