### PR TITLE
bbslist: Fix member initialization

### DIFF
--- a/src/bbslist/bbslistadmin.cpp
+++ b/src/bbslist/bbslistadmin.cpp
@@ -62,7 +62,7 @@ void BBSLIST::delete_admin()
 using namespace BBSLIST;
 
 BBSListAdmin::BBSListAdmin( const std::string& url )
-    : SKELETON::Admin( url ), m_toolbar( nullptr )
+    : SKELETON::Admin( url )
 {
     get_notebook()->set_dragable( false );
     get_notebook()->set_fixtab( true );

--- a/src/bbslist/bbslistadmin.h
+++ b/src/bbslist/bbslistadmin.h
@@ -25,7 +25,7 @@ namespace BBSLIST
 
     class BBSListAdmin : public SKELETON::Admin
     {
-        BBSListToolBar* m_toolbar;
+        BBSListToolBar* m_toolbar{};
 
       public:
 

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -128,18 +128,11 @@ show_popupmenu( url, slot ); \
 using namespace BBSLIST;
 
 
-BBSListViewBase::BBSListViewBase( const std::string& url,const std::string& arg1, const std::string& arg2 )
-    : SKELETON::View( url ),
-      m_treeview( url, DNDTARGET_FAVORITE, m_columns, true, CONFIG::get_fontname( FONT_BBS ), COLOR_CHAR_BBS, COLOR_BACK_BBS, COLOR_BACK_BBS_EVEN ),
-      m_ready_tree( false ),
-      m_clicked( false ),
-      m_jump_y( -1 ),
-      m_search_invert( false ),
-      m_open_only_onedir( false ),
-      m_cancel_expand( false ),
-      m_expanding( 0 ),
-      m_editlistwin( nullptr ),
-      m_set_bookmark( false )
+BBSListViewBase::BBSListViewBase( const std::string& url, const std::string& arg1, const std::string& arg2 )
+    : SKELETON::View( url )
+    , m_treeview( url, DNDTARGET_FAVORITE, m_columns, true, CONFIG::get_fontname( FONT_BBS ),
+                  COLOR_CHAR_BBS, COLOR_BACK_BBS, COLOR_BACK_BBS_EVEN )
+    , m_jump_y{ -1 }
 {
     m_scrwin.add( m_treeview );
     m_scrwin.set_policy( Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC );

--- a/src/bbslist/bbslistviewbase.h
+++ b/src/bbslist/bbslistviewbase.h
@@ -42,14 +42,14 @@ namespace BBSLIST
 
         std::string m_date_modified;
 
-        bool m_ready_tree; // ツリーがセットされているならtrue
+        bool m_ready_tree{}; // ツリーがセットされているならtrue
 
         BBSLIST::TreeColumns m_columns;
 
         Gtk::ScrolledWindow m_scrwin;
 
         // クリック状態
-        bool m_clicked;
+        bool m_clicked{};
 
         // ダブルクリック状態
         bool m_dblclicked;
@@ -62,12 +62,12 @@ namespace BBSLIST
         int m_jump_y;
 
         // サーチで使う変数
-        bool m_search_invert;
+        bool m_search_invert{};
         std::string m_pre_query;
 
-        bool m_open_only_onedir; // あるフォルダを開いたときに他のフォルダを閉じる
-        bool m_cancel_expand; // signal_row_expanded() をキャンセルする
-        bool m_expanding; // 行を開いている最中にtrueにしてsignal_row_collapsed()をキャンセルする
+        bool m_open_only_onedir{}; // あるフォルダを開いたときに他のフォルダを閉じる
+        bool m_cancel_expand{}; // signal_row_expanded() をキャンセルする
+        bool m_expanding{}; // 行を開いている最中にtrueにしてsignal_row_collapsed()をキャンセルする
 
         // ツリーに含まれているスレのURLを入れる hash_set
         // toggle_articleicon() で使用する
@@ -80,10 +80,10 @@ namespace BBSLIST
         // ツリーに含まれている画像のURLを入れる hash_set
         std::set< std::string > m_set_image;
 
-        EditListWin* m_editlistwin;
+        EditListWin* m_editlistwin{};
 
         // スレを追加したときにそのスレにしおりを付ける
-        bool m_set_bookmark;
+        bool m_set_bookmark{};
 
       protected:
 

--- a/src/bbslist/selectdialog.cpp
+++ b/src/bbslist/selectdialog.cpp
@@ -26,12 +26,11 @@ enum
 
 
 SelectListDialog::SelectListDialog( Gtk::Window* parent, const std::string& url, Glib::RefPtr< Gtk::TreeStore >& treestore )
-    : SKELETON::PrefDiag( parent, url, true ),
-      m_treestore( treestore ),
-      m_label_name( CORE::SBUF_size() == 1, "名前 ：" ),
-      m_label_dirs( "ディレクトリ ：" ),
-      m_bt_show_tree( "詳細" ),
-      m_selectview( nullptr )
+    : SKELETON::PrefDiag( parent, url, true )
+    , m_treestore( treestore )
+    , m_label_name( CORE::SBUF_size() == 1, "名前 ：" )
+    , m_label_dirs( "ディレクトリ ：" )
+    , m_bt_show_tree( "詳細" )
 {
     const int mrg = 8;
 

--- a/src/bbslist/selectdialog.h
+++ b/src/bbslist/selectdialog.h
@@ -29,7 +29,7 @@ namespace BBSLIST
 
         Gtk::ToggleButton m_bt_show_tree;
 
-        SelectListView* m_selectview;
+        SelectListView* m_selectview{};
 
       public:
 

--- a/src/bbslist/toolbar.cpp
+++ b/src/bbslist/toolbar.cpp
@@ -26,12 +26,9 @@
 using namespace BBSLIST;
 
 
-BBSListToolBar::BBSListToolBar() :
-    SKELETON::ToolBar( BBSLIST::get_admin() ),
-    m_button_toggle( "ページ切り替え", true, true, m_label ),
-    m_button_check_update_root( nullptr ),
-    m_button_check_update_open_root( nullptr ),
-    m_button_stop_check_update( nullptr )
+BBSListToolBar::BBSListToolBar()
+    : SKELETON::ToolBar( BBSLIST::get_admin() )
+    , m_button_toggle( "ページ切り替え", true, true, m_label )
 {
     m_button_toggle.get_button()->set_tooltip_arrow( "ページ切り替え\n\nマウスホイール回転でも切り替え可能" );
 

--- a/src/bbslist/toolbar.h
+++ b/src/bbslist/toolbar.h
@@ -21,9 +21,9 @@ namespace BBSLIST
         Gtk::Label m_label;
         SKELETON::ToolMenuButton m_button_toggle;
 
-        Gtk::ToolButton* m_button_check_update_root;
-        Gtk::ToolButton* m_button_check_update_open_root;
-        Gtk::ToolItem* m_button_stop_check_update;
+        Gtk::ToolButton* m_button_check_update_root{};
+        Gtk::ToolButton* m_button_check_update_open_root{};
+        Gtk::ToolItem* m_button_stop_check_update{};
 
       public:
 


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 


