### PR TITLE
MouseKeyConf: Add const qualifier to member function part2

### DIFF
--- a/src/control/mouseconfig.cpp
+++ b/src/control/mouseconfig.cpp
@@ -98,7 +98,7 @@ void MouseConfig::set_one_motion_impl( const int id, const int mode, const std::
 
 
 // 操作文字列取得
-std::string MouseConfig::get_str_motions( const int id_ )
+std::string MouseConfig::get_str_motions( const int id_ ) const
 {
     int id = id_;
 
@@ -110,7 +110,7 @@ std::string MouseConfig::get_str_motions( const int id_ )
 
 
 // IDからデフォルトの操作文字列取得
-std::string MouseConfig::get_default_motions( const int id_ )
+std::string MouseConfig::get_default_motions( const int id_ ) const
 {
     int id = id_;
     if( id == CONTROL::CancelMosaic ) id = CONTROL::CancelMosaicButton;

--- a/src/control/mouseconfig.h
+++ b/src/control/mouseconfig.h
@@ -21,10 +21,10 @@ namespace CONTROL
         void load_conf() override;
 
         // 操作文字列取得
-        std::string get_str_motions( const int id ) override;
+        std::string get_str_motions( const int id ) const override;
 
         // IDからデフォルトの操作文字列取得
-        std::string get_default_motions( const int id ) override;
+        std::string get_default_motions( const int id ) const override;
 
       private:
 

--- a/src/control/mousekeyconf.cpp
+++ b/src/control/mousekeyconf.cpp
@@ -138,11 +138,11 @@ std::vector< int > MouseKeyConf::check_conflict( const int mode, const std::stri
 
 
 // IDから操作文字列取得
-std::string MouseKeyConf::get_str_motions( const int id )
+std::string MouseKeyConf::get_str_motions( const int id ) const
 {
     std::string motions;
 
-    std::vector< MouseKeyItem >::iterator it = m_vec_items.begin();
+    auto it = m_vec_items.begin();
     for( ; it != m_vec_items.end(); ++it ){
 
         if( (*it).get_id() == id ){
@@ -156,9 +156,9 @@ std::string MouseKeyConf::get_str_motions( const int id )
 
 
 // IDからデフォルトの操作文字列取得
-std::string MouseKeyConf::get_default_motions( const int id )
+std::string MouseKeyConf::get_default_motions( const int id ) const
 {
-    std::map< int, std::string >::iterator it = m_map_default_motions.find( id );
+    auto it = m_map_default_motions.find( id );
     if( it != m_map_default_motions.end() ) return ( *it ).second;
 
     return std::string();

--- a/src/control/mousekeyconf.h
+++ b/src/control/mousekeyconf.h
@@ -50,10 +50,10 @@ namespace CONTROL
                       const bool dblclick, const bool trpclick ) const;
 
         // IDから操作文字列取得
-        virtual std::string get_str_motions( const int id );
+        virtual std::string get_str_motions( const int id ) const;
 
         // IDからデフォルトの操作文字列取得
-        virtual std::string get_default_motions( const int id );
+        virtual std::string get_default_motions( const int id ) const;
 
         // 同じモード内でモーションが重複していないかチェック
         // 戻り値 : コントロールID


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

- `MouseKeyConf::get_str_motions()`
- `MouseKeyConf::get_default_motions()`

関連のpull request: #682 