### PR TITLE
message: Fix member initialization

### DIFF
--- a/src/message/logitem.h
+++ b/src/message/logitem.h
@@ -14,8 +14,6 @@
 #include <list>
 #include <string>
 #include <sys/time.h>
-#include <cstring>
-#include <ctime>
 
 enum
 {
@@ -33,13 +31,14 @@ namespace MESSAGE
         std::string msg;
         time_t time_write;
         std::list< std::string > msg_lines;
-        char head[ LOGITEM_SIZE_HEAD ];
-        bool remove;
+        char head[ LOGITEM_SIZE_HEAD ]{};
+        bool remove{};
 
-      LogItem( const std::string& _url, const bool _newthread, const std::string& _msg )
-      : url( _url ), newthread( _newthread ), msg( _msg ), remove( false )
+        LogItem( const std::string& _url, const bool _newthread, const std::string& _msg )
+            : url( _url )
+            , newthread( _newthread )
+            , msg( _msg )
         {
-
             struct timeval tv;
             struct timezone tz;
             gettimeofday( &tv, &tz );
@@ -61,7 +60,6 @@ namespace MESSAGE
             msg_lines = MISC::get_lines( MISC::replace_str( MISC::remove_spaces( msg ), "\n", " \n" ) );
 
             // 簡易チェック用に先頭の文字列をコピー(空白は除く)
-            memset( head, 0, LOGITEM_SIZE_HEAD );
             for( size_t i = 0, i2 = 0; i < LOGITEM_SIZE_HEAD && i2 < msg.length(); ++i2 ){
                 if( msg.c_str()[ i2 ] != ' ' ) head[ i++ ] = msg.c_str()[ i2 ];
             }

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -65,14 +65,11 @@ enum
 };
 
 Post::Post( Gtk::Widget* parent, const std::string& url, const std::string& msg, bool new_article )
-    : SKELETON::Loadable(),
-      m_parent( parent ),
-      m_url( url ),
-      m_msg( msg ),
-      m_count( 0 ),
-      m_subbbs( 0 ),
-      m_new_article( new_article ),
-      m_writingdiag( nullptr )
+    : SKELETON::Loadable()
+    , m_parent( parent )
+    , m_url( url )
+    , m_msg( msg )
+    , m_new_article( new_article )
 {
 #ifdef _DEBUG
     std::cout << "Post::Post " << m_url << std::endl;

--- a/src/message/post.h
+++ b/src/message/post.h
@@ -45,12 +45,12 @@ namespace MESSAGE
         std::string m_errmsg;
         std::string m_rawdata;
 
-        int m_count; // 書き込み確認時の永久ループ防止用
-        bool m_subbbs; // true なら subbbs.cgiにpostする
+        int m_count{}; // 書き込み確認時の永久ループ防止用
+        bool m_subbbs{}; // true なら subbbs.cgiにpostする
         bool m_new_article; // 新スレ作成
 
         // 書き込んでいますのダイアログ
-        SKELETON::MsgDiag* m_writingdiag;
+        SKELETON::MsgDiag* m_writingdiag{};
 
         PostStrategy* m_post_strategy;
 

--- a/src/message/toolbar.cpp
+++ b/src/message/toolbar.cpp
@@ -20,10 +20,9 @@ using namespace MESSAGE;
 
 
 
-MessageToolBarBase::MessageToolBarBase() :
-    SKELETON::ToolBar( MESSAGE::get_admin() ),
-    m_enable_slot( true ),
-    m_button_preview( nullptr )
+MessageToolBarBase::MessageToolBarBase()
+    : SKELETON::ToolBar( MESSAGE::get_admin() )
+    , m_enable_slot( true )
 {}
 
 
@@ -71,13 +70,8 @@ void MessageToolBarBase::set_active_previewbutton( const bool active )
 
 // 通常のツールバー
 
-MessageToolBar::MessageToolBar() :
-    MessageToolBarBase(),
-    m_button_insert_draft( nullptr ),
-    m_button_undo( nullptr ),
-    m_show_entry_new_subject( false ),
-    m_tool_new_subject( nullptr ),
-    m_entry_new_subject( nullptr )
+MessageToolBar::MessageToolBar()
+    : MessageToolBarBase()
 {
     MessageToolBar::pack_buttons();
 }

--- a/src/message/toolbar.h
+++ b/src/message/toolbar.h
@@ -8,7 +8,6 @@
 #include <gtkmm.h>
 
 #include "skeleton/toolbar.h"
-#include "skeleton/label_entry.h"
 
 
 namespace MESSAGE
@@ -17,7 +16,7 @@ namespace MESSAGE
     {
         bool m_enable_slot;
 
-        Gtk::ToggleToolButton* m_button_preview;
+        Gtk::ToggleToolButton* m_button_preview{};
 
       public:
 
@@ -41,14 +40,14 @@ namespace MESSAGE
     // 通常
     class MessageToolBar : public MessageToolBarBase
     {
-        Gtk::ToolButton* m_button_insert_draft;
-        Gtk::ToolButton* m_button_undo;
+        Gtk::ToolButton* m_button_insert_draft{};
+        Gtk::ToolButton* m_button_undo{};
 
         // false ならスレ名ラベル、trueなら新規レス名entry表示
-        bool m_show_entry_new_subject;
+        bool m_show_entry_new_subject{};
 
-        Gtk::ToolItem* m_tool_new_subject;
-        Gtk::Entry* m_entry_new_subject;
+        Gtk::ToolItem* m_tool_new_subject{};
+        Gtk::Entry* m_entry_new_subject{};
 
       public:
 


### PR DESCRIPTION
Fix member initialization to use default member initializer or constructor. Fill zeroes for not having initial values. Remove unnecessary include directives.

related pull request: #581
