### PR TITLE
JDWindow: Add const qualifier to member function

### DIFF
--- a/src/image/imagewin.cpp
+++ b/src/image/imagewin.cpp
@@ -47,12 +47,12 @@ ImageWin::~ImageWin()
 }
 
 
-int ImageWin::get_x_win()
+int ImageWin::get_x_win() const
 {
     return SESSION::get_x_win_img();
 }
 
-int ImageWin::get_y_win()
+int ImageWin::get_y_win() const
 {
     return SESSION::get_y_win_img();
 }
@@ -67,12 +67,12 @@ void ImageWin::set_y_win( const int y )
     SESSION::set_y_win_img( y );
 }
 
-int ImageWin::get_width_win()
+int ImageWin::get_width_win() const
 {
     return SESSION::get_width_win_img();
 }
 
-int ImageWin::get_height_win()
+int ImageWin::get_height_win() const
 {
     return SESSION::get_height_win_img();
 }
@@ -87,7 +87,7 @@ void ImageWin::set_height_win( const int height )
     SESSION::set_height_win_img( height );
 }
 
-bool ImageWin::is_focus_win()
+bool ImageWin::is_focus_win() const
 {
     return SESSION::is_focus_win_img();
 }
@@ -98,7 +98,7 @@ void ImageWin::set_focus_win( const bool set )
 }
 
 
-bool ImageWin::is_maximized_win()
+bool ImageWin::is_maximized_win() const
 {
     return SESSION::is_maximized_win_img();
 }
@@ -109,7 +109,7 @@ void ImageWin::set_maximized_win( const bool set )
 }
 
 
-bool ImageWin::is_iconified_win()
+bool ImageWin::is_iconified_win() const
 {
     return SESSION::is_iconified_win_img();
 }
@@ -120,7 +120,7 @@ void ImageWin::set_iconified_win( const bool set )
 }
 
 
-bool ImageWin::is_shown_win()
+bool ImageWin::is_shown_win() const
 {
     return SESSION::is_shown_win_img();
 }

--- a/src/image/imagewin.h
+++ b/src/image/imagewin.h
@@ -28,29 +28,29 @@ namespace IMAGE
 
         void switch_admin() override;
 
-        int get_x_win() override;
-        int get_y_win() override;
+        int get_x_win() const override;
+        int get_y_win() const override;
         void set_x_win( const int x ) override;
         void set_y_win( const int y ) override;
 
-        int get_width_win() override;
-        int get_height_win() override;
+        int get_width_win() const override;
+        int get_height_win() const override;
         void set_width_win( const int width ) override;
         void set_height_win( const int height ) override;
 
-        bool is_focus_win() override;
+        bool is_focus_win() const override;
         void set_focus_win( const bool set ) override;
 
-        bool is_maximized_win() override;
+        bool is_maximized_win() const override;
         void set_maximized_win( const bool set ) override;
 
-        bool is_iconified_win() override;
+        bool is_iconified_win() const override;
         void set_iconified_win( const bool set ) override;
 
-        bool is_full_win() override { return false; }
+        bool is_full_win() const override { return false; }
         void set_full_win( const bool set ) override {}
 
-        bool is_shown_win() override;
+        bool is_shown_win() const override;
         void set_shown_win( const bool set ) override;
     };
 }

--- a/src/message/messagewin.cpp
+++ b/src/message/messagewin.cpp
@@ -60,12 +60,12 @@ bool MessageWin::on_delete_event( GdkEventAny* event )
 }
 
 
-int MessageWin::get_x_win()
+int MessageWin::get_x_win() const
 {
     return SESSION::get_x_win_mes();
 }
 
-int MessageWin::get_y_win()
+int MessageWin::get_y_win() const
 {
     return SESSION::get_y_win_mes();
 }
@@ -80,12 +80,12 @@ void MessageWin::set_y_win( const int y )
     SESSION::set_y_win_mes( y );
 }
 
-int MessageWin::get_width_win()
+int MessageWin::get_width_win() const
 {
     return SESSION::get_width_win_mes();
 }
 
-int MessageWin::get_height_win()
+int MessageWin::get_height_win() const
 {
     return SESSION::get_height_win_mes();
 }
@@ -100,7 +100,7 @@ void MessageWin::set_height_win( const int height )
     SESSION::set_height_win_mes( height );
 }
 
-bool MessageWin::is_focus_win()
+bool MessageWin::is_focus_win() const
 {
     return SESSION::is_focus_win_mes();
 }
@@ -111,7 +111,7 @@ void MessageWin::set_focus_win( const bool set )
 }
 
 
-bool MessageWin::is_maximized_win()
+bool MessageWin::is_maximized_win() const
 {
     return SESSION::is_maximized_win_mes();
 }
@@ -122,7 +122,7 @@ void MessageWin::set_maximized_win( const bool set )
 }
 
 
-bool MessageWin::is_iconified_win()
+bool MessageWin::is_iconified_win() const
 {
     return SESSION::is_iconified_win_mes();
 }
@@ -133,7 +133,7 @@ void MessageWin::set_iconified_win( const bool set )
 }
 
 
-bool MessageWin::is_shown_win()
+bool MessageWin::is_shown_win() const
 {
     return SESSION::is_shown_win_mes();
 }

--- a/src/message/messagewin.h
+++ b/src/message/messagewin.h
@@ -20,29 +20,29 @@ namespace MESSAGE
 
         void switch_admin() override;
 
-        int get_x_win() override;
-        int get_y_win() override;
+        int get_x_win() const override;
+        int get_y_win() const override;
         void set_x_win( const int x ) override;
         void set_y_win( const int y ) override;
 
-        int get_width_win() override;
-        int get_height_win() override;
+        int get_width_win() const override;
+        int get_height_win() const override;
         void set_width_win( const int width ) override;
         void set_height_win( const int height ) override;
 
-        bool is_focus_win() override;
+        bool is_focus_win() const override;
         void set_focus_win( const bool set ) override;
 
-        bool is_maximized_win() override;
+        bool is_maximized_win() const override;
         void set_maximized_win( const bool set ) override;
 
-        bool is_iconified_win() override;
+        bool is_iconified_win() const override;
         void set_iconified_win( const bool set ) override;
 
-        bool is_full_win() override { return false; }
+        bool is_full_win() const override { return false; }
         void set_full_win( const bool ) override {}
 
-        bool is_shown_win() override;
+        bool is_shown_win() const override;
         void set_shown_win( const bool set ) override;
 
         bool on_delete_event( GdkEventAny* event ) override;

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -340,7 +340,7 @@ void JDWindow::set_win_pos()
 
 
 // hide 中
-bool JDWindow::is_hide()
+bool JDWindow::is_hide() const
 {
     return ( m_mode == JDWIN_HIDE );
 }

--- a/src/skeleton/window.h
+++ b/src/skeleton/window.h
@@ -69,7 +69,7 @@ namespace SKELETON
         void set_spacing( int space );
 
         // hide 中
-        bool is_hide();
+        bool is_hide() const;
 
         // 起動中
         bool is_booting() const { return m_boot; }
@@ -80,7 +80,7 @@ namespace SKELETON
         void set_status( const std::string& stat );
         void set_status_temporary( const std::string& stat );
         void restore_status();
-        std::string get_status(){ return m_status; }
+        std::string get_status() const { return m_status; }
         void set_mginfo( const std::string& mginfo );
 
         // ステータスの色を変える
@@ -104,29 +104,29 @@ namespace SKELETON
 
         virtual void switch_admin(){}
 
-        virtual int get_x_win() = 0;
-        virtual int get_y_win() = 0;
+        virtual int get_x_win() const = 0;
+        virtual int get_y_win() const = 0;
         virtual void set_x_win( const int x ) = 0;
         virtual void set_y_win( const int y ) = 0;
 
-        virtual int get_width_win() = 0;
-        virtual int get_height_win() = 0;
+        virtual int get_width_win() const = 0;
+        virtual int get_height_win() const = 0;
         virtual void set_width_win( const int width ) = 0;
         virtual void set_height_win( const int height ) = 0;
 
-        virtual bool is_focus_win() = 0;
+        virtual bool is_focus_win() const = 0;
         virtual void set_focus_win( const bool set ) = 0;
 
-        virtual bool is_maximized_win() = 0;
+        virtual bool is_maximized_win() const = 0;
         virtual void set_maximized_win( const bool set ) = 0;
 
-        virtual bool is_iconified_win() = 0;
+        virtual bool is_iconified_win() const = 0;
         virtual void set_iconified_win( const bool set ) = 0;
 
-        virtual bool is_full_win() = 0;
+        virtual bool is_full_win() const = 0;
         virtual void set_full_win( const bool set ) = 0;
 
-        virtual bool is_shown_win() = 0;
+        virtual bool is_shown_win() const = 0;
         virtual void set_shown_win( const bool set ) = 0;
 
         bool on_focus_in_event( GdkEventFocus* event ) override;

--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -141,12 +141,12 @@ void JDWinMain::hide()
 }
 
 
-int JDWinMain::get_x_win()
+int JDWinMain::get_x_win() const
 {
     return SESSION::get_x_win_main();
 }
 
-int JDWinMain::get_y_win()
+int JDWinMain::get_y_win() const
 {
     return SESSION::get_y_win_main();
 }
@@ -161,12 +161,12 @@ void JDWinMain::set_y_win( const int y )
     SESSION::set_y_win_main( y );
 }
 
-int JDWinMain::get_width_win()
+int JDWinMain::get_width_win() const
 {
     return SESSION::get_width_win_main();
 }
 
-int JDWinMain::get_height_win()
+int JDWinMain::get_height_win() const
 {
     return SESSION::get_height_win_main();
 }
@@ -181,7 +181,7 @@ void JDWinMain::set_height_win( const int height )
     SESSION::set_height_win_main( height );
 }
 
-bool JDWinMain::is_focus_win()
+bool JDWinMain::is_focus_win() const
 {
     return SESSION::is_focus_win_main();
 }
@@ -192,7 +192,7 @@ void JDWinMain::set_focus_win( const bool set )
 }
 
 
-bool JDWinMain::is_maximized_win()
+bool JDWinMain::is_maximized_win() const
 {
     return SESSION::is_maximized_win_main();
 }
@@ -204,7 +204,7 @@ void JDWinMain::set_maximized_win( const bool set )
 }
 
 
-bool JDWinMain::is_iconified_win()
+bool JDWinMain::is_iconified_win() const
 {
     return SESSION::is_iconified_win_main();
 }
@@ -215,7 +215,7 @@ void JDWinMain::set_iconified_win( const bool set )
 }
 
 
-bool JDWinMain::is_full_win()
+bool JDWinMain::is_full_win() const
 {
     return SESSION::is_full_win_main();
 }
@@ -226,7 +226,7 @@ void JDWinMain::set_full_win( const bool set )
 }
 
 
-bool JDWinMain::is_shown_win()
+bool JDWinMain::is_shown_win() const
 {
     return SESSION::is_shown_win_main();
 }

--- a/src/winmain.h
+++ b/src/winmain.h
@@ -38,29 +38,29 @@ class JDWinMain : public SKELETON::JDWindow
 
   protected:
 
-    int get_x_win() override;
-    int get_y_win() override;
+    int get_x_win() const override;
+    int get_y_win() const override;
     void set_x_win( const int x ) override;
     void set_y_win( const int y ) override;
 
-    int get_width_win() override;
-    int get_height_win() override;
+    int get_width_win() const override;
+    int get_height_win() const override;
     void set_width_win( const int width ) override;
     void set_height_win( const int height ) override;
 
-    bool is_focus_win() override;
+    bool is_focus_win() const override;
     void set_focus_win( const bool set ) override;
 
-    bool is_maximized_win() override;
+    bool is_maximized_win() const override;
     void set_maximized_win( const bool set ) override;
 
-    bool is_iconified_win() override;
+    bool is_iconified_win() const override;
     void set_iconified_win( const bool set ) override;
 
-    bool is_full_win() override;
+    bool is_full_win() const override;
     void set_full_win( const bool set ) override;
 
-    bool is_shown_win() override;
+    bool is_shown_win() const override;
     void set_shown_win( const bool set ) override;
 
     bool on_delete_event( GdkEventAny* event ) override;


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

関連のpull request: #682 
