### PR TITLE
ArticleBase: Add const qualifier to member function part2

### DIFF
--- a/src/dbtree/article2ch.cpp
+++ b/src/dbtree/article2ch.cpp
@@ -66,18 +66,6 @@ std::string Article2ch::create_write_message( const std::string& name, const std
 }
 
 
-//
-// subbbscgi のURL
-//
-// (例) "http://www.hoge2ch.net/test/subbbs.cgi"
-//
-std::string Article2ch::url_subbbscgi()
-{
-    return Article2chCompati::url_subbbscgi();
-}
-
-
-
 NodeTreeBase* Article2ch::create_nodetree()
 {
     return new NodeTree2ch( get_url(), get_org_url(), get_date_modified(), get_since_time() );

--- a/src/dbtree/article2ch.h
+++ b/src/dbtree/article2ch.h
@@ -22,9 +22,6 @@ namespace DBTREE
         std::string create_write_message( const std::string& name, const std::string& mail,
                                           const std::string& msg ) override;
 
-        // subbbscgi のURL
-        std::string url_subbbscgi() override;
-
       protected:
 
         // dat落ちしたスレをロードするか

--- a/src/dbtree/article2chcompati.cpp
+++ b/src/dbtree/article2chcompati.cpp
@@ -84,10 +84,11 @@ std::string Article2chCompati::url_bbscgi() const
 //
 // (例) "http://www.hoge2ch.net/test/subbbs.cgi"
 //
-std::string Article2chCompati::url_subbbscgi()
+std::string Article2chCompati::url_subbbscgi() const
 {
     std::string cgibase = DBTREE::url_subbbscgibase( get_url() );
-    return cgibase.substr( 0, cgibase.length() -1 ); // 最後の '/' を除く
+    if( ! cgibase.empty() ) cgibase.pop_back(); // 最後の '/' を除く
+    return cgibase;
 }
 
 

--- a/src/dbtree/article2chcompati.h
+++ b/src/dbtree/article2chcompati.h
@@ -26,7 +26,7 @@ namespace DBTREE
         std::string url_bbscgi() const override;
 
         // subbbscgi のURL
-        std::string url_subbbscgi() override;
+        std::string url_subbbscgi() const override;
 
       private:
         

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -234,7 +234,7 @@ namespace DBTREE
         virtual std::string url_bbscgi() const { return {}; }
 
         // subbbscgi のURL
-        virtual std::string url_subbbscgi() { return std::string(); }
+        virtual std::string url_subbbscgi() const { return {}; }
 
         // 最終アクセス時間
         std::string get_access_time_str();

--- a/src/dbtree/articlejbbs.cpp
+++ b/src/dbtree/articlejbbs.cpp
@@ -80,7 +80,7 @@ std::string ArticleJBBS::url_bbscgi() const
 //
 // (例) "http://jbbs.shitaraba.net/bbs/write.cgi/computer/123/1234567/"
 //
-std::string ArticleJBBS::url_subbbscgi()
+std::string ArticleJBBS::url_subbbscgi() const
 {
     return DBTREE::url_subbbscgibase( get_url() ) + DBTREE::board_id( get_url() ) + "/" + get_key() + "/";
 }

--- a/src/dbtree/articlejbbs.h
+++ b/src/dbtree/articlejbbs.h
@@ -28,7 +28,7 @@ namespace DBTREE
         std::string url_bbscgi() const override;
 
         // subbbscgi のURL
-        std::string url_subbbscgi() override;
+        std::string url_subbbscgi() const override;
 
       private:
         

--- a/src/dbtree/articlemachi.cpp
+++ b/src/dbtree/articlemachi.cpp
@@ -78,10 +78,11 @@ std::string ArticleMachi::url_bbscgi() const
 //
 // (例) "http://www.machi.to/bbs/write.cgi"
 //
-std::string ArticleMachi::url_subbbscgi()
+std::string ArticleMachi::url_subbbscgi() const
 {
     std::string cgibase = DBTREE::url_subbbscgibase( get_url() );
-    return cgibase.substr( 0, cgibase.length() -1 ); // 最後の '/' を除く
+    if( ! cgibase.empty() ) cgibase.pop_back(); // 最後の '/' を除く
+    return cgibase;
 }
 
 

--- a/src/dbtree/articlemachi.h
+++ b/src/dbtree/articlemachi.h
@@ -28,7 +28,7 @@ namespace DBTREE
         std::string url_bbscgi() const override;
 
         // subbbscgi のURL
-        std::string url_subbbscgi() override;
+        std::string url_subbbscgi() const override;
 
       private:
         


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

- `ArticleBase::url_subbbscgi()`

関連のpull request: #682
