### PR TITLE
image: Fix member initialization

### DIFF
--- a/src/image/imageadmin.h
+++ b/src/image/imageadmin.h
@@ -31,9 +31,9 @@ namespace IMAGE
         std::list< SKELETON::View* > m_list_view;
 
         int m_scroll;
-        int m_counter_scroll;
+        int m_counter_scroll{};
 
-        double m_smooth_dy{ 0.0 }; // GDK_SCROLL_SMOOTH のスクロール変化量
+        double m_smooth_dy{}; // GDK_SCROLL_SMOOTH のスクロール変化量
 
         Glib::RefPtr<Gtk::GestureMultiPress> m_gesture_press_left;
         Glib::RefPtr<Gtk::GestureMultiPress> m_gesture_press_right;

--- a/src/image/imageareabase.cpp
+++ b/src/image/imageareabase.cpp
@@ -49,11 +49,8 @@ using namespace IMAGE;
 // 1 -> INTERP_BILINEAR
 // 3 -> INTERP_HYPER
 ImageAreaBase::ImageAreaBase( const std::string& url, const int interptype )
-    : m_url( url ),
-      m_img ( DBIMG::get_img( m_url ) ),
-      m_ready( false ),
-      m_width( 0 ),
-      m_height( 0 )
+    : m_url( url )
+    , m_img( DBIMG::get_img( m_url ) )
 {
 #ifdef _DEBUG
     std::cout << "ImageAreaBase::ImageAreaBase url = " << m_url << " type = " << interptype << std::endl;

--- a/src/image/imageareabase.h
+++ b/src/image/imageareabase.h
@@ -31,10 +31,10 @@ namespace IMAGE
 
         std::string m_errmsg; // エラーメッセージ
 
-        bool m_ready; // 画像がsetされた
+        bool m_ready{}; // 画像がsetされた
 
-        int m_width;
-        int m_height;
+        int m_width{};
+        int m_height{};
 
         // スレッド用変数
         JDLIB::Thread m_thread;

--- a/src/image/imageviewpopup.cpp
+++ b/src/image/imageviewpopup.cpp
@@ -19,9 +19,6 @@ using namespace IMAGE;
 
 ImageViewPopup::ImageViewPopup( const std::string& url )
     : ImageViewBase( url )
-    , m_label( nullptr )
-    , m_length_prev( 0 )
-    , m_clicked( false )
 {
 #ifdef _DEBUG
     std::cout << "ImageViewPopup::ImageViewPopup url = " << get_url() << std::endl;

--- a/src/image/imageviewpopup.h
+++ b/src/image/imageviewpopup.h
@@ -15,10 +15,10 @@ namespace IMAGE
     {
         Gtk::EventBox m_event_frame;
         Gtk::EventBox m_event_margin;
-        Gtk::Label* m_label;
-        size_t m_length_prev;
+        Gtk::Label* m_label{};
+        size_t m_length_prev{};
 
-        bool m_clicked;
+        bool m_clicked{};
 
       public:
 

--- a/src/image/imagewin.cpp
+++ b/src/image/imagewin.cpp
@@ -17,8 +17,7 @@ using namespace IMAGE;
 
 
 ImageWin::ImageWin()
-    : SKELETON::JDWindow( CONFIG::get_fold_image() ),
-      m_tab( nullptr )
+    : SKELETON::JDWindow( CONFIG::get_fold_image() )
 {
 #ifdef _DEBUG
     std::cout << "ImageWin::ImageWin x y w h = "

--- a/src/image/imagewin.h
+++ b/src/image/imagewin.h
@@ -15,7 +15,7 @@ namespace IMAGE
 {
     class ImageWin : public SKELETON::JDWindow
     {
-        Gtk::Widget* m_tab;
+        Gtk::Widget* m_tab{};
 
       public:
 


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 


