### PR TITLE
Core: Use std::unique_ptr instead of new/delete

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -237,7 +237,7 @@ Core::~Core()
     CORE::delete_dispatchmanager();
 
     // ツールバー削除
-    if( m_toolbar ) delete m_toolbar;
+    m_toolbar.reset();
 
     // 設定削除
     CONFIG::delete_confitem();
@@ -1291,7 +1291,7 @@ void Core::create_toolbar()
 {
     if( m_toolbar ) return;
 
-    m_toolbar = new MainToolBar();
+    m_toolbar = std::make_unique<MainToolBar>();
 
     m_toolbar->m_button_bbslist.signal_clicked().connect(
         sigc::bind< std::string, bool >( sigc::mem_fun(*this, &Core::switch_sidebar ), URL_BBSLISTVIEW, false ) );

--- a/src/core.h
+++ b/src/core.h
@@ -9,11 +9,6 @@
 
 #include "gtkmmversion.h"
 
-#include <gtkmm.h>
-#include <list>
-#include <memory>
-#include <string>
-
 #include "skeleton/dispatchable.h"
 #include "skeleton/hpaned.h"
 #include "skeleton/vpaned.h"
@@ -21,6 +16,13 @@
 #include "skeleton/vbox.h"
 
 #include "command_args.h"
+
+#include <gtkmm.h>
+
+#include <list>
+#include <memory>
+#include <string>
+
 
 class JDWinMain;
 
@@ -96,7 +98,7 @@ namespace CORE
         SKELETON::JDVPaned m_vpaned_message; // 埋め込み書き込みビュー用
 
         // ツールバー
-        MainToolBar* m_toolbar{};
+        std::unique_ptr<MainToolBar> m_toolbar;
 
         // タイトルに表示する文字列
         // set_maintitle() 参照


### PR DESCRIPTION
クラスのメンバーをスマートポインターに更新してnew/deleteによる
メモリ割り当てを整理します。

関連のpull request: #619 
