### PR TITLE
dbtree: Use std::unique_ptr instead of new/delete

### DIFF
--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -190,7 +190,7 @@ std::string Board2ch::get_write_referer( const std::string& url )
 // フロントページのダウンロード
 void Board2ch::download_front()
 {
-    if( ! m_frontloader ) m_frontloader.reset( new FrontLoader( url_boardbase() ) );
+    if( ! m_frontloader ) m_frontloader = std::make_unique<FrontLoader>( url_boardbase() );
     m_frontloader->reset();
     m_frontloader->download_text();
 }
@@ -235,7 +235,7 @@ std::string Board2ch::create_newarticle_message( const std::string& subject, con
 
     // スレ立てのメッセージを作成したらキーワードとフロントページの読み込み状況はリセットする
     set_keyword_for_newarticle( std::string{} );
-    m_frontloader->reset();
+    m_frontloader->reset(); // call SKELETON::TextLoader::reset()
 
     return ss_post.str();
 }

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -37,10 +37,8 @@ using namespace DBTREE;
 
 
 Board2chCompati::Board2chCompati( const std::string& root, const std::string& path_board, const std::string& name,
-    const std::string& basicauth)
-    : BoardBase( root, path_board, name ),
-      m_settingloader( nullptr ),
-      m_ruleloader( nullptr )
+                                  const std::string& basicauth )
+    : BoardBase( root, path_board, name )
 {
     set_path_dat( "/dat" );
     set_path_readcgi( "/test/read.cgi" );
@@ -59,15 +57,10 @@ Board2chCompati::~Board2chCompati()
 {
     if( m_settingloader ){
         m_settingloader->terminate_load();
-        delete m_settingloader;
     }
-    m_settingloader = nullptr;
-
     if( m_ruleloader ){
         m_ruleloader->terminate_load();
-        delete m_ruleloader;
     }
-    m_ruleloader = nullptr;
 }
 
 
@@ -499,10 +492,10 @@ void Board2chCompati::load_rule_setting()
     std::cout << "Board2chCompati::load_rule_setting\n";
 #endif
 
-    if( ! m_ruleloader ) m_ruleloader = new RuleLoader( url_boardbase() );
+    if( ! m_ruleloader ) m_ruleloader = std::make_unique<RuleLoader>( url_boardbase() );
     m_ruleloader->load_text();
 
-    if( ! m_settingloader ) m_settingloader = new SettingLoader( url_boardbase() );
+    if( ! m_settingloader ) m_settingloader = std::make_unique<SettingLoader>( url_boardbase() );
     m_settingloader->load_text();
 }
 
@@ -518,10 +511,10 @@ void Board2chCompati::download_rule_setting()
     std::cout << "Board2chCompati::download_rule_setting\n";
 #endif
 
-    if( ! m_ruleloader ) m_ruleloader = new RuleLoader( url_boardbase() );
+    if( ! m_ruleloader ) m_ruleloader = std::make_unique<RuleLoader>( url_boardbase() );
     m_ruleloader->download_text();
 
-    if( ! m_settingloader ) m_settingloader = new SettingLoader( url_boardbase() );
+    if( ! m_settingloader ) m_settingloader = std::make_unique<SettingLoader>( url_boardbase() );
     m_settingloader->download_text();
 }
 

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -9,6 +9,9 @@
 
 #include "boardbase.h"
 
+#include <memory>
+
+
 namespace DBTREE
 {
     class SettingLoader;
@@ -16,8 +19,8 @@ namespace DBTREE
 
     class Board2chCompati : public BoardBase
     {
-        SettingLoader* m_settingloader;
-        RuleLoader* m_ruleloader;
+        std::unique_ptr<SettingLoader> m_settingloader;
+        std::unique_ptr<RuleLoader> m_ruleloader;
 
       public:
 

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -82,8 +82,6 @@ BoardBase::~BoardBase()
     ArticleHashIterator it = m_hash_article->begin();
     for( ; it != m_hash_article->end(); ++it ) delete ( *it );
 
-    if( m_article_null ) delete m_article_null;
-
     delete m_hash_article;
 
 #ifdef _TEST_CACHE
@@ -99,8 +97,8 @@ BoardBase::~BoardBase()
 
 ArticleBase* BoardBase::get_article_null()
 {
-    if( ! m_article_null ) m_article_null = new DBTREE::ArticleBase( "", "", false );
-    return m_article_null;
+    if( ! m_article_null ) m_article_null = std::make_unique<DBTREE::ArticleBase>( "", "", false );
+    return m_article_null.get();
 }
 
 
@@ -340,8 +338,7 @@ void BoardBase::clear()
 
     m_get_article_url = std::string();
 
-    if( m_iconv ) delete m_iconv;
-    m_iconv = nullptr;
+    m_iconv.reset();
 
     m_list_artinfo.clear();
 }
@@ -1083,7 +1080,7 @@ void BoardBase::receive_data( const char* data, size_t size )
     if( m_rawdata_left.capacity() < SIZE_OF_RAWDATA ) {
         m_rawdata_left.reserve( SIZE_OF_RAWDATA );
     }
-    if( ! m_iconv ) m_iconv = new JDLIB::Iconv( "UTF-8", m_charset );
+    if( ! m_iconv ) m_iconv = std::make_unique<JDLIB::Iconv>( "UTF-8", m_charset );
 
     m_rawdata_left.append( data, size );
 

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -9,10 +9,11 @@
 #include "jdlib/jdregex.h"
 #include "skeleton/loadable.h"
 
-#include <string>
-#include <list>
-#include <vector>
 #include <ctime>
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
 
 
 namespace JDLIB
@@ -173,7 +174,7 @@ namespace DBTREE
 
         // ダウンロード用変数
         std::list< std::string > m_url_update_views; // CORE::core_set_command( "update_board" ) を送信するビューのアドレス
-        JDLIB::Iconv* m_iconv{};
+        std::unique_ptr<JDLIB::Iconv> m_iconv;
         std::string m_rawdata;
         std::string m_rawdata_left;
 
@@ -205,7 +206,7 @@ namespace DBTREE
         bool m_cancel_remove_abone_thread{};
 
         // Null artice クラス
-        ArticleBase* m_article_null{};
+        std::unique_ptr<ArticleBase> m_article_null;
 
       protected:
 

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -220,10 +220,10 @@ std::string BoardJBBS::url_settingtxt() const
 //
 void BoardJBBS::load_rule_setting()
 {
-    if( ! m_ruleloader ) m_ruleloader.reset( new RuleLoader( url_boardbase(), "MS932" ) );
+    if( ! m_ruleloader ) m_ruleloader = std::make_unique<RuleLoader>( url_boardbase(), "MS932" );
     m_ruleloader->load_text();
 
-    if( ! m_settingloader ) m_settingloader.reset( new SettingLoader( url_boardbase() ) );
+    if( ! m_settingloader ) m_settingloader = std::make_unique<SettingLoader>( url_boardbase() );
     m_settingloader->load_text();
 }
 
@@ -236,10 +236,10 @@ void BoardJBBS::load_rule_setting()
 //
 void BoardJBBS::download_rule_setting()
 {
-    if( ! m_ruleloader ) m_ruleloader.reset( new RuleLoader( url_boardbase(), "MS932" ) );
+    if( ! m_ruleloader ) m_ruleloader = std::make_unique<RuleLoader>( url_boardbase(), "MS932" );
     m_ruleloader->download_text();
 
-    if( ! m_settingloader ) m_settingloader.reset( new SettingLoader( url_boardbase() ) );
+    if( ! m_settingloader ) m_settingloader = std::make_unique<SettingLoader>( url_boardbase() );
     m_settingloader->download_text();
 }
 

--- a/src/dbtree/nodetree2chcompati.cpp
+++ b/src/dbtree/nodetree2chcompati.cpp
@@ -17,7 +17,6 @@ using namespace DBTREE;
 
 NodeTree2chCompati::NodeTree2chCompati( const std::string& url, const std::string& date_modified )
     : NodeTreeBase( url, date_modified )
-    , m_iconv( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "NodeTree2chCompati::NodeTree2chCompati url = " << url << " modified = " << date_modified << std::endl;
@@ -50,8 +49,7 @@ void NodeTree2chCompati::clear()
     NodeTreeBase::clear();
 
     // iconv 削除
-    if( m_iconv ) delete m_iconv;
-    m_iconv = nullptr;
+    m_iconv.reset();
 }
 
 
@@ -69,7 +67,7 @@ void NodeTree2chCompati::init_loading()
 
     // iconv 初期化
     std::string charset = DBTREE::board_charset( get_url() );
-    if( ! m_iconv ) m_iconv = new JDLIB::Iconv( "UTF-8", charset );
+    if( ! m_iconv ) m_iconv = std::make_unique<JDLIB::Iconv>( "UTF-8", charset );
 }
 
 

--- a/src/dbtree/nodetree2chcompati.h
+++ b/src/dbtree/nodetree2chcompati.h
@@ -9,6 +9,9 @@
 
 #include "nodetreebase.h"
 
+#include <memory>
+
+
 namespace JDLIB
 {
     class Iconv;
@@ -18,7 +21,7 @@ namespace DBTREE
 {
     class NodeTree2chCompati : public NodeTreeBase
     {
-        JDLIB::Iconv* m_iconv;
+        std::unique_ptr<JDLIB::Iconv> m_iconv;
 
       public:
 

--- a/src/dbtree/nodetreejbbs.cpp
+++ b/src/dbtree/nodetreejbbs.cpp
@@ -28,7 +28,6 @@ using namespace DBTREE;
 
 NodeTreeJBBS::NodeTreeJBBS( const std::string& url, const std::string& date_modified )
     : NodeTreeBase( url, date_modified )
-    , m_iconv( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "NodeTreeJBBS::NodeTreeJBBS url = " << get_url() << " modified = " << date_modified << std::endl;
@@ -57,8 +56,7 @@ void NodeTreeJBBS::clear()
     NodeTreeBase::clear();
 
     // iconv 削除
-    if( m_iconv ) delete m_iconv;
-    m_iconv = nullptr;
+    m_iconv.reset();
 
     m_decoded_lines.clear();
     m_decoded_lines.shrink_to_fit();
@@ -79,7 +77,7 @@ void NodeTreeJBBS::init_loading()
 
     // iconv 初期化
     std::string charset = DBTREE::board_charset( get_url() );
-    if( ! m_iconv ) m_iconv = new JDLIB::Iconv( "UTF-8", charset );
+    if( ! m_iconv ) m_iconv = std::make_unique<JDLIB::Iconv>( "UTF-8", charset );
 
     if( m_decoded_lines.capacity() < BUF_SIZE_ICONV_OUT ) {
         m_decoded_lines.reserve( BUF_SIZE_ICONV_OUT );

--- a/src/dbtree/nodetreejbbs.h
+++ b/src/dbtree/nodetreejbbs.h
@@ -9,7 +9,9 @@
 
 #include "nodetreebase.h"
 
+#include <memory>
 #include <string>
+
 
 namespace JDLIB
 {
@@ -21,7 +23,7 @@ namespace DBTREE
 {
     class NodeTreeJBBS : public NodeTreeBase
     {
-        JDLIB::Iconv* m_iconv;
+        std::unique_ptr<JDLIB::Iconv> m_iconv;
         std::string m_decoded_lines;
 
       public:

--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -28,8 +28,6 @@ constexpr size_t BUF_SIZE_200 = 256;
 
 NodeTreeMachi::NodeTreeMachi( const std::string& url, const std::string& date_modified )
     : NodeTreeBase( url, date_modified )
-    , m_regex( nullptr )
-    , m_iconv( nullptr )
 {
 #ifdef _DEBUG
     std::cout << "NodeTreeMachi::NodeTreeMachi url = " << get_url() << " modified = " << date_modified << std::endl;
@@ -57,13 +55,8 @@ void NodeTreeMachi::clear()
 #endif
     NodeTreeBase::clear();
 
-    // regex 削除
-    if( m_regex ) delete m_regex;
-    m_regex = nullptr;
-
-    // iconv 削除
-    if( m_iconv ) delete m_iconv;
-    m_iconv = nullptr;
+    m_regex.reset(); // regex 削除
+    m_iconv.reset(); // iconv 削除
 
     m_decoded_lines.clear();
     m_decoded_lines.shrink_to_fit();
@@ -89,11 +82,11 @@ void NodeTreeMachi::init_loading()
     NodeTreeBase::init_loading();
 
     // regex 初期化
-    if( ! m_regex ) m_regex = new JDLIB::Regex();
+    if( ! m_regex ) m_regex = std::make_unique<JDLIB::Regex>();
 
     // iconv 初期化
     std::string charset = DBTREE::board_charset( get_url() );
-    if( ! m_iconv ) m_iconv = new JDLIB::Iconv( "UTF-8", charset );
+    if( ! m_iconv ) m_iconv = std::make_unique<JDLIB::Iconv>( "UTF-8", charset );
 
     m_buffer_for_200.clear();
 

--- a/src/dbtree/nodetreemachi.h
+++ b/src/dbtree/nodetreemachi.h
@@ -9,6 +9,9 @@
 
 #include "nodetreebase.h"
 
+#include <memory>
+
+
 namespace JDLIB
 {
     class Iconv;
@@ -20,8 +23,8 @@ namespace DBTREE
 {
     class NodeTreeMachi : public NodeTreeBase
     {
-        JDLIB::Regex* m_regex;
-        JDLIB::Iconv* m_iconv;
+        std::unique_ptr<JDLIB::Regex> m_regex;
+        std::unique_ptr<JDLIB::Iconv> m_iconv;
         std::string m_decoded_lines;
         std::string m_buffer;
         std::string m_buffer_for_200;  // HTTP200が来た時のdat落ち判定用

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -62,6 +62,7 @@ enum
 
 Root::Root()
     : SKELETON::Loadable()
+    , m_board_null{ std::make_unique<DBTREE::BoardBase>( "", "", "" ) }
     , m_enable_save_movetable( true )
 {
     m_xml_document.clear();
@@ -80,7 +81,6 @@ Root::Root()
     // ローカルファイル
     set_board( URL_BOARD_LOCAL, "ローカルファイル" );
 
-    m_board_null = new DBTREE::BoardBase( "", "", "" );
 }
 
 
@@ -101,8 +101,6 @@ Root::~Root()
         ( *it )->terminate_load();
         delete ( *it );
     }
-
-    if( m_board_null ) delete m_board_null;
 
 #ifdef _TEST_CACHE
     std::cout << "board cache\n"
@@ -166,10 +164,10 @@ BoardBase* Root::get_board( const std::string& url, const int count )
 
         // ユーザープロフィールアドレス( http://be.2ch.net/test/p.php?u=d:http://〜 )の様に
         // 先頭以外に http:// が入っている場合は失敗
-        if( pos != std::string::npos && pos != 0 ) return m_board_null;
+        if( pos != std::string::npos && pos != 0 ) return m_board_null.get();
 
         size_t pos2 = url.rfind( "https://" );
-        if ( pos2 != std::string::npos && pos2 != 0 ) return m_board_null;
+        if ( pos2 != std::string::npos && pos2 != 0 ) return m_board_null.get();
         if ( pos2 == 0 ) pos = 0;
 
         // http[s]:// が含まれていなかったら先頭に追加して再帰呼び出し
@@ -260,7 +258,7 @@ BoardBase* Root::get_board( const std::string& url, const int count )
 #endif
     
     // それでも見つからなかったらNullクラスを返す
-    return m_board_null;
+    return m_board_null.get();
 }
 
 

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -13,9 +13,11 @@
 #include "skeleton/loadable.h"
 #include "xml/document.h"
 
-#include <string>
 #include <list>
+#include <memory>
 #include <set>
+#include <string>
+
 
 namespace DBTREE
 {
@@ -65,7 +67,7 @@ namespace DBTREE
         std::string m_move_info;  // 移転したときにダイアログに表示する移転済み板の一覧
 
         // Null board クラス
-        BoardBase* m_board_null;
+        std::unique_ptr<BoardBase> m_board_null;
 
         // get_board()のキャッシュ
         // get_article_fromURL()のキャッシュ


### PR DESCRIPTION
- スマートポインターの生成にヘルパー関数を使いnewをコードから取り除きます。
- クラスメンバーをスマートポインターに更新してnew/deleteによるメモリ割り当てを整理します。