### PR TITLE
IOMonitor: Fix member initialization

### DIFF
--- a/src/iomonitor.cpp
+++ b/src/iomonitor.cpp
@@ -27,10 +27,8 @@ using namespace CORE;
 /*-------------------------------------------------------------------*/
 IOMonitor::IOMonitor()
     : m_fifo_fd( -1 )
-    , m_iochannel( nullptr )
     , m_fifo_file( CACHE::path_lock() )
     , m_fifo_stat( FIFO_OK )
-    , m_main_process( false )
 {
     init();
 }

--- a/src/iomonitor.h
+++ b/src/iomonitor.h
@@ -32,7 +32,7 @@ namespace CORE
         int m_fifo_stat;
 
         // メインプロセスか否か
-        bool m_main_process;
+        bool m_main_process{};
 
       private:
 


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 
