### PR TITLE
Fix build error for meson 0.57

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -51,6 +51,10 @@ jobs:
           pip install meson==0.49.0
       - name: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
         run: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
+        # `compile` subcommand requires Meson 0.54 or later.
+      - name: ninja -C builddir
+        run: ninja -C builddir
+        # Since Meson 0.57, `test` subcommand will only rebuild test program.
       - name: meson test -C builddir
         run: meson test -C builddir
       - name: ./builddir/src/jdim -V
@@ -87,6 +91,8 @@ jobs:
           sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev libltdl-dev libtool meson zlib1g-dev ${{ matrix.sets.package }}
       - name: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
         run: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
+      - name: ninja -C builddir
+        run: ninja -C builddir
       - name: meson test -C builddir
         run: meson test -C builddir
       - name: ./builddir/src/jdim -V
@@ -184,6 +190,8 @@ jobs:
           sudo apt install meson libgtest-dev libtool libltdl-dev libgtkmm-3.0-dev ${{ matrix.deps.packages }} g++-9
       - name: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG" ${{ matrix.deps.config_args }}
         run: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG" ${{ matrix.deps.config_args }}
+      - name: ninja -C builddir
+        run: ninja -C builddir
       - name: meson test -C builddir
         run: meson test -C builddir
       - name: ./builddir/src/jdim -V

--- a/test/meson.build
+++ b/test/meson.build
@@ -14,7 +14,7 @@ deps = [
 
 
 test_exe = executable(
-  'gtest_jdim', [core_sources, sources],
+  'gtest_jdim', [buildinfo_h, core_sources, sources],
   dependencies : deps,
   include_directories : jdim_incs,
   link_with : jdim_libs,


### PR DESCRIPTION
Fixes #613

Since Meson 0.57, `test` subcommand will [only rebuild test program][1]. In JDim, this causes build error because generating rule of the test program does not include `buildinfo.h`. Therefore, fix the rule to include the header file.

Fix GitHub Actions CI settings to build the executable file explicitly.

Error message
```
In file included from ../src/environment.cpp:10:
../src/jdversion.h:10:10: fatal error: buildinfo.h: No such file or directory
   10 | #include "buildinfo.h"
      |          ^~~~~~~~~~~~~
```

[1]: https://mesonbuild.com/Release-notes-for-0-57-0.html#meson-test-only-rebuilds-test-dependencies