### PR TITLE
Update MISC::datetotime() to remove conditional compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,24 +26,6 @@ AC_PATH_PROG(GIT, git)
 AC_PATH_PROG(XSUM, md5sum, [cksum])
 AC_SUBST(ac_configure_args)
 
-dnl
-dnl OSを判定してOS別の設定
-dnl 
-case "${host_os}" in 
- freebsd*) 
-   AC_DEFINE(USE_MKTIME, , [use mktime])
-   ;;
- solaris*)
-   AC_DEFINE(NO_TIMEGM, , [no timegm])
-   ;;
- darwin*)
-   AC_DEFINE(USE_MKTIME, , [use mktime])
-   ;;
-dnl linux*|gnu*|*-gnu
- *)
-   ;;
-esac
-
 
 dnl ---------------------------------------------------
 dnl ---------------------------------------------------
@@ -98,6 +80,9 @@ dnl
 
 AC_CHECK_HEADERS([socket.h])
 AC_CHECK_LIB(socket,socket)
+
+AC_CHECK_FUNC([timegm], [],
+[AC_DEFINE(NO_TIMEGM, 1, [Define to 1 if you do not have the 'timegm' function])])
 
 
 dnl

--- a/meson.build
+++ b/meson.build
@@ -62,18 +62,6 @@ conf = configuration_data()
 # オプションの表示にはconfigureスタイル('--with-foo')が必要なので注意
 configure_args = []
 
-#
-# OSを判定してOS別の設定
-#
-system = host_machine.system()
-if system == 'freebsd'
-  conf.set('USE_MKTIME', 1)
-elif system == 'sunos'
-  conf.set('NO_TIMEGM', 1)
-elif system == 'darwin'
-  conf.set('USE_MKTIME', 1)
-endif
-
 
 #
 # 必須パッケージのチェック
@@ -98,6 +86,10 @@ if cpp_compiler.has_header('sys/socket.h')
   socket_dep = dependency('', required : false)
 else
   socket_dep = cpp_compiler.find_library('socket')
+endif
+
+if not cpp_compiler.has_function('timegm')
+  conf.set('NO_TIMEGM', 1)
 endif
 
 

--- a/test/gtest_jdlib_misctime.cpp
+++ b/test/gtest_jdlib_misctime.cpp
@@ -7,6 +7,57 @@
 #include <glibmm.h>
 #include <time.h> // tzset
 
+namespace {
+
+// NOTE: time_tのエポックはUnix epoch (1970-01-01T00:00:00 UTC)を想定している
+class MISC_DateToTimeTest : public ::testing::Test {};
+
+TEST_F(MISC_DateToTimeTest, empty_input)
+{
+    const std::time_t result = MISC::datetotime( "" );
+    EXPECT_EQ( result, 0 );
+}
+
+TEST_F(MISC_DateToTimeTest, invalid_format)
+{
+    const std::time_t result = MISC::datetotime( "hello world" );
+    EXPECT_EQ( result, 0 );
+}
+
+TEST_F(MISC_DateToTimeTest, unix_epoch)
+{
+    const std::time_t result = MISC::datetotime( "Thu, 01 Jan 1970 00:00:00 GMT" );
+    EXPECT_EQ( result, 0 );
+}
+
+TEST_F(MISC_DateToTimeTest, non_gmt_wont_be_parsed)
+{
+    const std::time_t result = MISC::datetotime( "Wed, 01 Jan 2020 12:34:56 JST" );
+    EXPECT_EQ( result, 0 );
+}
+
+TEST_F(MISC_DateToTimeTest, iso8601_wont_be_parsed)
+{
+    const std::time_t result = MISC::datetotime( "2006-01-27T03:48:59Z" );
+    EXPECT_EQ( result, 0 );
+}
+
+TEST_F(MISC_DateToTimeTest, one_hundred_million)
+{
+    const std::time_t result = MISC::datetotime( "Sat, 03 Mar 1973 09:46:40 GMT" );
+    EXPECT_EQ( result, 100'000'000 );
+}
+
+TEST_F(MISC_DateToTimeTest, wrong_day_will_be_parsed)
+{
+    // Although correct day of 2001-09-09 is Sunday, parsed time is right.
+    const std::time_t result = MISC::datetotime( "Mon, 09 Sep 2001 01:46:40 GMT" );
+    EXPECT_EQ( result, 1'000'000'000 );
+}
+
+} // namespace
+
+
 #ifdef _POSIX_C_SOURCE
 namespace {
 


### PR DESCRIPTION
Fixes #611 

Remove conditional compilation from the function that parses datetime string to `time_t`. Change input string requirement to [RFC 7232][3] [IMF-fixdate][4] (used for HTTP request) to limit timezone only to GMT.

New format: `"%a, %d %b %Y %T GMT"`

#### Previous implementation
The conditional compilation had been necessary, because the function had platform-specific code that parses timezone name by `strptime()` (POSIX does not provide [`%Z` format][1]).

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/strptime.html
[3]: https://tools.ietf.org/html/rfc7232#section-2.2
[4]: https://tools.ietf.org/html/rfc7231#section-7.1.1.1


#### NOTE
Tests assume that `time_t` epoch (i.e. `0`) is Unix epoch (1970-01-01T00:00:00 UTC), however [C/C++ standards have not defined it][2].

[2]: https://en.cppreference.com/w/cpp/chrono/c/time_t
> Although not defined, this is almost always an integral value holding the number of seconds (not counting leap seconds) since 00:00, Jan 1 1970 UTC, corresponding to POSIX time.