### PR TITLE
misctime: Use std::chrono::steady_clock instead of gettimeofday()

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -22,15 +22,15 @@
 #include <glib/gi18n.h>
 #include <gtkmm.h>
 
-#include <fstream>
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
 #include <dirent.h>
-
 #include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
 #include <cstring>
+#include <fstream>
 
 
 enum

--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -16,6 +16,7 @@
 
 #ifdef _DEBUG_TIME
 #include "misctime.h"
+#include <iostream>
 #endif
 
 #include "config/globalconf.h"
@@ -842,7 +843,7 @@ void Loader::run_main()
                 }
 
 #ifdef _DEBUG_TIME
-                std::cout << "size = " << tmpsize << " time = " << MISC::measurement( 0 ) << std::endl;
+                std::cout << "size = " << tmpsize << " time(ns) = " << MISC::measurement( 0 ) << std::endl;
 #endif
             }
 
@@ -942,7 +943,7 @@ void Loader::run_main()
     } while( !m_stop );
 
 #ifdef _DEBUG_TIME
-    std::cout << "loadingl time = " << MISC::measurement( 1 ) << std::endl;
+    std::cout << "Loader::run_main loading time(ns) = " << MISC::measurement( 1 ) << std::endl;
 #endif
 
     // 終了処理

--- a/src/jdlib/misctime.h
+++ b/src/jdlib/misctime.h
@@ -6,7 +6,6 @@
 #define _MISCTIME_H
 
 #include <string>
-#include <sys/time.h>
 #include <ctime>
 
 namespace MISC
@@ -37,8 +36,8 @@ namespace MISC
     std::string timettostr( const time_t time_from, const int mode );
 
     // 実行時間測定用
-    void start_measurement( const int id );
-    int measurement( const int id );
+    void start_measurement( const unsigned int id );
+    long long measurement( const unsigned int id );
 }
 
 #endif


### PR DESCRIPTION
非推奨とされている[`gettimeofday()`][1]のかわりに`std::chrono`を使います。
経過時間を測定するため標準で提供されているクロックのうち[monotonicなタイプ][2]を選択します。

includeディレクティブの変更でコンパイルエラーが発生したためロジックを変更していないソースファイルのヘッダーを整理しています。

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/gettimeofday.html
[2]: https://en.cppreference.com/w/cpp/chrono/steady_clock