### PR TITLE
Css_Manager: Fix member initialization

### DIFF
--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -52,8 +52,7 @@ enum
 
 
 Css_Manager::Css_Manager()
-    : m_heap( SIZE_OF_HEAP ),
-      m_last_dom( nullptr )
+    : m_heap( SIZE_OF_HEAP )
 {
 #ifdef _DEBUG
     std::cout << "Css_Manager::Css_Manager\n";

--- a/src/cssmanager.h
+++ b/src/cssmanager.h
@@ -141,8 +141,8 @@ namespace CORE
         std::vector< std::string > m_colors;
         std::list< std::string > m_css_class;
 
-        DOM* m_dom;
-        DOM* m_last_dom;
+        DOM* m_dom{};
+        DOM* m_last_dom{};
 
     public:
 


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 
