### PR TITLE
ImgRoot: Add const qualifier to member function

### DIFF
--- a/src/dbimg/imgroot.cpp
+++ b/src/dbimg/imgroot.cpp
@@ -106,7 +106,7 @@ Img* ImgRoot::get_img( const std::string& url )
 // 画像データの先頭のシグネチャを見て画像のタイプを取得
 // 画像ではない場合は T_NOIMG を返す
 //
-int ImgRoot::get_image_type( const unsigned char *sign )
+int ImgRoot::get_image_type( const unsigned char *sign ) const
 {
     int type = T_NOIMG;
 
@@ -141,13 +141,13 @@ int ImgRoot::get_image_type( const unsigned char *sign )
 // 拡張子からタイプを取得
 // 画像ではない場合は T_UNKNOWN を返す
 //
-int ImgRoot::get_type_ext( const std::string& url )
+int ImgRoot::get_type_ext( const std::string& url ) const
 {
     return get_type_ext( url.c_str(), url.length() );
 }
 
 
-int ImgRoot::get_type_ext( const char* url, int n )
+int ImgRoot::get_type_ext( const char* url, int n ) const
 {
     // Urlreplaceによる画像コントロールを取得する
     int imgctrl = CORE::get_urlreplace_manager()->get_imgctrl( url );

--- a/src/dbimg/imgroot.h
+++ b/src/dbimg/imgroot.h
@@ -31,7 +31,7 @@ namespace DBIMG
         void set_clock_in( Img* img );
         void reset_clock_in( Img* img );
         void remove_clock_in();
-        int get_wait_size(){ return m_list_wait.size(); }
+        int get_wait_size() const noexcept { return m_list_wait.size(); }
 
         // Imgクラス取得(無ければ作成)
         Img* get_img( const std::string& url );
@@ -41,12 +41,12 @@ namespace DBIMG
 
         // 画像データの先頭のシグネチャを見て画像のタイプを取得
         // 画像ではない場合は T_NOIMG を返す
-        int get_image_type( const unsigned char *sign );
+        int get_image_type( const unsigned char *sign ) const;
 
         // 拡張子から画像タイプを取得
         // 画像ではない場合は T_UNKNOWN を返す
-        int get_type_ext( const std::string& url );
-        int get_type_ext( const char* url, int n );
+        int get_type_ext( const std::string& url ) const;
+        int get_type_ext( const char* url, int n ) const;
 
         // キャッシュ削除
         void delete_cache( const std::string& url );
@@ -56,10 +56,10 @@ namespace DBIMG
 
       private:
 
-        bool is_jpg( const char* url, int n );
-        bool is_png( const char* url, int n );
-        bool is_gif( const char* url, int n );
-        bool is_bmp( const char* url, int n );
+        static bool is_jpg( const char* url, int n );
+        static bool is_png( const char* url, int n );
+        static bool is_gif( const char* url, int n );
+        static bool is_bmp( const char* url, int n );
 
         void reset_imgs();
     };


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

関連のpull request: #682 