### PR TITLE
CARET_POSITION: Fix member initialization

### DIFF
--- a/src/article/caret.h
+++ b/src/article/caret.h
@@ -13,14 +13,14 @@ namespace ARTICLE
 
       public:
 
-        long x; 
-        long y;
-        LAYOUT* layout; // キャレットの属するレイアウトノードへのポインタ
-        long byte; // 何バイト目の文字の「前」か
+        long x{};
+        long y{};
+        LAYOUT* layout{}; // キャレットの属するレイアウトノードへのポインタ
+        long byte{}; // 何バイト目の文字の「前」か
 
-        CARET_POSITION() : x( 0 ), y( 0 ), layout( nullptr ), byte( 0 ){}
-        ~CARET_POSITION(){}
-        
+        CARET_POSITION() noexcept = default;
+        ~CARET_POSITION() noexcept = default;
+
         // キャレット座標計算関数
         void set( LAYOUT* _layout, long _byte,
 


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 
