### PR TITLE
ArticleToolBar: Fix member initialization

### DIFF
--- a/src/article/toolbar.cpp
+++ b/src/article/toolbar.cpp
@@ -20,14 +20,11 @@
 using namespace ARTICLE;
 
 
-ArticleToolBar::ArticleToolBar() :
-    SKELETON::ToolBar( ARTICLE::get_admin() ),
-    m_enable_slot( true ),
-
-    m_button_drawout_and( ICON::SEARCH_AND, CONTROL::DrawOutAnd ),
-    m_button_drawout_or( ICON::SEARCH_OR, CONTROL::DrawOutOr ),
-
-    m_button_live_play_stop( nullptr )
+ArticleToolBar::ArticleToolBar()
+    : SKELETON::ToolBar( ARTICLE::get_admin() )
+    , m_enable_slot( true )
+    , m_button_drawout_and( ICON::SEARCH_AND, CONTROL::DrawOutAnd )
+    , m_button_drawout_or( ICON::SEARCH_OR, CONTROL::DrawOutOr )
 {
     // 検索バー
     set_tooltip( m_button_drawout_and, CONTROL::get_label_motions( CONTROL::DrawOutAnd ) );

--- a/src/article/toolbar.h
+++ b/src/article/toolbar.h
@@ -24,7 +24,7 @@ namespace ARTICLE
         SKELETON::ImgToolButton m_button_drawout_or;
 
         // 実況
-        Gtk::ToggleToolButton* m_button_live_play_stop;
+        Gtk::ToggleToolButton* m_button_live_play_stop{};
 
       public:
 


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 
