### PR TITLE
PopupWinBase: Uss css setting instead of drawing border lines

### DIFF
--- a/src/skeleton/compentry.cpp
+++ b/src/skeleton/compentry.cpp
@@ -20,7 +20,7 @@ enum
 CompletionEntry::CompletionEntry( const int mode )
     : m_mode( mode )
     , m_enable_changed( true )
-    , m_popup_win( true )
+    , m_popup_win( SKELETON::POPUPWIN_DRAWFRAME )
 {
     m_entry.signal_key_press().connect( sigc::mem_fun( *this, &CompletionEntry::slot_entry_key_press ) );
     m_entry.signal_button_press().connect( sigc::mem_fun(*this, &CompletionEntry::slot_entry_button_press ) );

--- a/src/skeleton/popupwinbase.cpp
+++ b/src/skeleton/popupwinbase.cpp
@@ -15,27 +15,17 @@ PopupWinBase::PopupWinBase( bool draw_frame )
     : Gtk::Window( Gtk::WINDOW_POPUP )
     , m_draw_frame( draw_frame )
 {
-    if( m_draw_frame ) set_border_width( 1 );
+    if( m_draw_frame ) {
+        set_border_width( 1 );
+
+        auto provider = Gtk::CssProvider::create();
+        provider->load_from_data( "window { border: 1px solid black; }" );
+        get_style_context()->add_provider( provider, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION );
+    }
 
     if ( auto main_window = CORE::get_mainwindow() ) {
         set_transient_for( *main_window );
     }
-}
-
-
-PopupWinBase::~PopupWinBase() noexcept = default;
-
-
-bool PopupWinBase::on_draw( const Cairo::RefPtr< Cairo::Context >& cr )
-{
-    const bool ret = Gtk::Window::on_draw( cr );
-    if( m_draw_frame ) {
-        Gdk::Cairo::set_source_rgba( cr, Gdk::RGBA( "black" ) );
-        cr->set_line_width( 1.0 );
-        cr->rectangle( 0.0, 0.0, get_width(), get_height() );
-        cr->stroke();
-    }
-    return ret;
 }
 
 

--- a/src/skeleton/popupwinbase.h
+++ b/src/skeleton/popupwinbase.h
@@ -3,14 +3,12 @@
 //
 // ポップアップウィンドウの基底クラス
 //
-// TODO: 枠線はcssで設定する
 
 #ifndef POPUPWINBASE_H
 #define POPUPWINBASE_H
 
-#include "gtkmmversion.h"
-
 #include <gtkmm.h>
+
 
 namespace SKELETON
 {
@@ -32,13 +30,12 @@ namespace SKELETON
 
         // draw_frame == true なら枠を描画する
         explicit PopupWinBase( bool draw_frame );
-        ~PopupWinBase() noexcept;
+        ~PopupWinBase() noexcept = default;
 
         SIG_CONFIGURED_POPUP sig_configured(){ return m_sig_configured; }
 
       protected:
 
-        bool on_draw( const Cairo::RefPtr< Cairo::Context >& cr ) override;
         bool on_configure_event( GdkEventConfigure* event ) override;
     };
 }


### PR DESCRIPTION
ポップアップウインドウの境界線を描画するかわりにcss設定を使います。