### PR TITLE
history: Fix member initialization

### DIFF
--- a/src/history/historymanager.cpp
+++ b/src/history/historymanager.cpp
@@ -68,12 +68,6 @@ using namespace HISTORY;
 
 
 History_Manager::History_Manager()
-    : m_menu_thread( nullptr ),
-      m_menu_board( nullptr ),
-      m_menu_close( nullptr ),
-      m_menu_closeboard( nullptr ),
-      m_menu_closeimg( nullptr ),
-      m_last_viewhistory( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "History_Manager::History_Manager\n";

--- a/src/history/historymanager.h
+++ b/src/history/historymanager.h
@@ -27,15 +27,15 @@ namespace HISTORY
     class History_Manager
     {
         // 履歴メニュー
-        HistoryMenu* m_menu_thread;
-        HistoryMenu* m_menu_board;
-        HistoryMenu* m_menu_close;
-        HistoryMenu* m_menu_closeboard;
-        HistoryMenu* m_menu_closeimg;
+        HistoryMenu* m_menu_thread{};
+        HistoryMenu* m_menu_board{};
+        HistoryMenu* m_menu_close{};
+        HistoryMenu* m_menu_closeboard{};
+        HistoryMenu* m_menu_closeimg{};
 
         // View履歴
         std::list< ViewHistory* > m_view_histories;
-        ViewHistory* m_last_viewhistory;
+        ViewHistory* m_last_viewhistory{};
 
       public:
 

--- a/src/history/historymenu.cpp
+++ b/src/history/historymenu.cpp
@@ -10,8 +10,7 @@ using namespace HISTORY;
 
 
 HistoryMenu::HistoryMenu( const std::string& url_history, const std::string& label )
-    : Gtk::MenuItem( label, true ),
-      m_activate( false )
+    : Gtk::MenuItem( label, true )
 {
     m_submenu = Gtk::manage( new HistorySubMenu( url_history ) );
     set_submenu( *m_submenu );

--- a/src/history/historymenu.h
+++ b/src/history/historymenu.h
@@ -16,7 +16,7 @@ namespace HISTORY
     class HistoryMenu : public Gtk::MenuItem
     {
         HistorySubMenu* m_submenu;
-        bool m_activate;
+        bool m_activate{};
 
       public:
 

--- a/src/history/historysubmenu.h
+++ b/src/history/historysubmenu.h
@@ -21,7 +21,7 @@ namespace HISTORY
 
         // ポップアップメニュー
         Gtk::Menu m_popupmenu;
-        int m_number_menuitem;
+        int m_number_menuitem{};
 
       public:
 

--- a/src/history/viewhistory.cpp
+++ b/src/history/viewhistory.cpp
@@ -14,7 +14,6 @@ enum
 
 
 ViewHistory::ViewHistory()
-   :  m_history_top( 0 ), m_history_current( 0 ), m_history_end( 0 )
 {
 #ifdef _DEBUG
     std::cout << "ViewHistory::ViewHistory\n";

--- a/src/history/viewhistory.h
+++ b/src/history/viewhistory.h
@@ -19,9 +19,9 @@ namespace HISTORY
 
         std::vector< ViewHistoryItem* > m_items;
 
-        int m_history_top;
-        int m_history_current;
-        int m_history_end;
+        int m_history_top{};
+        int m_history_current{};
+        int m_history_end{};
 
         ViewHistory();
         virtual ~ViewHistory();


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 


