### PR TITLE
History_Manager: Use incomplete type support for std::list

### DIFF
--- a/src/history/historymanager.h
+++ b/src/history/historymanager.h
@@ -35,13 +35,13 @@ namespace HISTORY
         std::unique_ptr<HistoryMenu> m_menu_closeimg;
 
         // View履歴
-        std::list< ViewHistory* > m_view_histories;
+        std::list<ViewHistory> m_view_histories;
         ViewHistory* m_last_viewhistory{};
 
       public:
 
         History_Manager();
-        virtual ~History_Manager();
+        virtual ~History_Manager() noexcept = default;
 
         // 履歴メニュー取得
         Gtk::MenuItem* get_menu_thread();

--- a/src/history/viewhistory.h
+++ b/src/history/viewhistory.h
@@ -25,8 +25,13 @@ namespace HISTORY
         int m_history_current{};
         int m_history_end{};
 
+      public:
+
+        // privateだと std::list<ViewHistory> で要素の構築・削除ができない
         ViewHistory() = default;
         virtual ~ViewHistory() noexcept = default;
+
+      private:
 
         int get_size() const noexcept { return m_items.size(); }
         const ViewHistoryItem* get_item( const int pos ) const { return m_items[ pos ].get(); }


### PR DESCRIPTION
`std::list`の要素をポインターから実値に変更してメモリ割り当てとソースコードを整理します。
C++17から[不完全型を`std::list`に指定できる][1]ようになりました。

関連のpull request: #653

[1]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4371.html