### PR TITLE
ArticleHash: Add const qualifier to member function

### DIFF
--- a/src/dbtree/articlehash.cpp
+++ b/src/dbtree/articlehash.cpp
@@ -40,7 +40,7 @@ ArticleHash::~ArticleHash()
 }
 
 
-int ArticleHash::get_hash( const std::string& id )
+int ArticleHash::get_hash( const std::string& id ) const
 {
     const size_t hash = atoi( id.c_str() ) & ( HASH_TBLSIZE -1 );
 

--- a/src/dbtree/articlehash.h
+++ b/src/dbtree/articlehash.h
@@ -50,7 +50,7 @@ namespace DBTREE
 
       private:
 
-        int get_hash( const std::string& id );
+        int get_hash( const std::string& id ) const;
 
         // iterator 用関数
         ArticleBase* it_get();


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

関連のpull request: #682 
