### PR TITLE
SelectListDialog: Add const qualifier to member function

### DIFF
--- a/src/bbslist/selectdialog.cpp
+++ b/src/bbslist/selectdialog.cpp
@@ -115,7 +115,7 @@ std::string SelectListDialog::get_name()
     return m_label_name.get_text();
 }
 
-std::string SelectListDialog::get_path()
+std::string SelectListDialog::get_path() const
 {
     std::string path;
     if( m_selectview ) path = m_selectview->get_current_path().to_string();

--- a/src/bbslist/selectdialog.h
+++ b/src/bbslist/selectdialog.h
@@ -39,7 +39,7 @@ namespace BBSLIST
         ~SelectListDialog() noexcept;
 
         std::string get_name();
-        std::string get_path();
+        std::string get_path() const;
 
       protected:
 


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

関連のpull request: #682 
