### PR TITLE
LayoutTree: Fix member initialization

### DIFF
--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -53,13 +53,10 @@ using namespace ARTICLE;
 // show_abone : true ならあぼーんしたレスも表示する
 // show_multispace : true なら連続空白ノードも表示
 LayoutTree::LayoutTree( const std::string& url, const bool show_abone, const bool show_multispace )
-    : m_heap( SIZE_OF_HEAP ),
-      m_url( url ),
-      m_local_nodetree( nullptr ),
-      m_separator_header( nullptr ),
-      m_show_abone( show_abone ),
-      m_show_multispace( show_multispace ),
-      m_last_dom_attr( 0 )
+    : m_heap( SIZE_OF_HEAP )
+    , m_url( url )
+    , m_show_abone( show_abone )
+    , m_show_multispace( show_multispace )
 {
 #ifdef _DEBUG
     std::cout << "LayoutTree::LayoutTree : url = " << url << " show_abone = " << m_show_abone << std::endl;

--- a/src/article/layouttree.h
+++ b/src/article/layouttree.h
@@ -87,7 +87,7 @@ namespace ARTICLE
         std::unordered_map< int, LAYOUT* > m_map_header;  // ヘッダのポインタの連想配列
 
         // コメントノードやプレビュー表示時に使うローカルなノードツリー
-        DBTREE::NodeTreeBase* m_local_nodetree; 
+        DBTREE::NodeTreeBase* m_local_nodetree{};
 
         LAYOUT* m_root_header;
         LAYOUT* m_last_header;
@@ -95,7 +95,7 @@ namespace ARTICLE
         LAYOUT* m_last_div;
 
         // 新着セパレータ
-        LAYOUT* m_separator_header;
+        LAYOUT* m_separator_header{};
 
         // 新着セパレータの位置(レス番号), 0の時は表示していない
         int m_separator_new;
@@ -114,7 +114,7 @@ namespace ARTICLE
         bool m_show_multispace;
 
         // 前回のブロックにあった、DOMノードのattribute
-        int m_last_dom_attr;
+        int m_last_dom_attr{};
 
       public:
         


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 