### PR TITLE
AAMenu: Fix member initialization

### DIFF
--- a/src/skeleton/aamenu.h
+++ b/src/skeleton/aamenu.h
@@ -26,7 +26,7 @@ namespace SKELETON
 
         std::map< Gtk::MenuItem*, int > m_map_items;
 
-        Gtk::MenuItem* m_activeitem;
+        Gtk::MenuItem* m_activeitem{};
 
       public:
 


### PR DESCRIPTION
Fix member initialization to use default member initializer or constructor. Fill zeroes for not having initial values.

related pull request: #581 
