### PR TITLE
AboutDiag: Remove empty member function

### DIFF
--- a/src/skeleton/aboutdiag.cpp
+++ b/src/skeleton/aboutdiag.cpp
@@ -31,8 +31,7 @@ AboutDiag::AboutDiag( const Glib::ustring& title )
     set_transient_for( *CORE::get_mainwindow() );
     set_resizable( false );
 
-    Gtk::Button* button = add_button( g_dgettext( GTK_DOMAIN, "_Close" ), Gtk::RESPONSE_CLOSE );
-    button->signal_clicked().connect( sigc::mem_fun( *this, &AboutDiag::slot_close_clicked ) );
+    add_button( g_dgettext( GTK_DOMAIN, "_Close" ), Gtk::RESPONSE_CLOSE );
 
     set_default_response( Gtk::RESPONSE_CLOSE );
 

--- a/src/skeleton/aboutdiag.h
+++ b/src/skeleton/aboutdiag.h
@@ -43,7 +43,6 @@ namespace SKELETON
 
         void init();
         void slot_button_website_clicked();
-        void slot_close_clicked() {}
         void slot_copy_environment();
 
       public:


### PR DESCRIPTION
Remove empty member function `AboutDiag::slot_close_button()`.