### PR TITLE
MouseKeyPref: Use std::unique_ptr instead of new/delete

### DIFF
--- a/src/control/buttonpref.cpp
+++ b/src/control/buttonpref.cpp
@@ -30,9 +30,9 @@ ButtonDiag::ButtonDiag( Gtk::Window* parent, const std::string& url, const int i
 {}
 
 
-InputDiag* ButtonDiag::create_inputdiag()
+std::unique_ptr<InputDiag> ButtonDiag::create_inputdiag()
 {
-    return new ButtonInputDiag( this, "", get_id() );
+    return std::make_unique<ButtonInputDiag>( this, "", get_id() );
 }
 
 
@@ -121,9 +121,9 @@ ButtonPref::ButtonPref( Gtk::Window* parent, const std::string& url )
 }
 
 
-MouseKeyDiag* ButtonPref::create_setting_diag( const int id, const std::string& str_motions )
+std::unique_ptr<MouseKeyDiag> ButtonPref::create_setting_diag( const int id, const std::string& str_motions )
 {
-    return new ButtonDiag( this, "", id, str_motions );
+    return std::make_unique<ButtonDiag>( this, "", id, str_motions );
 }
 
 

--- a/src/control/buttonpref.h
+++ b/src/control/buttonpref.h
@@ -39,7 +39,7 @@ namespace CONTROL
 
       protected:
 
-        InputDiag* create_inputdiag() override;
+        std::unique_ptr<InputDiag> create_inputdiag() override;
         std::string get_default_motions( const int id ) override;
         std::vector< int > check_conflict( const int mode, const std::string& str_motion ) override;
     };
@@ -59,7 +59,7 @@ namespace CONTROL
 
       protected:
 
-        MouseKeyDiag* create_setting_diag( const int id, const std::string& str_motions ) override;
+        std::unique_ptr<MouseKeyDiag> create_setting_diag( const int id, const std::string& str_motions ) override;
         std::string get_str_motions( const int id ) override;
         std::string get_default_motions( const int id ) override;
         void set_motions( const int id, const std::string& str_motions ) override;

--- a/src/control/keypref.cpp
+++ b/src/control/keypref.cpp
@@ -36,9 +36,9 @@ KeyDiag::KeyDiag( Gtk::Window* parent, const std::string& url, const int id, con
 }
 
 
-InputDiag* KeyDiag::create_inputdiag()
+std::unique_ptr<InputDiag> KeyDiag::create_inputdiag()
 {
-    return new KeyInputDiag( this, "", get_id() );
+    return std::make_unique<KeyInputDiag>( this, "", get_id() );
 }
 
 
@@ -231,9 +231,9 @@ KeyPref::KeyPref( Gtk::Window* parent, const std::string& url )
 }
 
 
-MouseKeyDiag* KeyPref::create_setting_diag( const int id, const std::string& str_motions )
+std::unique_ptr<MouseKeyDiag> KeyPref::create_setting_diag( const int id, const std::string& str_motions )
 {
-    return new KeyDiag( this, "", id, str_motions );
+    return std::make_unique<KeyDiag>( this, "", id, str_motions );
 }
 
 

--- a/src/control/keypref.h
+++ b/src/control/keypref.h
@@ -37,7 +37,7 @@ namespace CONTROL
 
       protected:
 
-        InputDiag* create_inputdiag() override;
+        std::unique_ptr<InputDiag> create_inputdiag() override;
         std::string get_default_motions( const int id ) override;
         std::vector< int > check_conflict( const int mode, const std::string& str_motion ) override;
     };
@@ -56,7 +56,7 @@ namespace CONTROL
 
       protected:
 
-        MouseKeyDiag* create_setting_diag( const int id, const std::string& str_motions ) override;
+        std::unique_ptr<MouseKeyDiag> create_setting_diag( const int id, const std::string& str_motions ) override;
         std::string get_str_motions( const int id ) override;
         std::string get_default_motions( const int id ) override;
         void set_motions( const int id, const std::string& str_motions ) override;

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -366,7 +366,7 @@ std::string MouseKeyDiag::show_inputdiag( bool is_append )
         }
     }
 
-    InputDiag* diag = create_inputdiag();
+    std::unique_ptr<InputDiag> diag = create_inputdiag();
     if( diag == nullptr ) return std::string();
 
     while( diag->run() == Gtk::RESPONSE_OK ){
@@ -389,7 +389,6 @@ std::string MouseKeyDiag::show_inputdiag( bool is_append )
         }
     }
 
-    delete diag;
     return str_motion;
 }
 
@@ -622,7 +621,7 @@ void MouseKeyPref::slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::Tr
     const int id = row[ get_colums().m_col_id ];
     if( id == CONTROL::None ) return;
 
-    MouseKeyDiag* diag = create_setting_diag( id, row[ get_colums().m_col_motions ] );
+    std::unique_ptr<MouseKeyDiag> diag = create_setting_diag( id, row[ get_colums().m_col_motions ] );
     if( diag->run() == Gtk::RESPONSE_OK ){
 
         const std::string motions = diag->get_str_motions();
@@ -634,8 +633,6 @@ void MouseKeyPref::slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::Tr
         remove_motions( id );
         set_motions( id, motions );
     }
-
-    delete diag;
 }
 
 

--- a/src/control/mousekeypref.h
+++ b/src/control/mousekeypref.h
@@ -11,6 +11,9 @@
 
 #include "control.h"
 
+#include <memory>
+
+
 namespace CONTROL
 {
     enum
@@ -116,7 +119,7 @@ namespace CONTROL
         int get_single() const { return m_single; }
         void set_single( bool single ){ m_single = single; }
 
-        virtual InputDiag* create_inputdiag() = 0;
+        virtual std::unique_ptr<InputDiag> create_inputdiag() = 0;
         virtual std::string get_default_motions( const int id ) = 0;
         virtual std::vector< int > check_conflict( const int mode, const std::string& str_motion ) = 0;
 
@@ -190,7 +193,7 @@ namespace CONTROL
         void append_row( const int id, const std::string& label = std::string() );
         void append_comment_row( const std::string& comment );
 
-        virtual MouseKeyDiag* create_setting_diag( const int id, const std::string& str_motions ) = 0;
+        virtual std::unique_ptr<MouseKeyDiag> create_setting_diag( const int id, const std::string& str_motions ) = 0;
         virtual std::string get_str_motions( const int id ) = 0;
         virtual std::string get_default_motions( const int id ) = 0;
         virtual void set_motions( const int id, const std::string& str_motions ) = 0;

--- a/src/control/mousepref.cpp
+++ b/src/control/mousepref.cpp
@@ -30,9 +30,9 @@ MouseDiag::MouseDiag( Gtk::Window* parent, const std::string& url, const int id,
 {}
 
 
-InputDiag* MouseDiag::create_inputdiag()
+std::unique_ptr<InputDiag> MouseDiag::create_inputdiag()
 {
-    return new MouseInputDiag( this, "", get_id() );
+    return std::make_unique<MouseInputDiag>( this, "", get_id() );
 }
 
 
@@ -112,9 +112,9 @@ MousePref::MousePref( Gtk::Window* parent, const std::string& url )
 }
 
 
-MouseKeyDiag* MousePref::create_setting_diag( const int id, const std::string& str_motions )
+std::unique_ptr<MouseKeyDiag> MousePref::create_setting_diag( const int id, const std::string& str_motions )
 {
-    return new MouseDiag( this, "", id, str_motions );
+    return std::make_unique<MouseDiag>( this, "", id, str_motions );
 }
 
 

--- a/src/control/mousepref.h
+++ b/src/control/mousepref.h
@@ -38,7 +38,7 @@ namespace CONTROL
 
       protected:
 
-        InputDiag* create_inputdiag() override;
+        std::unique_ptr<InputDiag> create_inputdiag() override;
         std::string get_default_motions( const int id ) override;
         std::vector< int > check_conflict( const int mode, const std::string& str_motion ) override;
     };
@@ -58,7 +58,7 @@ namespace CONTROL
 
       protected:
 
-        MouseKeyDiag* create_setting_diag( const int id, const std::string& str_motions ) override;
+        std::unique_ptr<MouseKeyDiag> create_setting_diag( const int id, const std::string& str_motions ) override;
         std::string get_str_motions( const int id ) override;
         std::string get_default_motions( const int id ) override;
         void set_motions( const int id, const std::string& str_motions ) override;


### PR DESCRIPTION
メンバー関数の戻り値をスマートポインターに取り替えてnew/deleteを整理します。

関連のpull request: #619 
