### PR TITLE
ImageViewPopup: Use std::unique_ptr instead of new/delete

### DIFF
--- a/src/image/imageviewpopup.cpp
+++ b/src/image/imageviewpopup.cpp
@@ -68,14 +68,6 @@ ImageViewPopup::ImageViewPopup( const std::string& url )
 }
 
 
-ImageViewPopup::~ImageViewPopup()
-{
-#ifdef _DEBUG
-    std::cout << "ImageViewPopup::~ImageViewPopup url = " << get_url() << std::endl;
-#endif    
-}
-
-
 //
 // クロック入力
 //
@@ -114,10 +106,8 @@ void ImageViewPopup::stop()
 void ImageViewPopup::set_label( const std::string& status )
 {
     if( !m_label ){
-        m_label = Gtk::manage( new Gtk::Label() );
-        assert( m_label );
+        m_label = std::make_unique<Gtk::Label>( status );
         get_event().add( *m_label );
-        m_label->set_text( status );
 
         std::string text_color = CONFIG::get_color( COLOR_CHAR );
         const int classid = CORE::get_css_manager()->get_classid( "imgpopup" );
@@ -141,8 +131,7 @@ void ImageViewPopup::remove_label()
 {
     if( m_label ){
         get_event().remove();
-        delete m_label;
-        m_label = nullptr;
+        m_label.reset();
     }
 }
 

--- a/src/image/imageviewpopup.h
+++ b/src/image/imageviewpopup.h
@@ -9,13 +9,16 @@
 
 #include "imageviewbase.h"
 
+#include <memory>
+
+
 namespace IMAGE
 {
     class ImageViewPopup : public ImageViewBase
     {
         Gtk::EventBox m_event_frame;
         Gtk::EventBox m_event_margin;
-        Gtk::Label* m_label{};
+        std::unique_ptr<Gtk::Label> m_label;
         size_t m_length_prev{};
 
         bool m_clicked{};
@@ -23,7 +26,7 @@ namespace IMAGE
       public:
 
         explicit ImageViewPopup( const std::string& url );
-        ~ImageViewPopup();
+        ~ImageViewPopup() noexcept = default;
 
         void clock_in() override;
 


### PR DESCRIPTION
クラスのメンバーをスマートポインターに更新してnew/deleteによるメモリ割り当てを整理します。
子ウィジェットを追加削除する処理があるため`Gtk::manage()`によるメモリ管理ではdeleteを整理できません。

関連のpull request: #619 
