### PR TITLE
BoardBase: Use concrete type member instead of dynamic allocation

### DIFF
--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -6,6 +6,8 @@
 #ifndef _BOARDBASE_H
 #define _BOARDBASE_H
 
+#include "articlehash.h"
+
 #include "jdlib/jdregex.h"
 #include "skeleton/loadable.h"
 
@@ -46,13 +48,12 @@ namespace DBTREE
 
     class Root;
     class ArticleBase;
-    class ArticleHash;
 
     class BoardBase : public SKELETON::Loadable
     {
         // ArticleBaseクラス のキャッシュ
         // ArticleBaseクラスは一度作ったら~BoardBase()以外ではdeleteしないこと
-        ArticleHash* m_hash_article;
+        ArticleHash m_hash_article;
 
         // subject.txt から作ったArticleBaseクラスのポインタのリスト
         // subject.txt と同じ順番で、ロードされるたびに更新される
@@ -212,7 +213,7 @@ namespace DBTREE
 
         ARTICLE_INFO_LIST& get_list_artinfo(){ return m_list_artinfo; }
 
-        ArticleHash* get_hash_article(){ return m_hash_article; }
+        ArticleHash* get_hash_article(){ return &m_hash_article; }
         std::list< std::string >& get_url_update_views(){ return  m_url_update_views; }
 
         ArticleBase* get_article_null();


### PR DESCRIPTION
メンバー変数の型をポインターから実値に変更してメモリの動的割り当てを回避します。
また、[範囲ベースfor文の制限緩和][*]を利用してループを整理します。

[*]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0184r0.html