### PR TITLE
Fix initial settings for thread title search (2021-04)

### DIFF
--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -208,10 +208,10 @@ namespace CONFIG
 
 // スレタイ検索用メニュータイトルアドレス
 #define CONF_MENU_SEARCH_TITLE  "スレタイ検索 (ff5ch.syoboi.jp)"
-#define CONF_URL_SEARCH_TITLE "https://ff5ch.syoboi.jp/?q=$TEXTU"
+#define CONF_URL_SEARCH_TITLE "https://ff5ch.syoboi.jp/?alt=tsv&q=$TEXTU"
 
 // スレタイ検索用正規表現
-#define CONF_REGEX_SEARCH_TITLE R"=(<a [^>]*?href="(http[^"]+)">([^<]+)</a><span[[:space:]]+class="count"> \(([0-9]+)\))="
+#define CONF_REGEX_SEARCH_TITLE R"=(^(?=[^\t\n]+\t[^\t\n]+\t([^\t\n]+))([^\t\n]+)\t([^\t\n]+))="
 
 // WEB検索用メニュータイトルアドレス
 #define CONF_MENU_SEARCH_WEB  "WEB検索 (google)"


### PR DESCRIPTION
Fixes #679

初期設定のスレタイ検索サイト https://ff5ch.syoboi.jp の検索結果が2021年4月中旬から変更されてスレッド抽出に失敗するようになりました。
そのためabout:config「スレタイ検索用のアドレス」と「スレタイ検索時にアドレスとスレタイを取得する正規表現」のデフォルト設定を更新します。

#### 正規表現の説明
```
^(?=[^\t\n]+\t[^\t\n]+\t([^\t\n]+))([^\t\n]+)\t([^\t\n]+)
```
- まず行頭`^`をマッチさせる
- 次にlook ahead`(?=...)`を使って3列目をグループ1にキャプチャ
- そのあと改めて行頭から1列目、2列目をグループ2、グループ3にキャプチャ

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1615781919/451
https://mao.5ch.net/test/read.cgi/linux/1615781919/482-484