### PR TITLE
Use std::time() instead of gettimeofday()

### DIFF
--- a/src/dbimg/delimgcachediag.cpp
+++ b/src/dbimg/delimgcachediag.cpp
@@ -18,7 +18,7 @@
 
 #include <glib/gi18n.h>
 
-#include <sys/time.h>
+#include <ctime>
 
 
 using namespace DBIMG;
@@ -181,13 +181,11 @@ void DelImgCacheDiag::callback_dispatch()
 //
 time_t DelImgCacheDiag::get_days( const std::string& path )
 {
-        struct timeval tv;
-        struct timezone tz;
-        gettimeofday( &tv, &tz );
-        time_t mtime = CACHE::get_filemtime( path );
-        if( ! mtime ) return -1;
+    const std::time_t current = std::time( nullptr );
+    const std::time_t mtime = CACHE::get_filemtime( path );
+    if( ! mtime ) return -1;
 
-        return ( tv.tv_sec - mtime ) / ( 60 * 60 * 24 );
+    return ( current - mtime ) / ( 60 * 60 * 24 );
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,16 +53,14 @@ JDWinMain* Win_Main = nullptr;
 // バックアップ復元
 void restore_bkup( const bool no_restore_bkup )
 {
-    struct timeval tv;
-    struct timezone tz;
-    gettimeofday( &tv, &tz );
+    const std::string current_str = std::to_string( std::time( nullptr ) );
 
     const std::string path_main = CACHE::path_xml_listmain();
     const std::string path_favor = CACHE::path_xml_favorite();
     const std::string path_main_bkup = CACHE::path_xml_listmain_bkup();
     const std::string path_favor_bkup = CACHE::path_xml_favorite_bkup();
-    const std::string path_main_old = path_main + "." + std::to_string( tv.tv_sec );
-    const std::string path_favor_old = path_favor + "." + std::to_string( tv.tv_sec );
+    const std::string path_main_old = path_main + "." + current_str;
+    const std::string path_favor_old = path_favor + "." + current_str;
 
     const bool bkup_main = ( CACHE::file_exists( path_main_bkup ) == CACHE::EXIST_FILE );
     const bool bkup_favor = ( CACHE::file_exists( path_favor_bkup ) == CACHE::EXIST_FILE );

--- a/src/message/logitem.h
+++ b/src/message/logitem.h
@@ -11,9 +11,10 @@
 
 #include "jdlib/miscutil.h"
 
+#include <ctime>
 #include <list>
 #include <string>
-#include <sys/time.h>
+
 
 enum
 {
@@ -29,7 +30,7 @@ namespace MESSAGE
         std::string url;
         const bool newthread;
         std::string msg;
-        time_t time_write;
+        std::time_t time_write;
         std::list< std::string > msg_lines;
         char head[ LOGITEM_SIZE_HEAD ]{};
         bool remove{};
@@ -38,12 +39,8 @@ namespace MESSAGE
             : url( _url )
             , newthread( _newthread )
             , msg( _msg )
+            , time_write{ std::time( nullptr ) }
         {
-            struct timeval tv;
-            struct timezone tz;
-            gettimeofday( &tv, &tz );
-            time_write = tv.tv_sec;
-
             if( newthread && url.find( ID_OF_NEWTHREAD ) != std::string::npos ) url = url.substr( 0, url.find( ID_OF_NEWTHREAD ) );
 
             // WAVE DASH 問題

--- a/src/message/logmanager.cpp
+++ b/src/message/logmanager.cpp
@@ -17,10 +17,10 @@
 #include "cache.h"
 #include "session.h"
 
-#include <sys/time.h>
 #include <cstring>
-#include <sys/types.h> // chmod
+#include <ctime>
 #include <sys/stat.h>
+#include <sys/types.h> // chmod
 
 
 enum
@@ -120,9 +120,7 @@ bool Log_Manager::has_items( const std::string& url, const bool newthread )
 
 void Log_Manager::remove_items( const std::string& url )
 {
-    struct timeval tv;
-    struct timezone tz;
-    gettimeofday( &tv, &tz );
+    const std::time_t current = std::time( nullptr );
 
     if( ! m_logitems.size() ) return;
 
@@ -138,7 +136,7 @@ void Log_Manager::remove_items( const std::string& url )
             || ( (*it)->newthread && url.find( (*it)->url ) == 0 )
             ){
 
-            const time_t elapsed = tv.tv_sec - (*it)->time_write;
+            const std::time_t elapsed = current - (*it)->time_write;
 
 #ifdef _DEBUG
             std::cout << "elapsed = " << elapsed << std::endl;
@@ -301,12 +299,10 @@ void Log_Manager::save( const std::string& url,
 
     if( ! CACHE::mkdir_logroot() ) return;
 
-    struct timeval tv;
-    struct timezone tz;
-    gettimeofday( &tv, &tz );
+    const std::time_t current = std::time( nullptr );
 
     // 保存メッセージ作成
-    const std::string date = MISC::timettostr( tv.tv_sec, MISC::TIME_WEEK );
+    const std::string date = MISC::timettostr( current, MISC::TIME_WEEK );
     const bool include_url = false; // URLを除外して msg をエスケープ
 
     std::string html = "<hr><br>" + DBTREE::url_readcgi( url, 0, 0 ) + "<br>"

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -37,9 +37,9 @@
 #include "global.h"
 #include "compmanager.h"
 
-#include <sstream>
-#include <sys/time.h>
 #include <cstring>
+#include <ctime>
+#include <sstream>
 
 
 using namespace MESSAGE;
@@ -909,10 +909,8 @@ void MessageViewBase::slot_switch_page( Gtk::Widget*, guint page )
 
         ss << "<>" << mail  << "<>";
 
-        struct timeval tv;
-        struct timezone tz;
-        gettimeofday( &tv, &tz );
-        ss << MISC::timettostr( tv.tv_sec, MISC::TIME_WEEK );
+        const std::time_t current = std::time( nullptr );
+        ss << MISC::timettostr( current, MISC::TIME_WEEK );
 
         ss << " ID:???" << "<>" << msg << "<>\n";
 


### PR DESCRIPTION
[非推奨][1]とされている`gettimeofday()`のかわりに`std::time()`を使います。[リファレンス][1]には`clock_gettime()`を使用すると書いてありますがコンマ以下の時間(`tv_usec`)を使っていないためシンプルな`std::time()`を選択します。

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/gettimeofday.html
