### PR TITLE
MessageViewBase: Use std::unique_ptr instead of new/delete

### DIFF
--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -101,9 +101,6 @@ MessageViewBase::~MessageViewBase()
     CORE::get_completion_manager()->set_query( CORE::COMP_NAME, name );
     CORE::get_completion_manager()->set_query( CORE::COMP_MAIL, mail );
 
-    if( m_preview ) delete m_preview;
-    m_preview = nullptr;
-
     if( m_post ){
         m_post->terminate_load();
         m_post.reset();
@@ -467,7 +464,7 @@ void MessageViewBase::pack_widget()
     m_text_message->get_buffer()->signal_changed().connect( sigc::mem_fun(*this, &MessageViewBase::slot_text_changed ) );
 
     // プレビュー
-    m_preview = CORE::ViewFactory( CORE::VIEW_ARTICLEPREVIEW, get_url() );
+    m_preview.reset( CORE::ViewFactory( CORE::VIEW_ARTICLEPREVIEW, get_url() ) );
 
     m_notebook.set_show_tabs( false );
     m_notebook.set_show_border( false );

--- a/src/message/messageviewbase.h
+++ b/src/message/messageviewbase.h
@@ -35,7 +35,7 @@ namespace MESSAGE
         std::unique_ptr<Post> m_post;
 
         Gtk::Notebook m_notebook;
-        SKELETON::View* m_preview{};
+        std::unique_ptr<SKELETON::View> m_preview;
         Gtk::VBox m_msgview;
 
         SKELETON::JDToolbar m_toolbar_name_mail;


### PR DESCRIPTION
クラスのメンバーをスマートポインターに更新してnew/deleteによるメモリ割り当てを整理します。

関連のpull request: #619 
