### PR TITLE
Dom: Implement member function size()

### DIFF
--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -2218,7 +2218,7 @@ void BBSListViewBase::xml2tree( const std::string& root_name, const std::string&
 
 #ifdef _DEBUG
     std::cout << " ルートノード名=" << root_name;
-    std::cout << " 子ノード数=" << m_document.childNodes().size() << std::endl;
+    std::cout << " 子ノード数=" << m_document.size() << std::endl;
 #endif
 
     m_treeview.xml2tree( m_document, m_treestore, root_name );

--- a/src/linkfiltermanager.cpp
+++ b/src/linkfiltermanager.cpp
@@ -61,7 +61,7 @@ void Linkfilter_Manager::xml2list( const std::string& xml )
 
 #ifdef _DEBUG
     std::cout << "Linkfilter_Manager::xml2list";
-    std::cout << " children =" << document.childNodes().size() << std::endl;
+    std::cout << " children =" << document.size() << std::endl;
 #endif
 
     for( const XML::Dom* child : domlist ){

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -312,7 +312,7 @@ void EditTreeView::xml2tree( const XML::Document& document, Glib::RefPtr< Gtk::T
 #ifdef _DEBUG
     std::cout << "EditTreeView::xml2tree ";
     std::cout << " root = " << root_name;
-    std::cout << " size = " << document.childNodes().size() << std::endl;
+    std::cout << " size = " << document.size() << std::endl;
 #endif
 
     treestore->clear();
@@ -362,7 +362,7 @@ void EditTreeView::tree2xml( XML::Document& document, const std::string& root_na
 #ifdef _DEBUG
     std::cout << "EditTreeView::tree2xml ";
     std::cout << " root = " << root_name;
-    std::cout << " size = " << document.childNodes().size() << std::endl;
+    std::cout << " size = " << document.size() << std::endl;
 #endif
 }
 

--- a/src/xml/document.cpp
+++ b/src/xml/document.cpp
@@ -98,7 +98,7 @@ void Document::set_treestore( Glib::RefPtr< Gtk::TreeStore >& treestore, SKELETO
 {
     treestore->clear();
 
-    if( childNodes().size() )
+    if( size() )
     {
         // ルートの子要素以下が対象
         const Dom* root = get_root_element( root_name );

--- a/src/xml/dom.h
+++ b/src/xml/dom.h
@@ -134,6 +134,8 @@ namespace XML
         bool setAttribute( const std::string& name, const std::string& value );
         bool setAttribute( const std::string& name, const int value );
         bool removeAttribute( const std::string& name ) = delete;
+
+        std::size_t size() const noexcept { return m_childNodes.size(); }
     };
 }
 


### PR DESCRIPTION
子要素数を取得するメンバー関数を実装します。
これまでは子要素のリストを複製してサイズを取得していましたが直接取得できるようにします。
また、`childNodes().size()`を呼び出していた箇所を`size()`に修正します。