### PR TITLE
SKELETON::ToolBar: Remove unused member function

### DIFF
--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -59,12 +59,6 @@ void ToolBar::set_url( const std::string& url )
 }
 
 
-bool ToolBar::is_empty()
-{
-    return ( ! m_buttonbar.get_children().size() );
-}
-
-
 //
 // タブが切り替わった時にDragableNoteBook::set_current_toolbar()から呼び出される( Viewの情報を取得する )
 //

--- a/src/skeleton/toolbar.h
+++ b/src/skeleton/toolbar.h
@@ -80,8 +80,6 @@ namespace SKELETON
         void set_url( const std::string& url );
         const std::string& get_url() const { return m_url; }
 
-        bool is_empty();
-
         // タブが切り替わった時にDragableNoteBookから呼び出される( Viewの情報を取得する )
         virtual void set_view( SKELETON::View * view );
 


### PR DESCRIPTION
使われてないツールバーの子要素があるか真偽値を返す関数`is_empty()`を削除します。