### PR TITLE
TextLoader: Add const qualifier to member function

### DIFF
--- a/src/dbtree/frontloader.cpp
+++ b/src/dbtree/frontloader.cpp
@@ -23,7 +23,7 @@ FrontLoader::FrontLoader( const std::string& url_boadbase )
 }
 
 
-std::string FrontLoader::get_charset()
+std::string FrontLoader::get_charset() const
 {
     return DBTREE::board_charset( m_url_boadbase );
 }

--- a/src/dbtree/frontloader.h
+++ b/src/dbtree/frontloader.h
@@ -28,9 +28,9 @@ namespace DBTREE
 
       protected:
 
-        std::string get_url() override { return m_url_boadbase; }
-        std::string get_path() override { return {}; } // キャッシュには保存しない
-        std::string get_charset() override;
+        std::string get_url() const override { return m_url_boadbase; }
+        std::string get_path() const override { return {}; } // キャッシュには保存しない
+        std::string get_charset() const override;
 
         // ロード用データ作成
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;

--- a/src/dbtree/ruleloader.cpp
+++ b/src/dbtree/ruleloader.cpp
@@ -38,19 +38,19 @@ RuleLoader::~RuleLoader()
 }
 
 
-std::string RuleLoader::get_url()
+std::string RuleLoader::get_url() const
 {
     return m_url_boadbase + HEAD_TXT;
 }
 
 
-std::string RuleLoader::get_path()
+std::string RuleLoader::get_path() const
 {
     return CACHE::path_board_root( m_url_boadbase ) + HEAD_TXT;
 }
 
 
-std::string RuleLoader::get_charset()
+std::string RuleLoader::get_charset() const
 {
     return m_override_charset ? m_override_charset : DBTREE::board_charset( m_url_boadbase );
 }

--- a/src/dbtree/ruleloader.h
+++ b/src/dbtree/ruleloader.h
@@ -31,9 +31,9 @@ namespace DBTREE
 
       protected:
 
-        std::string get_url() override;
-        std::string get_path() override;
-        std::string get_charset() override;
+        std::string get_url() const override;
+        std::string get_path() const override;
+        std::string get_charset() const override;
 
         // ロード用データ作成
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;

--- a/src/dbtree/settingloader.cpp
+++ b/src/dbtree/settingloader.cpp
@@ -36,19 +36,19 @@ SettingLoader::~SettingLoader()
 }
 
 
-std::string SettingLoader::get_url()
+std::string SettingLoader::get_url() const
 {
     return DBTREE::url_settingtxt( m_url_boadbase );
 }
 
 
-std::string SettingLoader::get_path()
+std::string SettingLoader::get_path() const
 {
     return CACHE::path_board_root( m_url_boadbase ) + DBTREE::kSettingTxt;
 }
 
 
-std::string SettingLoader::get_charset()
+std::string SettingLoader::get_charset() const
 {
     return DBTREE::board_charset( m_url_boadbase );
 }

--- a/src/dbtree/settingloader.h
+++ b/src/dbtree/settingloader.h
@@ -48,9 +48,9 @@ namespace DBTREE
 
       protected:
 
-        std::string get_url() override;
-        std::string get_path() override;
-        std::string get_charset() override;
+        std::string get_url() const override;
+        std::string get_path() const override;
+        std::string get_charset() const override;
 
         // ロード用データ作成
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;

--- a/src/searchloader.cpp
+++ b/src/searchloader.cpp
@@ -44,7 +44,7 @@ SearchLoader::~SearchLoader()
 }
 
 
-std::string SearchLoader::get_url()
+std::string SearchLoader::get_url() const
 {
     std::string url = get_usrcmd_manager()->replace_cmd( CONFIG::get_url_search_title(), "", "", m_query, 0 );
 

--- a/src/searchloader.h
+++ b/src/searchloader.h
@@ -33,9 +33,9 @@ namespace CORE
 
       protected:
 
-        std::string get_url() override;
-        std::string get_path() override { return {}; }
-        std::string get_charset() override { return m_charset; }
+        std::string get_url() const override;
+        std::string get_path() const override { return {}; }
+        std::string get_charset() const override { return m_charset; }
 
         // ロード用データ作成
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;

--- a/src/skeleton/textloader.h
+++ b/src/skeleton/textloader.h
@@ -46,9 +46,9 @@ namespace SKELETON
 
       protected:
 
-        virtual std::string get_url() = 0;
-        virtual std::string get_path() = 0;
-        virtual std::string get_charset() = 0;
+        virtual std::string get_url() const = 0;
+        virtual std::string get_path() const = 0;
+        virtual std::string get_charset() const = 0;
 
         // ロード用データ作成
         virtual void create_loaderdata( JDLIB::LOADERDATA& data ) = 0;


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

関連のpull request: #682 
