### PR TITLE
board: Use std::unique_ptr instead of new/delete

### DIFF
--- a/src/board/boardadmin.cpp
+++ b/src/board/boardadmin.cpp
@@ -64,16 +64,6 @@ BoardAdmin::BoardAdmin( const std::string& url )
 }
 
 
-BoardAdmin::~BoardAdmin()
-{
-#ifdef _DEBUG    
-    std::cout << "BoardAdmin::~BoardAdmin\n";
-#endif
-
-    if( m_toolbar ) delete m_toolbar;
-}
-
-
 void BoardAdmin::save_session()
 {
     Admin::save_session();
@@ -296,7 +286,7 @@ void BoardAdmin::show_toolbar()
 {
     // まだ作成されていない場合は作成する
     if( ! m_toolbar ){
-        m_toolbar = new BoardToolBar();
+        m_toolbar = std::make_unique<BoardToolBar>();
         get_notebook()->append_toolbar( *m_toolbar );
 
         if( SESSION::get_show_board_toolbar() ) m_toolbar->open_buttonbar();

--- a/src/board/boardadmin.h
+++ b/src/board/boardadmin.h
@@ -10,7 +10,9 @@
 
 #include "sign.h"
 
+#include <memory>
 #include <string>
+
 
 namespace BOARD
 {
@@ -18,11 +20,11 @@ namespace BOARD
 
     class BoardAdmin : public SKELETON::Admin
     {
-        BoardToolBar* m_toolbar{};
+        std::unique_ptr<BoardToolBar> m_toolbar;
 
       public:
         explicit BoardAdmin( const std::string& url );
-        ~BoardAdmin();
+        ~BoardAdmin() = default;
 
         void save_session() override;
 

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -211,7 +211,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     m_vbox.pack_end( m_frame_write, Gtk::PACK_SHRINK );
 
     // ローカルルール
-    m_localrule = CORE::ViewFactory( CORE::VIEW_ARTICLEINFO, get_url() );
+    m_localrule.reset( CORE::ViewFactory( CORE::VIEW_ARTICLEINFO, get_url() ) );
 
     // プロキシ
     std::string host;
@@ -366,13 +366,6 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
 }
 
 
-Preferences::~Preferences()
-{
-    if( m_localrule ) delete m_localrule;
-    m_localrule = nullptr;
-}
-
-
 void Preferences::slot_clear_modified()
 {
     DBTREE::board_set_date_modified( get_url(), "" );
@@ -460,7 +453,7 @@ void Preferences::slot_remove_old_title()
 
 void Preferences::slot_switch_page( Gtk::Widget*, guint page )
 {
-    if( m_notebook.get_nth_page( page ) == m_localrule ){
+    if( m_notebook.get_nth_page( page ) == m_localrule.get() ){
         m_localrule->set_command( "clear_screen" );
         m_localrule->set_command( "append_html", DBTREE::localrule( get_url() ) );
     }

--- a/src/board/preference.h
+++ b/src/board/preference.h
@@ -10,6 +10,8 @@
 #include "skeleton/editview.h"
 #include "skeleton/label_entry.h"
 
+#include <memory>
+
 
 namespace BOARD
 {
@@ -138,14 +140,14 @@ namespace BOARD
         Gtk::Button m_button_remove_old_title;
 
         // ローカルルール
-        SKELETON::View* m_localrule{};
+        std::unique_ptr<SKELETON::View> m_localrule;
 
         // SETTING.TXT
         SKELETON::EditView m_edit_settingtxt;
 
       public:
         Preferences( Gtk::Window* parent, const std::string& url, const std::string& command );
-        ~Preferences();
+        ~Preferences() noexcept = default;
 
       private:
         void slot_clear_modified();


### PR DESCRIPTION
クラスのメンバーをスマートポインターに更新してnew/deleteによるメモリ割り当てを整理します。

関連のpull request: #619 
