### PR TITLE
message: Use std::unique_ptr instead of new/delete

### DIFF
--- a/src/message/messageadmin.cpp
+++ b/src/message/messageadmin.cpp
@@ -40,23 +40,10 @@ using namespace MESSAGE;
 
 
 MessageAdmin::MessageAdmin( const std::string& url )
-    : SKELETON::Admin( url ), m_toolbar( nullptr ), m_toolbar_preview( nullptr ), m_text_message( nullptr )
+    : SKELETON::Admin( url )
 {
     get_notebook()->set_show_tabs( false );
 }
-
-
-MessageAdmin::~MessageAdmin()
-{
-#ifdef _DEBUG
-    std::cout << "MessageAdmin::~MessageAdmin\n";
-#endif 
-
-    if( m_toolbar ) delete m_toolbar;
-    if( m_toolbar_preview ) delete m_toolbar_preview;
-    if( m_text_message ) delete m_text_message;
-}
-
 
 
 void MessageAdmin::show_entry_new_subject( bool show )
@@ -75,9 +62,9 @@ std::string MessageAdmin::get_new_subject()
 
 SKELETON::EditView* MessageAdmin::get_text_message()
 {
-    if( ! m_text_message ) m_text_message = new SKELETON::EditView();
+    if( ! m_text_message ) m_text_message = std::make_unique<SKELETON::EditView>();
 
-    return m_text_message;
+    return m_text_message.get();
 }
 
 
@@ -349,12 +336,12 @@ void MessageAdmin::show_toolbar()
     if( ! m_toolbar ){
 
         // 通常のツールバー
-        m_toolbar = new MessageToolBar();
+        m_toolbar = std::make_unique<MessageToolBar>();
         get_notebook()->append_toolbar( *m_toolbar );
         m_toolbar->open_buttonbar();
 
         // プレビュー用のツールバー
-        m_toolbar_preview = new MessageToolBarPreview();
+        m_toolbar_preview = std::make_unique<MessageToolBarPreview>();
         get_notebook()->append_toolbar( *m_toolbar_preview );
         m_toolbar_preview->open_buttonbar();
     }

--- a/src/message/messageadmin.h
+++ b/src/message/messageadmin.h
@@ -9,6 +9,9 @@
 
 #include "skeleton/admin.h"
 
+#include <memory>
+
+
 namespace SKELETON
 {
     class EditView;
@@ -31,18 +34,18 @@ namespace MESSAGE
 
     class MessageAdmin : public SKELETON::Admin
     {
-        MessageToolBar* m_toolbar;
-        MessageToolBarPreview* m_toolbar_preview;
+        std::unique_ptr<MessageToolBar> m_toolbar;
+        std::unique_ptr<MessageToolBarPreview> m_toolbar_preview;
 
         // 書き込み用のメッセージ欄
         // インスタンスを破棄しないで、前回書き込みビューを閉じた時の
         // 日本語のON/OFF状態を次回開いたときに継続させる
-        SKELETON::EditView* m_text_message;
+        std::unique_ptr<SKELETON::EditView> m_text_message;
 
       public:
 
         explicit MessageAdmin( const std::string& url );
-        ~MessageAdmin();
+        ~MessageAdmin() = default;
 
         void save_session() override {}
 

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -77,7 +77,7 @@ MessageViewBase::MessageViewBase( const std::string& url )
     m_max_line = DBTREE::line_number( get_url() ) * 2;
     m_max_str = DBTREE::message_count( get_url() );
 
-    m_iconv = new JDLIB::Iconv( DBTREE::board_charset( get_url() ), "UTF-8" );;
+    m_iconv = std::make_unique<JDLIB::Iconv>( DBTREE::board_charset( get_url() ), "UTF-8" );;
 
     m_lng_iconv = m_max_str * 3;
     if( ! m_lng_iconv ) m_lng_iconv = MAX_STR_ICONV;
@@ -106,12 +106,8 @@ MessageViewBase::~MessageViewBase()
 
     if( m_post ){
         m_post->terminate_load();
-        delete m_post;
+        m_post.reset();
     }
-    m_post = nullptr;
-
-    if( m_iconv ) delete m_iconv;
-    m_iconv = nullptr;
 
     SESSION::set_close_mes( ! is_locked() );
 }
@@ -797,9 +793,8 @@ void MessageViewBase::post_msg( const std::string& msg, bool new_article )
 
     if( m_post ){
         m_post->terminate_load();
-        delete m_post;
     }
-    m_post = new Post( this, get_url(),  msg, new_article );
+    m_post = std::make_unique<Post>( this, get_url(),  msg, new_article );
     m_post->sig_fin().connect( sigc::mem_fun( *this, &MessageViewBase::post_fin ) );
     m_post->post_msg();
 

--- a/src/message/messageviewbase.h
+++ b/src/message/messageviewbase.h
@@ -9,6 +9,8 @@
 #include "skeleton/compentry.h"
 #include "skeleton/jdtoolbar.h"
 
+#include <memory>
+
 
 namespace JDLIB
 {
@@ -30,7 +32,7 @@ namespace MESSAGE
 
     class MessageViewBase : public SKELETON::View
     {
-        Post* m_post{};
+        std::unique_ptr<Post> m_post;
 
         Gtk::Notebook m_notebook;
         SKELETON::View* m_preview{};
@@ -57,7 +59,7 @@ namespace MESSAGE
         bool m_enable_focus;
 
         // 文字数計算用
-        JDLIB::Iconv* m_iconv;
+        std::unique_ptr<JDLIB::Iconv> m_iconv;
         int m_max_line;
         int m_max_str;
         int m_lng_str_enc{};

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -90,9 +90,6 @@ Post::~Post()
 #endif
 
     clear();
-
-    if( m_writingdiag ) delete m_writingdiag;
-    m_writingdiag = nullptr;
 }
 
 
@@ -119,8 +116,7 @@ void Post::emit_sigfin()
 
     clear();
 
-    if( m_writingdiag ) delete m_writingdiag;
-    m_writingdiag = nullptr;
+    m_writingdiag.reset();
 }
 
 
@@ -136,7 +132,8 @@ void Post::show_writingdiag( const bool show_buttons )
     if( show_buttons ) buttons = Gtk::BUTTONS_OK;
 
     if( ! m_writingdiag ){
-        m_writingdiag = new SKELETON::MsgDiag( *toplevel, "書き込み中・・・", false, Gtk::MESSAGE_INFO, buttons, false );
+        m_writingdiag = std::make_unique<SKELETON::MsgDiag>( *toplevel, "書き込み中・・・", false, Gtk::MESSAGE_INFO,
+                                                             buttons, false );
         m_writingdiag->signal_response().connect( sigc::mem_fun( *this, &Post::slot_response ) );
     }
     m_writingdiag->show();

--- a/src/message/post.h
+++ b/src/message/post.h
@@ -10,7 +10,10 @@
 #include "skeleton/loadable.h"
 
 #include <gtkmm.h>
+
+#include <memory>
 #include <string>
+
 
 namespace SKELETON
 {
@@ -50,7 +53,7 @@ namespace MESSAGE
         bool m_new_article; // 新スレ作成
 
         // 書き込んでいますのダイアログ
-        SKELETON::MsgDiag* m_writingdiag{};
+        std::unique_ptr<SKELETON::MsgDiag> m_writingdiag;
 
         PostStrategy* m_post_strategy;
 


### PR DESCRIPTION
クラスメンバーをスマートポインターに更新してnew/deleteによるメモリ割り当てを整理します。

関連のpull request: #619 