### PR TITLE
Fix compile error on FreeBSD

### DIFF
--- a/src/jdlib/misctime.h
+++ b/src/jdlib/misctime.h
@@ -5,8 +5,10 @@
 #ifndef _MISCTIME_H
 #define _MISCTIME_H
 
-#include <string>
 #include <ctime>
+#include <string>
+#include <sys/time.h>
+
 
 namespace MISC
 {


### PR DESCRIPTION
FreeBSD 12.2でコンパイルエラーが発生したため修正します。

コンパイラのレポート
```
../src/jdlib/misctime.cpp:28:17: error: member access into incomplete type 'const struct timeval'
    sstr << ( tv.tv_sec >> 16 ) << " " << ( tv.tv_sec & 0xffff ) << " " << tv.tv_usec;
                ^
../src/jdlib/misctime.h:28:44: note: forward declaration of 'MISC::timeval'
    std::string timevaltostr( const struct timeval& tv );
                                           ^
```

修正にあたり不具合報告をしていただきありがとうございました。
https://next2ch.net/linux/1613035222/99