### PR TITLE
dbimg: Fix member initialization

### DIFF
--- a/src/dbimg/delimgcachediag.cpp
+++ b/src/dbimg/delimgcachediag.cpp
@@ -26,6 +26,7 @@ using namespace DBIMG;
 
 DelImgCacheDiag::DelImgCacheDiag()
     : m_label( "画像キャッシュ削除中・・・\n\nしばらくお待ち下さい" )
+    , m_stop{ true }
 {
     add_button( g_dgettext( GTK_DOMAIN, "_Cancel" ), Gtk::RESPONSE_CANCEL )
     ->signal_clicked().connect( sigc::mem_fun(*this, &DelImgCacheDiag::slot_cancel_clicked ) );

--- a/src/dbimg/delimgcachediag.h
+++ b/src/dbimg/delimgcachediag.h
@@ -19,7 +19,7 @@ namespace DBIMG
     class DelImgCacheDiag : public Gtk::Dialog, SKELETON::Dispatchable
     {
         Gtk::Label m_label;
-       
+
         bool m_stop; // = true にするとスレッド停止
         JDLIB::Thread m_thread;
 

--- a/src/dbimg/img.cpp
+++ b/src/dbimg/img.cpp
@@ -59,9 +59,7 @@ using namespace DBIMG;
 
 Img::Img( const std::string& url )
     : SKELETON::Loadable()
-    ,m_url( url )
-    ,m_count_redirect( 0 )
-    ,m_fout( nullptr )
+    , m_url( url )
 {
 #ifdef _DEBUG
     std::cout << "Img::Img url = " << m_url <<  std::endl;

--- a/src/dbimg/img.h
+++ b/src/dbimg/img.h
@@ -20,7 +20,7 @@ namespace DBIMG
     {
         std::string m_url;
         std::string m_url_alt; // リダイレクトなどで使用するアドレス
-        int m_count_redirect; // リダイレクト回数
+        int m_count_redirect{}; // リダイレクト回数
 
         int m_imgctrl; // 画像コントロール
         int m_type; // 画像タイプ
@@ -49,8 +49,8 @@ namespace DBIMG
         int m_wait_counter;
 
         // 保存用ファイルハンドラ
-        FILE* m_fout;
-        
+        FILE* m_fout{};
+
       public:
 
         explicit Img( const std::string& url );


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 


