### PR TITLE
bbslist: Use std::unique_ptr instead of new/delete

### DIFF
--- a/src/bbslist/bbslistadmin.cpp
+++ b/src/bbslist/bbslistadmin.cpp
@@ -75,7 +75,6 @@ BBSListAdmin::~BBSListAdmin()
     std::cout << "BBSListAdmin::~BBSListAdmin\n";
 #endif
 
-    if( m_toolbar ) delete m_toolbar;
     BBSLIST::delete_undo_buffer_favorite();
 }
 
@@ -153,7 +152,7 @@ void BBSListAdmin::show_toolbar()
 {
     // まだ作成されていない場合は作成する
     if( ! m_toolbar ){
-        m_toolbar = new BBSListToolBar();
+        m_toolbar = std::make_unique<BBSListToolBar>();
         get_notebook()->append_toolbar( *m_toolbar );
 
         if( SESSION::get_show_bbslist_toolbar() ) m_toolbar->open_buttonbar();

--- a/src/bbslist/bbslistadmin.h
+++ b/src/bbslist/bbslistadmin.h
@@ -11,8 +11,10 @@
 #include "type.h"
 #include "data_info.h"
 
+#include <memory>
 #include <string>
 #include <vector>
+
 
 namespace SKELETON
 {
@@ -25,7 +27,7 @@ namespace BBSLIST
 
     class BBSListAdmin : public SKELETON::Admin
     {
-        BBSListToolBar* m_toolbar{};
+        std::unique_ptr<BBSListToolBar> m_toolbar;
 
       public:
 

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -497,15 +497,8 @@ BBSListViewBase::BBSListViewBase( const std::string& url, const std::string& arg
 }
 
 
-BBSListViewBase::~BBSListViewBase()
-{
-#ifdef _DEBUG
-    std::cout << "BBSListViewBase::~BBSListViewBase : " << get_url() << std::endl;
-#endif
-
-    if( m_editlistwin ) delete m_editlistwin;
-    m_editlistwin = nullptr;
-}
+// EditListWin が不完全型のためヘッダーではデストラクタを定義できない
+BBSListViewBase::~BBSListViewBase() noexcept = default;
 
 
 void BBSListViewBase::save_session()
@@ -3078,7 +3071,7 @@ void BBSListViewBase::edit_tree()
 
     else{
 
-        m_editlistwin = new EditListWin( get_url(), get_treestore() );
+        m_editlistwin = std::make_unique<EditListWin>( get_url(), get_treestore() );
         m_editlistwin->signal_hide().connect( sigc::mem_fun(*this, &BBSListViewBase::slot_hide_editlistwin ) );
         m_editlistwin->show();
     }
@@ -3094,8 +3087,7 @@ void BBSListViewBase::slot_hide_editlistwin()
     std::cout << "BBSListViewBase::slot_hide_editlistwin\n";
 #endif
 
-    if( m_editlistwin ) delete m_editlistwin;
-    m_editlistwin = nullptr;
+    m_editlistwin.reset();
 }
 
 

--- a/src/bbslist/bbslistviewbase.h
+++ b/src/bbslist/bbslistviewbase.h
@@ -16,8 +16,10 @@
 
 #include <gtkmm.h>
 
+#include <memory>
 #include <string>
 #include <unordered_set>
+
 
 namespace SKELETON
 {
@@ -80,7 +82,7 @@ namespace BBSLIST
         // ツリーに含まれている画像のURLを入れる hash_set
         std::set< std::string > m_set_image;
 
-        EditListWin* m_editlistwin{};
+        std::unique_ptr<EditListWin> m_editlistwin;
 
         // スレを追加したときにそのスレにしおりを付ける
         bool m_set_bookmark{};
@@ -183,7 +185,7 @@ namespace BBSLIST
       public:
 
         explicit BBSListViewBase( const std::string& url, const std::string& arg1 = {}, const std::string& arg2 = {} );
-        ~BBSListViewBase();
+        ~BBSListViewBase() noexcept;
 
         //
         // SKELETON::View の関数のオーバロード

--- a/src/bbslist/selectdialog.h
+++ b/src/bbslist/selectdialog.h
@@ -11,6 +11,8 @@
 #include "skeleton/label_entry.h"
 
 #include <vector>
+#include <memory>
+
 
 namespace BBSLIST
 {
@@ -29,12 +31,12 @@ namespace BBSLIST
 
         Gtk::ToggleButton m_bt_show_tree;
 
-        SelectListView* m_selectview{};
+        std::unique_ptr<SelectListView> m_selectview;
 
       public:
 
         SelectListDialog( Gtk::Window* parent, const std::string& url, Glib::RefPtr< Gtk::TreeStore >& treestore );
-        ~SelectListDialog();
+        ~SelectListDialog() noexcept;
 
         std::string get_name();
         std::string get_path();


### PR DESCRIPTION
クラスのメンバーをスマートポインターに更新してnew/deleteによるメモリ割り当てを整理します。

関連のpull request: #619 
