### PR TITLE
DND_Manager: Fix member initialization

### DIFF
--- a/src/dndmanager.h
+++ b/src/dndmanager.h
@@ -22,11 +22,11 @@ namespace CORE
     class DND_Manager
     {
         // true ならd&d中
-        bool m_dnd;
+        bool m_dnd{};
 
       public:
 
-        DND_Manager():m_dnd( false ){}
+        DND_Manager() noexcept = default;
         virtual ~DND_Manager() noexcept = default;
 
         bool now_dnd() const { return m_dnd; }


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 
