### PR TITLE
ArticleBase: Add const qualifier to member function part5

### DIFF
--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -105,7 +105,7 @@ bool ArticleBase::equal( const std::string& datbase, const std::string& id )
 //
 // 移転する前のオリジナルのURL
 //
-std::string ArticleBase::get_org_url()
+std::string ArticleBase::get_org_url() const
 {
     std::string newhost = MISC::get_hostname( m_url );
     return m_org_host + m_url.substr( newhost.length() );
@@ -546,7 +546,7 @@ void ArticleBase::set_bookmarked_thread( const bool bookmarked )
 //
 // キャッシュがあって、かつ新着の読み込みが可能
 //
-bool ArticleBase::enable_load()
+bool ArticleBase::enable_load() const
 {
     return ( is_cached() && ( m_status & STATUS_UPDATE ) && ! ( m_status & STATUS_OLD ) );
 }
@@ -555,7 +555,7 @@ bool ArticleBase::enable_load()
 //
 // キャッシュはあるが規定のレス数を越えていて、かつ全てのレスが既読
 //
-bool ArticleBase::is_finished()
+bool ArticleBase::is_finished() const
 {
     if( is_cached() && ! enable_load() &&  m_number_max && get_number_seen() >= m_number_max ){
 
@@ -573,7 +573,7 @@ bool ArticleBase::is_finished()
 //
 // 透明あぼーん
 //
-bool ArticleBase::get_abone_transparent()
+bool ArticleBase::get_abone_transparent() const
 {
     if( CONFIG::get_abone_transparent() ) return true;
 
@@ -584,7 +584,7 @@ bool ArticleBase::get_abone_transparent()
 //
 // 連鎖あぼーん
 //
-bool ArticleBase::get_abone_chain()
+bool ArticleBase::get_abone_chain() const
 {
     if( CONFIG::get_abone_chain() ) return true;
 

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -132,7 +132,7 @@ namespace DBTREE
         void update_datbase( const std::string& datbase );
 
         // 移転する前のオリジナルのURL
-        std::string get_org_url();
+        std::string get_org_url() const;
 
         // 移転する前のオリジナルのホスト名
         const std::string& get_org_host() const { return m_org_host; }
@@ -307,10 +307,10 @@ namespace DBTREE
         bool is_cache_read() const noexcept { return static_cast<bool>( m_nodetree ); }
 
         // キャッシュがあって、かつ新着の読み込みが可能
-        bool enable_load();
+        bool enable_load() const;
 
         // キャッシュはあるが規定のレス数を越えていて、かつ全てのレスが既読
-        bool is_finished();
+        bool is_finished() const;
 
         // あぼーん情報
         const std::list<std::string>& get_abone_list_id() const { return m_list_abone_id; }
@@ -320,10 +320,10 @@ namespace DBTREE
         const std::unordered_set< int >& get_abone_reses() const noexcept { return m_abone_reses; }
 
         // 透明
-        bool get_abone_transparent();
+        bool get_abone_transparent() const;
 
         // 連鎖
-        bool get_abone_chain();
+        bool get_abone_chain() const;
 
         // ageあぼーん
         bool get_abone_age() const { return m_abone_age; }


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

- `ArticleBase::get_abone_chain()`
- `ArticleBase::get_abone_transparent()`
- `ArticleBase::enable_load()`
- `ArticleBase::is_finished()`
- `ArticleBase::get_org_url()`

関連のpull request: #682 
