### PR TITLE
EditListWin: Set window display position to center

### DIFF
--- a/src/bbslist/editlistwin.cpp
+++ b/src/bbslist/editlistwin.cpp
@@ -66,6 +66,7 @@ EditListWin::EditListWin( const std::string& url, const Glib::RefPtr< Gtk::TreeS
 
     add( m_vbox );
     set_title( "お気に入りの編集" );
+    set_position( Gtk::WIN_POS_CENTER );
     resize( EDITWIN_WIDTH, EDITWIN_HEIGHT );
 
     show_all_children();


### PR DESCRIPTION
お気に入り編集ウインドウの表示位置を中央に設定します。