### PR TITLE
dialog: Add Client-Side Decoration support

### DIFF
--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -263,6 +263,8 @@ void AboutConfig::append_rows()
     append_row( "スレビューのスクロールバーを左に配置する", get_confitem()->left_scrbar, CONF_LEFT_SCRBAR );
     append_row( "メニューバーを非表示にした時にダイアログを表示", get_confitem()->show_hide_menubar_diag, CONF_SHOW_HIDE_MENUBAR_DIAG );
     append_row( "状態変更時にメインステータスバーの色を変える", get_confitem()->change_stastatus_color, CONF_CHANGE_STASTATUS_COLOR );
+    append_row( "Client-Side Decorationを使うか( 0: 使わない 1: 使う 2: デスクトップに合わせる )",
+                get_confitem()->use_header_bar, CONF_USE_HEADER_BAR );
 
     // 次スレ検索
     append_row( "" );

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -557,6 +557,9 @@ bool ConfigItems::load( const bool restore )
     // 状態変更時にメインステータスバーの色を変える
     change_stastatus_color = cf.get_option_bool( "change_stastatus_color", CONF_CHANGE_STASTATUS_COLOR );
 
+    // Client-Side Decorationを使うか( 0: 使わない 1: 使う 2: デスクトップに合わせる )
+    use_header_bar = cf.get_option_int( "use_header_bar", CONF_USE_HEADER_BAR, 0, 2 );
+
     // まちBBSの取得に offlaw.cgi を使用する
     use_machi_offlaw = cf.get_option_bool( "use_machi_offlaw", CONF_USE_MACHI_OFFLAW );
 
@@ -908,6 +911,7 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "disable_close", disable_close );
     cf.update( "show_hide_menubar_diag", show_hide_menubar_diag );
     cf.update( "change_stastatus_color", change_stastatus_color );
+    cf.update( "use_header_bar", use_header_bar );
     cf.update( "use_machi_offlaw", use_machi_offlaw );
     cf.update( "show_del_written_thread_diag", show_del_written_thread_diag );
     cf.update( "delete_img_in_thread", delete_img_in_thread );

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -506,6 +506,9 @@ namespace CONFIG
         // 状態変更時にメインステータスバーの色を変える
         bool change_stastatus_color{};
 
+        // Client-Side Decorationを使うか( 0: 使わない 1: 使う 2: デスクトップに合わせる )
+        int use_header_bar{};
+
         // まちBBSの取得に offlaw.cgi を使用する
         bool use_machi_offlaw{};
 

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -154,6 +154,7 @@ namespace CONFIG
         CONF_DISABLE_CLOSE = 0, // Ctrl+qでウィンドウを閉じない
         CONF_SHOW_HIDE_MENUBAR_DIAG = 1, // メニューバーを非表示にした時にダイアログを表示
         CONF_CHANGE_STASTATUS_COLOR = 1, // 状態変更時にメインステータスバーの色を変える
+        CONF_USE_HEADER_BAR = 2, // Client-Side Decorationを使うか( 0: 使わない 1: 使う 2: デスクトップに合わせる )
         CONF_USE_MACHI_OFFLAW = 0, // まちBBSの取得に offlaw.cgi を使用する
         CONF_SHOW_DEL_WRITTEN_THREAD_DIAG = 1, // 書き込み履歴のあるスレを削除する時にダイアログを表示
         CONF_DELETE_IMG_IN_THREAD = 0, // スレを削除する時に画像キャッシュも削除する ( 0: ダイアログ表示 1: 削除 2: 削除しない )

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -583,6 +583,9 @@ void CONFIG::set_show_hide_menubar_diag( const bool set ){ get_confitem()->show_
 // 状態変更時にメインステータスバーの色を変える
 bool CONFIG::get_change_stastatus_color(){ return get_confitem()->change_stastatus_color; }
 
+// Client-Side Decorationを使うか( 0: 使わない 1: 使う 2: デスクトップに合わせる )
+int CONFIG::get_use_header_bar() { return get_confitem()->use_header_bar; }
+
 // まちBBSの取得に offlaw.cgi を使用する
 bool CONFIG::get_use_machi_offlaw(){ return get_confitem()->use_machi_offlaw; }
 void CONFIG::set_use_machi_offlaw( const bool set ){ get_confitem()->use_machi_offlaw = set; }

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -580,6 +580,9 @@ namespace CONFIG
     // 状態変更時にメインステータスバーの色を変える
     bool get_change_stastatus_color();
 
+    // Client-Side Decorationを使うか( 0: 使わない 1: 使う 2: デスクトップに合わせる )
+    int get_use_header_bar();
+
     // まちBBSの取得に offlaw.cgi を使用する
     bool get_use_machi_offlaw();
     void set_use_machi_offlaw( const bool set );

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -13,7 +13,7 @@
 #include <cstring>
 #include <sstream>
 
-#include "gtkmm.h"
+#include <gtkmm.h>
 
 #if __has_include(<sys/utsname.h>)
 #define HAVE_SYS_UTSNAME_H
@@ -511,3 +511,24 @@ std::string ENVIRONMENT::get_jdinfo()
     return jd_info.str();
 }
 
+
+// Client-Side Decorationを使うか
+static bool should_use_header_bar()
+{
+    const int flag = CONFIG::get_use_header_bar();
+    // 0: 使わない 1: 使う
+    if( flag == 0 || flag == 1 ) return static_cast<bool>( flag );
+
+    // 2: デスクトップに合わせる のときはデスクトップ環境を調べる
+    return ENVIRONMENT::get_wm() == ENVIRONMENT::DesktopType::gnome;
+}
+
+
+// ダイアログでClient-Side Decorationを使うか
+// JDimの設定とGtkSettingsから使うか判断する
+bool ENVIRONMENT::get_dialog_use_header_bar()
+{
+    const bool dialog_use_header = Gtk::Settings::get_default()->property_gtk_dialogs_use_header();
+
+    return dialog_use_header && should_use_header_bar();
+}

--- a/src/environment.h
+++ b/src/environment.h
@@ -51,6 +51,10 @@ namespace ENVIRONMENT
 	std::string get_glibmm_version();
     std::string get_tlslib_version();
     std::string get_jdinfo();
+
+    // ダイアログでClient-Side Decorationを使うか
+    // JDimの設定とGtkSettingsから使うか判断する
+    bool get_dialog_use_header_bar();
 }
 
 

--- a/src/skeleton/aboutdiag.cpp
+++ b/src/skeleton/aboutdiag.cpp
@@ -25,8 +25,9 @@ enum
 
 
 AboutDiag::AboutDiag( const Glib::ustring& title )
-    : Gtk::Dialog( title ),
-      m_button_copy_environment( "クリップボードへコピー" )
+    : Gtk::Dialog( title, ENVIRONMENT::get_dialog_use_header_bar() ? Gtk::DIALOG_USE_HEADER_BAR
+                                                                   : Gtk::DialogFlags{} )
+    , m_button_copy_environment( "クリップボードへコピー" )
 {
     set_transient_for( *CORE::get_mainwindow() );
     set_resizable( false );

--- a/src/skeleton/prefdiag.cpp
+++ b/src/skeleton/prefdiag.cpp
@@ -7,24 +7,32 @@
 #include "label_entry.h"
 
 #include "command.h"
-#include "session.h"
 #include "dispatchmanager.h"
+#include "environment.h"
 #include "global.h"
+#include "session.h"
 
 #include <glib/gi18n.h>
 
 
 using namespace SKELETON;
 
-PrefDiag::PrefDiag( Gtk::Window* parent, const std::string& url, const bool add_cancel, const bool add_apply, const bool add_open )
-    : Gtk::Dialog()
+
+PrefDiag::PrefDiag( Gtk::Window* parent, const std::string& url, const bool add_cancel, const bool add_apply,
+                    const bool add_open )
+    : Gtk::Dialog( "", ENVIRONMENT::get_dialog_use_header_bar() ? Gtk::DIALOG_USE_HEADER_BAR
+                                                                : Gtk::DialogFlags{} )
     , m_url( url )
     , m_bt_apply( g_dgettext( GTK_DOMAIN, "_Apply" ), true )
 {
     if( add_apply ){
         m_bt_apply.signal_clicked().connect( sigc::mem_fun(*this, &PrefDiag::slot_apply_clicked ) );
-        get_action_area()->pack_start( m_bt_apply );
-
+        if( property_use_header_bar() ) {
+            get_header_bar()->pack_start( m_bt_apply );
+        }
+        else {
+            get_action_area()->pack_start( m_bt_apply );
+        }
     }
 
     if( add_cancel ){


### PR DESCRIPTION

Client-Side Decoration(CSD)の設定を追加します。

#### Client-Side Decorationとは
デスクトップ(ウインドウマネージャ)が制御していたタイトルバーをアプリケーションの領域として使う概念です。

#### 設定値と意味
CSDはデスクトップ環境との関係が強いためabout:configに項目を追加します。

- 0: CSDを使わない
- 1: CSDを使う
- 2: デスクトップに合わせる (デフォルト)

「デスクトップに合わせる」にするとCSDが導入されたデスクトップ環境では「使う」になります。

#### ダイアログ
ダイアログボックスにCSDサポートを追加します。CSDが使われる条件は下記の2通りです。

- about:config「Client-Side Decorationを使うか」の値が`1`(使う)
  GtkSettings `gtk-dialogs-use-header`の値が`true`

- about:config「Client-Side Decorationを使うか」の値が`2`(合わせる)
  デスクトップ環境がGNOME
  GtkSettings `gtk-dialogs-use-header`の値が`true`

関連のissue: #602
