### PR TITLE
JDWindow: remove dummy window for transient setting

### DIFF
--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -99,7 +99,6 @@ JDWindow::JDWindow( const bool fold_when_focusout, const bool need_mginfo )
 
 JDWindow::~JDWindow()
 {
-    if( m_dummywin ) delete m_dummywin;
     if( m_vbox_view ) delete m_vbox_view;
     if( m_scrwin ) delete m_scrwin;
 }
@@ -118,12 +117,6 @@ void JDWindow::init_win()
         m_scrwin->set_policy( Gtk::POLICY_NEVER, Gtk::POLICY_NEVER );
         m_scrwin->add( *m_vbox_view );
         m_vbox.pack_remove_end( false, *m_scrwin, Gtk::PACK_EXPAND_WIDGET );
-
-        m_dummywin = new Gtk::Window();
-        m_dummywin->resize( 1, 1 );
-        m_dummywin->move( -1, -1 );
-        m_dummywin->hide();
-        m_dummywin->set_skip_taskbar_hint( true );
 
         set_skip_taskbar_hint( true );
         resize( get_width_win(), 1 );
@@ -456,9 +449,9 @@ void JDWindow::set_transient( bool set )
             m_transient = true;
         }
 
-        // ダミーwindowを使ってtransientを外す
+        // transientを外す
         else if( ! set && m_transient ){
-            set_transient_for( *m_dummywin );
+            unset_transient_for();
             m_transient = false;
         }
     }

--- a/src/skeleton/window.h
+++ b/src/skeleton/window.h
@@ -30,7 +30,6 @@ namespace SKELETON
         int m_mode;
         int m_counter{};
         int m_count_focusout{}; // フォーカス制御用カウンタ
-        Gtk::Window* m_dummywin{}; // set_transient()で使うダミーwindow
 
         SKELETON::JDVBox m_vbox;
 


### PR DESCRIPTION
ダミーウインドウのかわりに`Gtk::Window::unset_transient_for()`([gtkmm 2.20から追加][1])を使ってtransient設定を解除します。

[1]: https://developer.gnome.org/gtkmm/3.24/classGtk_1_1Window.html#a8765c60eaa06575d86d877cd5ba75d6d