### PR TITLE
EmbeddedImage: Change unnecessary member to local variable

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -2613,7 +2613,7 @@ bool DrawAreaBase::draw_one_img_node( LAYOUT* layout, const CLIPINFO& ci )
         // 描画
         else{
 
-            Glib::RefPtr< Gdk::Pixbuf > pixbuf = layout->eimg->get_pixbuf();
+            Glib::RefPtr<Gdk::Pixbuf>& pixbuf = layout->eimg->get_pixbuf();
             if( pixbuf ){
 
                 const int s_top = MAX( 0, ci.upper - ( rect->y + 1 ) );

--- a/src/article/embeddedimage.cpp
+++ b/src/article/embeddedimage.cpp
@@ -87,8 +87,6 @@ void EmbeddedImage::stop()
 #ifdef _DEBUG    
     std::cout << "EmbeddedImage::stop" << std::endl;
 #endif 
-    if( m_imgloader )
-        m_imgloader->request_stop();
 }
 
 
@@ -139,8 +137,8 @@ void EmbeddedImage::resize_thread()
 
     if( m_img->get_type() == DBIMG::T_BMP ) pixbufonly = false; // BMP の場合 pixbufonly = true にすると真っ黒になる
     
-    m_imgloader = JDLIB::ImgLoader::get_loader( m_img->get_cache_path() );
-    Glib::RefPtr<Gdk::Pixbuf> pixbuf = m_imgloader->get_pixbuf( pixbufonly );
+    Glib::RefPtr<JDLIB::ImgLoader> imgloader = JDLIB::ImgLoader::get_loader( m_img->get_cache_path() );
+    Glib::RefPtr<Gdk::Pixbuf> pixbuf = imgloader->get_pixbuf( pixbufonly );
     if( pixbuf ){
         Gdk::InterpType interptype = Gdk::INTERP_NEAREST;
         if( CONFIG::get_imgemb_interp() == 1 ) interptype = Gdk::INTERP_BILINEAR;
@@ -148,7 +146,7 @@ void EmbeddedImage::resize_thread()
 
         m_pixbuf = pixbuf->scale_simple( width, height, interptype );
     }
-    m_imgloader.reset();
+    imgloader.reset();
 
     // メインスレッドにリサイズが終わったことを知らせて
     // メインスレッドがpthread_join()を呼び出す

--- a/src/article/embeddedimage.h
+++ b/src/article/embeddedimage.h
@@ -27,14 +27,12 @@ namespace ARTICLE
         DBIMG::Img* m_img;
         JDLIB::Thread m_thread;
 
-        Glib::RefPtr< JDLIB::ImgLoader > m_imgloader;
-
       public:
 
         explicit EmbeddedImage( const std::string& url );
         ~EmbeddedImage();
 
-        Glib::RefPtr< Gdk::Pixbuf > get_pixbuf(){ return m_pixbuf; }
+        Glib::RefPtr<Gdk::Pixbuf>& get_pixbuf() { return m_pixbuf; }
 
         void show();
         void resize_thread();


### PR DESCRIPTION
クラスのメンバー変数として保持しておく必要がない画像ローダーオブジェクトをローカル変数に変更します。
