### PR TITLE
Add WebP and AVIF support

### DIFF
--- a/src/dbimg/imginterface.h
+++ b/src/dbimg/imginterface.h
@@ -24,6 +24,7 @@ namespace DBIMG
         T_PNG,
         T_GIF,
         T_BMP,
+        T_WEBP,
 
         T_LARGE,
         T_NOSIZE,

--- a/src/dbimg/imginterface.h
+++ b/src/dbimg/imginterface.h
@@ -25,6 +25,7 @@ namespace DBIMG
         T_GIF,
         T_BMP,
         T_WEBP,
+        T_AVIF,
 
         T_LARGE,
         T_NOSIZE,

--- a/src/dbimg/imgroot.cpp
+++ b/src/dbimg/imgroot.cpp
@@ -33,6 +33,9 @@ ImgRoot::ImgRoot()
         if( name == "webp" ) {
             m_webp_support = true;
         }
+        else if( name == "avif" ) {
+            m_avif_support = true;
+        }
     }
 }
 
@@ -151,6 +154,16 @@ int ImgRoot::get_image_type( const unsigned char *sign ) const
              && sign[ 10 ] == 'B'
              && sign[ 11 ] == 'P' ) type = T_WEBP;
 
+    // avif
+    else if( sign[ 4 ] == 'f'
+             && sign[ 5 ] == 't'
+             && sign[ 6 ] == 'y'
+             && sign[ 7 ] == 'p'
+             && sign[ 8 ] == 'a'
+             && sign[ 9 ] == 'v'
+             && sign[ 10 ] == 'i'
+             && sign[ 11 ] == 'f' ) type = T_AVIF;
+
     return type;
 }
 
@@ -178,6 +191,7 @@ int ImgRoot::get_type_ext( const char* url, int n ) const
     if( is_gif( url, n ) ) return T_GIF;
     if( is_bmp( url, n ) ) return T_BMP;
     if( m_webp_support && is_webp( url, n ) ) return T_WEBP;
+    if( m_avif_support && is_avif( url, n ) ) return T_AVIF;
 
     // URLに拡張子がない場合でも画像として扱うか
     if( imgctrl & CORE::IMGCTRL_FORCEIMAGE ) return T_FORCEIMAGE;
@@ -279,6 +293,25 @@ bool ImgRoot::is_webp( const char* url, int n )
         *( url + n -3 ) == 'E' &&
         *( url + n -2 ) == 'B' &&
         *( url + n -1 ) == 'P'  ) return true;
+
+    return false;
+}
+
+
+bool ImgRoot::is_avif( const char* url, int n )
+{
+    // .avif
+    if( *( url + n -5 ) == '.' &&
+        *( url + n -4 ) == 'a' &&
+        *( url + n -3 ) == 'v' &&
+        *( url + n -2 ) == 'i' &&
+        *( url + n -1 ) == 'f'  ) return true;
+
+    if( *( url + n -5 ) == '.' &&
+        *( url + n -4 ) == 'A' &&
+        *( url + n -3 ) == 'V' &&
+        *( url + n -2 ) == 'I' &&
+        *( url + n -1 ) == 'F'  ) return true;
 
     return false;
 }

--- a/src/dbimg/imgroot.h
+++ b/src/dbimg/imgroot.h
@@ -21,6 +21,7 @@ namespace DBIMG
         std::list< Img* > m_list_wait; // ロード待ち状態のImgクラス
         std::list< Img* > m_list_delwait; // ロード待ち状態のImgクラスを削除する時の一時変数
         bool m_webp_support{}; // WebP の読み込みに対応しているか
+        bool m_avif_support{}; // AVIF の読み込みに対応しているか
 
       public:
         ImgRoot();
@@ -62,6 +63,7 @@ namespace DBIMG
         static bool is_gif( const char* url, int n );
         static bool is_bmp( const char* url, int n );
         static bool is_webp( const char* url, int n );
+        static bool is_avif( const char* url, int n );
 
         void reset_imgs();
     };

--- a/src/dbimg/imgroot.h
+++ b/src/dbimg/imgroot.h
@@ -20,7 +20,8 @@ namespace DBIMG
         std::map<std::string, std::unique_ptr<Img>> m_map_img;
         std::list< Img* > m_list_wait; // ロード待ち状態のImgクラス
         std::list< Img* > m_list_delwait; // ロード待ち状態のImgクラスを削除する時の一時変数
-        
+        bool m_webp_support{}; // WebP の読み込みに対応しているか
+
       public:
         ImgRoot();
         ~ImgRoot();
@@ -60,6 +61,7 @@ namespace DBIMG
         static bool is_png( const char* url, int n );
         static bool is_gif( const char* url, int n );
         static bool is_bmp( const char* url, int n );
+        static bool is_webp( const char* url, int n );
 
         void reset_imgs();
     };

--- a/src/image/imageviewbase.cpp
+++ b/src/image/imageviewbase.cpp
@@ -908,6 +908,7 @@ void ImageViewBase::slot_cancel_mosaic()
             case DBIMG::T_PNG: type += "PNG"; break;
             case DBIMG::T_GIF: type += "GIF"; break;
             case DBIMG::T_BMP: type += "BMP"; break;
+            case DBIMG::T_WEBP: type += "WebP"; break;
         }
         type += "です。";
 

--- a/src/image/imageviewbase.cpp
+++ b/src/image/imageviewbase.cpp
@@ -909,6 +909,7 @@ void ImageViewBase::slot_cancel_mosaic()
             case DBIMG::T_GIF: type += "GIF"; break;
             case DBIMG::T_BMP: type += "BMP"; break;
             case DBIMG::T_WEBP: type += "WebP"; break;
+            case DBIMG::T_AVIF: type += "AVIF"; break;
         }
         type += "です。";
 

--- a/src/image/preference.cpp
+++ b/src/image/preference.cpp
@@ -54,6 +54,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url )
         case DBIMG::T_GIF: type = "GIF"; break;
         case DBIMG::T_BMP: type = "BMP"; break;
         case DBIMG::T_WEBP: type = "WebP"; break;
+        case DBIMG::T_AVIF: type = "AVIF"; break;
     }
 
     if( DBIMG::is_fake( get_url() ) ) type += " ※拡張子が偽装されています※";

--- a/src/image/preference.cpp
+++ b/src/image/preference.cpp
@@ -53,6 +53,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url )
         case DBIMG::T_PNG: type = "PNG"; break;
         case DBIMG::T_GIF: type = "GIF"; break;
         case DBIMG::T_BMP: type = "BMP"; break;
+        case DBIMG::T_WEBP: type = "WebP"; break;
     }
 
     if( DBIMG::is_fake( get_url() ) ) type += " ※拡張子が偽装されています※";


### PR DESCRIPTION
Fixes #727 

#### WebP画像のサポートを追加します。
起動時にWebPに対応しているか確認してサポートしているときは`.webp`で終わるURLを画像リンクとして扱います。

NOTE:   GTKにはGdkPixbufのWebPサポートが含まれていません。WebPを表示するには[サードパーティライブラリ][2]をインストールする必要があります。

  [2]: https://github.com/aruiz/webp-pixbuf-loader

#### AVIF画像のサポートを追加します。
起動時にAVIFに対応しているか確認してサポートしているときは`.avif`で終わるURLを画像リンクとして扱います。

NOTE:  GTKにはGdkPixbufのAVIFサポートが含まれていません。AVIFを表示するにはGdkPixbufを有効にした[libavif][1]をインストールする必要があります。

  libavifのパッケージが導入されたLinuxディストロ
  - [Debian](https://tracker.debian.org/pkg/libavif)
  - [Fedora](https://src.fedoraproject.org/rpms/libavif)
  - [Ubuntu](https://launchpad.net/ubuntu/+source/libavif)

  [1]: https://github.com/AOMediaCodec/libavif

#### 画像形式をマジックナンバーで判定する関数に渡すバッファに対してサイズチェックを追加します。
関数が処理できるサイズより小さい場合は関数呼び出しを行わず判定しません。

