### PR TITLE
MouseKeyDiag: Fix member initialization

### DIFF
--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -266,14 +266,13 @@ std::string InputDiag::get_button_label()
 //
 MouseKeyDiag::MouseKeyDiag( Gtk::Window* parent, const std::string& url,
                             const int id, const std::string& target, const std::string& str_motions )
-    : SKELETON::PrefDiag( parent, url ),
-      m_id( id ),
-      m_controlmode( CONTROL::get_mode( m_id ) ),
-      m_single( false ),
-      m_label( "編集したい" + target + "設定をダブルクリックして下さい。" ),
-      m_button_delete( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Delete", 12 ), true ),
-      m_button_add( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Add", 12 ), true ),
-      m_button_reset( "デフォルト" )
+    : SKELETON::PrefDiag( parent, url )
+    , m_id( id )
+    , m_controlmode( CONTROL::get_mode( m_id ) )
+    , m_label( "編集したい" + target + "設定をダブルクリックして下さい。" )
+    , m_button_delete( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Delete", 12 ), true )
+    , m_button_add( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Add", 12 ), true )
+    , m_button_reset( "デフォルト" )
 {
     m_liststore = Gtk::ListStore::create( m_columns );
     m_treeview.set_model( m_liststore );

--- a/src/control/mousekeypref.h
+++ b/src/control/mousekeypref.h
@@ -84,7 +84,7 @@ namespace CONTROL
     {
         int m_id;
         int m_controlmode;
-        bool m_single;
+        bool m_single{};
 
         SKELETON::JDTreeViewBase m_treeview;
         Glib::RefPtr< Gtk::ListStore > m_liststore;


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 
