### PR TITLE
ArticleBase: Add const qualifier to member function part4

### DIFF
--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -313,10 +313,10 @@ namespace DBTREE
         bool is_finished();
 
         // あぼーん情報
-        const std::list< std::string >& get_abone_list_id(){ return m_list_abone_id; }
-        const std::list< std::string >& get_abone_list_name(){ return m_list_abone_name; }
-        const std::list< std::string >& get_abone_list_word(){ return m_list_abone_word; }
-        const std::list< std::string >& get_abone_list_regex(){ return m_list_abone_regex; }
+        const std::list<std::string>& get_abone_list_id() const { return m_list_abone_id; }
+        const std::list<std::string>& get_abone_list_name() const { return m_list_abone_name; }
+        const std::list<std::string>& get_abone_list_word() const { return m_list_abone_word; }
+        const std::list<std::string>& get_abone_list_regex() const { return m_list_abone_regex; }
         const std::unordered_set< int >& get_abone_reses() const noexcept { return m_abone_reses; }
 
         // 透明


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

- `ArticleBase::get_abone_list_id()`
- `ArticleBase::get_abone_list_name()`
- `ArticleBase::get_abone_list_word()`
- `ArticleBase::get_abone_list_regex()`

関連のpull request: #682 