### PR TITLE
Log_Manager: Use incomplete type support for std::list

### DIFF
--- a/src/message/logmanager.h
+++ b/src/message/logmanager.h
@@ -16,7 +16,7 @@ namespace MESSAGE
 
     class Log_Manager
     {
-        std::list< LogItem* > m_logitems;
+        std::list<LogItem> m_logitems;
 
       public:
 
@@ -24,7 +24,7 @@ namespace MESSAGE
         virtual ~Log_Manager();
 
         int size() const { return m_logitems.size(); }
-        bool has_items( const std::string& url, const bool newthread );
+        bool has_items( const std::string& url, const bool newthread ) const;
         void remove_items( const std::string& url );
 
         // messageが自分の書き込んだものかチェックする


### PR DESCRIPTION
`std::list`の要素をポインターから実値に変更してメモリ割り当てとソースコードを整理します。
C++17から[不完全型を`std::list`に指定できる][1]ようになりました。

[1]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4371.html