### PR TITLE
Search_Manager: Use std::unique_ptr instead of new/delete

### DIFF
--- a/src/searchmanager.cpp
+++ b/src/searchmanager.cpp
@@ -46,8 +46,6 @@ Search_Manager::~Search_Manager()
 
     stop( std::string() );
     wait();
-
-    if( m_searchloader ) delete m_searchloader;
 }
 
 
@@ -228,7 +226,7 @@ bool Search_Manager::search_title( const std::string& id, const std::string& que
 
     // スレタイの検索が終わったら search_fin_title が呼び出される
     if( ! m_searchloader ){
-        m_searchloader = new SearchLoader();
+        m_searchloader = std::make_unique<SearchLoader>();
         m_searchloader->sig_search_fin().connect( sigc::mem_fun( *this, &Search_Manager::search_fin_title ) );
     }
 
@@ -292,7 +290,7 @@ void Search_Manager::search_fin_title()
         }
     }
 
-    m_searchloader->reset();
+    m_searchloader->reset(); // call SKELETON::TextLoader::reset()
 
     search_fin();
 }

--- a/src/searchmanager.h
+++ b/src/searchmanager.h
@@ -9,11 +9,14 @@
 
 #include "skeleton/dispatchable.h"
 
-#include <gtkmm.h>
 #include "jdlib/jdthread.h"
 
-#include <string>
+#include <gtkmm.h>
+
 #include <list>
+#include <memory>
+#include <string>
+
 
 namespace DBTREE
 {
@@ -68,7 +71,7 @@ namespace CORE
         bool m_stop{};
 
         // スレタイ検索ローダ
-        SearchLoader* m_searchloader{};
+        std::unique_ptr<SearchLoader> m_searchloader;
 
       public:
 


### PR DESCRIPTION
クラスメンバーをスマートポインターに更新してnew/deleteによるメモリ割り当てを整理します。

関連のpull request: #619 