### PR TITLE
Refactor Dom part3

### DIFF
--- a/src/aamanager.cpp
+++ b/src/aamanager.cpp
@@ -156,7 +156,7 @@ void AAManager::load_history()
     if( ! root ) return;
 
     std::list< std::string > tmp_history;
-    for( const XML::Dom* child : root->childNodes() ){
+    for( const XML::Dom* child : *root ) {
         if( static_cast<int>( tmp_history.size() ) >= CONFIG::get_aahistory_size() ) break;
 
         if( child->nodeType() == XML::NODE_TYPE_ELEMENT ){

--- a/src/bbslist/bbslistview.cpp
+++ b/src/bbslist/bbslistview.cpp
@@ -95,8 +95,8 @@ void BBSListViewMain::update_view()
     // <subdir>を挿入
     // ルート要素の有無で処理を分ける( 旧様式=無, 新様式=有 )
     XML::Dom* subdir = nullptr;
-    if( root ) subdir = root->insertBefore( XML::NODE_TYPE_ELEMENT, "subdir", root->firstChild() );
-    else subdir = get_document().insertBefore( XML::NODE_TYPE_ELEMENT, "subdir", get_document().firstChild() );
+    if( root ) subdir = root->emplace_front( XML::NODE_TYPE_ELEMENT, "subdir" );
+    else subdir = get_document().emplace_front( XML::NODE_TYPE_ELEMENT, "subdir" );
     subdir->setAttribute( "name", std::string( SUBDIR_ETCLIST ) );
 
     // 子要素( <board> )を追加

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -3170,7 +3170,7 @@ void BBSListViewBase::save_xml_impl( const std::string& file, const std::string&
     if( ! remove_dir.empty() )
     {
         XML::Dom* domroot = m_document.get_root_element( root );
-        for( XML::Dom* child : domroot->childNodes() )
+        for( XML::Dom* child : *domroot )
         {
             if( child->nodeName() == "subdir"
                 && child->getAttribute( "name" ) == remove_dir )

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -454,8 +454,7 @@ void Root::bbsmenu2xml( const std::string& menu )
         MISC::ERRMSG( "parse error for bbsmenu" );
         return;
     }
-    targets = targets.front()->childNodes();
-    for( const XML::Dom* child : targets )
+    for( const XML::Dom* child : *targets.front() )
     {
         // 要素b( カテゴリ名 )
         if( child->nodeName() == "b" )

--- a/src/history/historymanager.cpp
+++ b/src/history/historymanager.cpp
@@ -215,9 +215,7 @@ void History_Manager::xml2viewhistory()
 
     const XML::Dom* root = document.get_root_element( std::string( ROOT_NODE_NAME ) );
 
-    const std::list<XML::Dom*> domlist = root->childNodes();
-
-    for( const XML::Dom* subdir : domlist ){
+    for( const XML::Dom* subdir : *root ){
 
         if( subdir->nodeType() != XML::NODE_TYPE_ELEMENT ) continue;
 
@@ -240,8 +238,7 @@ void History_Manager::xml2viewhistory()
         ViewHistory& history = m_view_histories.back();
 
         // viewhistory に item を append
-        const std::list<XML::Dom*> domlist_hist = subdir->childNodes();
-        for( const XML::Dom* histitem : domlist_hist ){
+        for( const XML::Dom* histitem : *subdir ) {
 
             if( histitem->nodeType() != XML::NODE_TYPE_ELEMENT ) continue;
 

--- a/src/linkfiltermanager.cpp
+++ b/src/linkfiltermanager.cpp
@@ -57,14 +57,13 @@ void Linkfilter_Manager::xml2list( const std::string& xml )
 
     const XML::Dom* root = document.get_root_element( std::string( ROOT_NODE_NAME_LINKFILTER ) );
     if( ! root ) return;
-    const std::list<XML::Dom*> domlist = root->childNodes();
 
 #ifdef _DEBUG
     std::cout << "Linkfilter_Manager::xml2list";
     std::cout << " children =" << document.size() << std::endl;
 #endif
 
-    for( const XML::Dom* child : domlist ){
+    for( const XML::Dom* child : *root ) {
 
         if( child->nodeType() == XML::NODE_TYPE_ELEMENT ){
 

--- a/src/replacestrmanager.cpp
+++ b/src/replacestrmanager.cpp
@@ -148,9 +148,9 @@ void ReplaceStr_Manager::xml2list( const std::string& xml )
     }
     if( xml.empty() ) return;
 
-    XML::Document document( xml );
+    const XML::Document document( xml );
 
-    XML::Dom* const root = document.get_root_element( kRootNodeNameReplaceStr );
+    const XML::Dom* const root = document.get_root_element( kRootNodeNameReplaceStr );
     if( ! root ) return;
 
     const std::list<XML::Dom*> domlist = root->childNodes();

--- a/src/replacestrmanager.cpp
+++ b/src/replacestrmanager.cpp
@@ -153,8 +153,7 @@ void ReplaceStr_Manager::xml2list( const std::string& xml )
     const XML::Dom* const root = document.get_root_element( kRootNodeNameReplaceStr );
     if( ! root ) return;
 
-    const std::list<XML::Dom*> domlist = root->childNodes();
-    for( const XML::Dom* dom : domlist ) {
+    for( const XML::Dom* dom : *root ) {
 
         if( dom->nodeType() != XML::NODE_TYPE_ELEMENT ) continue;
 
@@ -166,8 +165,7 @@ void ReplaceStr_Manager::xml2list( const std::string& xml )
 
         m_chref[id] = dom->getAttribute( "chref" ) == "true";
 
-        const std::list<XML::Dom*> domlist_query = dom->childNodes();
-        for( const XML::Dom* query : domlist_query ) {
+        for( const XML::Dom* query : *dom ) {
 
             if( query->nodeType() != XML::NODE_TYPE_ELEMENT ) continue;
 

--- a/src/usrcmdmanager.cpp
+++ b/src/usrcmdmanager.cpp
@@ -449,8 +449,7 @@ std::string Usrcmd_Manager::create_usrcmd_menu( Glib::RefPtr< Gtk::ActionGroup >
     std::string menu;
     if( ! dom ) return menu;
 
-    const std::list<XML::Dom*> domlist = dom->childNodes();
-    for( const XML::Dom* child : domlist )
+    for( const XML::Dom* child : *dom )
     {
         if( child->nodeType() == XML::NODE_TYPE_ELEMENT )
         {

--- a/src/xml/document.cpp
+++ b/src/xml/document.cpp
@@ -115,13 +115,25 @@ void Document::set_treestore( Glib::RefPtr< Gtk::TreeStore >& treestore, SKELETO
 //
 // node_name : 要素名で限定、空の時は要素名問わず取得
 //
-Dom* Document::get_root_element( const std::string& node_name ) const
+static Dom* get_root_element_impl( const std::list<Dom*>& children, const std::string& node_name )
 {
-    const std::list<Dom*> children = childNodes();
     auto it = std::find_if( children.cbegin(), children.cend(),
                             []( const Dom* c ) { return c->nodeType() == NODE_TYPE_ELEMENT; } );
 
     if( it != children.cend()
         && ( node_name.empty() || (*it)->nodeName() == node_name ) ) return *it;
     return nullptr;
+}
+
+
+Dom* Document::get_root_element( const std::string& node_name )
+{
+    // Domのfriend classなのでアクセス可能
+    return get_root_element_impl( m_childNodes, node_name );
+}
+
+
+const Dom* Document::get_root_element( const std::string& node_name ) const
+{
+    return get_root_element_impl( m_childNodes, node_name );
 }

--- a/src/xml/document.h
+++ b/src/xml/document.h
@@ -47,7 +47,8 @@ namespace XML
                             const std::string& root_name, std::list< Gtk::TreePath >& list_path_expand ) const;
 
         // ルート要素を取得する
-        Dom* get_root_element( const std::string& node_name = std::string() ) const;
+        Dom* get_root_element( const std::string& node_name = {} );
+        const Dom* get_root_element( const std::string& node_name = {} ) const;
     };
 }
 

--- a/src/xml/dom.cpp
+++ b/src/xml/dom.cpp
@@ -620,22 +620,14 @@ bool Dom::removeChild( Dom* node )
 
 
 //
-// ノード：insertBefore()
+// insertBefore() の機能をフルに使っていなかったためシンプルにした関数を導入する
 //
-Dom* Dom::insertBefore( const int node_type, const std::string& node_name, Dom* insNode )
+Dom* Dom::emplace_front( const int node_type, const std::string& node_name )
 {
-    if( ! insNode ) return appendChild( node_type, node_name );
-
-    Dom* newNode = nullptr;
-
-    const auto it = std::find( m_childNodes.begin(), m_childNodes.end(), insNode );
-    if( it != m_childNodes.end() )
-    {
-        newNode = new Dom( node_type, node_name );
-        newNode->m_parentNode = insNode->m_parentNode;
-        m_childNodes.insert( it, newNode );
-    }
-    return newNode;
+    Dom* node = new Dom( node_type, node_name );
+    node->m_parentNode = this;
+    m_childNodes.push_front( node );
+    return node;
 }
 
 

--- a/src/xml/dom.h
+++ b/src/xml/dom.h
@@ -102,7 +102,7 @@ namespace XML
         void nodeValue( const std::string& value ) { m_nodeValue = value; }
 
         // ノード
-        // 注意：appendChild(), insertBefore() は
+        // 注意：appendChild() は
         // 戻り値と引数がJavascriptなどのDOMとは異なります。
         //
         // delete忘れを防ぐために外部でnewしない方が良いだろうという
@@ -116,7 +116,7 @@ namespace XML
         Dom* firstChild() const;
         Dom* appendChild( const int node_type, const std::string& node_name );
         bool removeChild( Dom* node );
-        Dom* insertBefore( const int node_type, const std::string& node_name, Dom* insNode );
+        Dom* emplace_front( int node_type, const std::string& node_name );
 
         // 属性
         std::string getAttribute( const std::string& name ) const;

--- a/src/xml/dom.h
+++ b/src/xml/dom.h
@@ -70,7 +70,6 @@ namespace XML
         void parse( const Gtk::TreeModel::Children& children, SKELETON::EditColumns& columns );
 
         // プロパティをセットするアクセッサ
-        void parentNode( Dom* parent ) = delete;
         void copy_childNodes( const Dom& dom ); // dom の子ノードをコピーする
 
         // ノードを分解して Gtk::TreeStore へ Gtk::TreeModel::Row を追加
@@ -103,7 +102,7 @@ namespace XML
         void nodeValue( const std::string& value ) { m_nodeValue = value; }
 
         // ノード
-        // 注意：appendChild(), replaceChild(), insertBefore() は
+        // 注意：appendChild(), insertBefore() は
         // 戻り値と引数がJavascriptなどのDOMとは異なります。
         //
         // delete忘れを防ぐために外部でnewしない方が良いだろうという
@@ -112,28 +111,17 @@ namespace XML
         //
         // クラス外で使用していないメンバ関数は削除してあります。
 
-        Dom* ownerDocument() const noexcept = delete;
-        Dom* parentNode() const noexcept = delete;
         bool hasChildNodes() const noexcept;
         std::list<Dom*> childNodes() const { return m_childNodes; }
         Dom* firstChild() const;
-        Dom* lastChild() const = delete;
         Dom* appendChild( const int node_type, const std::string& node_name );
         bool removeChild( Dom* node );
-        Dom* replaceChild( const int node_type, const std::string& node_name, Dom* oldNode ) = delete;
         Dom* insertBefore( const int node_type, const std::string& node_name, Dom* insNode );
-        Dom* previousSibling() const = delete;
-        Dom* nextSibling() const = delete;
 
         // 属性
-        bool hasAttributes() const noexcept = delete;
-        std::map< std::string, std::string > attributes() const = delete;
-        void attributes( std::map< std::string, std::string > attributes ) = delete;
-        bool hasAttribute( const std::string& name ) const = delete;
         std::string getAttribute( const std::string& name ) const;
         bool setAttribute( const std::string& name, const std::string& value );
         bool setAttribute( const std::string& name, const int value );
-        bool removeAttribute( const std::string& name ) = delete;
 
         std::size_t size() const noexcept { return m_childNodes.size(); }
     };

--- a/src/xml/dom.h
+++ b/src/xml/dom.h
@@ -112,7 +112,7 @@ namespace XML
         // クラス外で使用していないメンバ関数は削除してあります。
 
         bool hasChildNodes() const noexcept;
-        std::list<Dom*> childNodes() const { return m_childNodes; }
+        std::list<Dom*> childNodes() const = delete;
         Dom* firstChild() const;
         Dom* appendChild( const int node_type, const std::string& node_name );
         bool removeChild( Dom* node );
@@ -124,6 +124,9 @@ namespace XML
         bool setAttribute( const std::string& name, const int value );
 
         std::size_t size() const noexcept { return m_childNodes.size(); }
+
+        auto begin() const noexcept { return m_childNodes.cbegin(); }
+        auto end() const noexcept { return m_childNodes.cend(); }
     };
 }
 

--- a/test/gtest_xml_dom.cpp
+++ b/test/gtest_xml_dom.cpp
@@ -184,7 +184,7 @@ TEST_F(XML_DomChildren, child_nodes)
     XML::Dom* second = dom.appendChild( XML::NODE_TYPE_TEXT, "text" );
     XML::Dom* third = dom.appendChild( XML::NODE_TYPE_DOCUMENT, "document" );
     const std::list<XML::Dom*> expect = { first, second, third };
-    const std::list<XML::Dom*> result = dom.childNodes();
+    const std::list<XML::Dom*> result{ dom.begin(), dom.end() };
     EXPECT_EQ( expect, result );
 }
 

--- a/test/gtest_xml_dom.cpp
+++ b/test/gtest_xml_dom.cpp
@@ -223,20 +223,16 @@ TEST_F(XML_DomChildren, remove_child)
     EXPECT_FALSE( dom.hasChildNodes() );
 }
 
-TEST_F(XML_DomChildren, insert_before)
+TEST_F(XML_DomChildren, emplace_front)
 {
     XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };
 
-    XML::Dom* first_child = dom.appendChild( XML::NODE_TYPE_ELEMENT, "child1" );
-    XML::Dom* second_child = dom.insertBefore( XML::NODE_TYPE_ELEMENT, "child2", first_child );
+    dom.appendChild( XML::NODE_TYPE_ELEMENT, "child1" );
+    XML::Dom* second_child = dom.emplace_front( XML::NODE_TYPE_ELEMENT, "child2" );
     EXPECT_EQ( dom.firstChild(), second_child );
 
-    XML::Dom* third_child = dom.insertBefore( XML::NODE_TYPE_ELEMENT, "child2", nullptr );
-    EXPECT_EQ( dom.childNodes().back(), third_child );
-
-    XML::Dom not_child{ XML::NODE_TYPE_UNKNOWN, "test" };
-    XML::Dom* null_child = dom.insertBefore( XML::NODE_TYPE_ELEMENT, "null", &not_child );
-    EXPECT_EQ( nullptr, null_child );
+    XML::Dom* third_child = dom.emplace_front( XML::NODE_TYPE_ELEMENT, "child2" );
+    EXPECT_EQ( dom.firstChild(), third_child );
 }
 
 TEST_F(XML_DomChildren, children_clear)


### PR DESCRIPTION
- 使われてないメンバー関数のdelete宣言を取り除いてヘッダーを整理します。

- `insertBefore()`の機能をフルに使っていなかったためシンプルにした関数に交換します。
   新しい`emplace_front()`は[C++ standard container][a]のAPIを参考にしていますが同等の機能ではありません。

- 目的に応じてconst/non-const版を使い分けられるように両バージョンのメンバー関数を用意します。

- 子要素を走査するためのメンバー関数`begin()`と`end()`を実装します。また、実装した関数を利用してクライアントコードも更新します。これまでは子要素のリストを複製して走査を行っていましたが直接イテレートできるようにします。また、使われなくなった`childNodes()`を削除します。

[a]: https://en.cppreference.com/w/cpp/container