### PR TITLE
NodeTreeBase: Add const qualifier to member function part2

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -190,7 +190,7 @@ int NodeTreeBase::get_res_number() const
 //
 // number 番のレスのヘッダのポインタを返す
 //
-NODE* NodeTreeBase::res_header( int number )
+const NODE* NodeTreeBase::res_header( int number ) const
 {
     if( number > m_id_header || number <= 0 ) return nullptr;
     

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -163,7 +163,11 @@ namespace DBTREE
         bool is_checking_update() const { return m_check_update; }
 
         // number番のレスのヘッダノードのポインタを返す
-        NODE* res_header( int number );
+        const NODE* res_header( int number ) const;
+        NODE* res_header( int number )
+        {
+            return const_cast<NODE*>( static_cast<const NodeTreeBase&>( *this ).res_header( number ) );
+        }
 
         // number番の名前
         std::string get_name( int number );


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

- `NodeTreeBase::res_header()`
  constメンバー関数の実装は重複を避ける手法を使います。
  https://stackoverflow.com/questions/123758/123995#123995

関連のpull request: #682 