### PR TITLE
KeyConfig: Add const qualifier to member function

### DIFF
--- a/src/control/keyconfig.cpp
+++ b/src/control/keyconfig.cpp
@@ -268,7 +268,7 @@ void KeyConfig::set_one_motion_impl( const int id, const int mode, const std::st
 
 
 // editviewの操作をemacs風か
-bool KeyConfig::is_emacs_mode()
+bool KeyConfig::is_emacs_mode() const
 {
     return ( get_str_motions( CONTROL::UpEdit ).find( "Ctrl+p" ) != std::string::npos );
 }
@@ -321,7 +321,7 @@ void KeyConfig::toggle_emacs_mode()
 
 
 // タブで開くキーを入れ替えているか
-bool KeyConfig::is_toggled_tab_key()
+bool KeyConfig::is_toggled_tab_key() const
 {
     const bool ret = ( get_str_motions( CONTROL::OpenBoard ).find( "Ctrl+Space" ) != std::string::npos
                        && get_str_motions( CONTROL::OpenBoardTab ).find( "Space" ) != std::string::npos
@@ -369,7 +369,7 @@ void KeyConfig::toggle_tab_key( const bool toggle )
 //
 // Gtk アクセラレーションキーを取得
 //
-Gtk::AccelKey KeyConfig::get_accelkey( const int id )
+Gtk::AccelKey KeyConfig::get_accelkey( const int id ) const
 {
     guint motion;
     bool ctrl, shift, alt, dblclick, trpclick;

--- a/src/control/keyconfig.h
+++ b/src/control/keyconfig.h
@@ -22,14 +22,14 @@ namespace CONTROL
         void load_conf() override;
 
         // editviewの操作をemacs風にする
-        bool is_emacs_mode();
+        bool is_emacs_mode() const;
         void toggle_emacs_mode();
 
-        bool is_toggled_tab_key(); // タブで開くキーを入れ替えているか
+        bool is_toggled_tab_key() const; // タブで開くキーを入れ替えているか
         void toggle_tab_key( const bool toggle ); // タブで開くキーを入れ替える
 
         // Gtk アクセラレーションキーを取得
-        Gtk::AccelKey get_accelkey( const int id );
+        Gtk::AccelKey get_accelkey( const int id ) const;
 
       private:
 


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

関連のpull request: #682 
