### PR TITLE
MessageAdmin: Fix unexpected mouse cursor on text selection

### DIFF
--- a/src/message/messageadmin.cpp
+++ b/src/message/messageadmin.cpp
@@ -296,6 +296,8 @@ void MessageAdmin::open_view( const COMMAND_ARGS& command )
     show_toolbar();
 
     SKELETON::View *view = CORE::ViewFactory( type, url_msg, args );
+    view->set_margin_start( 10 );
+    view->set_margin_end( 10 );
     get_notebook()->append_page( url_msg, *view );
 
     // ウィンドウ表示


### PR DESCRIPTION
Fixes #714

埋め込み表示中の書き込みビューに入力したテキストをビュー左端からマウスで選択しようとするとマウスカーソルがペインの幅調節に変わり選択ができない不具合を修正します。

入力欄の周りに余白が追加されるGTKテーマだと不具合は起きませんがGTKのデフォルトテーマAdwaitaで発生していました。

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1594134444/621-623n