### PR TITLE
skeleton: Fix member initialization

### DIFF
--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -51,14 +51,7 @@ using namespace SKELETON;
 
 
 Admin::Admin( const std::string& url )
-    : m_url( url ),
-      m_win( nullptr ),
-      m_notebook( nullptr ),
-      m_focus( false ),
-      m_move_menu( nullptr ),
-      m_tabswitchmenu( nullptr ),
-      m_use_viewhistory( false ),
-      m_use_switchhistory( false )
+    : m_url( url )
 {
     m_notebook = new DragableNoteBook();
 

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -7,8 +7,6 @@
 #ifndef _ADMIN_H
 #define _ADMIN_H
 
-#include "gtkmmversion.h"
-
 #include "dispatchable.h"
 
 #include <gtkmm.h>
@@ -29,13 +27,13 @@ namespace SKELETON
     {
         std::string m_url;
 
-        JDWindow * m_win;
+        JDWindow* m_win{};
 
     protected:
-        DragableNoteBook* m_notebook;
+        DragableNoteBook* m_notebook{};
 
     private:
-        bool m_focus;
+        bool m_focus{};
 
         std::list< COMMAND_ARGS > m_list_command;
 
@@ -46,17 +44,17 @@ namespace SKELETON
 
         // 移動サブメニュー
         Gtk::MenuItem* m_move_menuitem;
-        TabSwitchMenu* m_move_menu;
+        TabSwitchMenu* m_move_menu{};
 
         // タブ切り替えメニュー
-        TabSwitchMenu* m_tabswitchmenu;
+        TabSwitchMenu* m_tabswitchmenu{};
 
         // view履歴使用
-        bool m_use_viewhistory;
+        bool m_use_viewhistory{};
         std::string m_last_closed_url;
 
         // タブの切り替え履歴
-        bool m_use_switchhistory;
+        bool m_use_switchhistory{};
         std::list< std::string > m_list_switchhistory;
 
     public:

--- a/src/skeleton/compentry.cpp
+++ b/src/skeleton/compentry.cpp
@@ -18,11 +18,9 @@ enum
 
 
 CompletionEntry::CompletionEntry( const int mode )
-    : m_mode( mode ),
-      m_enable_changed( true ),
-      m_focused( false ),
-      m_show_popup( false ),
-      m_popup_win( true )
+    : m_mode( mode )
+    , m_enable_changed( true )
+    , m_popup_win( true )
 {
     m_entry.signal_key_press().connect( sigc::mem_fun( *this, &CompletionEntry::slot_entry_key_press ) );
     m_entry.signal_button_press().connect( sigc::mem_fun(*this, &CompletionEntry::slot_entry_button_press ) );

--- a/src/skeleton/compentry.h
+++ b/src/skeleton/compentry.h
@@ -28,10 +28,10 @@ namespace SKELETON
 
         JDEntry m_entry;
         bool m_enable_changed;
-        bool m_focused;
+        bool m_focused{};
 
         // ポップアップ
-        bool m_show_popup;
+        bool m_show_popup{};
         PopupWinBase m_popup_win;
         Gtk::ScrolledWindow m_scr_win;
         JDTreeViewBase m_treeview;

--- a/src/skeleton/detaildiag.cpp
+++ b/src/skeleton/detaildiag.cpp
@@ -15,9 +15,8 @@ DetailDiag::DetailDiag( Gtk::Window* parent, const std::string& url,
                         const bool add_cancel,
                         const std::string& message, const std::string& tab_message,
                         const std::string& detail_html, const std::string& tab_detail )
-    : SKELETON::PrefDiag( parent, url, add_cancel ),
-      m_message( message ),
-      m_detail( nullptr )
+    : SKELETON::PrefDiag( parent, url, add_cancel )
+    , m_message( message )
 {
     m_message.set_width_chars( 60 );
     m_message.set_line_wrap( true );

--- a/src/skeleton/detaildiag.h
+++ b/src/skeleton/detaildiag.h
@@ -5,8 +5,6 @@
 #ifndef _DETAILDIAG_H
 #define _DETAILDIAG_H
 
-#include "gtkmmversion.h"
-
 #include "prefdiag.h"
 
 
@@ -18,7 +16,7 @@ namespace SKELETON
     {
         Gtk::Notebook m_notebook;
         Gtk::Label m_message;
-        SKELETON::View* m_detail;
+        SKELETON::View* m_detail{};
 
       public:
 

--- a/src/skeleton/dragnote.cpp
+++ b/src/skeleton/dragnote.cpp
@@ -26,10 +26,9 @@ DragableNoteBook::DragableNoteBook()
     , m_notebook_toolbar( this )
     , m_notebook_view( this )
     , m_bt_tabswitch( this )
+    , m_show_tabs{ true }
+    , m_show_toolbar{ true }
     , m_page( -1 )
-    , m_dragging_tab( false )
-    , m_dragable( false )
-    , m_down_arrow( nullptr )
 {
     set_spacing( 0 );
 
@@ -48,10 +47,6 @@ DragableNoteBook::DragableNoteBook()
     pack_start( m_hbox_tab, Gtk::PACK_SHRINK );
     pack_start( m_notebook_toolbar, Gtk::PACK_SHRINK );
     pack_start( m_notebook_view );
-    m_show_tabs = true;
-    m_show_toolbar = true;
-
-    memset( &m_alloc_old, 0, sizeof( Alloc_NoteBook ) );
 
     show_all_children();
 }

--- a/src/skeleton/dragnote.h
+++ b/src/skeleton/dragnote.h
@@ -82,20 +82,18 @@ namespace SKELETON
         int m_page;
 
         // タブをドラッグ中
-        bool m_dragging_tab;
+        bool m_dragging_tab{};
 
-        bool m_dblclick;
+        bool m_dblclick{};
 
         // 入力コントローラ
         CONTROL::Control m_control;
 
-        bool m_dragable;
+        bool m_dragable{};
 
-        SKELETON::IconPopup* m_down_arrow;
+        SKELETON::IconPopup* m_down_arrow{};
 
-        Alloc_NoteBook m_alloc_old;
-
-        double m_smooth_dy{ 0.0 }; // GDK_SCROLL_SMOOTH のスクロール変化量
+        double m_smooth_dy{}; // GDK_SCROLL_SMOOTH のスクロール変化量
 
       public:
 

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -1847,10 +1847,9 @@ void EditTreeView::sort( const Gtk::TreePath& path, const int mode )
 // path が empty の時はルートから反復する
 //
 EditTreeViewIterator::EditTreeViewIterator( EditTreeView& treeview, EditColumns& columns, const Gtk::TreePath path )
-    : m_treeview( treeview ),
-      m_columns( columns ),
-      m_end( false ),
-      m_path( path )
+    : m_treeview( treeview )
+    , m_columns( columns )
+    , m_path( path )
 {
     const bool root = ( m_path.empty() );
     if( root ){

--- a/src/skeleton/edittreeview.h
+++ b/src/skeleton/edittreeview.h
@@ -270,7 +270,7 @@ namespace SKELETON
         EditTreeView& m_treeview;
         EditColumns& m_columns;
         Gtk::TreePath::size_type m_depth;
-        bool m_end;
+        bool m_end{};
 
         Gtk::TreePath m_path;
 

--- a/src/skeleton/editview.cpp
+++ b/src/skeleton/editview.cpp
@@ -42,12 +42,11 @@ static inline bool is_separate_char( char32_t c )
 }
 
 
-EditTextView::EditTextView() :
-    Gtk::TextView(),
-    m_cancel_change( false ),
-    m_line_offset( -1 ),
-    m_context_menu( nullptr ),
-    m_aapopupmenu( nullptr )
+EditTextView::EditTextView()
+    : Gtk::TextView()
+    , m_pre_offset{ -1 }
+    , m_pre_line{ -1 }
+    , m_line_offset{ -1 }
 {
     // コントロールモード設定
     m_control.add_mode( CONTROL::MODE_EDIT );

--- a/src/skeleton/editview.h
+++ b/src/skeleton/editview.h
@@ -3,12 +3,10 @@
 #ifndef _EDITVIEW_H
 #define _EDITVIEW_H
 
-#include "gtkmmversion.h"
-
 #include <gtkmm.h>
 
 #include "control/control.h"
-#include "jdlib/miscutil.h"
+
 
 namespace SKELETON
 {
@@ -40,10 +38,10 @@ namespace SKELETON
 
         // undo 用
         std::vector< UNDO_DATA > m_undo_tree;
-        int m_undo_pos;
+        int m_undo_pos{};
         Glib::ustring m_pre_text;
-        bool m_cancel_change;
-        bool m_delete_pushed;
+        bool m_cancel_change{};
+        bool m_delete_pushed{};
 
         // カーソル移動用
         int m_pre_offset;
@@ -51,10 +49,10 @@ namespace SKELETON
         int m_line_offset;
 
         // コンテキストメニュー
-        Gtk::Menu* m_context_menu;
+        Gtk::Menu* m_context_menu{};
 
         // AAポップアップ
-        AAMenu* m_aapopupmenu;
+        AAMenu* m_aapopupmenu{};
 
       public:
 

--- a/src/skeleton/lockable.h
+++ b/src/skeleton/lockable.h
@@ -14,16 +14,15 @@ namespace SKELETON
 {
     class Lockable
     {
-        int m_lock;
+        int m_lock{};
 
     public:
 
-        Lockable() :m_lock( 0 ){}
-        
+        Lockable() = default;
         virtual ~Lockable() noexcept = default;
 
         int get_lock() const { return m_lock; }
-    
+
         void lock(){ ++m_lock; }
         void unlock(){
             --m_lock;

--- a/src/skeleton/login.cpp
+++ b/src/skeleton/login.cpp
@@ -17,7 +17,7 @@
 using namespace SKELETON;
 
 Login::Login( const std::string& url )
-    : m_url( url ), m_login_now( 0 ), m_save_info( 0 )
+    : m_url( url )
 {
 #ifdef _DEBUG
     std::cout << "Login::Login " << get_url() << std::endl;

--- a/src/skeleton/login.h
+++ b/src/skeleton/login.h
@@ -16,8 +16,8 @@ namespace SKELETON
     class Login : public SKELETON::Loadable
     {
         std::string m_url;
-        bool m_login_now;
-        bool m_save_info;
+        bool m_login_now{};
+        bool m_save_info{};
 
         std::string m_username;
         std::string m_passwd;

--- a/src/skeleton/menubutton.cpp
+++ b/src/skeleton/menubutton.cpp
@@ -21,14 +21,12 @@ enum
 
 
 MenuButton::MenuButton( const bool show_arrow, Gtk::Widget& label )
-    : m_label( nullptr )
 {
     setup( show_arrow, &label );
 }
 
 
 MenuButton::MenuButton( const bool show_arrow, const int id )
-    : m_label( nullptr )
 {
     setup( show_arrow, Gtk::manage( new Gtk::Image( ICON::get_icon( id ) ) ), Gtk::PACK_SHRINK );
 }
@@ -39,8 +37,6 @@ void MenuButton::setup( const bool show_arrow, Gtk::Widget* label, Gtk::PackOpti
     const int space = 4;
 
     m_label = label;
-    m_popupmenu =  nullptr;
-    m_on_arrow = false;
     m_enable_sig_clicked = true;
 
     Gtk::HBox *hbox = Gtk::manage( new Gtk::HBox() );

--- a/src/skeleton/menubutton.h
+++ b/src/skeleton/menubutton.h
@@ -21,13 +21,13 @@ namespace SKELETON
         SIG_BUTTON_CLICKED m_sig_clicked;
         SIG_SELECTED m_sig_selected;
 
-        Gtk::Menu* m_popupmenu;
+        Gtk::Menu* m_popupmenu{};
         std::vector< Gtk::MenuItem* > m_menuitems;
-        Gtk::Widget* m_label;
+        Gtk::Widget* m_label{};
 
         Gtk::Image* m_arrow{};
 
-        bool m_on_arrow;
+        bool m_on_arrow{};
         bool m_enable_sig_clicked;
 
       public:

--- a/src/skeleton/tabswitchmenu.cpp
+++ b/src/skeleton/tabswitchmenu.cpp
@@ -20,7 +20,10 @@ enum
 using namespace SKELETON;
 
 TabSwitchMenu::TabSwitchMenu( DragableNoteBook* notebook, Admin* admin )
-    : Gtk::Menu(), m_parentadmin( admin ), m_parentnote( notebook ), m_deactivated( true ), m_size( 0 )
+    : Gtk::Menu()
+    , m_parentadmin( admin )
+    , m_parentnote( notebook )
+    , m_deactivated{ true }
 {
 
 #ifdef _DEBUG

--- a/src/skeleton/tabswitchmenu.h
+++ b/src/skeleton/tabswitchmenu.h
@@ -16,7 +16,7 @@ namespace SKELETON
         Admin* m_parentadmin;
         DragableNoteBook* m_parentnote;
         bool m_deactivated;
-        int m_size;
+        int m_size{};
 
         std::vector< Gtk::MenuItem* > m_vec_items;
         std::vector< Gtk::Label* > m_vec_labels;

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -34,42 +34,8 @@ constexpr const char* ToolBar::s_css_label;
 constexpr const char* ToolBar::s_css_leave;
 
 ToolBar::ToolBar( Admin* admin )
-    : m_admin( admin ),
-      m_enable_slot( true ),
-      m_buttonbar_shown( false ),
-      m_buttonbar_packed( false ),
-
-      m_tool_label( nullptr ),
-      m_ebox_label( nullptr ),
-      m_label( nullptr ),
-
-      m_searchbar( nullptr ),
-      m_searchbar_shown( false ),
-      m_searchbar_packed( false ),
-      m_button_open_searchbar( nullptr ),
-      m_button_close_searchbar( nullptr ),
-      m_button_up_search( nullptr ),
-      m_button_down_search( nullptr ),
-      m_button_clear_highlight( nullptr ),
-
-      m_tool_search( nullptr ),
-      m_entry_search( nullptr ),
-
-      m_label_board( nullptr ),
-      m_button_board( nullptr ),
-
-      m_button_write( nullptr ),
-      m_button_reload( nullptr ),
-      m_button_stop( nullptr ),
-      m_button_close( nullptr ),
-      m_button_delete( nullptr ),
-      m_button_favorite( nullptr ),
-      m_button_undo( nullptr ),
-      m_button_redo( nullptr ),
-      m_button_lock( nullptr ),
-
-      m_button_back( nullptr ),
-      m_button_forward( nullptr )
+    : m_admin( admin )
+    , m_enable_slot{ true }
 {
     m_buttonbar.set_border_width( 0 );
     m_buttonbar.set_icon_size( Gtk::ICON_SIZE_MENU );

--- a/src/skeleton/toolbar.h
+++ b/src/skeleton/toolbar.h
@@ -9,7 +9,7 @@
 #include "jdtoolbar.h"
 
 #include <gtkmm.h>
-#include "gtkmmversion.h"
+
 
 namespace SKELETON
 {
@@ -29,45 +29,45 @@ namespace SKELETON
 
         // ボタンバー
         SKELETON::JDToolbar m_buttonbar;
-        bool m_buttonbar_shown;
-        bool m_buttonbar_packed;
+        bool m_buttonbar_shown{};
+        bool m_buttonbar_packed{};
 
         // ラベル
-        Gtk::ToolItem* m_tool_label;
-        Gtk::EventBox* m_ebox_label;
-        Gtk::Label* m_label;
+        Gtk::ToolItem* m_tool_label{};
+        Gtk::EventBox* m_ebox_label{};
+        Gtk::Label* m_label{};
 
         // 検索関係
-        Gtk::Toolbar* m_searchbar; // 検索バー
-        bool m_searchbar_shown;
-        bool m_searchbar_packed;
-        Gtk::ToolButton* m_button_open_searchbar;
-        Gtk::ToolButton* m_button_close_searchbar;
-        Gtk::ToolButton* m_button_up_search;
-        Gtk::ToolButton* m_button_down_search;
-        Gtk::ToolButton* m_button_clear_highlight;
+        Gtk::Toolbar* m_searchbar{}; // 検索バー
+        bool m_searchbar_shown{};
+        bool m_searchbar_packed{};
+        Gtk::ToolButton* m_button_open_searchbar{};
+        Gtk::ToolButton* m_button_close_searchbar{};
+        Gtk::ToolButton* m_button_up_search{};
+        Gtk::ToolButton* m_button_down_search{};
+        Gtk::ToolButton* m_button_clear_highlight{};
 
-        Gtk::ToolItem* m_tool_search;
-        SKELETON::CompletionEntry* m_entry_search;
+        Gtk::ToolItem* m_tool_search{};
+        SKELETON::CompletionEntry* m_entry_search{};
 
         // 板を開く
-        Gtk::Label* m_label_board;
-        SKELETON::ToolMenuButton* m_button_board;
+        Gtk::Label* m_label_board{};
+        SKELETON::ToolMenuButton* m_button_board{};
 
         // その他ボタン
-        Gtk::ToolButton* m_button_write;
-        Gtk::ToolButton* m_button_reload;
-        Gtk::ToolButton* m_button_stop;
-        Gtk::ToolButton* m_button_close;
-        Gtk::ToolButton* m_button_delete;
-        Gtk::ToolButton* m_button_favorite;
-        Gtk::ToolButton* m_button_undo;
-        Gtk::ToolButton* m_button_redo;
-        Gtk::ToggleToolButton* m_button_lock;
+        Gtk::ToolButton* m_button_write{};
+        Gtk::ToolButton* m_button_reload{};
+        Gtk::ToolButton* m_button_stop{};
+        Gtk::ToolButton* m_button_close{};
+        Gtk::ToolButton* m_button_delete{};
+        Gtk::ToolButton* m_button_favorite{};
+        Gtk::ToolButton* m_button_undo{};
+        Gtk::ToolButton* m_button_redo{};
+        Gtk::ToggleToolButton* m_button_lock{};
 
         // 進む、戻るボタン
-        SKELETON::ToolBackForwardButton* m_button_back;
-        SKELETON::ToolBackForwardButton* m_button_forward;
+        SKELETON::ToolBackForwardButton* m_button_back{};
+        SKELETON::ToolBackForwardButton* m_button_forward{};
 
         static constexpr const char* s_css_label = u8"jd-toolbar-label";
         Glib::RefPtr< Gtk::CssProvider > m_label_provider = Gtk::CssProvider::create();

--- a/src/skeleton/treeviewbase.cpp
+++ b/src/skeleton/treeviewbase.cpp
@@ -12,7 +12,6 @@ using namespace SKELETON;
 
 
 JDTreeViewBase::JDTreeViewBase()
-    : m_column_for_height( 0 )
 {
     add_events( Gdk::KEY_PRESS_MASK );
     add_events( Gdk::KEY_RELEASE_MASK );

--- a/src/skeleton/treeviewbase.h
+++ b/src/skeleton/treeviewbase.h
@@ -30,7 +30,7 @@ namespace SKELETON
         SIG_MOTION_NOTIFY m_sig_motion_notify;
 
         // get_row_height() で高さを取得するためのcolumn番号
-        int m_column_for_height;
+        int m_column_for_height{};
 
       public:
 

--- a/src/skeleton/undobuffer.cpp
+++ b/src/skeleton/undobuffer.cpp
@@ -9,7 +9,7 @@ using namespace SKELETON;
 
 
 UNDO_BUFFER::UNDO_BUFFER()
-    : m_pos( 0 ), m_max( 0 ), m_first( true )
+    : m_first{ true }
 {
     m_vec_undo.push_back( UNDO_DATA() );
 }

--- a/src/skeleton/undobuffer.h
+++ b/src/skeleton/undobuffer.h
@@ -45,8 +45,8 @@ namespace SKELETON
     {
         std::vector< UNDO_DATA > m_vec_undo;
 
-        int m_pos;
-        int m_max;
+        int m_pos{};
+        int m_max{};
         bool m_first;
 
         SIG_UNDO m_sig_undo;


### PR DESCRIPTION
Fix member initialization to use default member initializer and constructor. Fill no-specific initial values with zeroes. Remove
unnecessary include directives.

related pull request: #581 
