### PR TITLE
PrefDiagFactory: Use std::unique_ptr instead of new/delete

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -1366,9 +1366,8 @@ void ArticleViewBase::show_preference()
     std::cout << "ArticleViewBase::show_preference\n";
 #endif
 
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_ARTICLE, m_url_article );
+    auto pref = CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_ARTICLE, m_url_article );
     pref->run();
-    delete pref;
 }
 
 
@@ -1380,9 +1379,8 @@ void ArticleViewBase::slot_preferences_image()
     if( m_url_tmp.empty() ) return;
     std::string url = m_url_tmp;
 
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_IMAGE, url );
+    auto pref = CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_IMAGE, url );
     pref->run();
-    delete pref;
 }
 
 
@@ -1558,24 +1556,21 @@ void ArticleViewBase::slot_copy_article_info()
 //
 void ArticleViewBase::slot_setup_abone()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_ARTICLE, m_url_article, "show_abone" );
+    auto pref = CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_ARTICLE, m_url_article, "show_abone" );
     pref->run();
-    delete pref;
 }
 
 void ArticleViewBase::slot_setup_abone_board()
 {
-    SKELETON::PrefDiag* pref = CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_BOARD,
-                                                      DBTREE::url_boardbase( m_url_article ), "show_abone_article" );
+    auto pref = CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_BOARD,
+                                       DBTREE::url_boardbase( m_url_article ), "show_abone_article" );
     pref->run();
-    delete pref;
 }
 
 void ArticleViewBase::slot_setup_abone_all()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_GLOBALABONE, "" );
+    auto pref = CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_GLOBALABONE, "" );
     pref->run();
-    delete pref;
 }
 
 

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -1791,10 +1791,8 @@ void BBSListViewBase::slot_preferences_board()
     if( m_path_selected.empty() ) return;
     std::string url = path2url( m_path_selected );
 
-    SKELETON::PrefDiag* pref = CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_BOARD,
-                                                      DBTREE::url_boardbase( url ) );
+    auto pref = CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_BOARD, DBTREE::url_boardbase( url ) );
     pref->run();
-    delete pref;
 }
 
 
@@ -1807,9 +1805,8 @@ void BBSListViewBase::slot_preferences_article()
     if( m_path_selected.empty() ) return;
     std::string url = path2url( m_path_selected );
 
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_ARTICLE, DBTREE::url_dat( url ) );
+    auto pref = CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_ARTICLE, DBTREE::url_dat( url ) );
     pref->run();
-    delete pref;
 }
 
 
@@ -1821,9 +1818,8 @@ void BBSListViewBase::slot_preferences_image()
     if( m_path_selected.empty() ) return;
     std::string url = path2url( m_path_selected );
 
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_IMAGE, url );
+    auto pref = CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_IMAGE, url );
     pref->run();
-    delete pref;
 }
 
 

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -2734,9 +2734,8 @@ void BoardViewBase::show_preference()
     const std::string url_board = path2url_board( m_path_selected );
     if( url_board.empty() ) return;
 
-    SKELETON::PrefDiag* pref =  CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_BOARD, url_board );
+    auto pref = CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_BOARD, url_board );
     pref->run();
-    delete pref;
 }
 
 
@@ -2748,9 +2747,8 @@ void BoardViewBase::slot_preferences_article()
     if( m_path_selected.empty() ) return;
     const std::string url = path2daturl( m_path_selected );
 
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_ARTICLE, url );
+    auto pref = CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_ARTICLE, url );
     pref->run();
-    delete pref;
 }
 
 

--- a/src/dbimg/imgroot.cpp
+++ b/src/dbimg/imgroot.cpp
@@ -302,9 +302,8 @@ void ImgRoot::delete_all_files()
     std::cout << "ImgRoot::delete_all_files\n";
 #endif
 
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_DELIMG, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_DELIMG, "" );
     int ret = pref->run();
-    delete pref;
     if( ret != Gtk::RESPONSE_OK ) return;
 
     // 画像キャッシュ削除ダイアログ表示

--- a/src/history/historysubmenu.cpp
+++ b/src/history/historysubmenu.cpp
@@ -314,7 +314,7 @@ void HistorySubMenu::slot_show_property()
         std::cout << "url " << info_list[ i ].url << std::endl;
 #endif
 
-        SKELETON::PrefDiag* pref = nullptr;
+        std::unique_ptr<SKELETON::PrefDiag> pref;
         switch( info_list[ i ].type ){
 
             case TYPE_THREAD: 
@@ -338,7 +338,6 @@ void HistorySubMenu::slot_show_property()
 
         if( pref ){
             pref->run();
-            delete pref;
         }
     }
 }

--- a/src/image/imageviewbase.cpp
+++ b/src/image/imageviewbase.cpp
@@ -564,13 +564,11 @@ void ImageViewBase::show_preference()
 {
     CORE::core_set_command( "hide_popup" );
 
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_IMAGE, get_url() );
+    auto pref = CORE::PrefDiagFactory( get_parent_win(), CORE::PREFDIAG_IMAGE, get_url() );
 
     IMAGE::get_admin()->set_command_immediately( "disable_fold_win" ); // run 直前に呼ぶこと
     pref->run();
     IMAGE::get_admin()->set_command_immediately( "enable_fold_win" );  // run 直後に呼ぶこと
-
-    delete pref;
 }
 
 

--- a/src/menuslots.cpp
+++ b/src/menuslots.cpp
@@ -52,9 +52,8 @@ using namespace CORE;
 //
 void Core::slot_openurl()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_OPENURL, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_OPENURL, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -465,9 +464,8 @@ void Core::slot_toggle_show_ssspicon()
 //
 void Core::slot_setup_boarditem_column()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BOARDITEM_COLUM, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BOARDITEM_COLUM, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -476,9 +474,8 @@ void Core::slot_setup_boarditem_column()
 //
 void Core::slot_setup_mainitem()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_MAINITEM, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_MAINITEM, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -487,9 +484,8 @@ void Core::slot_setup_mainitem()
 //
 void Core::slot_setup_sidebaritem()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_SIDEBARITEM, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_SIDEBARITEM, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -498,9 +494,8 @@ void Core::slot_setup_sidebaritem()
 //
 void Core::slot_setup_boarditem()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BOARDITEM, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BOARDITEM, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -509,9 +504,8 @@ void Core::slot_setup_boarditem()
 //
 void Core::slot_setup_articleitem()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_ARTICLEITEM, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_ARTICLEITEM, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -520,9 +514,8 @@ void Core::slot_setup_articleitem()
 //
 void Core::slot_setup_searchitem()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_SEARCHITEM, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_SEARCHITEM, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -531,9 +524,8 @@ void Core::slot_setup_searchitem()
 //
 void Core::slot_setup_msgitem()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_MSGITEM, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_MSGITEM, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -543,9 +535,8 @@ void Core::slot_setup_msgitem()
 //
 void Core::slot_setup_boarditem_menu()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BOARDITEM_MENU, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BOARDITEM_MENU, "" );
     pref->run();
-    delete pref;
 }
 
 //
@@ -553,9 +544,8 @@ void Core::slot_setup_boarditem_menu()
 //
 void Core::slot_setup_articleitem_menu()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_ARTICLEITEM_MENU, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_ARTICLEITEM_MENU, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -724,9 +714,8 @@ void Core::slot_toggle_emacsmode()
 //
 void Core::slot_setup_mouse()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_MOUSE, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_MOUSE, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -735,9 +724,8 @@ void Core::slot_setup_mouse()
 //
 void Core::slot_setup_key()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_KEY, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_KEY, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -746,9 +734,8 @@ void Core::slot_setup_key()
 //
 void Core::slot_setup_button()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BUTTON, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BUTTON, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -901,9 +888,8 @@ void Core::slot_changecolor_back_tree()
 //
 void Core::slot_setup_fontcolor()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_FONTCOLOR, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_FONTCOLOR, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -912,9 +898,8 @@ void Core::slot_setup_fontcolor()
 //
 void Core::slot_setup_proxy()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_PROXY, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_PROXY, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -923,9 +908,8 @@ void Core::slot_setup_proxy()
 //
 void Core::slot_setup_browser()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BROWSER, URL_BROWSER );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_BROWSER, URL_BROWSER );
     pref->run();
-    delete pref;
 }
 
 
@@ -934,9 +918,8 @@ void Core::slot_setup_browser()
 //
 void Core::slot_setup_passwd()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_PASSWD, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_PASSWD, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -954,9 +937,8 @@ void Core::slot_toggle_ipv6()
 //
 void Core::slot_setup_abone()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_GLOBALABONE, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_GLOBALABONE, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -965,9 +947,8 @@ void Core::slot_setup_abone()
 //
 void Core::slot_setup_abone_thread()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_GLOBALABONETHREAD, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_GLOBALABONETHREAD, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -1008,9 +989,8 @@ void Core::slot_toggle_abone_icase_wchar()
 // 実況設定
 void Core::slot_setup_live()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_LIVE, "" );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_LIVE, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -1019,9 +999,8 @@ void Core::slot_setup_live()
 //
 void Core::slot_usrcmd_pref()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_USRCMD, URL_USRCMD );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_USRCMD, URL_USRCMD );
     pref->run();
-    delete pref;
 }
 
 
@@ -1030,9 +1009,8 @@ void Core::slot_usrcmd_pref()
 //
 void Core::slot_filter_pref()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_LINKFILTER, URL_LINKFILTER );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_LINKFILTER, URL_LINKFILTER );
     pref->run();
-    delete pref;
 }
 
 
@@ -1041,9 +1019,8 @@ void Core::slot_filter_pref()
 //
 void Core::slot_replace_pref()
 {
-    SKELETON::PrefDiag* pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_REPLACESTR, URL_REPLACESTR );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_REPLACESTR, URL_REPLACESTR );
     pref->run();
-    delete pref;
 }
 
 
@@ -1052,9 +1029,8 @@ void Core::slot_replace_pref()
 //
 void Core::slot_aboutconfig()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_ABOUTCONFIG, URL_ABOUTCONFIG );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_ABOUTCONFIG, URL_ABOUTCONFIG );
     pref->run();
-    delete pref;
 }
 
 
@@ -1062,9 +1038,8 @@ void Core::slot_aboutconfig()
 // プライバシー情報のクリア
 void Core::slot_clear_privacy()
 {
-    SKELETON::PrefDiag* pref= CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_PRIVACY, URL_PRIVACY );
+    auto pref = CORE::PrefDiagFactory( nullptr, CORE::PREFDIAG_PRIVACY, URL_PRIVACY );
     pref->run();
-    delete pref;
 }
 
 

--- a/src/prefdiagfactory.cpp
+++ b/src/prefdiagfactory.cpp
@@ -36,97 +36,97 @@
 
 #include "config/aboutconfig.h"
 
-SKELETON::PrefDiag* CORE::PrefDiagFactory( Gtk::Window* parent, const int type, const std::string& url,
-                                           const std::string& command )
+std::unique_ptr<SKELETON::PrefDiag> CORE::PrefDiagFactory( Gtk::Window* parent, const int type, const std::string& url,
+                                                           const std::string& command )
 {
     switch( type )
     {
         case PREFDIAG_PASSWD:
-            return new CORE::PasswdPref( parent, url );
+            return std::make_unique<CORE::PasswdPref>( parent, url );
 
         case PREFDIAG_PRIVACY:
-            return new CORE::PrivacyPref( parent, url );
+            return std::make_unique<CORE::PrivacyPref>( parent, url );
 
         case PREFDIAG_BROWSER:
-            return new CORE::BrowserPref( parent, url );
+            return std::make_unique<CORE::BrowserPref>( parent, url );
 
         case PREFDIAG_LINKFILTER:
-            return new CORE::LinkFilterPref( parent, url );
+            return std::make_unique<CORE::LinkFilterPref>( parent, url );
 
         case PREFDIAG_REPLACESTR:
-            return new CORE::ReplaceStrPref( parent, url );
+            return std::make_unique<CORE::ReplaceStrPref>( parent, url );
 
         case PREFDIAG_USRCMD:
-            return new CORE::UsrCmdPref( parent, url );
+            return std::make_unique<CORE::UsrCmdPref>( parent, url );
 
         case PREFDIAG_PROXY:
-            return new CORE::ProxyPref( parent, url );
+            return std::make_unique<CORE::ProxyPref>( parent, url );
 
         case PREFDIAG_GLOBALABONE:
-            return new CORE::GlobalAbonePref( parent, url );
+            return std::make_unique<CORE::GlobalAbonePref>( parent, url );
 
         case PREFDIAG_GLOBALABONETHREAD:
-            return new CORE::GlobalAboneThreadPref( parent, url );
+            return std::make_unique<CORE::GlobalAboneThreadPref>( parent, url );
 
         case PREFDIAG_FONTCOLOR:
-            return new CORE::FontColorPref( parent, url );
+            return std::make_unique<CORE::FontColorPref>( parent, url );
 
         case PREFDIAG_LIVE:
-            return new CORE::LivePref( parent, url );
+            return std::make_unique<CORE::LivePref>( parent, url );
 
         case PREFDIAG_MAINITEM:
-            return new CORE::MainItemPref( parent, url );            
+            return std::make_unique<CORE::MainItemPref>( parent, url );
 
         case PREFDIAG_SIDEBARITEM:
-            return new CORE::SidebarItemPref( parent, url );            
+            return std::make_unique<CORE::SidebarItemPref>( parent, url );
 
         case PREFDIAG_BOARDITEM_COLUM:
-            return new CORE::BoardItemColumnPref( parent, url );            
+            return std::make_unique<CORE::BoardItemColumnPref>( parent, url );
 
         case PREFDIAG_BOARDITEM:
-            return new CORE::BoardItemPref( parent, url );            
+            return std::make_unique<CORE::BoardItemPref>( parent, url );
 
         case PREFDIAG_BOARDITEM_MENU:
-            return new CORE::BoardItemMenuPref( parent, url );
+            return std::make_unique<CORE::BoardItemMenuPref>( parent, url );
 
         case PREFDIAG_ARTICLEITEM:
-            return new CORE::ArticleItemPref( parent, url );            
+            return std::make_unique<CORE::ArticleItemPref>( parent, url );
 
         case PREFDIAG_ARTICLEITEM_MENU:
-            return new CORE::ArticleItemMenuPref( parent, url );
+            return std::make_unique<CORE::ArticleItemMenuPref>( parent, url );
 
         case PREFDIAG_SEARCHITEM:
-            return new CORE::SearchItemPref( parent, url );            
+            return std::make_unique<CORE::SearchItemPref>( parent, url );
 
         case PREFDIAG_MSGITEM:
-            return new CORE::MsgItemPref( parent, url );            
+            return std::make_unique<CORE::MsgItemPref>( parent, url );
 
         case PREFDIAG_DELIMG:
-            return new DBIMG::DelImgDiag( parent, url );
+            return std::make_unique<DBIMG::DelImgDiag>( parent, url );
 
         case PREFDIAG_BOARD:
-            return new BOARD::Preferences( parent, url, command );
+            return std::make_unique<BOARD::Preferences>( parent, url, command );
 
         case PREFDIAG_ARTICLE:
-            return new ARTICLE::Preferences( parent, url, command );
+            return std::make_unique<ARTICLE::Preferences>( parent, url, command );
 
         case PREFDIAG_IMAGE:
-            return new IMAGE::Preferences( parent, url );
+            return std::make_unique<IMAGE::Preferences>( parent, url );
 
         case PREFDIAG_KEY:
-            return new CONTROL::KeyPref( parent, url );
+            return std::make_unique<CONTROL::KeyPref>( parent, url );
 
         case PREFDIAG_MOUSE:
-            return new CONTROL::MousePref( parent, url );
+            return std::make_unique<CONTROL::MousePref>( parent, url );
 
         case PREFDIAG_BUTTON:
-            return new CONTROL::ButtonPref( parent, url );
+            return std::make_unique<CONTROL::ButtonPref>( parent, url );
 
         case PREFDIAG_ABOUTCONFIG:
-            return new CONFIG::AboutConfig( parent );
+            return std::make_unique<CONFIG::AboutConfig>( parent );
 
         case PREFDIAG_OPENURL:
-            return new CORE::OpenURLDialog( url );
+            return std::make_unique<CORE::OpenURLDialog>( url );
 
         default:
             return nullptr;

--- a/src/prefdiagfactory.h
+++ b/src/prefdiagfactory.h
@@ -10,7 +10,10 @@
 #include "skeleton/prefdiag.h"
 
 #include <gtkmm.h>
+
+#include <memory>
 #include <string>
+
 
 namespace CORE
 {
@@ -54,9 +57,9 @@ namespace CORE
 
         PREFDIAG_NONE
     };
-    
-    SKELETON::PrefDiag* PrefDiagFactory( Gtk::Window* parent, const int type, const std::string& url,
-                                         const std::string& command = {} );
+
+    std::unique_ptr<SKELETON::PrefDiag> PrefDiagFactory( Gtk::Window* parent, const int type, const std::string& url,
+                                                         const std::string& command = {} );
 }
 
 #endif

--- a/src/setupwizard.cpp
+++ b/src/setupwizard.cpp
@@ -78,9 +78,8 @@ PageNet::PageNet( Gtk::Window* parent )
 //
 void PageNet::slot_setup_proxy()
 {
-    SKELETON::PrefDiag* pref = CORE::PrefDiagFactory( m_parent, CORE::PREFDIAG_PROXY, "" );
+    auto pref = CORE::PrefDiagFactory( m_parent, CORE::PREFDIAG_PROXY, "" );
     pref->run();
-    delete pref;
 }
 
 
@@ -89,9 +88,8 @@ void PageNet::slot_setup_proxy()
 //
 void PageNet::slot_setup_browser()
 {
-    SKELETON::PrefDiag* pref = CORE::PrefDiagFactory( m_parent, CORE::PREFDIAG_BROWSER, "" );
+    auto pref = CORE::PrefDiagFactory( m_parent, CORE::PREFDIAG_BROWSER, "" );
     pref->run();
-    delete pref;
 
     m_label_browser.set_text( CONFIG::get_command_openurl() );
 }

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -632,7 +632,7 @@ void ToolBar::slot_menu_board( int i )
 {
     if( ! m_enable_slot ) return;
 
-    SKELETON::PrefDiag* pref = nullptr;
+    std::unique_ptr<SKELETON::PrefDiag> pref;
 
     // ToolBar::get_button_board()で作成したメニューの順番に内容を合わせる
     if( i == 0 ) slot_open_board();
@@ -644,7 +644,6 @@ void ToolBar::slot_menu_board( int i )
 
     if( pref ){
         pref->run();
-        delete pref;
     }
 }
 


### PR DESCRIPTION
関数の戻り値をスマートポインターに更新してnew/deleteによるメモリ割り当てを整理します。

関連のpull request: #619 