### PR TITLE
BoardFactory: Use std::unique_ptr instead of raw pointer

### DIFF
--- a/src/dbtree/boardfactory.cpp
+++ b/src/dbtree/boardfactory.cpp
@@ -9,20 +9,22 @@
 
 #include "type.h"
 
-DBTREE::BoardBase* DBTREE::BoardFactory( int type, const std::string& root, const std::string& path_board, const std::string& name,
-                                         const std::string& basicauth )
+
+std::unique_ptr<DBTREE::BoardBase> DBTREE::BoardFactory( int type, const std::string& root,
+                                                         const std::string& path_board, const std::string& name,
+                                                         const std::string& basicauth )
 {
     switch( type )
     {
-        case TYPE_BOARD_2CH: return new DBTREE::Board2ch( root, path_board, name );
+        case TYPE_BOARD_2CH: return std::make_unique<Board2ch>( root, path_board, name );
 
-        case TYPE_BOARD_2CH_COMPATI: return new DBTREE::Board2chCompati( root, path_board, name, basicauth );
+        case TYPE_BOARD_2CH_COMPATI: return std::make_unique<Board2chCompati>( root, path_board, name, basicauth );
 
-        case TYPE_BOARD_LOCAL: return new DBTREE::BoardLocal( root, path_board, name );
+        case TYPE_BOARD_LOCAL: return std::make_unique<BoardLocal>( root, path_board, name );
 
-        case TYPE_BOARD_JBBS:return  new DBTREE::BoardJBBS( root, path_board, name );
+        case TYPE_BOARD_JBBS: return std::make_unique<BoardJBBS>( root, path_board, name );
 
-        case TYPE_BOARD_MACHI:return  new DBTREE::BoardMachi( root, path_board, name );
+        case TYPE_BOARD_MACHI: return std::make_unique<BoardMachi>( root, path_board, name );
 
         default: return nullptr;
     }

--- a/src/dbtree/boardfactory.h
+++ b/src/dbtree/boardfactory.h
@@ -7,14 +7,16 @@
 #ifndef _BOARDFACTORY_H
 #define _BOARDFACTORY_H
 
+#include <memory>
 #include <string>
+
 
 namespace DBTREE
 {
     class BoardBase;
 
-    DBTREE::BoardBase* BoardFactory( int type, const std::string& root, const std::string& path_board, const std::string& name,
-                                     const std::string& basicauth );
+    std::unique_ptr<DBTREE::BoardBase> BoardFactory( int type, const std::string& root, const std::string& path_board,
+                                                     const std::string& name, const std::string& basicauth );
 }
 
 

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -702,9 +702,10 @@ bool Root::set_board( const std::string& url, const std::string& name, const std
     // 新板登録
     if( stat == BOARD_NEW ){
 
-        board = DBTREE::BoardFactory( type, root, path_board, name, basicauth );
-        if( board ){
-            m_list_board.push_back( std::unique_ptr<BoardBase>( board ) );
+        auto uniq = DBTREE::BoardFactory( type, root, path_board, name, basicauth );
+        if( uniq ){
+            board = uniq.get();
+            m_list_board.push_back( std::move( uniq ) );
             if( m_analyzing_board_xml ) m_analyzed_path_board.insert( path_board );
         }
     }


### PR DESCRIPTION
メンバー関数の戻り値をスマートポインターに更新してnew/deleteによるメモリ割り当てを整理します。

関連のpull request: #619 
