### PR TITLE
skeleton: Use delegating constructors instead of setup function

### DIFF
--- a/src/skeleton/menubutton.cpp
+++ b/src/skeleton/menubutton.cpp
@@ -20,29 +20,14 @@ enum
 };
 
 
-MenuButton::MenuButton( const bool show_arrow, Gtk::Widget& label )
+MenuButton::MenuButton( const bool show_arrow, Gtk::Widget* label, Gtk::PackOptions options )
+    : m_label{ label }
+    , m_enable_sig_clicked{ true }
 {
-    setup( show_arrow, &label );
-}
+    Gtk::Box* hbox = Gtk::manage( new Gtk::Box( Gtk::ORIENTATION_HORIZONTAL ) );
 
-
-MenuButton::MenuButton( const bool show_arrow, const int id )
-{
-    setup( show_arrow, Gtk::manage( new Gtk::Image( ICON::get_icon( id ) ) ), Gtk::PACK_SHRINK );
-}
-
-
-void MenuButton::setup( const bool show_arrow, Gtk::Widget* label, Gtk::PackOptions options, guint padding )
-{
-    const int space = 4;
-
-    m_label = label;
-    m_enable_sig_clicked = true;
-
-    Gtk::HBox *hbox = Gtk::manage( new Gtk::HBox() );
-
-    hbox->set_spacing( space );
-    if( m_label ) hbox->pack_start( *m_label, options, padding );
+    hbox->set_spacing( 4 );
+    if( m_label ) hbox->pack_start( *m_label, options );
 
     if( show_arrow ){
         m_arrow = Gtk::manage( new Gtk::Image() );
@@ -69,11 +54,23 @@ void MenuButton::setup( const bool show_arrow, Gtk::Widget* label, Gtk::PackOpti
         Glib::RefPtr< Gtk::Action > action = Gtk::Action::create( "menu" + std::to_string( i ), "dummy" );
         action->set_accel_group( agroup );
         Gtk::MenuItem* item = Gtk::manage( action->create_menu_item() );
-        actiongroup->add( action, sigc::bind< int >( sigc::mem_fun( *this, &MenuButton::slot_menu_selected ), i ) );
+        actiongroup->add( action, [this, i] { slot_menu_selected( i ); } );
         m_menuitems.push_back( item );
     }
 
     set_focus_on_click( false );
+}
+
+
+MenuButton::MenuButton( const bool show_arrow, Gtk::Widget& label )
+    : MenuButton( show_arrow, &label )
+{
+}
+
+
+MenuButton::MenuButton( const bool show_arrow, const int id )
+    : MenuButton( show_arrow, Gtk::manage( new Gtk::Image( ICON::get_icon( id ) ) ), Gtk::PACK_SHRINK )
+{
 }
 
 

--- a/src/skeleton/menubutton.h
+++ b/src/skeleton/menubutton.h
@@ -30,6 +30,8 @@ namespace SKELETON
         bool m_on_arrow{};
         bool m_enable_sig_clicked;
 
+        MenuButton( const bool show_arrow, Gtk::Widget* label, Gtk::PackOptions options = Gtk::PACK_EXPAND_WIDGET );
+
       public:
 
         MenuButton( const bool show_arrow, Gtk::Widget& label );
@@ -62,8 +64,6 @@ namespace SKELETON
       virtual void show_popupmenu();
 
       private:
-
-      void setup( const bool show_arrow, Gtk::Widget* label, Gtk::PackOptions options = Gtk::PACK_EXPAND_WIDGET, guint padding = 0 );
 
       void slot_menu_selected( int i );
 

--- a/src/skeleton/toolmenubutton.cpp
+++ b/src/skeleton/toolmenubutton.cpp
@@ -14,27 +14,27 @@ ToolMenuButton::ToolMenuButton() = default;
 
 ToolMenuButton::ToolMenuButton( const std::string& label, const bool expand,
                                 const bool show_arrow, Gtk::Widget& widget )
+    : ToolMenuButton( Gtk::manage( new SKELETON::MenuButton( show_arrow, widget ) ),
+                      label, expand )
 {
-    SKELETON::MenuButton *button = Gtk::manage( new SKELETON::MenuButton( show_arrow, widget ) );
-    setup( button, label, expand );
 }
 
 
 ToolMenuButton::ToolMenuButton( const std::string& label, const bool expand,
-                                const bool show_arrow ,
+                                const bool show_arrow,
                                 const int id )
+    : ToolMenuButton( Gtk::manage( new SKELETON::MenuButton( show_arrow, id ) ),
+                      label, expand )
 {
-    SKELETON::MenuButton *button = Gtk::manage( new SKELETON::MenuButton( show_arrow, id ) );
-    setup( button, label, expand );
 }
 
 
 ToolMenuButton::~ToolMenuButton() noexcept = default;
 
 
-void ToolMenuButton::setup( SKELETON::MenuButton* button, const std::string& label, const bool expand )
+ToolMenuButton::ToolMenuButton( SKELETON::MenuButton* button, const std::string& label, const bool expand )
+    : m_button{ button }
 {
-    m_button = button;
     assert( m_button != nullptr );
 
     Gtk::Widget* label_widget = m_button->get_label_widget();
@@ -77,9 +77,9 @@ void ToolMenuButton::setup( SKELETON::MenuButton* button, const std::string& lab
 
 ToolBackForwardButton::ToolBackForwardButton( const std::string& label, const bool expand,
                                               const std::string& url, const bool back )
+    : ToolMenuButton( Gtk::manage( new SKELETON::BackForwardButton( url, back ) ),
+                      label, expand )
 {
-    SKELETON::MenuButton *button = Gtk::manage( new SKELETON::BackForwardButton( url, back ) );
-    setup( button, label, expand );
 }
 
 

--- a/src/skeleton/toolmenubutton.h
+++ b/src/skeleton/toolmenubutton.h
@@ -17,7 +17,7 @@ namespace SKELETON
 
     class ToolMenuButton : public Gtk::ToolItem
     {
-        SKELETON::MenuButton* m_button = nullptr;
+        SKELETON::MenuButton* m_button{};
 
       public:
 
@@ -37,7 +37,7 @@ namespace SKELETON
 
       protected:
 
-        void setup( SKELETON::MenuButton* button, const std::string& label, const bool expand );
+        ToolMenuButton( SKELETON::MenuButton* button, const std::string& label, const bool expand );
     };
 
     //////////////////////////


### PR DESCRIPTION
初期化を整理して委譲コンストラクタを使うように修正します。

