### PR TITLE
jdlib: Add const qualifier member function

### DIFF
--- a/src/jdlib/confloader.cpp
+++ b/src/jdlib/confloader.cpp
@@ -53,13 +53,6 @@ ConfLoader::ConfLoader( const std::string& file, std::string str_conf )
 
 
 
-bool ConfLoader::empty()
-{
-    return m_data.empty();
-}
-
-
-
 // 保存
 void ConfLoader::save()
 {

--- a/src/jdlib/confloader.h
+++ b/src/jdlib/confloader.h
@@ -34,8 +34,8 @@ namespace JDLIB
         // もしstr_confがemptyの時はfileから読み込む
         ConfLoader( const std::string& file, std::string str_conf );
 
-        bool empty();
-        bool is_broken(){ return m_broken; }
+        bool empty() const noexcept { return m_data.empty(); }
+        bool is_broken() const noexcept { return m_broken; }
 
         // 保存
         void save();

--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -1047,7 +1047,7 @@ struct addrinfo* Loader::get_addrinfo( const std::string& hostname, const int po
 //
 // 送信メッセージ作成
 //
-std::string Loader::create_msg_send()
+std::string Loader::create_msg_send() const
 {
     bool post_msg = ( !m_data.str_post.empty() && !m_data.head );
     bool use_proxy = ( ! m_data.host_proxy.empty() );
@@ -1259,7 +1259,7 @@ bool Loader::analyze_header()
 //
 // analyze_header() から呼ばれるオプションの値を取り出す関数
 //
-std::string Loader::analyze_header_option( const std::string& option )
+std::string Loader::analyze_header_option( const std::string& option ) const
 {
     const std::size_t i = m_data.str_header.find( option, 0 );
     if( i != std::string::npos ){
@@ -1277,7 +1277,7 @@ std::string Loader::analyze_header_option( const std::string& option )
 //
 // analyze_header() から呼ばれるオプションの値を取り出す関数(リスト版)
 //
-std::list< std::string > Loader::analyze_header_option_list( const std::string& option )
+std::list< std::string > Loader::analyze_header_option_list( const std::string& option ) const
 {
     std::list< std::string > str_list;
 

--- a/src/jdlib/loader.h
+++ b/src/jdlib/loader.h
@@ -85,7 +85,7 @@ namespace JDLIB
         void clear();
         void run_main();
         struct addrinfo* get_addrinfo( const std::string& hostname, const int port );
-        std::string create_msg_send();
+        std::string create_msg_send() const;
         bool wait_recv_send( const int fd, const bool recv );
         bool send_connect( const int soc, std::string& errmsg );
 
@@ -95,8 +95,8 @@ namespace JDLIB
         // ヘッダ用
         int receive_header( char* buf, size_t& read_size );
         bool analyze_header();
-        std::string analyze_header_option( const std::string& option );
-        std::list< std::string > analyze_header_option_list( const std::string& option );
+        std::string analyze_header_option( const std::string& option ) const;
+        std::list< std::string > analyze_header_option_list( const std::string& option ) const;
 
         // chunk用
         bool skip_chunk( char* buf, size_t& read_size );

--- a/src/jdlib/ssl.h
+++ b/src/jdlib/ssl.h
@@ -42,7 +42,7 @@ namespace JDLIB
         JDSSL();
         virtual ~JDSSL();
 
-        const std::string& get_errmsg(){ return m_errmsg; }
+        const std::string& get_errmsg() const { return m_errmsg; }
 
         bool connect( const int soc, const char* host );
         bool close();


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

- ConfLoader: Add const qualifier to member function
- Loader: Add const qualifier to member function
- JDSSL: Add const qualifier to member function

関連のpull request: #682 
