### PR TITLE
MISC::get_pointer_at_window(): Add const qualifier to argument

### DIFF
--- a/src/jdlib/miscgtk.cpp
+++ b/src/jdlib/miscgtk.cpp
@@ -160,7 +160,7 @@ void MISC::CopyClipboard( const std::string& str )
 
 
 // ウインドウの左上隅を基準としたマウスポインターの座標を取得
-Glib::RefPtr<Gdk::Window> MISC::get_pointer_at_window( const Glib::RefPtr<Gdk::Window>& window, int& x, int& y )
+Glib::RefPtr<Gdk::Window> MISC::get_pointer_at_window( const Glib::RefPtr<const Gdk::Window>& window, int& x, int& y )
 {
     assert( window );
     Gdk::ModifierType unused;

--- a/src/jdlib/miscgtk.h
+++ b/src/jdlib/miscgtk.h
@@ -41,7 +41,7 @@ namespace MISC
     void CopyClipboard( const std::string& str );
 
     // ウィジェット左上隅を基準としたマウスポインターの座標を取得
-    Glib::RefPtr<Gdk::Window> get_pointer_at_window( const Glib::RefPtr<Gdk::Window>& window, int& x, int& y );
+    Glib::RefPtr<Gdk::Window> get_pointer_at_window( const Glib::RefPtr<const Gdk::Window>& window, int& x, int& y );
 }
 
 #endif


### PR DESCRIPTION
const型で必要な操作ができる引数にconst修飾子を追加します。