### PR TITLE
jdlib: Fix member initialization

### DIFF
--- a/src/jdlib/confloader.cpp
+++ b/src/jdlib/confloader.cpp
@@ -20,8 +20,7 @@ using namespace JDLIB;
 // もしstr_confがemptyの時はfileから読み込む
 //
 ConfLoader::ConfLoader( const std::string& file, std::string str_conf )
-    : m_file( file ),
-      m_broken( false )
+    : m_file( file )
 {
     if( str_conf.empty() ) CACHE::load_rawdata( m_file, str_conf );
 

--- a/src/jdlib/confloader.h
+++ b/src/jdlib/confloader.h
@@ -25,7 +25,7 @@ namespace JDLIB
     {
         std::string m_file;
         std::list< ConfData > m_data;
-        bool m_broken;
+        bool m_broken{};
 
     public:
 

--- a/src/jdlib/constptr.h
+++ b/src/jdlib/constptr.h
@@ -12,23 +12,23 @@ namespace JDLIB
     template < typename T >
     class ConstPtr
     {
-        T *m_p;
+        T* m_p{};
 
     public:
 
         T* operator -> () noexcept { return m_p; }
         const T* operator -> () const noexcept { return m_p; }
-        bool operator == ( const T *p ) const { return( m_p == p ); }
-        bool operator != ( const T *p ) const { return( m_p != p ); }
-        bool operator ! () const { return ( m_p == nullptr ); }
-        T& operator * () const { return *m_p; }
-        operator bool () const { return ( m_p != nullptr ); }
-        T& operator [] ( const int i ){ return m_p[ i ]; }
+        bool operator == ( const T* p ) const noexcept { return ( m_p == p ); }
+        bool operator != ( const T* p ) const noexcept { return ( m_p != p ); }
+        bool operator ! () const noexcept { return ( m_p == nullptr ); }
+        operator bool () const noexcept { return ( m_p != nullptr ); }
+        T& operator * () { return *m_p; }
+        const T& operator * () const { return *m_p; }
+        T& operator [] ( int i ) { return m_p[i]; }
+        const T& operator [] ( int i ) const { return m_p[i]; }
 
-        ConstPtr< T >& operator = ( const ConstPtr< T >& a ){ m_p = a.m_p; return *this; }
-        ConstPtr< T >& operator = ( ConstPtr< T >& a ){ m_p = a.m_p; return *this; }
-        ConstPtr< T >& operator = ( const T *p ){ m_p = p; return *this; }    
-        ConstPtr< T >& operator = ( T *p ){ m_p = p; return *this; }
+        ConstPtr& operator = ( const ConstPtr& a ) { m_p = a.m_p; return *this; }
+        ConstPtr& operator = ( T* p ) { m_p = p; return *this; }
 
         void reset() { m_p = nullptr; }
 
@@ -38,9 +38,8 @@ namespace JDLIB
             reset();
         }
 
-        ConstPtr() : m_p (nullptr){}
-        ConstPtr( T *p ) : m_p (p){}
-        ConstPtr( const T *p ) : m_p (p){}
+        ConstPtr() noexcept = default;
+        ConstPtr( T* p ) : m_p( p ) {}
     };
 }
 

--- a/src/jdlib/heap.cpp
+++ b/src/jdlib/heap.cpp
@@ -13,8 +13,6 @@ using namespace JDLIB;
 
 HEAP::HEAP( std::size_t blocksize ) noexcept
     : m_blocksize{ blocksize }
-    , m_space_avail{ 0 }
-    , m_ptr_head{ nullptr }
 {}
 
 

--- a/src/jdlib/heap.h
+++ b/src/jdlib/heap.h
@@ -15,8 +15,8 @@ namespace JDLIB
     {
         std::list< std::unique_ptr<unsigned char[]> > m_heap_list;
         std::size_t m_blocksize; // ブロックサイズ
-        std::size_t m_space_avail; // ブロックの未使用サイズ
-        void* m_ptr_head; // 検索開始位置
+        std::size_t m_space_avail{}; // ブロックの未使用サイズ
+        void* m_ptr_head{}; // 検索開始位置
 
       public:
         explicit HEAP( std::size_t blocksize ) noexcept;

--- a/src/jdlib/refptr_lock.h
+++ b/src/jdlib/refptr_lock.h
@@ -14,10 +14,10 @@ namespace JDLIB
     template < typename T >
     class RefPtr_Lock
     {
-        T *m_p;
+        T* m_p{};
 
     public:
-    
+
         void clear(){
             if( m_p ){
                 m_p->unlock();
@@ -25,31 +25,26 @@ namespace JDLIB
             }
         }
 
-        void set( T *p ){
+        void set( T* p ){
             clear();
             m_p = p;
             if( m_p ) m_p->lock();
-        }        
-
+        }
 
         T* operator -> () noexcept { return m_p; }
         const T* operator -> () const noexcept { return m_p; }
-        bool operator == ( const T *p ) const { return( m_p == p ); }
-        bool operator != ( const T *p ) const { return( m_p != p ); }
-        bool operator ! () const { return ( m_p == nullptr ); }
-        operator bool () const { return ( m_p != nullptr ); }
-    
-        RefPtr_Lock< T >& operator = ( const RefPtr_Lock< T >& a ){ set( a.m_p ); return *this; }
-        RefPtr_Lock< T >& operator = ( RefPtr_Lock< T >& a ){ set( a.m_p ); return *this; }
-        RefPtr_Lock< T >& operator = ( const T *p ){ set( p ); return *this; }    
-        RefPtr_Lock< T >& operator = ( T *p ){ set( p ); return *this; }
-    
-        RefPtr_Lock() : m_p (nullptr){}
-        RefPtr_Lock( const RefPtr_Lock< T >& a ): m_p (nullptr){ set( a.m_p ); }
-        RefPtr_Lock( RefPtr_Lock< T >& a ) : m_p (nullptr){ set( a.m_p ); }
-        RefPtr_Lock( T *p ) : m_p (nullptr){ set( p ); }
-        RefPtr_Lock( const T *p ) : m_p (nullptr){ set( p ); }
-    
+        bool operator == ( const T* p ) const noexcept { return ( m_p == p ); }
+        bool operator != ( const T* p ) const noexcept { return ( m_p != p ); }
+        bool operator ! () const noexcept { return ( m_p == nullptr ); }
+        operator bool () const noexcept { return ( m_p != nullptr ); }
+
+        RefPtr_Lock& operator = ( const RefPtr_Lock& a ) { set( a.m_p ); return *this; }
+        RefPtr_Lock& operator = ( T* p ) { set( p ); return *this; }
+
+        RefPtr_Lock() noexcept = default;
+        RefPtr_Lock( const RefPtr_Lock& a ) { set( a.m_p ); }
+        RefPtr_Lock( T* p ) { set( p ); }
+
         virtual ~RefPtr_Lock(){ clear();}
     };
 }

--- a/src/jdlib/ssl.cpp
+++ b/src/jdlib/ssl.cpp
@@ -34,8 +34,6 @@ void JDLIB::deinit_ssl()
 
 
 JDSSL::JDSSL()
-    : m_session( nullptr ),
-      m_cred( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "JDSSL::JDSSL(gnutls)\n";
@@ -202,8 +200,6 @@ void JDLIB::deinit_ssl()
 
 
 JDSSL::JDSSL()
-    : m_ctx( nullptr ),
-      m_ssl( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "JDSSL::JDSSL(openssl)\n";

--- a/src/jdlib/ssl.h
+++ b/src/jdlib/ssl.h
@@ -29,12 +29,12 @@ namespace JDLIB
         std::string m_errmsg;
 
 #ifdef USE_GNUTLS
-        gnutls_session_t m_session;
-        gnutls_certificate_credentials_t m_cred;
+        gnutls_session_t m_session{};
+        gnutls_certificate_credentials_t m_cred{};
 
 #else // USE_GNUTLS
-        SSL_CTX *m_ctx;
-        SSL* m_ssl;
+        SSL_CTX* m_ctx{};
+        SSL* m_ssl{};
 #endif // USE_GNUTLS
 
       public:


### PR DESCRIPTION
デフォルトメンバ初期化子とコンストラクタでメンバーを初期化するように修正します。初期値が特に決まっていないものはゼロ初期化します。

関連のpull request: #581 


