### PR TITLE
ArticleHash: Use std::unique_ptr instead of raw pointer

### DIFF
--- a/src/dbtree/articlehash.h
+++ b/src/dbtree/articlehash.h
@@ -8,8 +8,10 @@
 #ifndef _ARTICLEHASH_H
 #define _ARTICLEHASH_H
 
-#include <vector>
+#include <memory>
 #include <string>
+#include <vector>
+
 
 namespace DBTREE
 {
@@ -22,7 +24,7 @@ namespace DBTREE
 
         size_t m_size{};
         size_t m_min_hash;
-        std::vector< std::vector< ArticleBase* > > m_table;
+        std::vector< std::vector<std::unique_ptr<ArticleBase>> > m_table;
 
         // iterator 用変数
         size_t m_it_hash{};
@@ -39,7 +41,7 @@ namespace DBTREE
 
         size_t size() const { return m_size; }
 
-        void push( ArticleBase* article );
+        ArticleBase* insert( std::unique_ptr<ArticleBase> article );
 
         ArticleBase* find( const std::string& datbase, const std::string& id );
 

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -274,10 +274,8 @@ ArticleBase* Board2ch::append_article( const std::string& datbase, const std::st
 {
     if( empty() ) return get_article_null();
 
-    ArticleBase* article = new DBTREE::Article2ch( datbase, id, cached );
+    ArticleBase* article = insert( std::make_unique<DBTREE::Article2ch>( datbase, id, cached ) );
     if( article ){
-        get_hash_article()->push( article );
-
         // 最大レス数セット
         article->set_number_max( get_number_max_res() );
     }

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -236,10 +236,8 @@ ArticleBase* Board2chCompati::append_article( const std::string& datbase, const 
 {
     if( empty() ) return get_article_null();
 
-    ArticleBase* article = new DBTREE::Article2chCompati( datbase, id, cached );
+    ArticleBase* article = insert( std::make_unique<DBTREE::Article2chCompati>( datbase, id, cached ) );
     if( article ){
-        get_hash_article()->push( article );
-
         // 最大レス数セット
         article->set_number_max( get_number_max_res() );
     }

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -78,8 +78,6 @@ BoardBase::~BoardBase()
 
     clear();
 
-    for( ArticleBase* a : m_hash_article ) delete a;
-
 #ifdef _TEST_CACHE
     if( m_hash_article.size() ){
         std::cout << "article cache\n"
@@ -902,6 +900,10 @@ ArticleBase* BoardBase::get_article_create( const std::string& datbase, const st
 }
 
 
+ArticleBase* BoardBase::insert( std::unique_ptr<ArticleBase> article )
+{
+    return m_hash_article.insert( std::move( article ) );
+}
 
 
 //

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -213,12 +213,13 @@ namespace DBTREE
 
         ARTICLE_INFO_LIST& get_list_artinfo(){ return m_list_artinfo; }
 
-        ArticleHash* get_hash_article(){ return &m_hash_article; }
         std::list< std::string >& get_url_update_views(){ return  m_url_update_views; }
 
         ArticleBase* get_article_null();
         ArticleBase* get_article( const std::string& datbase, const std::string& id );
         ArticleBase* get_article_create( const std::string& datbase, const std::string& id );
+
+        ArticleBase* insert( std::unique_ptr<ArticleBase> article );
 
         void set_path_dat( const std::string& str ){ m_path_dat = str; }
         void set_path_readcgi( const std::string& str ){ m_path_readcgi = str; }

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -75,10 +75,8 @@ ArticleBase* BoardJBBS::append_article( const std::string& datbase, const std::s
 {
     if( empty() ) return get_article_null();
 
-    ArticleBase* article = new DBTREE::ArticleJBBS( datbase, id, cached );
+    ArticleBase* article = insert( std::make_unique<DBTREE::ArticleJBBS>( datbase, id, cached ) );
     if( article ){
-        get_hash_article()->push( article );
-
         // 最大レス数セット
         article->set_number_max( get_number_max_res() );
     }

--- a/src/dbtree/boardlocal.cpp
+++ b/src/dbtree/boardlocal.cpp
@@ -83,11 +83,8 @@ ArticleBase* BoardLocal::append_article( const std::string& datbase, const std::
               << ", id = " << id << std::endl;
 #endif
 
-    ArticleBase* article = new DBTREE::ArticleLocal( datbase, id );
+    ArticleBase* article = insert( std::make_unique<DBTREE::ArticleLocal>( datbase, id ) );
     if( article ){
-
-        get_hash_article()->push( article );
-
         // subject にも追加する
         get_list_subject().push_back( article );
     }

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -78,10 +78,8 @@ ArticleBase* BoardMachi::append_article( const std::string& datbase, const std::
 {
     if( empty() ) return get_article_null();
 
-    ArticleBase* article = new DBTREE::ArticleMachi( datbase, id, cached );
+    ArticleBase* article = insert( std::make_unique<DBTREE::ArticleMachi>( datbase, id, cached ) );
     if( article ){
-        get_hash_article()->push( article );
-
         // 最大レス数セット
         article->set_number_max( get_number_max_res() );
     }


### PR DESCRIPTION
クラスのメンバーをスマートポインターに更新してnew/deleteによるメモリ割り当てを整理します。

関連のpull request: #619 
