### PR TITLE
BoardBase: Use std::time_t instead of struct timeval

### DIFF
--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -30,8 +30,9 @@
 
 #include <glib/gi18n.h>
 
-#include <sstream>
+#include <algorithm>
 #include <cstring>
+#include <sstream>
 
 
 #ifdef _TEST_CACHE
@@ -390,16 +391,14 @@ ArticleBase* BoardBase::append_article( const std::string& datbase, const std::s
 //
 void BoardBase::update_writetime()
 {
-    struct timeval tv;
-    struct timezone tz;
-    if( gettimeofday( &tv, &tz ) == 0 ){
-
-        m_write_time = tv;
+    const std::time_t current = std::time( nullptr );
+    if( current != std::time_t(-1) ) {
+        m_write_time = current;
+    }
 
 #ifdef _DEBUG
-        std::cout << "BoardBase::update_writetime : " << m_write_time.tv_sec << std::endl;
+    std::cout << "BoardBase::update_writetime : " << m_write_time << std::endl;
 #endif
-    }
 }
 
 
@@ -408,13 +407,12 @@ void BoardBase::update_writetime()
 //
 time_t BoardBase::get_write_pass() const
 {
-    time_t ret = 0;
-    struct timeval tv;
-    struct timezone tz;
+    std::time_t current;
+    if( m_write_time && std::time( &current ) != std::time_t(-1) ) {
 
-    if( m_write_time.tv_sec && gettimeofday( &tv, &tz ) == 0 ) ret = MAX( 0, tv.tv_sec - m_write_time.tv_sec );
-
-    return ret;
+        return std::max<std::time_t>( 0, current - m_write_time );
+    }
+    return 0;
 }
 
 

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -158,7 +158,7 @@ namespace DBTREE
         std::string m_write_mail;
 
         // 最終書き込み時間
-        struct timeval m_write_time{};
+        std::time_t m_write_time{};
 
         // samba(秒)
         std::time_t m_samba_sec{};
@@ -515,7 +515,7 @@ namespace DBTREE
 
         // 最終書き込み時間
         void update_writetime();
-        time_t get_write_time() const { return m_write_time.tv_sec; } // 秒
+        time_t get_write_time() const noexcept { return m_write_time; } // 秒
         time_t get_write_pass() const; // 経過時間(秒)
         time_t get_samba_sec() const { return m_samba_sec; } // samba(秒)
         void set_samba_sec( time_t sec ){ m_samba_sec = sec; }


### PR DESCRIPTION
コンマ以下の時間(`tv_usec`)を使用していないため`struct timeval`のクラスメンバーを`std::time_t`に交換します。