### PR TITLE
NodeTreeBase: Add const qualifier to member function part5

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -246,7 +246,7 @@ int NodeTreeBase::get_num_id_name( const int number ) const
 //
 // 指定した発言者IDを持つレス番号をリストにして取得
 //
-std::list< int > NodeTreeBase::get_res_id_name( const std::string& id_name )
+std::list< int > NodeTreeBase::get_res_id_name( const std::string& id_name ) const
 {
     std::list< int > list_resnum;          
     for( int i = 1; i <= m_id_header ; ++i ){
@@ -265,7 +265,7 @@ std::list< int > NodeTreeBase::get_res_id_name( const std::string& id_name )
 // str_num は "from-to"　の形式 (例) 3から10をセットしたいなら "3-10"
 // list_jointは出力で true のスレは前のスレに連結される (例) "3+4" なら 4が3に連結
 //
-std::list< int > NodeTreeBase::get_res_str_num( const std::string& str_num, std::list< bool >& list_joint )
+std::list< int > NodeTreeBase::get_res_str_num( const std::string& str_num, std::list< bool >& list_joint ) const
 {
 #ifdef _DEBUG
     std::cout << "NodeTreeBase::get_res_str_num " << str_num << std::endl;
@@ -550,7 +550,7 @@ std::list< ANCINFO* > NodeTreeBase::get_res_anchors( const int number )
 //
 // mode_or == true なら OR抽出
 //
-std::list< int > NodeTreeBase::get_res_query( const std::string& query, const bool mode_or )
+std::list< int > NodeTreeBase::get_res_query( const std::string& query, const bool mode_or ) const
 {
     std::list< int > list_resnum;
     if( query.empty() ) return list_resnum;
@@ -679,7 +679,7 @@ std::string NodeTreeBase::get_name( int number ) const
 //
 // number番の名前の重複数( = 発言数 )
 //
-int NodeTreeBase::get_num_name( int number )
+int NodeTreeBase::get_num_name( int number ) const
 {
     int num = 0;
     std::string name = get_name( number );
@@ -697,7 +697,7 @@ int NodeTreeBase::get_num_name( int number )
 //
 // 指定した発言者の名前のレス番号をリストにして取得
 //
-std::list< int > NodeTreeBase::get_res_name( const std::string& name )
+std::list< int > NodeTreeBase::get_res_name( const std::string& name ) const
 {
     std::list< int > list_resnum;          
     for( int i = 1; i <= m_id_header ; ++i ){
@@ -714,7 +714,7 @@ std::list< int > NodeTreeBase::get_res_name( const std::string& name )
 // number番のレスの時刻を文字列で取得
 // 内部で regex　を使っているので遅い
 //
-std::string NodeTreeBase::get_time_str( int number )
+std::string NodeTreeBase::get_time_str( int number ) const
 {
     std::string res_str = get_res_str( number );
     if( res_str.empty() ) return std::string();
@@ -3696,7 +3696,7 @@ int NodeTreeBase::convert_amp( char* text, const int n )
 
 
 // 自分の書き込みにレスしたか
-bool NodeTreeBase::is_refer_posted( const int number )
+bool NodeTreeBase::is_refer_posted( const int number ) const
 {
     return m_refer_posts.find( number ) != m_refer_posts.end();
 }

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -173,14 +173,14 @@ namespace DBTREE
         std::string get_name( int number ) const;
 
         // number番の名前の重複数( = 発言数 )
-        int get_num_name( int number );
+        int get_num_name( int number ) const;
 
         // 指定した発言者の名前のレス番号をリストにして取得
-        std::list< int > get_res_name( const std::string& name );
+        std::list< int > get_res_name( const std::string& name ) const;
 
         // number番のレスの時刻を文字列で取得
         // 内部で regex　を使っているので遅い
-        std::string get_time_str( int number );
+        std::string get_time_str( int number ) const;
 
         // number番のID
         std::string get_id_name( int number ) const;
@@ -193,12 +193,12 @@ namespace DBTREE
         int get_num_id_name( const int number ) const;
 
         // 指定した発言者IDを持つレス番号をリストにして取得
-        std::list< int > get_res_id_name( const std::string& id_name );
+        std::list< int > get_res_id_name( const std::string& id_name ) const;
 
         // str_num で指定したレス番号をリストにして取得
         // str_num は "from-to"　の形式 (例) 3から10をセットしたいなら "3-10"
         // list_jointは出力で true のスレは前のスレに連結される (例) "3+4" なら 4が3に連結
-        std::list< int > get_res_str_num( const std::string& str_num, std::list< bool >& list_joint );
+        std::list< int > get_res_str_num( const std::string& str_num, std::list< bool >& list_joint ) const;
 
         // URL を含むレス番号をリストにして取得
         std::list< int > get_res_with_url() const;
@@ -217,7 +217,7 @@ namespace DBTREE
 
         // query を含むレス番号をリストにして取得
         // mode_or == true なら OR抽出
-        std::list< int > get_res_query( const std::string& query, const bool mode_or );
+        std::list< int > get_res_query( const std::string& query, const bool mode_or ) const;
 
 
         // number番のレスの文字列を返す
@@ -259,7 +259,7 @@ namespace DBTREE
         const std::unordered_set< int >& get_posts() const noexcept { return m_posts; }
 
         // 自分の書き込みにレスしたか
-        bool is_refer_posted( const int number );
+        bool is_refer_posted( const int number ) const;
 
         // 書き込みマークセット
         void set_posted( const int number, const bool set );


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

- `NodeTreeBase::get_res_str_name()`
- `NodeTreeBase::get_num_name()`
- `NodeTreeBase::get_res_name()`
- `NodeTreeBase::get_time_str()`
- `NodeTreeBase::get_res_query()`
- `NodeTreeBase::get_res_id_name()`
- `NodeTreeBase::is_refer_posted()`

関連のpull request: #682 
