### PR TITLE
DrawAreaBase: Use incomplete type support for std::list

### DIFF
--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -213,8 +213,8 @@ namespace ARTICLE
         // 入力コントローラ
         CONTROL::Control m_control;
 
-        // 埋め込み画像のポインタ
-        std::list< EmbeddedImage* > m_eimgs;
+        // 埋め込み画像を保持するリスト
+        std::list<EmbeddedImage> m_eimgs;
 
         // ブックマークアイコン
         Glib::RefPtr< Gdk::Pixbuf > m_pixbuf_bkmk;


### PR DESCRIPTION
`std::list`の要素をポインターから実値に変更してメモリ割り当てとソースコードを整理します。
C++17から[不完全型を`std::list`に指定できる][1]ようになりました。

関連のpull request: #653 

[1]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4371.html