### PR TITLE
Completion_Manager: Simplify memory allocation for std::vector elements

### DIFF
--- a/src/compmanager.h
+++ b/src/compmanager.h
@@ -30,11 +30,11 @@ namespace CORE
 
     class Completion_Manager
     {
-        std::vector< COMPLIST* > m_lists;
+        std::vector<COMPLIST> m_lists;
 
     public:
         Completion_Manager();
-        virtual ~Completion_Manager();
+        virtual ~Completion_Manager() noexcept = default;
 
         COMPLIST get_list( const int mode, const std::string& query );
         void set_query( const int mode, const std::string& query );


### PR DESCRIPTION
std::vectorの要素型をポインターから実値(value)に変更してメモリの割り当てを単純化します。