### PR TITLE
BBSListViewBase: Add const qualifier to member function argument

### DIFF
--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -2137,7 +2137,7 @@ bool BBSListViewBase::is_etcdir( Gtk::TreePath path )
 //
 // 外部板か
 //
-bool BBSListViewBase::is_etcboard( Gtk::TreeModel::iterator& it )
+bool BBSListViewBase::is_etcboard( const Gtk::TreeModel::iterator& it )
 {
     Gtk::TreePath path = get_treestore()->get_path( *it );
     return is_etcboard( path );

--- a/src/bbslist/bbslistviewbase.h
+++ b/src/bbslist/bbslistviewbase.h
@@ -119,7 +119,7 @@ namespace BBSLIST
         bool is_etcdir( Gtk::TreePath path );
 
         // 外部板か
-        bool is_etcboard( Gtk::TreeModel::iterator& it );
+        bool is_etcboard( const Gtk::TreeModel::iterator& it );
         bool is_etcboard( Gtk::TreePath path );
 
         // 起動時や移転があったときなどに行に含まれるURlを変更する


### PR DESCRIPTION
メンバー関数の引数に`const`をつけられるとcppcheckに指摘されたため修正します。

cppcheckのレポート
```
src/bbslist/bbslistviewbase.cpp:2140:62: style: Parameter 'it' can be declared with const [constParameter]
bool BBSListViewBase::is_etcboard( Gtk::TreeModel::iterator& it )
                                                             ^
```