### PR TITLE
notebook: Use Gtk::manage() instead of operator delete

### DIFF
--- a/src/skeleton/dragnote.cpp
+++ b/src/skeleton/dragnote.cpp
@@ -145,7 +145,7 @@ int DragableNoteBook::append_page( const std::string& url, Gtk::Widget& child )
 
     m_bt_tabswitch.show_button();
 
-    SKELETON::TabLabel* tablabel = create_tablabel( url );
+    SKELETON::TabLabel* tablabel = Gtk::manage( create_tablabel( url ) );
     return m_notebook_tab.append_tab( *tablabel );
 }
 
@@ -156,7 +156,7 @@ int DragableNoteBook::insert_page( const std::string& url, Gtk::Widget& child, i
 
     m_bt_tabswitch.show_button();
 
-    SKELETON::TabLabel* tablabel = create_tablabel( url );
+    SKELETON::TabLabel* tablabel = Gtk::manage( create_tablabel( url ) );
     return m_notebook_tab.insert_tab( *tablabel, page );
 }
 
@@ -186,12 +186,9 @@ void DragableNoteBook::set_tab_fulltext( const std::string& str, const int page 
 //
 void DragableNoteBook::remove_page( const int page, const bool adjust_tab )
 {
-    SKELETON::TabLabel* tablabel = m_notebook_tab.get_tablabel( page );
-
+    // タブはGtk::manage()の効果でdeleteされる
     m_notebook_tab.remove_tab( page, adjust_tab );
     m_notebook_view.remove_page( page );
-
-    if( tablabel ) delete tablabel;
 
     if( ! get_n_pages() ) m_bt_tabswitch.hide_button();
 }

--- a/src/skeleton/tabnote.cpp
+++ b/src/skeleton/tabnote.cpp
@@ -105,8 +105,7 @@ int TabNotebook::append_tab( Widget& tab )
 #endif
 
     // ダミーWidgetを作成してtabにappend (表示はされない )
-    // remove_tab()でdeleteする
-    DummyWidget* dummypage = new DummyWidget();
+    DummyWidget* dummypage = Gtk::manage( new DummyWidget );
 
     return append_page( *dummypage , tab );
 }
@@ -119,8 +118,7 @@ int TabNotebook::insert_tab( Widget& tab, int page )
 #endif
 
     // ダミーWidgetを作成してtabにappend (表示はされない )
-    // remove_tab()でdeleteする
-    DummyWidget* dummypage = new DummyWidget();
+    DummyWidget* dummypage = Gtk::manage( new DummyWidget );
 
     return insert_page( *dummypage, tab, page );
 }
@@ -132,11 +130,8 @@ void TabNotebook::remove_tab( const int page, const bool adjust_tab )
     std::cout << "TabNotebook::remove_tab page = " << page << std::endl;
 #endif
 
-    // ダミーWidgetをdelete
-    Gtk::Widget* dummypage = get_nth_page( page );
+    // ダミーWidgetはGtk::manage()の効果でdeleteされる
     remove_page( page );
-
-    if( dummypage ) delete dummypage;
 
     if( adjust_tab ) adjust_tabwidth();
 }


### PR DESCRIPTION
`Gtk::Notebook`に配置されてるページを取り除くときdeleteされるように`Gtk::manage()`によるメモリ管理を使います。

`Gtk::Notebook`に配置されてるタブを取り除くときdeleteされるように`Gtk::manage()`によるメモリ管理を使います。

