### PR TITLE
Remove unused MISC::get_sec_str()

### DIFF
--- a/src/jdlib/misctime.cpp
+++ b/src/jdlib/misctime.cpp
@@ -19,23 +19,6 @@
 
 
 //
-// gettimeofday()の秒を文字列で取得
-//
-std::string MISC::get_sec_str()
-{
-	std::ostringstream sec_str;
-
-	struct timeval tv;
-    struct timezone tz;
-    gettimeofday( &tv, &tz );
-
-    sec_str << tv.tv_sec;
-
-    return sec_str.str();
-}
-
-
-//
 // timeval を str に変換
 //
 std::string MISC::timevaltostr( const struct timeval& tv )

--- a/src/jdlib/misctime.h
+++ b/src/jdlib/misctime.h
@@ -25,9 +25,6 @@ namespace MISC
         TIME_NUM
     };
 
-    // gettimeofday()の秒を文字列で取得
-    std::string get_sec_str();
-
     // timeval を str に変換
     std::string timevaltostr( const struct timeval& tv );
 


### PR DESCRIPTION
使われてない`gettimeofday()`の秒を文字列で取得する関数を削除します。