### PR TITLE
ArticleBase: Use std::time_t instead of struct timeval

### DIFF
--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -16,7 +16,6 @@
 #include <ctime>
 #include <list>
 #include <string>
-#include <sys/time.h>
 #include <unordered_set>
 #include <vector>
 
@@ -63,7 +62,7 @@ namespace DBTREE
         std::time_t m_access_time{};     // ユーザが最後にロードした時間
         std::string m_access_date;       // ユーザが最後にロードした月日( string型 )
         std::time_t m_check_update_time{}; // 最終更新チェック時間
-        struct timeval m_write_time{}; // 最終書き込み時間
+        std::time_t m_write_time{};    // 最終書き込み時間
         std::string m_write_time_date; // 最終書き込み月日( string型 )
         std::string m_write_name;      // 書き込み時の名前
         std::string m_write_mail;      // 書き込み時のメアド
@@ -244,7 +243,7 @@ namespace DBTREE
         void reset_access_date(){ m_access_date = std::string(); }
 
         // 最終書き込み時間
-        time_t get_write_time() const { return m_write_time.tv_sec; } // 秒
+        time_t get_write_time() const noexcept { return m_write_time; } // 秒
         const std::string& get_write_date(); // string型
         void reset_write_date(){ m_write_time_date = std::string(); }
 

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -60,7 +60,7 @@ namespace DBTREE
         int m_number_before_load{};      // ロード前のレスの数( m_number_new を計算するのに使う )
         int m_number_seen{};             // どこまで読んだか
         int m_number_max{};              // 規定の最大レス数(0:未設定)
-        struct timeval m_access_time{};  // ユーザが最後にロードした時間
+        std::time_t m_access_time{};     // ユーザが最後にロードした時間
         std::string m_access_date;       // ユーザが最後にロードした月日( string型 )
         std::time_t m_check_update_time{}; // 最終更新チェック時間
         struct timeval m_write_time{}; // 最終書き込み時間
@@ -239,7 +239,7 @@ namespace DBTREE
 
         // 最終アクセス時間
         std::string get_access_time_str();
-        time_t get_access_time() const { return m_access_time.tv_sec; } // 秒
+        time_t get_access_time() const noexcept { return m_access_time; } // 秒
         const std::string& get_access_date(); // string型
         void reset_access_date(){ m_access_date = std::string(); }
 

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -62,7 +62,7 @@ namespace DBTREE
         int m_number_max{};              // 規定の最大レス数(0:未設定)
         struct timeval m_access_time{};  // ユーザが最後にロードした時間
         std::string m_access_date;       // ユーザが最後にロードした月日( string型 )
-        struct timeval m_check_update_time{};  // 最終更新チェック時間
+        std::time_t m_check_update_time{}; // 最終更新チェック時間
         struct timeval m_write_time{}; // 最終書き込み時間
         std::string m_write_time_date; // 最終書き込み月日( string型 )
         std::string m_write_name;      // 書き込み時の名前


### PR DESCRIPTION
Fixes #625 

小数点以下の時間を使用していないため`struct timeval`型のクラスメンバーを`std::time_t`で置き換えます。
micro秒部分(`tv_usec`)の解析が省略されて固定値(`0`)で処理されるため一部の未使用データが失われますがプログラムに
影響はありません。

非推奨とされている[`gettimeofday()`][1]のかわりに`std::time()`を使います。

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/gettimeofday.html



