### PR TITLE
skeleton: Add const qualifier member function part1

### DIFF
--- a/src/skeleton/aamenu.cpp
+++ b/src/skeleton/aamenu.cpp
@@ -47,7 +47,7 @@ AAMenu::~AAMenu()
 }
 
 
-int AAMenu::get_size()
+int AAMenu::get_size() const
 {
     return static_cast< int >( get_children().size() );
 }

--- a/src/skeleton/aamenu.h
+++ b/src/skeleton/aamenu.h
@@ -44,7 +44,7 @@ namespace SKELETON
 
       private:
 
-        int get_size();
+        int get_size() const;
 
         void set_text( const std::string& text );
         void create_menuitem( Glib::RefPtr< Gtk::ActionGroup > actiongroup, Gtk::Menu* menu, const int id );

--- a/src/skeleton/compentry.cpp
+++ b/src/skeleton/compentry.cpp
@@ -73,12 +73,6 @@ bool CompletionEntry::completion()
 }
 
 
-Glib::ustring CompletionEntry::get_text()
-{
-    return m_entry.get_text();
-}
-
-
 void CompletionEntry::set_text( const Glib::ustring& text )
 {
     m_enable_changed = false;

--- a/src/skeleton/compentry.h
+++ b/src/skeleton/compentry.h
@@ -56,7 +56,7 @@ namespace SKELETON
         // 補完実行
         bool completion();
 
-        Glib::ustring get_text();
+        Glib::ustring get_text() const { return m_entry.get_text(); }
         void set_text( const Glib::ustring& text );
         void grab_focus();
 

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -89,7 +89,7 @@ class compare_path
     SKELETON::EditColumns& m_columns;
     int m_mode;
 
-    int type_to_order( const int type )
+    int type_to_order( const int type ) const
     {
         int order[]={
 

--- a/src/skeleton/edittreeview.h
+++ b/src/skeleton/edittreeview.h
@@ -140,7 +140,7 @@ namespace SKELETON
 
         // pathで指定した行の名前の変更
         void rename_row( const Gtk::TreePath& path );
-        bool is_renaming_row(){ return m_ren_text->property_editable(); }
+        bool is_renaming_row() const { return m_ren_text->property_editable(); }
 
         // list_info を path_dest 以下に追加
         //

--- a/src/skeleton/iconpopup.h
+++ b/src/skeleton/iconpopup.h
@@ -35,8 +35,8 @@ namespace SKELETON
             show_all_children();
         }
 
-        int get_img_width(){ return m_pixbuf->get_width(); }
-        int get_img_height(){ return m_pixbuf->get_height(); }
+        int get_img_width() const { return m_pixbuf->get_width(); }
+        int get_img_height() const { return m_pixbuf->get_height(); }
     };
 
 }

--- a/src/skeleton/label_entry.cpp
+++ b/src/skeleton/label_entry.cpp
@@ -87,7 +87,7 @@ void LabelEntry::grab_focus()
 }
 
 
-bool LabelEntry::has_grab()
+bool LabelEntry::has_grab() const
 {
     if( m_editable ) return m_entry.has_grab();
     return false;

--- a/src/skeleton/label_entry.h
+++ b/src/skeleton/label_entry.h
@@ -40,7 +40,7 @@ namespace SKELETON
         Glib::ustring get_text() const;
 
         void grab_focus();
-        bool has_grab();
+        bool has_grab() const;
 
       private:
 

--- a/src/skeleton/selectitempref.cpp
+++ b/src/skeleton/selectitempref.cpp
@@ -247,7 +247,7 @@ void SelectItemPref::append_rows( const std::string& str )
 //
 // 全ての有効な項目を文字列で取得
 //
-std::string SelectItemPref::get_items()
+std::string SelectItemPref::get_items() const
 {
     std::string items;
 

--- a/src/skeleton/selectitempref.h
+++ b/src/skeleton/selectitempref.h
@@ -106,7 +106,7 @@ namespace SKELETON
         void append_rows( const std::string& str );
 
         // 全ての有効な項目を文字列で取得
-        std::string get_items();
+        std::string get_items() const;
 
         // 表示項目に指定した項目を追加
         Gtk::TreeRow append_shown( const std::string& name, const bool set_cursor );

--- a/src/skeleton/tablabel.cpp
+++ b/src/skeleton/tablabel.cpp
@@ -109,7 +109,7 @@ void TabLabel::set_dragable( bool dragable, int button )
 //
 // 本体の横幅 - ラベルの横幅
 //
-int TabLabel::get_label_margin()
+int TabLabel::get_label_margin() const
 {
     int label_margin;
 

--- a/src/skeleton/tablabel.h
+++ b/src/skeleton/tablabel.h
@@ -71,12 +71,12 @@ namespace SKELETON
         Pango::FontDescription get_label_font_description(){
             return m_label.get_pango_context()->get_font_description(); }
 
-        const std::string& get_url(){ return m_url; }
+        const std::string& get_url() const { return m_url; }
 
         void set_dragable( bool dragable, int button );
 
         // 本体の横幅 - ラベルの横幅
-        int get_label_margin();
+        int get_label_margin() const;
 
         // カットしていない全体の文字列
         const std::string& get_fulltext() const { return m_fulltext; }

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -448,7 +448,7 @@ void ToolBar::add_search_control_mode( const int mode )
 }
 
 
-std::string ToolBar::get_search_text()
+std::string ToolBar::get_search_text() const
 {
     if( ! m_entry_search ) return std::string();
 

--- a/src/skeleton/toolbar.h
+++ b/src/skeleton/toolbar.h
@@ -78,7 +78,7 @@ namespace SKELETON
         ~ToolBar() noexcept;
 
         void set_url( const std::string& url );
-        const std::string& get_url() { return m_url; }
+        const std::string& get_url() const { return m_url; }
 
         bool is_empty();
 
@@ -135,7 +135,7 @@ namespace SKELETON
         // CompletionEntry の入力コントローラのモード設定
         void add_search_control_mode( const int mode );
 
-        std::string get_search_text();
+        std::string get_search_text() const;
 
         // 上検索
         Gtk::ToolButton* get_button_up_search();

--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -167,7 +167,7 @@ bool View::release_keyjump_key( int key )
 
 
 // view 上にマウスポインタがあれば true
-bool View::is_mouse_on_view()
+bool View::is_mouse_on_view() const
 {
     bool ret = false;
 

--- a/src/skeleton/view.h
+++ b/src/skeleton/view.h
@@ -202,7 +202,7 @@ namespace SKELETON
         void set_popup_upside( const bool upside ){ m_popup_upside = upside; }
 
         // view 上にマウスポインタがあれば true
-        bool is_mouse_on_view();
+        bool is_mouse_on_view() const;
 
         // 各view個別のコマンド
         virtual bool set_command( const std::string& command,


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

- AAMenu: Add const qualifier to member function
- EditTreeView: Add const qualifier to member function
- IconPopup: Add const qualifier to member function
- LabelEntry: Add const qualifier to member function
- SelectItemPref: Add const qualifier to member function
- TabLabel: Add const qualifier to member function
- SKELETON::ToolBar: Add const qualifier to member function
- SKELETON::View: Add const qualifier to member function
- CompletionEntry: Add const qualifier to member function

関連のpull request: #682 
