### PR TITLE
Use static allocation for local dialog var instead of new/delete

### DIFF
--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -396,28 +396,22 @@ void AboutConfig::slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::Tre
     const int type = row[ m_columns.m_col_type ];
     if( type == CONFTYPE_COMMENT ) return;
 
-    SKELETON::PrefDiag* pref = nullptr;
+    else if( type == CONFTYPE_STR ) {
 
-    switch( type ){
-
-        case CONFTYPE_STR:
-            pref = new AboutConfigDiagStr( this, row[ m_columns.m_col_value_str ], row[ m_columns.m_col_default_str ] );
-            pref->run();
-            set_value( row, *row[ m_columns.m_col_value_str ] );
-            break;
-
-        case CONFTYPE_INT:
-            pref = new AboutConfigDiagInt( this, row[ m_columns.m_col_value_int ], row[ m_columns.m_col_default_int ] );
-            pref->run();
-            set_value( row, *row[ m_columns.m_col_value_int ] );
-            break;
-
-        case CONFTYPE_BOOL:
-            pref = new AboutConfigDiagBool( this, row[ m_columns.m_col_value_bool ], row[ m_columns.m_col_default_bool ] );
-            pref->run();
-            set_value( row, *row[ m_columns.m_col_value_bool ] );
-            break;
+        AboutConfigDiagStr pref( this, row[ m_columns.m_col_value_str ], row[ m_columns.m_col_default_str ] );
+        pref.run();
+        set_value( row, *row[ m_columns.m_col_value_str ] );
     }
+    else if( type == CONFTYPE_INT ) {
 
-    if( pref ) delete pref;
+        AboutConfigDiagInt pref( this, row[ m_columns.m_col_value_int ], row[ m_columns.m_col_default_int ] );
+        pref.run();
+        set_value( row, *row[ m_columns.m_col_value_int ] );
+    }
+    else if( type == CONFTYPE_BOOL ) {
+
+        AboutConfigDiagBool pref( this, row[ m_columns.m_col_value_bool ], row[ m_columns.m_col_default_bool ] );
+        pref.run();
+        set_value( row, *row[ m_columns.m_col_value_bool ] );
+    }
 }

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -586,23 +586,20 @@ bool ConfigItems::load( const bool restore )
     if( cf.is_broken() )
     {
         std::string msg;
-        Gtk::MessageDialog *mdiag;
 
         // 非resotreモードでバックアップが存在する
         if( ! restore && CACHE::file_exists( CACHE::path_conf_bkup() ) == CACHE::EXIST_FILE )
         {
             msg = "設定ファイル (" + path_conf + ")に異常な値があります。全設定をバックアップから復元しますか？";
-            mdiag = new Gtk::MessageDialog( msg, false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
-            int ret = mdiag->run();
-            delete mdiag;
+            Gtk::MessageDialog mdiag( msg, false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
+            const int ret = mdiag.run();
             if( ret != Gtk::RESPONSE_YES ) load( true ); // resotreモードで再帰
         }
         else
         {
             msg = "設定ファイル (" + path_conf + ")に異常な値があるため、一部をデフォルトに設定しました。";
-            mdiag = new Gtk::MessageDialog( msg );
-            mdiag->run();
-            delete mdiag;
+            Gtk::MessageDialog mdiag( msg );
+            mdiag.run();
         }
     }
     // 正常ならバックアップ

--- a/src/dbimg/imgroot.cpp
+++ b/src/dbimg/imgroot.cpp
@@ -307,9 +307,8 @@ void ImgRoot::delete_all_files()
     if( ret != Gtk::RESPONSE_OK ) return;
 
     // 画像キャッシュ削除ダイアログ表示
-    DelImgCacheDiag* deldiag = new DelImgCacheDiag();
-    deldiag->run();
-    delete deldiag;
+    DelImgCacheDiag deldiag;
+    deldiag.run();
 
     reset_imgs();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,13 +71,12 @@ void restore_bkup( const bool no_restore_bkup )
 
         if( ! no_restore_bkup ){
 
-            Gtk::MessageDialog* mdiag = new Gtk::MessageDialog(
+            Gtk::MessageDialog mdiag(
                 "前回の起動時に正しくJDimが終了されませんでした。\n\n"
                 "板リストとお気に入りをバックアップファイルから復元しますか？\n"
                 "いいえを押すとバックアップファイルを削除します。",
                 false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
-            if( mdiag->run() == Gtk::RESPONSE_YES ) restore = true;
-            delete mdiag;
+            if( mdiag.run() == Gtk::RESPONSE_YES ) restore = true;
         }
 
         if( restore ){
@@ -98,9 +97,8 @@ void restore_bkup( const bool no_restore_bkup )
 
             msg += "\nに移動しました。";
 
-            Gtk::MessageDialog* mdiag = new Gtk::MessageDialog( msg );
-            mdiag->run();
-            delete mdiag;
+            Gtk::MessageDialog mdiag( msg );
+            mdiag.run();
         }
         else{
             if( bkup_main ) unlink( to_locale_cstr( path_main_bkup ) );
@@ -477,10 +475,8 @@ int main( int argc, char **argv )
 
             std::string msg = "JDimの設定ファイル(" + CACHE::path_conf()
                               + ")は存在しますが読み込むことが出来ませんでした。\n\n起動しますか？";
-            Gtk::MessageDialog* mdiag = new Gtk::MessageDialog( msg,
-                                                                false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
-            int ret = mdiag->run();
-            delete mdiag;
+            Gtk::MessageDialog mdiag( msg, false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
+            const int ret = mdiag.run();
             if( ret != Gtk::RESPONSE_YES ) return 0;
         }
 
@@ -533,18 +529,16 @@ int main( int argc, char **argv )
     {
         if( CONFIG::get_show_diag_fifo_error() )
         {
-            Gtk::MessageDialog* mdiag = new Gtk::MessageDialog( CACHE::path_lock() + "の作成またはオープンに問題があります。このまま起動しますか？",
-                                                                false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
+            Gtk::MessageDialog mdiag( CACHE::path_lock() + "の作成またはオープンに問題があります。このまま起動しますか？",
+                                      false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
 
             Gtk::CheckButton chk_button( "今後表示しない" );
-            mdiag->get_content_area()->pack_start( chk_button, Gtk::PACK_SHRINK );
+            mdiag.get_content_area()->pack_start( chk_button, Gtk::PACK_SHRINK );
             chk_button.show();
 
-            const int ret = mdiag->run();
+            const int ret = mdiag.run();
 
             CONFIG::set_show_diag_fifo_error( ! chk_button.get_active() );
-
-            delete mdiag;
 
             if( ret != Gtk::RESPONSE_YES )
             {


### PR DESCRIPTION
ローカル変数のdialogオブジェクトをメモリの動的割り当てから静的割り当てに変更します。
