### PR TITLE
Img: Add const qualifier to member function

### DIFF
--- a/src/dbimg/img.cpp
+++ b/src/dbimg/img.cpp
@@ -208,7 +208,7 @@ int Img::get_height_mosaic()
 }
 
 
-bool Img::is_cached()
+bool Img::is_cached() const
 {
     if( is_loading() ) return false;
     if( is_wait() ) return false;
@@ -237,7 +237,7 @@ void Img::set_abone( bool abone )
 }
 
 
-std::string Img::get_cache_path()
+std::string Img::get_cache_path() const
 {
     if( m_protect ) return CACHE::path_img_protect( m_url );
 
@@ -420,7 +420,7 @@ void Img::set_protect( bool protect )
 
 
 // 拡張子が偽装されているか
-bool Img::is_fake()
+bool Img::is_fake() const
 {
     if( ! is_cached() ) return false;
     if( m_imgctrl & CORE::IMGCTRL_GENUINE ) return false;

--- a/src/dbimg/img.h
+++ b/src/dbimg/img.h
@@ -62,7 +62,7 @@ namespace DBIMG
         void clear();
 
         const std::string& url() const { return m_url; }
-        std::string get_cache_path();
+        std::string get_cache_path() const;
 
         bool is_wait() const { return m_wait; }
 
@@ -83,7 +83,7 @@ namespace DBIMG
         int get_width_mosaic();
         int get_height_mosaic();
 
-        bool is_cached();
+        bool is_cached() const;
 
         bool get_abone() const { return m_abone; }
         void set_abone( bool abone );
@@ -107,7 +107,7 @@ namespace DBIMG
         void set_protect( bool protect );
 
         // 拡張子が偽装されているか
-        bool is_fake();
+        bool is_fake() const;
 
         // ロード開始
         // receive_data()　と receive_finish() がコールバックされる


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

関連のpull request: #682 
