### PR TITLE
ArticleBase: Add const qualifier to member function part1

### DIFF
--- a/src/dbtree/article2ch.cpp
+++ b/src/dbtree/article2ch.cpp
@@ -67,19 +67,6 @@ std::string Article2ch::create_write_message( const std::string& name, const std
 
 
 //
-// bbscgi のURL
-//
-// (例) "http://www.hoge2ch.net/test/bbs.cgi"
-//
-//
-std::string Article2ch::url_bbscgi()
-{
-    return Article2chCompati::url_bbscgi();
-}
-
-
-
-//
 // subbbscgi のURL
 //
 // (例) "http://www.hoge2ch.net/test/subbbs.cgi"

--- a/src/dbtree/article2ch.h
+++ b/src/dbtree/article2ch.h
@@ -22,9 +22,6 @@ namespace DBTREE
         std::string create_write_message( const std::string& name, const std::string& mail,
                                           const std::string& msg ) override;
 
-        // bbscgi のURL
-        std::string url_bbscgi() override;
-        
         // subbbscgi のURL
         std::string url_subbbscgi() override;
 

--- a/src/dbtree/article2chcompati.cpp
+++ b/src/dbtree/article2chcompati.cpp
@@ -70,10 +70,11 @@ std::string Article2chCompati::create_write_message( const std::string& name, co
 // (例) "http://www.hoge2ch.net/test/bbs.cgi"
 //
 //
-std::string Article2chCompati::url_bbscgi()
+std::string Article2chCompati::url_bbscgi() const
 {
     std::string cgibase = DBTREE::url_bbscgibase( get_url() );
-    return cgibase.substr( 0, cgibase.length() -1 ); // 最後の '/' を除く
+    if( ! cgibase.empty() ) cgibase.pop_back(); // 最後の '/' を除く
+    return cgibase;
 }
 
 

--- a/src/dbtree/article2chcompati.h
+++ b/src/dbtree/article2chcompati.h
@@ -23,8 +23,8 @@ namespace DBTREE
                                           const std::string& msg ) override;
 
         // bbscgi のURL
-        std::string url_bbscgi() override;
-        
+        std::string url_bbscgi() const override;
+
         // subbbscgi のURL
         std::string url_subbbscgi() override;
 

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -231,7 +231,7 @@ namespace DBTREE
                                                   const std::string& msg ) { return {}; }
 
         // bbscgi のURL
-        virtual std::string url_bbscgi() { return std::string(); }
+        virtual std::string url_bbscgi() const { return {}; }
 
         // subbbscgi のURL
         virtual std::string url_subbbscgi() { return std::string(); }

--- a/src/dbtree/articlejbbs.cpp
+++ b/src/dbtree/articlejbbs.cpp
@@ -69,7 +69,7 @@ std::string ArticleJBBS::create_write_message( const std::string& name, const st
 // (例) "http://jbbs.shitaraba.net/bbs/write.cgi/computer/123/1234567/"
 //
 //
-std::string ArticleJBBS::url_bbscgi()
+std::string ArticleJBBS::url_bbscgi() const
 {
     return DBTREE::url_bbscgibase( get_url() ) + DBTREE::board_id( get_url() ) + "/" + get_key() + "/";
 }

--- a/src/dbtree/articlejbbs.h
+++ b/src/dbtree/articlejbbs.h
@@ -25,8 +25,8 @@ namespace DBTREE
                                           const std::string& msg ) override;
 
         // bbscgi のURL
-        std::string url_bbscgi() override;
-        
+        std::string url_bbscgi() const override;
+
         // subbbscgi のURL
         std::string url_subbbscgi() override;
 

--- a/src/dbtree/articlemachi.cpp
+++ b/src/dbtree/articlemachi.cpp
@@ -65,10 +65,11 @@ std::string ArticleMachi::create_write_message( const std::string& name, const s
 // (例) "http://www.machi.to/bbs/write.cgi"
 //
 //
-std::string ArticleMachi::url_bbscgi()
+std::string ArticleMachi::url_bbscgi() const
 {
     std::string cgibase = DBTREE::url_bbscgibase( get_url() );
-    return cgibase.substr( 0, cgibase.length() -1 ); // 最後の '/' を除く
+    if( ! cgibase.empty() ) cgibase.pop_back(); // 最後の '/' を除く
+    return cgibase;
 }
 
 

--- a/src/dbtree/articlemachi.h
+++ b/src/dbtree/articlemachi.h
@@ -25,8 +25,8 @@ namespace DBTREE
                                           const std::string& msg ) override;
 
         // bbscgi のURL
-        std::string url_bbscgi() override;
-        
+        std::string url_bbscgi() const override;
+
         // subbbscgi のURL
         std::string url_subbbscgi() override;
 


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

- `ArticleBase::url_bbscgi()`

関連のpull request: #682 
