### PR TITLE
Use static allocation for local iconv var instead of new/delete

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1290,12 +1290,10 @@ std::string MISC::Iconv( const std::string& str, const std::string& coding_to, c
 
     std::string str_bk = str;
 
-    JDLIB::Iconv* libiconv = new JDLIB::Iconv( coding_to, coding_from );
+    JDLIB::Iconv libiconv( coding_to, coding_from );
     int byte_out;
 
-    std::string str_enc = libiconv->convert( &*str_bk.begin(), str_bk.size(), byte_out );
-
-    delete libiconv;
+    std::string str_enc = libiconv.convert( &*str_bk.begin(), str_bk.size(), byte_out );
 
     return str_enc;
 }

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -236,11 +236,12 @@ void Post::receive_finish()
     std::cout << "Post::receive_finish\n";
 #endif
 
-    std::string charset = DBTREE::board_charset( m_url );
-    JDLIB::Iconv* libiconv = new JDLIB::Iconv( "UTF-8", charset );
-    int byte_out;
-    m_return_html = libiconv->convert( &*m_rawdata.begin(), m_rawdata.size(), byte_out );
-    delete libiconv;
+    {
+        const std::string charset = DBTREE::board_charset( m_url );
+        JDLIB::Iconv libiconv( "UTF-8", charset );
+        int byte_out;
+        m_return_html = libiconv.convert( &*m_rawdata.begin(), m_rawdata.size(), byte_out );
+    }
 
 #ifdef _DEBUG
     std::cout << "code = " << get_code() << std::endl;

--- a/src/skeleton/textloader.cpp
+++ b/src/skeleton/textloader.cpp
@@ -172,15 +172,10 @@ void TextLoader::receive_finish()
     set_str_code( std::string() );
 
     // UTF-8に変換しておく
-    JDLIB::Iconv* libiconv = new JDLIB::Iconv( "UTF-8", get_charset() );
+    JDLIB::Iconv libiconv( "UTF-8", get_charset() );
     int byte_out;
-    m_data = libiconv->convert( &*m_rawdata.begin(), m_rawdata.size(),  byte_out );
-    delete libiconv;
+    m_data = libiconv.convert( &*m_rawdata.begin(), m_rawdata.size(),  byte_out );
     clear();
-
-#ifdef _DEBUG
-//    std::cout << m_data << std::endl;
-#endif
 
     receive_cookies();
 


### PR DESCRIPTION
ローカル変数のiconvオブジェクトをメモリの動的割り当てから静的割り当てに変更します。

