### PR TITLE
InputDiag: Add const qualifier to member function

### DIFF
--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -207,7 +207,7 @@ bool InputDiag::on_motion_notify_event( GdkEventMotion* event )
 }
 
 
-std::string InputDiag::get_key_label()
+std::string InputDiag::get_key_label() const
 {
     std::string label;
 
@@ -225,7 +225,7 @@ std::string InputDiag::get_key_label()
 
 
 
-std::string InputDiag::get_mouse_label()
+std::string InputDiag::get_mouse_label() const
 {
     std::string label;
 
@@ -242,7 +242,7 @@ std::string InputDiag::get_mouse_label()
 }
 
 
-std::string InputDiag::get_button_label()
+std::string InputDiag::get_button_label() const
 {
     std::string label;
 

--- a/src/control/mousekeypref.h
+++ b/src/control/mousekeypref.h
@@ -51,9 +51,9 @@ namespace CONTROL
 
         int get_id() const { return m_id; }
 
-        std::string get_key_label();
-        std::string get_mouse_label();
-        std::string get_button_label();
+        std::string get_key_label() const;
+        std::string get_mouse_label() const;
+        std::string get_button_label() const;
 
       private:
 


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

関連のpull request: #682 
