### PR TITLE
skeleton: Use std::unique_ptr instead of new/delete part2

### DIFF
--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -602,8 +602,8 @@ void ImageAdmin::open_window()
     ImageWin* win = dynamic_cast< ImageWin* >( get_jdwin() );
 
     if( ! SESSION::get_embedded_img() && ! win && ! empty() ){
-        win = new IMAGE::ImageWin();
-        set_jdwin( win );
+        set_jdwin( std::make_unique<IMAGE::ImageWin>() );
+        win = dynamic_cast<IMAGE::ImageWin*>( get_jdwin() );
         win->pack_remove_tab( false, m_tab );
         win->pack_remove_end( false, m_view );
         win->show_all();

--- a/src/message/messageadmin.cpp
+++ b/src/message/messageadmin.cpp
@@ -175,8 +175,8 @@ void MessageAdmin::open_window()
     std::cout << "MessageAdmin::open_window\n";
 #endif
 
-        win = new MESSAGE::MessageWin();
-        set_jdwin( win );
+        set_jdwin( std::make_unique<MESSAGE::MessageWin>() );
+        win = get_jdwin();
         win->pack_remove_end( false, *get_widget() );
         win->show_all();
     }

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -100,7 +100,6 @@ Admin::~Admin()
     m_list_command.clear();
 
     Admin::close_window();
-    delete_jdwin();
 }
 
 
@@ -270,16 +269,19 @@ Gtk::Widget* Admin::get_widget()
 
 Gtk::Window* Admin::get_win()
 {
-    return dynamic_cast< Gtk::Window*>( m_win );
+    return static_cast<Gtk::Window*>( m_win.get() );
+}
+
+
+void Admin::set_jdwin( std::unique_ptr<JDWindow> win )
+{
+    m_win = std::move( win );
 }
 
 
 void Admin::delete_jdwin()
 {
-    if( m_win ){
-        delete m_win;
-        m_win = nullptr;
-    }
+    m_win.reset();
 }
 
 

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -29,7 +29,7 @@ namespace SKELETON
     {
         std::string m_url;
 
-        JDWindow* m_win{};
+        std::unique_ptr<JDWindow> m_win;
 
     protected:
         std::unique_ptr<DragableNoteBook> m_notebook;
@@ -149,8 +149,8 @@ namespace SKELETON
 
         void set_use_switchhistory( const bool use ){ m_use_switchhistory = use; }
 
-        JDWindow* get_jdwin(){ return m_win; }
-        void set_jdwin( JDWindow* win ){ m_win = win; }
+        JDWindow* get_jdwin(){ return m_win.get(); }
+        void set_jdwin( std::unique_ptr<JDWindow> win );
         void delete_jdwin();
 
         // URLやステータスを更新

--- a/src/skeleton/menubutton.cpp
+++ b/src/skeleton/menubutton.cpp
@@ -74,13 +74,6 @@ MenuButton::MenuButton( const bool show_arrow, const int id )
 }
 
 
-// virtual
-MenuButton::~MenuButton()
-{
-    if( m_popupmenu ) delete m_popupmenu;
-}
-
-
 void MenuButton::set_tooltip_arrow( const std::string& tooltip )
 {
     if( m_arrow ) {
@@ -98,14 +91,13 @@ void MenuButton::append_menu( std::vector< std::string >& items )
     if( m_popupmenu ){
         const int menusize = m_popupmenu->get_children().size();
         for( int i = 0; i < menusize; ++i ) m_popupmenu->remove( *m_menuitems[ i ] );
-        delete m_popupmenu;
+        m_popupmenu.reset();
     }
-    m_popupmenu = nullptr;
 
     if( ! items.size() ) return;
 
     // 新しくメニューを作成して項目追加
-    m_popupmenu = Gtk::manage( new Gtk::Menu() );
+    m_popupmenu = std::make_unique<Gtk::Menu>();
     const size_t size = MIN( items.size(), MAX_MENU_SIZE );
     for( size_t i = 0 ; i < size; ++i ){
 

--- a/src/skeleton/menubutton.h
+++ b/src/skeleton/menubutton.h
@@ -6,8 +6,11 @@
 #define _MENUBUTTON_H
 
 #include <gtkmm.h>
+
+#include <memory>
 #include <string>
 #include <vector>
+
 
 constexpr size_t MAX_MENU_SIZE = 20;
 
@@ -21,7 +24,7 @@ namespace SKELETON
         SIG_BUTTON_CLICKED m_sig_clicked;
         SIG_SELECTED m_sig_selected;
 
-        Gtk::Menu* m_popupmenu{};
+        std::unique_ptr<Gtk::Menu> m_popupmenu;
         std::vector< Gtk::MenuItem* > m_menuitems;
         Gtk::Widget* m_label{};
 
@@ -38,7 +41,7 @@ namespace SKELETON
 
         MenuButton( const bool show_arrow , const int id );
 
-      ~MenuButton();
+        ~MenuButton() noexcept = default;
 
       Gtk::Widget* get_label_widget(){ return m_label; }
 

--- a/src/skeleton/popupwin.cpp
+++ b/src/skeleton/popupwin.cpp
@@ -9,11 +9,11 @@ using namespace SKELETON;
 
 
 PopupWin::PopupWin( Gtk::Widget* parent, SKELETON::View* view, const int mrg_x, const int mrg_y )
-    : PopupWinBase( POPUPWIN_NOFRAME ),
-      m_parent( parent ),
-      m_view( view ),
-      m_mrg_x( mrg_x ),
-      m_mrg_y( mrg_y )
+    : PopupWinBase( POPUPWIN_NOFRAME )
+    , m_parent{ parent }
+    , m_view{ view }
+    , m_mrg_x{ mrg_x }
+    , m_mrg_y{ mrg_y }
 {
 #ifdef _DEBUG
     std::cout << "PopupWin::PopupWin\n";
@@ -29,12 +29,6 @@ PopupWin::PopupWin( Gtk::Widget* parent, SKELETON::View* view, const int mrg_x, 
         set_transient_for( *dynamic_cast< Gtk::Window* >( toplevel ) );
     }
     slot_resize_popup();
-}
-
-
-PopupWin::~PopupWin()
-{
-    if( m_view ) delete m_view;
 }
 
 

--- a/src/skeleton/popupwin.h
+++ b/src/skeleton/popupwin.h
@@ -13,6 +13,8 @@
 #include "popupwinbase.h"
 #include "view.h"
 
+#include <memory>
+
 
 namespace SKELETON
 {
@@ -21,20 +23,20 @@ namespace SKELETON
         SIG_HIDE_POPUP m_sig_hide_popup;
 
         Gtk::Widget* m_parent;
-        SKELETON::View* m_view;
+        std::unique_ptr<SKELETON::View> m_view;
         int m_mrg_x;  // ポップアップとマウスカーソルの間のマージン(水平方向)
         int m_mrg_y;  // ポップアップとマウスカーソルの間のマージン(垂直方向)
 
     public:
 
         PopupWin( Gtk::Widget* parent, SKELETON::View* view, const int mrg_x, const int mrg_y );
-        ~PopupWin();
+        ~PopupWin() noexcept = default;
 
         // m_view　からの hide シグナルをブリッジする
         SIG_HIDE_POPUP& sig_hide_popup() { return m_sig_hide_popup; }
         void slot_hide_popup(){ m_sig_hide_popup.emit(); }
 
-        SKELETON::View* view(){ return m_view; }
+        SKELETON::View* view(){ return m_view.get(); }
 
         // ポップアップウィンドウの座標と幅と高さを計算して移動とリサイズ
         void slot_resize_popup();

--- a/src/skeleton/tablabel.cpp
+++ b/src/skeleton/tablabel.cpp
@@ -41,16 +41,6 @@ TabLabel::TabLabel( const std::string& url )
 }
 
 
-TabLabel::~TabLabel()
-{
-#ifdef _DEBUG
-    std::cout << "TabLabel::~TabLabel " << m_fulltext << std::endl;
-#endif
-
-    if( m_image ) delete m_image;
-}
-
-
 // アイコンセット
 void TabLabel::set_id_icon( const int id )
 {
@@ -59,7 +49,7 @@ void TabLabel::set_id_icon( const int id )
     if( id == ICON::NONE ) return;
 
     if( !m_image ){
-        m_image = new Gtk::Image();
+        m_image = std::make_unique<Gtk::Image>();
         m_hbox.remove( m_label );
         m_hbox.set_spacing( SPACING_LABEL );
         m_hbox.pack_start( *m_image, Gtk::PACK_SHRINK );

--- a/src/skeleton/tablabel.h
+++ b/src/skeleton/tablabel.h
@@ -4,7 +4,10 @@
 #define _TABLABEL_H
 
 #include <gtkmm.h>
+
+#include <memory>
 #include <string>
+
 
 namespace SKELETON
 {
@@ -38,7 +41,7 @@ namespace SKELETON
         Gtk::Label m_label;
 
         // アイコン画像
-        Gtk::Image* m_image{};
+        std::unique_ptr<Gtk::Image> m_image;
 
         // ラベルに表示する文字列の全体
         std::string m_fulltext;
@@ -46,7 +49,7 @@ namespace SKELETON
       public:
 
         explicit TabLabel( const std::string& url );
-        ~TabLabel();
+        ~TabLabel() noexcept = default;
 
         SIG_TAB_MOTION_EVENT sig_tab_motion_event(){ return  m_sig_tab_motion_event; }
         SIG_TAB_LEAVE_EVENT sig_tab_leave_event(){ return m_sig_tab_leave_event; }

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -97,21 +97,14 @@ JDWindow::JDWindow( const bool fold_when_focusout, const bool need_mginfo )
 }
 
 
-JDWindow::~JDWindow()
-{
-    if( m_vbox_view ) delete m_vbox_view;
-    if( m_scrwin ) delete m_scrwin;
-}
-
-
 // windowの初期設定(サイズ変更や移動など)
 void JDWindow::init_win()
 {
     // フォーカスアウトで折り畳む場合
     if( m_fold_when_focusout ){
 
-        m_scrwin = new Gtk::ScrolledWindow();
-        m_vbox_view = new SKELETON::JDVBox();
+        m_scrwin = std::make_unique<Gtk::ScrolledWindow>();
+        m_vbox_view = std::make_unique<SKELETON::JDVBox>();
 
         m_scrwin->set_size_request( 0, 0 );
         m_scrwin->set_policy( Gtk::POLICY_EXTERNAL, Gtk::POLICY_EXTERNAL );

--- a/src/skeleton/window.h
+++ b/src/skeleton/window.h
@@ -7,10 +7,14 @@
 #ifndef _JDWINDOW_H
 #define _JDWINDOW_H
 
-#include <gtkmm.h>
 #include "gtkmmversion.h"
 
 #include "vbox.h"
+
+#include <gtkmm.h>
+
+#include <memory>
+
 
 namespace SKELETON
 {
@@ -33,8 +37,8 @@ namespace SKELETON
 
         SKELETON::JDVBox m_vbox;
 
-        Gtk::ScrolledWindow* m_scrwin{};
-        SKELETON::JDVBox* m_vbox_view{};
+        std::unique_ptr<Gtk::ScrolledWindow> m_scrwin;
+        std::unique_ptr<SKELETON::JDVBox> m_vbox_view;
 
         // ステータスバー
         std::string m_status;
@@ -51,7 +55,7 @@ namespace SKELETON
       public:
 
         explicit JDWindow( const bool fold_when_focusout, const bool need_mginfo = true );
-        ~JDWindow();
+        ~JDWindow() noexcept = default;
 
         Gtk::HBox& get_statbar(){ return  m_statbar; }
 


### PR DESCRIPTION
クラスのメンバーをスマートポインターに更新してnew/deleteによるメモリ割り当てを整理します。

関連のpull request: #619 


