### PR TITLE
Loader: Get rid of DNT: 1 from HTTP request header

### DIFF
--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -1096,7 +1096,6 @@ std::string Loader::create_msg_send() const
     // その他のフィールド
     if( ! m_data.ex_field.empty() ) msg << m_data.ex_field;
 
-    msg << "DNT: 1\r\n";
     msg << "Connection: close\r\n";
 
     // POST する文字列


### PR DESCRIPTION
HTTPリクエストから`DNT: 1`を取り除きます。
トラッキングを拒否すると書き込みに失敗する掲示板があると報告がありました。

修正にあたり不具合報告や動作検証をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1615781919/539
https://mao.5ch.net/test/read.cgi/linux/1615781919/585-589n