### PR TITLE
dbtree: Fix member initialization

### DIFF
--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -62,9 +62,6 @@ enum
 
 Root::Root()
     : SKELETON::Loadable()
-    , m_analyzing_board_xml( false )
-    , m_board_null( nullptr )
-    , m_get_board( nullptr )
     , m_enable_save_movetable( true )
 {
     m_xml_document.clear();

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -60,7 +60,7 @@ namespace DBTREE
         std::list< DBTREE::ETCBOARDINFO > m_etcboards; // 外部板情報
 
         // 移転処理用変数
-        bool m_analyzing_board_xml;  // XML 解析中
+        bool m_analyzing_board_xml{};  // XML 解析中
         std::set< std::string > m_analyzed_path_board; // XML 解析中に処理済みの板のpath
         std::string m_move_info;  // 移転したときにダイアログに表示する移転済み板の一覧
 
@@ -70,7 +70,7 @@ namespace DBTREE
         // get_board()のキャッシュ
         // get_article_fromURL()のキャッシュ
         std::string m_get_board_url;
-        BoardBase* m_get_board;
+        BoardBase* m_get_board{};
 
         bool m_enable_save_movetable;
 

--- a/src/dbtree/settingloader.cpp
+++ b/src/dbtree/settingloader.cpp
@@ -17,10 +17,8 @@
 using namespace DBTREE;
 
 SettingLoader::SettingLoader( const std::string& url_boadbase )
-    : SKELETON::TextLoader(),
-      m_url_boadbase( url_boadbase ),
-      m_line_number( 0 ),
-      m_message_count( 0 )
+    : SKELETON::TextLoader()
+    , m_url_boadbase( url_boadbase )
 {
 #ifdef _DEBUG
     std::cout << "SettingLoader::SettingLoader : " << m_url_boadbase << std::endl;

--- a/src/dbtree/settingloader.h
+++ b/src/dbtree/settingloader.h
@@ -28,10 +28,10 @@ namespace DBTREE
         std::string m_default_noname;
 
         // 最大改行数/2
-        int m_line_number;
+        int m_line_number{};
 
         // 最大書き込みバイト数
-        int m_message_count;
+        int m_message_count{};
 
         // 特殊文字書き込み
         std::string m_unicode;


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 


