### PR TITLE
message: Add const qualifier member function

### DIFF
--- a/src/message/messageadmin.cpp
+++ b/src/message/messageadmin.cpp
@@ -52,7 +52,7 @@ void MessageAdmin::show_entry_new_subject( bool show )
 }
 
 
-std::string MessageAdmin::get_new_subject()
+std::string MessageAdmin::get_new_subject() const
 {
     if( m_toolbar ) return m_toolbar->get_new_subject();
 

--- a/src/message/messageadmin.h
+++ b/src/message/messageadmin.h
@@ -50,7 +50,7 @@ namespace MESSAGE
         void save_session() override {}
 
         void show_entry_new_subject( bool show );
-        std::string get_new_subject();
+        std::string get_new_subject() const;
 
         SKELETON::EditView* get_text_message();
 

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -242,7 +242,7 @@ void MessageViewBase::set_message( const std::string& msg )
 }
 
 
-Glib::ustring MessageViewBase::get_message()
+Glib::ustring MessageViewBase::get_message() const
 {
     if( m_text_message ) return m_text_message->get_text();
 

--- a/src/message/messageviewbase.h
+++ b/src/message/messageviewbase.h
@@ -160,10 +160,10 @@ namespace MESSAGE
         SKELETON::Admin* get_admin() override;
 
         void set_message( const std::string& msg );
-        Glib::ustring get_message();
+        Glib::ustring get_message() const;
 
-        SKELETON::CompletionEntry& get_entry_name(){ return m_entry_name; }
-        SKELETON::CompletionEntry& get_entry_mail(){ return m_entry_mail; }
+        const SKELETON::CompletionEntry& get_entry_name() const { return m_entry_name; }
+        const SKELETON::CompletionEntry& get_entry_mail() const { return m_entry_mail; }
         SKELETON::EditView* get_text_message() { return m_text_message; }
 
         void post_msg( const std::string& msg, bool new_article );

--- a/src/message/toolbar.cpp
+++ b/src/message/toolbar.cpp
@@ -89,7 +89,7 @@ void MessageToolBar::show_entry_new_subject( bool show )
 }
 
 
-std::string MessageToolBar::get_new_subject()
+std::string MessageToolBar::get_new_subject() const
 {
     if( m_show_entry_new_subject && m_entry_new_subject ) return m_entry_new_subject->get_text();
 

--- a/src/message/toolbar.h
+++ b/src/message/toolbar.h
@@ -55,7 +55,7 @@ namespace MESSAGE
         ~MessageToolBar() noexcept;
 
         void show_entry_new_subject( bool show );
-        std::string get_new_subject();
+        std::string get_new_subject() const;
         void clear_new_subject();
 
       protected:


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

- MessageToolBar: Add const qualifier to member function
- MessageViewBase: Add const qualifier to member function
- MessageAdmin: Add const qualifier to member function 

関連のpull request: #682 
