### PR TITLE
BBSListViewBase: Add const qualifier to member function

### DIFF
--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -2056,7 +2056,7 @@ std::string BBSListViewBase::path2url( const Gtk::TreePath& path )
 // 板の場合は boardbase
 // スレの場合は dat 型のアドレスを返す
 //
-std::string BBSListViewBase::row2url( const Gtk::TreeModel::Row& row )
+std::string BBSListViewBase::row2url( const Gtk::TreeModel::Row& row ) const
 {
     if( ! row ) return {};
     const Glib::ustring& ustr_url = row[ m_columns.m_url ];
@@ -2079,7 +2079,7 @@ std::string BBSListViewBase::path2name( const Gtk::TreePath& path )
 //
 // row -> name 変換
 //
-std::string BBSListViewBase::row2name( const Gtk::TreeModel::Row& row )
+std::string BBSListViewBase::row2name( const Gtk::TreeModel::Row& row ) const
 {
     if( ! row ) return {};
     const Glib::ustring& ustr_name = row[ m_columns.m_name ];
@@ -2100,7 +2100,7 @@ int BBSListViewBase::path2type( const Gtk::TreePath& path )
 //
 // row -> type 変換
 //
-int BBSListViewBase::row2type( const Gtk::TreeModel::Row& row )
+int BBSListViewBase::row2type( const Gtk::TreeModel::Row& row ) const
 {
     if( ! row ) return TYPE_UNKNOWN;
     return row[ m_columns.m_type ];
@@ -2110,7 +2110,7 @@ int BBSListViewBase::row2type( const Gtk::TreeModel::Row& row )
 //
 // row -> dirid 変換
 //
-size_t BBSListViewBase::row2dirid( const Gtk::TreeModel::Row& row )
+size_t BBSListViewBase::row2dirid( const Gtk::TreeModel::Row& row ) const
 {
     if( !row ) return 0;
     return row[ m_columns.m_dirid ];
@@ -2913,15 +2913,15 @@ void BBSListViewBase::append_history()
 //
 // 履歴を DATA_INFO_LIST 型で取得
 //
-void BBSListViewBase::get_history( CORE::DATA_INFO_LIST& info_list )
+void BBSListViewBase::get_history( CORE::DATA_INFO_LIST& info_list ) const
 {
     info_list.clear();
 
     CORE::DATA_INFO info;
 
     // 履歴はサブディレクトリが無いと仮定してサブディレクトリの探査はしない
-    Gtk::TreeModel::iterator it = get_treestore()->children().begin();
-    for( ; it != get_treestore()->children().end(); ++it ){
+    Gtk::TreeModel::iterator it = m_treestore->children().begin();
+    for( ; it != m_treestore->children().end(); ++it ){
 
         Gtk::TreeModel::Row row = *it;
 

--- a/src/bbslist/bbslistviewbase.h
+++ b/src/bbslist/bbslistviewbase.h
@@ -141,18 +141,18 @@ namespace BBSLIST
         int path2type( const Gtk::TreePath& path );
 
         // row からタイプを取得
-        int row2type( const Gtk::TreeModel::Row& row );
+        int row2type( const Gtk::TreeModel::Row& row ) const;
 
         // row -> name 変換
-        std::string row2name( const Gtk::TreeModel::Row& row );
+        std::string row2name( const Gtk::TreeModel::Row& row ) const;
 
         // row -> url 変換
         // 板の場合は boardbase
         // スレの場合は dat 型のアドレスを返す
-        std::string row2url( const Gtk::TreeModel::Row& row );
+        std::string row2url( const Gtk::TreeModel::Row& row ) const;
 
         // row -> dirid 変換
-        size_t row2dirid( const Gtk::TreeModel::Row& row );
+        size_t row2dirid( const Gtk::TreeModel::Row& row ) const;
 
         // path からその行の名前を取得
         std::string path2name( const Gtk::TreePath& path );
@@ -238,7 +238,7 @@ namespace BBSLIST
         void append_history();
 
         // 履歴を DATA_INFO_LIST 型で取得
-        void get_history( CORE::DATA_INFO_LIST& info_list );
+        void get_history( CORE::DATA_INFO_LIST& info_list ) const;
 
         // 指定したidのディレクトリに含まれるスレのアドレスを取得
         void get_threads( const size_t dirid, std::vector< std::string >& list_url );


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

関連のpull request: #682 
