### PR TITLE
Replace Gtk::Menu::popup() with new API

### DIFF
--- a/src/history/historysubmenu.cpp
+++ b/src/history/historysubmenu.cpp
@@ -210,7 +210,7 @@ bool HistorySubMenu::slot_button_press( GdkEventButton* event, int i )
     // ポップアップメニュー表示
     if( event->button == 3 )
     {
-        m_popupmenu.popup( 0, gtk_get_current_event_time() );
+        m_popupmenu.popup_at_pointer( reinterpret_cast<GdkEvent*>( event ) );
     }
 
     return true;

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -2208,7 +2208,7 @@ void Admin::slot_tab_menu( int page, int x, int y )
         if( label ) label->set_text_with_mnemonic( ITEM_NAME_GO + std::string( " [ タブ数 " )
                                                    + std::to_string( m_notebook->get_n_pages() ) +" ](_M)" );
 
-        popupmenu->popup( 0, gtk_get_current_event_time() );
+        popupmenu->popup_at_pointer( nullptr ); // current event
     }
 }
 

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -2227,28 +2227,9 @@ void Admin::slot_show_tabswitchmenu()
     m_tabswitchmenu->update_labels();
     m_tabswitchmenu->update_icons();
 
-    m_tabswitchmenu->popup( Gtk::Menu::SlotPositionCalc( sigc::mem_fun( *this, &Admin::slot_popup_pos ) ),
-                            0, gtk_get_current_event_time() );
-}
-
-
-// タブ切り替えメニューの位置決め
-void Admin::slot_popup_pos( int& x, int& y, bool& push_in )
-{
-    if( ! m_tabswitchmenu ) return;
-
-    const int mrg = 16;
-
-    m_notebook->get_tabswitch_button().get_pointer( x, y );
-
-    int ox, oy;
-    m_notebook->get_tabswitch_button().get_window()->get_origin( ox, oy );
-    const Gdk::Rectangle rect = m_notebook->get_tabswitch_button().get_allocation();
-
-    x += ox + rect.get_x() - mrg;
-    y = oy + rect.get_y() + rect.get_height();
-
-    push_in = false;
+    // Specify the current event by nullptr.
+    m_tabswitchmenu->popup_at_widget( &( m_notebook->get_tabswitch_button() ),
+                                      Gdk::GRAVITY_SOUTH_EAST, Gdk::GRAVITY_NORTH_EAST, nullptr );
 }
 
 

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -285,9 +285,6 @@ namespace SKELETON
         // タブ切り替えメニュー表示
         void slot_show_tabswitchmenu();
 
-        // タブ切り替えメニューの位置決め
-        void slot_popup_pos( int& x, int& y, bool& push_in );
-
         // 右クリックメニュー
         virtual void slot_close_tab();
         virtual void slot_lock();

--- a/src/skeleton/menubutton.cpp
+++ b/src/skeleton/menubutton.cpp
@@ -127,8 +127,8 @@ void MenuButton::show_popupmenu()
 {
     if( ! m_popupmenu ) return;
 
-    m_popupmenu->popup( Gtk::Menu::SlotPositionCalc( sigc::mem_fun( *this, &MenuButton::slot_popup_pos ) ),
-                        0, gtk_get_current_event_time() );
+    // Specify the current event by nullptr.
+    m_popupmenu->popup_at_widget( this, Gdk::GRAVITY_SOUTH_WEST, Gdk::GRAVITY_NORTH_WEST, nullptr );
 }
 
 
@@ -156,20 +156,6 @@ void MenuButton::on_clicked()
 
     if( ! m_enable_sig_clicked || m_on_arrow ) show_popupmenu();
     else m_sig_clicked.emit();
-}
-
-
-//
-// ポップアップメニューの位置決め
-//
-void MenuButton::slot_popup_pos( int& x, int& y, bool& push_in )
-{
-    int ox, oy;
-    get_window()->get_origin( ox, oy );
-    Gdk::Rectangle rect = get_allocation();
-    x = ox + rect.get_x();
-    y = oy + rect.get_y() + rect.get_height();
-    push_in = false;
 }
 
 

--- a/src/skeleton/menubutton.h
+++ b/src/skeleton/menubutton.h
@@ -70,8 +70,6 @@ namespace SKELETON
 
       void slot_menu_selected( int i );
 
-      void slot_popup_pos( int& x, int& y, bool& push_in );
-
       bool slot_enter( GdkEventCrossing* event );
       bool slot_leave( GdkEventCrossing* event );
       bool slot_motion( GdkEventMotion* event );

--- a/src/usrcmdpref.cpp
+++ b/src/usrcmdpref.cpp
@@ -268,7 +268,8 @@ void UsrCmdPref::show_popupmenu()
         if( act_del ) act_del->set_sensitive( true );
     }
 
-    menu->popup( 0, gtk_get_current_event_time() );
+    // Specify the current event by nullptr.
+    menu->popup_at_pointer( nullptr );
 }
 
 


### PR DESCRIPTION
- GTK3.22から廃止予定になった`Gtk::Menu::popup()`のかわりに`popup_at_poitner()`を使います。
  この修正でメニューを表示したときに出る警告も表示されなくなります。

  非推奨シンボルを無効化したときのコンパイルエラー
  ```
  ../src/history/historysubmenu.cpp:213:21: error: 'class Gtk::Menu' has no member named 'popup'
    213 |         m_popupmenu.popup( 0, gtk_get_current_event_time() );
        |                     ^~~~~
  ../src/skeleton/admin.cpp:2211:20: error: 'class Gtk::Menu' has no member named 'popup'
   2211 |         popupmenu->popup( 0, gtk_get_current_event_time() );
        |                    ^~~~~
  ../src/usrcmdpref.cpp:271:11: error: 'class Gtk::Menu' has no member named 'popup'
    271 |     menu->popup( 0, gtk_get_current_event_time() );
        |           ^~~~~
  ```

- GTK3.22から廃止予定になった`Gtk::Menu::popup()`のかわりに`popup_at_widget()`を使います。
  この修正でメニューを表示したときに出る警告も表示されなくなります。

  非推奨シンボルを無効化したときのコンパイルエラー
  ```
  ../src/skeleton/admin.cpp:2231:22: error: 'class SKELETON::TabSwitchMenu' has no member named 'popup'
   2231 |     m_tabswitchmenu->popup( Gtk::Menu::SlotPositionCalc( sigc::mem_fun( *this, &Admin::slot_popup_pos ) ),
        |                      ^~~~~
  ../src/skeleton/admin.cpp:2231:40: error: 'SlotPositionCalc' is not a member of 'Gtk::Menu'
   2231 |     m_tabswitchmenu->popup( Gtk::Menu::SlotPositionCalc( sigc::mem_fun( *this, &Admin::slot_popup_pos ) ),
        |                                        ^~~~~~~~~~~~~~~~
  ../src/skeleton/menubutton.cpp:130:18: error: 'class Gtk::Menu' has no member named 'popup'
    130 |     m_popupmenu->popup( Gtk::Menu::SlotPositionCalc( sigc::mem_fun( *this, &MenuButton::slot_popup_pos ) ),
        |                  ^~~~~
  ../src/skeleton/menubutton.cpp:130:36: error: 'SlotPositionCalc' is not a member of 'Gtk::Menu'
    130 |     m_popupmenu->popup( Gtk::Menu::SlotPositionCalc( sigc::mem_fun( *this, &MenuButton::slot_popup_pos ) ),
        |                                    ^~~~~~~~~~~~~~~~
  ```

実行時にメニュー表示したときの警告
```
Gdk-Message: 14:27:42.082: Window 0x55f2df8abd40 is a temporary window without parent, application will not be able to position it on screen.

(jdim:120146): Gdk-CRITICAL **: 14:27:42.091: gdk_wayland_window_handle_configure_popup: assertion 'impl->transient_for' failed
```

