### PR TITLE
SearchToolBar: Fix member initialization

### DIFF
--- a/src/article/toolbarsearch.cpp
+++ b/src/article/toolbarsearch.cpp
@@ -18,10 +18,9 @@
 
 using namespace ARTICLE;
 
-SearchToolBar::SearchToolBar() :
-    SKELETON::ToolBar( ARTICLE::get_admin() ),
-    m_searchview( nullptr ),
-    m_check_bm( "しおり" )
+SearchToolBar::SearchToolBar()
+    : SKELETON::ToolBar( ARTICLE::get_admin() )
+    , m_check_bm( "しおり" )
 {
     m_tool_bm.add( m_check_bm );
     m_tool_bm.set_expand( false );

--- a/src/article/toolbarsearch.h
+++ b/src/article/toolbarsearch.h
@@ -16,9 +16,9 @@ namespace ARTICLE
 
     class SearchToolBar : public SKELETON::ToolBar
     {
-        ArticleViewSearch* m_searchview;
+        ArticleViewSearch* m_searchview{};
 
-        bool m_enable_slot;
+        bool m_enable_slot{};
 
         Gtk::ToolItem m_tool_bm;
         Gtk::CheckButton m_check_bm;


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 
