### PR TITLE
filtering: Add const qualifier member function

### DIFF
--- a/src/linkfilterpref.h
+++ b/src/linkfilterpref.h
@@ -26,8 +26,8 @@ namespace CORE
 
         LinkFilterDiag( Gtk::Window* parent, const std::string& url, const std::string& cmd );
 
-        Glib::ustring get_url() { return m_entry_url.get_text(); }
-        Glib::ustring get_cmd() { return m_entry_cmd.get_text(); }
+        Glib::ustring get_url() const { return m_entry_url.get_text(); }
+        Glib::ustring get_cmd() const { return m_entry_cmd.get_text(); }
 
       private:
         void slot_show_manual();

--- a/src/urlreplacemanager.cpp
+++ b/src/urlreplacemanager.cpp
@@ -154,7 +154,7 @@ void Urlreplace_Manager::conf2list( const std::string& conf )
 //
 // URLを任意の正規表現で変換する
 //
-bool Urlreplace_Manager::exec( std::string &url )
+bool Urlreplace_Manager::exec( std::string &url ) const
 {
     if( m_list_cmd.empty() ) return false;
 
@@ -181,7 +181,7 @@ bool Urlreplace_Manager::exec( std::string &url )
 //
 // URLからリファラを求める
 //
-bool Urlreplace_Manager::referer( const std::string &url, std::string &refstr )
+bool Urlreplace_Manager::referer( const std::string &url, std::string &refstr ) const
 {
     if( m_list_cmd.empty() ) return false;
 
@@ -210,7 +210,7 @@ bool Urlreplace_Manager::referer( const std::string &url, std::string &refstr )
 //
 // URLの画像コントロールを取得する
 //
-int Urlreplace_Manager::get_imgctrl( const std::string &url )
+int Urlreplace_Manager::get_imgctrl( const std::string &url ) const
 {
     if( m_list_cmd.empty() ) return IMGCTRL_NONE;
 

--- a/src/urlreplacemanager.h
+++ b/src/urlreplacemanager.h
@@ -41,13 +41,13 @@ namespace CORE
         virtual ~Urlreplace_Manager() noexcept;
 
         // URLを任意の正規表現で変換する
-        bool exec( std::string& url );
+        bool exec( std::string& url ) const;
 
         // URLからリファラを求める
-        bool referer( const std::string& url, std::string& refstr );
+        bool referer( const std::string& url, std::string& refstr ) const;
 
         // URLの画像コントロールを取得する
-        int get_imgctrl( const std::string& url );
+        int get_imgctrl( const std::string& url ) const;
 
       private:
 

--- a/src/usrcmdmanager.cpp
+++ b/src/usrcmdmanager.cpp
@@ -65,7 +65,7 @@ public:
         show_all_children();
     }
 
-    const Glib::ustring get_text() { return m_entry.get_text(); }
+    Glib::ustring get_text() const { return m_entry.get_text(); }
 };
 
 ///////////////////////////////////////////////
@@ -222,7 +222,7 @@ void Usrcmd_Manager::exec( const std::string& command, // コマンド
 //
 // 文字列置換用テキストダイアログ表示
 //
-bool Usrcmd_Manager::show_replacetextdiag( std::string& texti, const std::string& title )
+bool Usrcmd_Manager::show_replacetextdiag( std::string& texti, const std::string& title ) const
 {
     if( ! texti.empty() ) return true;
 
@@ -240,7 +240,7 @@ std::string Usrcmd_Manager::replace_cmd( const std::string& cmd,
                                          const std::string& url,
                                          const std::string& link,
                                          const std::string& text,
-                                         const int number )
+                                         const int number ) const
 {
     std::string cmd_out = cmd;
     const std::string oldhostl = DBTREE::article_org_host( link );
@@ -354,7 +354,7 @@ std::string Usrcmd_Manager::replace_cmd( const std::string& cmd,
 //
 // メニューをアクティブにするか
 //
-bool Usrcmd_Manager::is_sensitive( int num, const std::string& link, const std::string& selection )
+bool Usrcmd_Manager::is_sensitive( int num, const std::string& link, const std::string& selection ) const
 {
     const unsigned int max_selection_str = 1024;
 
@@ -394,7 +394,7 @@ bool Usrcmd_Manager::is_sensitive( int num, const std::string& link, const std::
 //
 // メニューを隠すか
 //
-bool Usrcmd_Manager::is_hide( int num, const std::string& url )
+bool Usrcmd_Manager::is_hide( int num, const std::string& url ) const
 {
     if( num >= m_size ) return false;
 

--- a/src/usrcmdmanager.h
+++ b/src/usrcmdmanager.h
@@ -58,7 +58,7 @@ namespace CORE
                                  const std::string& url,
                                  const std::string& link,
                                  const std::string& text,
-                                 const int number );
+                                 const int number ) const;
 
         // ユーザコマンドメニューの作成
         std::string create_usrcmd_menu( Glib::RefPtr< Gtk::ActionGroup >& action_group );
@@ -74,11 +74,11 @@ namespace CORE
                                const std::string& str_select );
       private:
 
-        bool show_replacetextdiag( std::string& texti, const std::string& title );
+        bool show_replacetextdiag( std::string& texti, const std::string& title ) const;
         void set_cmd( const std::string& cmd );
 
-        bool is_sensitive( int num, const std::string& link, const std::string& selection );
-        bool is_hide( int num, const std::string& url );
+        bool is_sensitive( int num, const std::string& link, const std::string& selection ) const;
+        bool is_hide( int num, const std::string& url ) const;
     };
 
     ///////////////////////////////////////

--- a/src/usrcmdpref.h
+++ b/src/usrcmdpref.h
@@ -27,8 +27,8 @@ namespace CORE
 
         UsrCmdDiag( Gtk::Window* parent, const Glib::ustring& name, const Glib::ustring& cmd );
 
-        Glib::ustring get_name() { return m_entry_name.get_text(); }
-        Glib::ustring get_cmd() { return m_entry_cmd.get_text(); }
+        Glib::ustring get_name() const { return m_entry_name.get_text(); }
+        Glib::ustring get_cmd() const { return m_entry_cmd.get_text(); }
 
       private:
         void slot_show_manual();


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

- LinkFilterDiag: Add const qualifier to member function
- Urlreplace_Manager: Add const qualifier to member function
- Usrcmd_Manager: Add const qualifier to member function
- UsrCmdDiag: Add const qualifier to member function

関連のpull request: #682 
