### PR TITLE
JDWindow: Fix expanding image view window by focus-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ WaylandやXWaylandではX11限定の機能を使うことができないため�
 * 32bit OSの古いMATE環境（バージョン[1.10][mate-1-10]から[1.16][mate-1-16]？）でJDim GTK3版を実行したとき
   スレビューの上に別のウインドウを重ねて移動させると残像でスレビュー内のみ描画が乱れる。
   スレビューをスクロール等させて再描画すると直る。([背景事情][mate-background])
+* Wayland環境では画像ビュー(ウインドウ表示)のフォーカスが外れたら折りたたむ機能が正常に動作しない。
 
 [mate-1-10]: https://mate-desktop.org/blog/2015-06-11-mate-1-10-released/ "GTK3の実験的なサポート追加"
 [mate-1-16]: https://mate-desktop.org/blog/2016-09-21-mate-1-16-released/ "GTK3に移行途中"

--- a/docs/manual/start.md
+++ b/docs/manual/start.md
@@ -139,6 +139,7 @@ WaylandやXWaylandではX11限定の機能を使うことができないため�
 * 32bit OSの古いMATE環境（バージョン[1.10][mate-1-10]から[1.16][mate-1-16]？）でJDim GTK3版を実行したとき
   スレビューの上に別のウインドウを重ねて移動させると残像でスレビュー内のみ描画が乱れる。
   スレビューをスクロール等させて再描画すると直る。([背景事情][mate-background])
+* Wayland環境では画像ビュー(ウインドウ表示)のフォーカスが外れたら折りたたむ機能が正常に動作しない。
 
 [mate-1-10]: https://mate-desktop.org/blog/2015-06-11-mate-1-10-released/ "GTK3の実験的なサポート追加"
 [mate-1-16]: https://mate-desktop.org/blog/2016-09-21-mate-1-16-released/ "GTK3に移行途中"

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -114,7 +114,7 @@ void JDWindow::init_win()
         m_vbox_view = new SKELETON::JDVBox();
 
         m_scrwin->set_size_request( 0, 0 );
-        m_scrwin->set_policy( Gtk::POLICY_NEVER, Gtk::POLICY_NEVER );
+        m_scrwin->set_policy( Gtk::POLICY_EXTERNAL, Gtk::POLICY_EXTERNAL );
         m_scrwin->add( *m_vbox_view );
         m_vbox.pack_remove_end( false, *m_scrwin, Gtk::PACK_EXPAND_WIDGET );
 


### PR DESCRIPTION
Fixes #645 

ウインドウ表示の画像ビューでフォーカスによる展開縮小が正常に動作しない不具合を修正します。

- 展開: 画像ビューをフォーカスしてもウインドウが展開しない
- 縮小: ウインドウが完全に折り畳まれず画像の上部が表示されたままになる

#### 既知の問題
Wayland環境では画像ウインドウの展開縮小が正常に動作せず、フォーカスが外れたときウインドウの幅が広がります。
埋め込み表示またはXWaylandでは問題ありません。
