### PR TITLE
misctrip: Add configure check for thread-safe crypt_r

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -36,6 +36,11 @@ jobs:
           - cc: clang-7
             cxx: clang++-7
             package: clang-7
+          # failed by SIGABRT on Ubuntu 20.04
+          # https://github.com/JDimproved/JDim/runs/2589523269?check_suite_focus=true
+          - cc: clang-9
+            cxx: clang++-9
+            package: clang-9
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -77,9 +82,6 @@ jobs:
           - cc: clang-8
             cxx: clang++-8
             package: clang-8
-          - cc: clang-9
-            cxx: clang++-9
-            package: clang-9
           - cc: clang-10
             cxx: clang++-10
             package: clang-10

--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,9 @@ dnl
 dnl crypt
 dnl
 AC_CHECK_LIB(crypt,crypt)
+AC_CHECK_LIB(crypt, crypt_r,
+  [AC_DEFINE(HAVE_CRYPT_R, [1], [Define to 1 if you have the 'crypt_r' function])],
+)
 
 
 dnl

--- a/meson.build
+++ b/meson.build
@@ -80,6 +80,9 @@ endif
 if not crypt_dep.found()
   crypt_dep = dependency('libxcrypt')
 endif
+if cpp_compiler.has_function('crypt_r', dependencies : crypt_dep)
+  conf.set('HAVE_CRYPT_R', 1)
+endif
 
 # socket
 if cpp_compiler.has_header('sys/socket.h')

--- a/src/jdlib/misctrip.cpp
+++ b/src/jdlib/misctrip.cpp
@@ -147,7 +147,13 @@ std::string create_trip_newtype( const std::string& key )
                     salt.append( ".." );
 
                     // crypt (key は先頭8文字しか使われない)
-                    const char *crypted = crypt( key_binary, salt.c_str() );
+#ifdef HAVE_CRYPT_R
+                    struct crypt_data data;
+                    data.initialized = 0;
+                    const char* crypted = crypt_r( key_binary, salt.c_str(), &data );
+#else
+                    const char* crypted = crypt( key_binary, salt.c_str() );
+#endif
 
                     // 末尾から10文字(cryptの戻り値はnullptrでなければ必ず13文字)
                     if( crypted ) trip = std::string( crypted + 3 );
@@ -221,7 +227,13 @@ std::string create_trip_conventional( const std::string& key )
     salt.append( "H." );
 
     // crypt (key は先頭8文字しか使われない)
-    const char *crypted = crypt( key.c_str(), salt.c_str() );
+#ifdef HAVE_CRYPT_R
+    struct crypt_data data;
+    data.initialized = 0;
+    const char* crypted = crypt_r( key.c_str(), salt.c_str(), &data );
+#else
+    const char* crypted = crypt( key.c_str(), salt.c_str() );
+#endif
 
     std::string trip;
 


### PR DESCRIPTION
`crypt`関数のスレッドセーフなバージョンが使える環境では`crypt_r`を使うように変更します。

#### 参考文献
- <https://linux.die.net/man/3/crypt_r>
- <https://www.freebsd.org/cgi/man.cgi?query=crypt_r&apropos=0&sektion=0&manpath=FreeBSD+12-current&arch=default&format=html>

