### PR TITLE
ArticleBase: Add const qualifier to member function part3

### DIFF
--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -531,15 +531,6 @@ void ArticleBase::update_writetime()
 
 
 //
-// 書き込み数
-//
-int ArticleBase::get_num_posted()
-{
-    return m_posts.size();
-}
-
-
-//
 // スレ自体のスレ一覧でのブックマーク
 //
 void ArticleBase::set_bookmarked_thread( const bool bookmarked )
@@ -851,15 +842,6 @@ void ArticleBase::set_abone_global( const bool set )
 
     m_save_info = true;
 } 
-
-
-//
-// ブックマークの数
-//
-int ArticleBase::get_num_bookmark()
-{
-    return m_bookmarks.size();
-}
 
 
 //

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -248,7 +248,7 @@ namespace DBTREE
         void reset_write_date(){ m_write_time_date = std::string(); }
 
         // 書き込み数
-        int get_num_posted();
+        int get_num_posted() const noexcept { return m_posts.size(); }
 
         // 自分の書き込みか
         bool is_posted( const int number );
@@ -367,7 +367,7 @@ namespace DBTREE
         bool is_bookmarked_thread() const { return m_bookmarked_thread; }
 
         // 「レス」のブックマーク
-        int get_num_bookmark();
+        int get_num_bookmark() const noexcept { return m_bookmarks.size(); }
         bool is_bookmarked( const int number );
         void set_bookmark( const int number, const bool set );
 


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

- `ArticleBase::get_num_bookmark()`
- `ArticleBase::get_num_posted()`

関連のpull request: #682 
