### PR TITLE
article: Use std::unique_ptr instead of new/delete

### DIFF
--- a/src/article/articleadmin.cpp
+++ b/src/article/articleadmin.cpp
@@ -80,10 +80,6 @@ ArticleAdmin::~ArticleAdmin()
     std::cout << "ArticleAdmin::~ArticleAdmin\n";
 #endif
 
-    if( m_toolbar ) delete m_toolbar;
-    if( m_toolbarsimple ) delete m_toolbarsimple;
-    if( m_search_toolbar ) delete m_search_toolbar;
-
     ARTICLE::init_font();
 }
 
@@ -580,15 +576,15 @@ void ArticleAdmin::show_toolbar()
     if( ! m_toolbar ){
 
         // 通常のツールバー( TOOLBAR_ARTICLE )
-        m_toolbar = new ArticleToolBar();
+        m_toolbar = std::make_unique<ArticleToolBar>();
         get_notebook()->append_toolbar( *m_toolbar );
 
         // 簡易版ツールバー( TOOLBAR_SIMPLE )
-        m_toolbarsimple = new ArticleToolBarSimple();
+        m_toolbarsimple = std::make_unique<ArticleToolBarSimple>();
         get_notebook()->append_toolbar( *m_toolbarsimple );
 
         // ログ検索などのツールバー( TOOLBAR_SEARCH )
-        m_search_toolbar = new SearchToolBar();
+        m_search_toolbar = std::make_unique<SearchToolBar>();
         get_notebook()->append_toolbar( *m_search_toolbar );
 
         if( SESSION::get_show_article_toolbar() ){

--- a/src/article/articleadmin.h
+++ b/src/article/articleadmin.h
@@ -36,9 +36,9 @@ namespace ARTICLE
 
     class ArticleAdmin : public SKELETON::Admin
     {
-        ArticleToolBar* m_toolbar{};
-        ArticleToolBarSimple* m_toolbarsimple{};
-        SearchToolBar* m_search_toolbar{};
+        std::unique_ptr<ArticleToolBar> m_toolbar;
+        std::unique_ptr<ArticleToolBarSimple> m_toolbarsimple;
+        std::unique_ptr<SearchToolBar> m_search_toolbar;
 
         std::unique_ptr<JDLIB::Timeout> m_conn_timer;
 

--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -2846,7 +2846,7 @@ void ArticleViewBase::show_popup( SKELETON::View* view, const int mrg_x, const i
 
     delete_popup();
 
-    m_popup_win = new SKELETON::PopupWin( this, view, mrg_x, mrg_y );
+    m_popup_win = std::make_unique<SKELETON::PopupWin>( this, view, mrg_x, mrg_y );
     m_popup_win->signal_leave_notify_event().connect( sigc::mem_fun( *this, &ArticleViewBase::slot_popup_leave_notify_event ) );
     m_popup_win->sig_hide_popup().connect( sigc::mem_fun( *this, &ArticleViewBase::slot_hide_popup ) );
     m_popup_shown = true;
@@ -2952,8 +2952,7 @@ void ArticleViewBase::delete_popup()
     std::cout << "ArticleViewBase::delete_popup " << get_url() << std::endl;
 #endif
 
-    if( m_popup_win ) delete m_popup_win;
-    m_popup_win = nullptr;
+    m_popup_win.reset();
     m_popup_shown = false;
 }
 

--- a/src/article/articleviewbase.h
+++ b/src/article/articleviewbase.h
@@ -10,7 +10,9 @@
 #include "jdlib/refptr_lock.h"
 
 #include <gtkmm.h>
+
 #include <list>
+#include <memory>
 
 
 namespace SKELETON
@@ -56,7 +58,7 @@ namespace ARTICLE
         std::string m_name;    // 名前
 
         // ポップアップ
-        SKELETON::PopupWin* m_popup_win{};
+        std::unique_ptr<SKELETON::PopupWin> m_popup_win;
         bool m_popup_shown{}; // 表示されているならtrue, falseでもdeleteしない限りは m_popup_win != nullptrに注意
         int m_hidepopup_counter{}; // ポップアップを消すまでのカウンタ
         std::string m_popup_url; // 表示中のポップアップのアドレス

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -152,8 +152,6 @@ DrawAreaBase::~DrawAreaBase()
 
     cancel_deceleration();
 
-    if( m_layout_tree ) delete m_layout_tree;
-    m_layout_tree = nullptr;
     clear();
 }
 
@@ -167,12 +165,10 @@ DrawAreaBase::~DrawAreaBase()
 //
 void DrawAreaBase::setup( const bool show_abone, const bool show_scrbar, const bool show_multispace )
 {
-    if( m_layout_tree ) delete m_layout_tree;
-    m_layout_tree = nullptr;
     clear();
 
     m_article = DBTREE::get_article( m_url );
-    m_layout_tree = new LayoutTree( m_url, show_abone, show_multispace );
+    m_layout_tree = std::make_unique<LayoutTree>( m_url, show_abone, show_multispace );
 
     // デフォルトではoffになってるイベントを追加
     m_view.add_events( Gdk::BUTTON_PRESS_MASK );

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -18,6 +18,8 @@
 #include <gtkmm.h>
 
 #include <chrono>
+#include <memory>
+
 
 namespace ARTICLE
 {
@@ -111,7 +113,7 @@ namespace ARTICLE
         Gtk::Scrollbar* m_vscrbar{};
 
         // レイアウトツリー
-        LayoutTree* m_layout_tree{};
+        std::unique_ptr<LayoutTree> m_layout_tree;
 
         // 描画領域の幅、高さ( != ウィンドウサイズ )
         int m_width_client{};

--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -92,8 +92,7 @@ void LayoutTree::clear()
     m_id_header = -STEP_ID; // ルートヘッダのIDが 0 になるように -STEP_ID を入れておく
     m_root_header = create_layout_header();
     
-    if( m_local_nodetree ) delete m_local_nodetree;
-    m_local_nodetree = nullptr;
+    m_local_nodetree.reset();
 
     m_last_div = nullptr;
 
@@ -500,7 +499,7 @@ void LayoutTree::append_html( const std::string& html )
     std::cout << "LayoutTree::append_html url = " << m_url << " html = " << html << std::endl;
 #endif    
 
-    if( ! m_local_nodetree ) m_local_nodetree = new DBTREE::NodeTreeDummy( m_url );
+    if( ! m_local_nodetree ) m_local_nodetree = std::make_unique<DBTREE::NodeTreeDummy>( m_url );
     DBTREE::NODE* node_header = m_local_nodetree->append_html( html );
     if( !node_header ) {
         return;
@@ -525,7 +524,7 @@ void LayoutTree::append_html( const std::string& html )
 void LayoutTree::append_dat( const std::string& dat, int num )
 {
     if( dat.empty() ) return;
-    if( ! m_local_nodetree ) m_local_nodetree = new DBTREE::NodeTreeBase( m_url, std::string() );
+    if( ! m_local_nodetree ) m_local_nodetree = std::make_unique<DBTREE::NodeTreeBase>( m_url, std::string() );
 
     // ダミーのノードを作って番号を調整する
     int res_num = m_local_nodetree->get_res_number();

--- a/src/article/layouttree.h
+++ b/src/article/layouttree.h
@@ -6,13 +6,15 @@
 #ifndef _LAYOUTTREE_H
 #define _LAYOUTTREE_H
 
-#include <string>
-#include <unordered_map>
-
 #include "jdlib/refptr_lock.h"
 #include "jdlib/heap.h"
 
 #include "cssmanager.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
 
 namespace DBTREE
 {
@@ -87,7 +89,7 @@ namespace ARTICLE
         std::unordered_map< int, LAYOUT* > m_map_header;  // ヘッダのポインタの連想配列
 
         // コメントノードやプレビュー表示時に使うローカルなノードツリー
-        DBTREE::NodeTreeBase* m_local_nodetree{};
+        std::unique_ptr<DBTREE::NodeTreeBase> m_local_nodetree;
 
         LAYOUT* m_root_header;
         LAYOUT* m_last_header;


### PR DESCRIPTION
クラスのメンバーをスマートポインターに更新してnew/deleteによるメモリ割り当てを整理します。

関連のpull request: #619 