### PR TITLE
AAManager: Add const qualifier to member function

### DIFF
--- a/src/aamanager.cpp
+++ b/src/aamanager.cpp
@@ -226,13 +226,13 @@ void AAManager::save_history()
 
 
 // ラベル、AA取得
-std::string AAManager::get_label( const int id )
+std::string AAManager::get_label( const int id ) const
 {
     if( id >= (int) m_vec_label.size() ) return std::string();
     return m_vec_label[ id ];
 }
 
-std::string AAManager::get_aa( const int id )
+std::string AAManager::get_aa( const int id ) const
 {
     if( id >= (int) m_vec_aa.size() ) return std::string();
     return m_vec_aa[ id ]; 
@@ -261,11 +261,11 @@ std::string AAManager::id2shortcut( const int id )
 
 
 // ショートカットからid取得
-int AAManager::shortcut2id( const char key )
+int AAManager::shortcut2id( const char key ) const
 {
     if( key == '\0' ) return -1;
 
-    std::map< int, char >::iterator it = m_map_shortcut.begin();
+    auto it = m_map_shortcut.begin();
     for( ; it != m_map_shortcut.end(); ++it ){
         if( (*it).second == key ) return (*it).first;
     }
@@ -281,7 +281,7 @@ void AAManager::append_history( const int id )
     if( id >= 0 && id < get_size() ){
 
         // 既に履歴に含まれている場合
-        std::list< int >::iterator it = m_history.begin();
+        auto it = m_history.begin();
         for( ; it != m_history.end(); ++it ){
 
             if( *it == id ){
@@ -299,11 +299,11 @@ void AAManager::append_history( const int id )
 
 
 // num 番目の履歴をIDに変換
-int AAManager::history2id( const int num )
+int AAManager::history2id( const int num ) const
 {
     if( num < 0 || num >= get_historysize() ) return -1;
 
-    std::list< int >::iterator it = m_history.begin();
+    auto it = m_history.begin();
     for( int i = 0; i < num; ++i, ++it );
 
 #ifdef _DEBUG

--- a/src/aamanager.h
+++ b/src/aamanager.h
@@ -26,23 +26,23 @@ namespace CORE
         AAManager();
         virtual ~AAManager();
 
-        int get_size(){ return m_vec_label.size(); }
-        int get_historysize(){ return m_history.size(); }
+        int get_size() const noexcept { return m_vec_label.size(); }
+        int get_historysize() const noexcept { return m_history.size(); }
 
-        std::string get_label( const int id );
-        std::string get_aa( const int id );
+        std::string get_label( const int id ) const;
+        std::string get_aa( const int id ) const;
 
         // ショートカットキー取得
         std::string id2shortcut( const int id );
 
         // ショートカットからid取得
-        int shortcut2id( const char key );
+        int shortcut2id( const char key ) const;
 
         // id 番を履歴に追加
         void append_history( const int id );
 
         // num 番目の履歴をIDに変換
-        int history2id( const int num );
+        int history2id( const int num ) const;
 
         void save_history();
 


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

`id2shortcut()`は[]アクセスでデフォルト値を代入する可能性があるためそのままnon-constにします。