### PR TITLE
skeleton: Use std::unique_ptr instead of new/delete

### DIFF
--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -52,9 +52,8 @@ using namespace SKELETON;
 
 Admin::Admin( const std::string& url )
     : m_url( url )
+    , m_notebook{ std::make_unique<DragableNoteBook>() }
 {
-    m_notebook = new DragableNoteBook();
-
     m_notebook->signal_switch_page().connect( sigc::mem_fun( *this, &Admin::slot_switch_page ) );
     m_notebook->set_scrollable( true );
 
@@ -102,10 +101,6 @@ Admin::~Admin()
 
     Admin::close_window();
     delete_jdwin();
-
-    if( m_notebook ) delete m_notebook;
-    if( m_move_menu ) delete m_move_menu;
-    if( m_tabswitchmenu ) delete m_tabswitchmenu;
 }
 
 
@@ -217,7 +212,7 @@ void Admin::setup_menu()
     Gtk::MenuItem* item;
 
     // 移動サブメニュー
-    m_move_menu = new SKELETON::TabSwitchMenu( m_notebook, this );
+    m_move_menu = std::make_unique<SKELETON::TabSwitchMenu>( m_notebook.get(), this );
 
     // 進む、戻る
     Glib::RefPtr< Gtk::Action > act;
@@ -269,7 +264,7 @@ void Admin::slot_popupmenu_deactivate()
 
 Gtk::Widget* Admin::get_widget()
 {
-    return dynamic_cast< Gtk::Widget*>( m_notebook );
+    return static_cast<Gtk::Widget*>( m_notebook.get() );
 }
 
 
@@ -2225,7 +2220,7 @@ void Admin::slot_show_tabswitchmenu()
     std::cout << "Admin::slot_show_tabswitchmenu\n";
 #endif
 
-    if( ! m_tabswitchmenu ) m_tabswitchmenu = new SKELETON::TabSwitchMenu( m_notebook, this );
+    if( ! m_tabswitchmenu ) m_tabswitchmenu = std::make_unique<SKELETON::TabSwitchMenu>( m_notebook.get(), this );
 
     m_tabswitchmenu->remove_items();
     m_tabswitchmenu->append_items();

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -9,11 +9,13 @@
 
 #include "dispatchable.h"
 
-#include <gtkmm.h>
-#include <string>
-#include <list>
-
 #include "command_args.h"
+
+#include <gtkmm.h>
+
+#include <list>
+#include <memory>
+#include <string>
 
 
 namespace SKELETON
@@ -30,7 +32,7 @@ namespace SKELETON
         JDWindow* m_win{};
 
     protected:
-        DragableNoteBook* m_notebook{};
+        std::unique_ptr<DragableNoteBook> m_notebook;
 
     private:
         bool m_focus{};
@@ -44,10 +46,10 @@ namespace SKELETON
 
         // 移動サブメニュー
         Gtk::MenuItem* m_move_menuitem;
-        TabSwitchMenu* m_move_menu{};
+        std::unique_ptr<TabSwitchMenu> m_move_menu;
 
         // タブ切り替えメニュー
-        TabSwitchMenu* m_tabswitchmenu{};
+        std::unique_ptr<TabSwitchMenu> m_tabswitchmenu;
 
         // view履歴使用
         bool m_use_viewhistory{};
@@ -154,7 +156,7 @@ namespace SKELETON
         // URLやステータスを更新
         void update_status( View* view, const bool force );
 
-        DragableNoteBook* get_notebook(){ return m_notebook; }
+        DragableNoteBook* get_notebook(){ return m_notebook.get(); }
 
         // コマンド入力
         // immediately = true のときディスパッチャを呼ばずにすぐさま実行

--- a/src/skeleton/detaildiag.cpp
+++ b/src/skeleton/detaildiag.cpp
@@ -24,7 +24,7 @@ DetailDiag::DetailDiag( Gtk::Window* parent, const std::string& url,
     m_message.set_selectable( true );
     m_message.property_can_focus() = false;
 
-    m_detail = CORE::ViewFactory( CORE::VIEW_ARTICLEINFO, get_url() );
+    m_detail.reset( CORE::ViewFactory( CORE::VIEW_ARTICLEINFO, get_url() ) );
     if( ! detail_html.empty() ) m_detail->set_command( "append_html", detail_html );
 
     m_notebook.append_page( m_message, tab_message );
@@ -38,10 +38,8 @@ DetailDiag::DetailDiag( Gtk::Window* parent, const std::string& url,
 }
 
 
-DetailDiag::~DetailDiag()
-{
-    if( m_detail ) delete m_detail;
-}
+// メンバーに不完全型のスマートポインターがあるためデストラクタはinlineにできない
+DetailDiag::~DetailDiag() noexcept = default;
 
 
 void DetailDiag::timeout()
@@ -52,6 +50,5 @@ void DetailDiag::timeout()
 
 void DetailDiag::slot_switch_page( Gtk::Widget*, guint page )
 {
-    if( get_notebook().get_nth_page( page ) == m_detail ) m_detail->redraw_view();
+    if( get_notebook().get_nth_page( page ) == m_detail.get() ) m_detail->redraw_view();
 }
-

--- a/src/skeleton/detaildiag.h
+++ b/src/skeleton/detaildiag.h
@@ -7,6 +7,8 @@
 
 #include "prefdiag.h"
 
+#include <memory>
+
 
 namespace SKELETON
 {
@@ -16,7 +18,7 @@ namespace SKELETON
     {
         Gtk::Notebook m_notebook;
         Gtk::Label m_message;
-        SKELETON::View* m_detail{};
+        std::unique_ptr<SKELETON::View> m_detail;
 
       public:
 
@@ -25,12 +27,12 @@ namespace SKELETON
                     const std::string& message, const std::string& tab_message,
                     const std::string& detail_html, const std::string& tab_detail
             );
-        ~DetailDiag();
+        ~DetailDiag() noexcept;
 
       protected:
 
         Gtk::Notebook& get_notebook(){ return  m_notebook; }
-        SKELETON::View* get_detail(){ return m_detail; }
+        SKELETON::View* get_detail(){ return m_detail.get(); }
 
       private:
 

--- a/src/skeleton/dragnote.cpp
+++ b/src/skeleton/dragnote.cpp
@@ -52,12 +52,8 @@ DragableNoteBook::DragableNoteBook()
 }
 
 
-
-DragableNoteBook::~DragableNoteBook()
-{
-    if( m_down_arrow ) delete m_down_arrow;
-}
-
+// メンバーに不完全型のスマートポインターがあるためデストラクタはinlineにできない
+DragableNoteBook::~DragableNoteBook() noexcept = default;
 
 
 //
@@ -574,7 +570,7 @@ void DragableNoteBook::slot_drag_motion( const int page, const int tab_x, const 
     }
     else if( m_dragging_tab ){
 
-        if( ! m_down_arrow ) m_down_arrow = new SKELETON::IconPopup( ICON::DOWN );
+        if( ! m_down_arrow ) m_down_arrow = std::make_unique<SKELETON::IconPopup>( ICON::DOWN );
         m_down_arrow->show();
 
         const int space = 4;

--- a/src/skeleton/dragnote.h
+++ b/src/skeleton/dragnote.h
@@ -20,6 +20,9 @@
 
 #include <gtkmm.h>
 
+#include <memory>
+
+
 namespace SKELETON
 {
     class View;
@@ -91,7 +94,7 @@ namespace SKELETON
 
         bool m_dragable{};
 
-        SKELETON::IconPopup* m_down_arrow{};
+        std::unique_ptr<SKELETON::IconPopup> m_down_arrow;
 
         double m_smooth_dy{}; // GDK_SCROLL_SMOOTH のスクロール変化量
 
@@ -107,7 +110,7 @@ namespace SKELETON
         SIG_DRAG_DATA_GET sig_drag_data_get() { return m_sig_drag_data_get; }
 
         DragableNoteBook();
-        ~DragableNoteBook();
+        ~DragableNoteBook() noexcept;
 
         void clock_in();
 

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -79,10 +79,8 @@ DragTreeView::DragTreeView( const std::string& url, const std::string& dndtarget
 }
 
 
-DragTreeView::~DragTreeView()
-{
-    delete_popup();
-}
+// メンバーに不完全型のスマートポインターがあるためデストラクタはinlineにできない
+DragTreeView::~DragTreeView() noexcept = default;
 
 
 //
@@ -197,7 +195,7 @@ void DragTreeView::show_popup( const std::string& url, View* view )
 
     delete_popup();
 
-    m_popup_win = new PopupWin( this, view, mrg_x, mrg_y );
+    m_popup_win = std::make_unique<PopupWin>( this, view, mrg_x, mrg_y );
     m_popup_win->signal_leave_notify_event().connect( sigc::mem_fun( *this, &DragTreeView::slot_popup_leave_notify_event ) );
     m_popup_win->sig_hide_popup().connect( sigc::mem_fun( *this, &DragTreeView::hide_popup ) );
 
@@ -263,10 +261,8 @@ void DragTreeView::delete_popup()
         std::cout << "DragTreeView::delete_popup\n";
 #endif
 
-        delete m_popup_win;
-        m_popup_win = nullptr;
-
-        m_pre_popup_url = std::string();
+        m_popup_win.reset();
+        m_pre_popup_url.clear();
         m_popup_shown = false;
     }
 }

--- a/src/skeleton/dragtreeview.h
+++ b/src/skeleton/dragtreeview.h
@@ -19,6 +19,9 @@
 
 #include <gtkmm.h>
 
+#include <memory>
+
+
 namespace SKELETON
 {
     class View;
@@ -48,7 +51,7 @@ namespace SKELETON
         Gdk::RGBA m_color_bg_even;
 
         // ポップアップウィンドウ用
-        PopupWin* m_popup_win{};
+        std::unique_ptr<PopupWin> m_popup_win;
         std::string m_pre_popup_url;
         bool m_popup_shown{};
         
@@ -65,7 +68,7 @@ namespace SKELETON
         // use_usr_fontcolor が true の時はフォントや色を指定する
         DragTreeView( const std::string& url, const std::string& dndtarget,
                       const bool use_usr_fontcolor, const std::string& fontname, const int colorid_text, const int colorid_bg, const int colorid_bg_even );
-        ~DragTreeView();
+        ~DragTreeView() noexcept;
 
         virtual void clock_in();
 

--- a/src/skeleton/editview.cpp
+++ b/src/skeleton/editview.cpp
@@ -60,11 +60,8 @@ EditTextView::EditTextView()
 }
 
 
-EditTextView::~EditTextView()
-{
-    if( m_aapopupmenu ) delete m_aapopupmenu;
-    m_aapopupmenu = nullptr;
-}
+// メンバーに不完全型のスマートポインターがあるためデストラクタはinlineにできない
+EditTextView::~EditTextView() noexcept = default;
 
 
 //
@@ -651,9 +648,7 @@ void EditTextView::show_aalist_popup()
 {
     if( CORE::get_aamanager()->get_size() )
     {
-        if( m_aapopupmenu ) delete m_aapopupmenu;
-
-        m_aapopupmenu = Gtk::manage( new AAMenu( *dynamic_cast< Gtk::Window* >( get_toplevel() ) ) );
+        m_aapopupmenu = std::make_unique<AAMenu>( *dynamic_cast<Gtk::Window*>( get_toplevel() ) );
 
         m_aapopupmenu->sig_selected().connect( sigc::mem_fun( *this, &EditTextView::slot_aamenu_selected ) );
         m_aapopupmenu->signal_map().connect( sigc::mem_fun( *this, &EditTextView::slot_map_aamenu ) ); 

--- a/src/skeleton/editview.h
+++ b/src/skeleton/editview.h
@@ -3,9 +3,11 @@
 #ifndef _EDITVIEW_H
 #define _EDITVIEW_H
 
+#include "control/control.h"
+
 #include <gtkmm.h>
 
-#include "control/control.h"
+#include <memory>
 
 
 namespace SKELETON
@@ -52,7 +54,7 @@ namespace SKELETON
         Gtk::Menu* m_context_menu{};
 
         // AAポップアップ
-        AAMenu* m_aapopupmenu{};
+        std::unique_ptr<AAMenu> m_aapopupmenu;
 
       public:
 
@@ -61,7 +63,7 @@ namespace SKELETON
         SIG_BUTTON_PRESS sig_button_press() { return m_sig_button_press; }
 
         EditTextView();
-        ~EditTextView();
+        ~EditTextView() noexcept;
 
         void insert_str( const std::string& str, bool use_br );
 

--- a/src/skeleton/loadable.h
+++ b/src/skeleton/loadable.h
@@ -29,7 +29,7 @@
 
 (6) ディスパッチャ経由で Dispatchable::callback_dispatch() が呼び出される
 (7) クッキー、更新時刻などを取得する
-(8) delete_loader()でローダの停止を待って削除する
+(8) m_loader.reset()でローダの停止を待って削除する
 (9) receive_finish()を呼び出す 
 
 注意点
@@ -47,8 +47,11 @@
 #include "dispatchable.h"
 
 #include <gtkmm.h>
-#include <list>
+
 #include <ctime>
+#include <list>
+#include <memory>
+
 
 namespace JDLIB
 {
@@ -61,7 +64,7 @@ namespace SKELETON
 {
     class Loadable : public Dispatchable
     {
-        JDLIB::Loader* m_loader{};
+        std::unique_ptr<JDLIB::Loader> m_loader;
 
         bool m_low_priority{};
 
@@ -138,7 +141,6 @@ namespace SKELETON
         virtual void receive_data( const char* , size_t ){};
         virtual void receive_finish(){};
 
-        void delete_loader();
         void callback_dispatch() override;
 
         int get_loader_code() const;


### PR DESCRIPTION
クラスのメンバーをスマートポインターに更新してnew/deleteによるメモリ割り当てを整理します。

関連のpull request: #619 
