### PR TITLE
JDWinMain: Fix member initialization

### DIFF
--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -27,9 +27,7 @@
 
 JDWinMain::JDWinMain( const bool init, const bool skip_setupdiag,
                       const int init_w, const int init_h, const int init_x, const int init_y )
-    : SKELETON::JDWindow( false ),
-      m_core( nullptr ),
-      m_cancel_state_event( false )
+    : SKELETON::JDWindow( false )
 {
 #ifdef _DEBUG
     std::cout << "JDWinMain::JDWinMain init = " << init << std::endl

--- a/src/winmain.h
+++ b/src/winmain.h
@@ -18,8 +18,8 @@ namespace CORE
 class JDWinMain : public SKELETON::JDWindow
 {
     CORE::Core* m_core;
-    bool m_cancel_state_event;
-    
+    bool m_cancel_state_event{};
+
     // 入力コントローラ
     CONTROL::Control m_control;
 


### PR DESCRIPTION
Fix member initialization to use default member initializer or constructor. Fill zeroes for not having initial values.

related pull request: #581 
