### PR TITLE
ArticleBase: Add const qualifier to member function part6

### DIFF
--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -126,10 +126,10 @@ const std::string& ArticleBase::get_since_date()
 
 
 // スレ速度
-int ArticleBase::get_speed()
+int ArticleBase::get_speed() const
 {
-    time_t current_t = time( nullptr );
-    return ( static_cast<std::time_t>( get_number() ) * 60 * 60 * 24 ) / MAX( 1, current_t - get_since_time() );
+    std::time_t current = std::time( nullptr );
+    return ( static_cast<std::time_t>( get_number() ) * 60 * 60 * 24 ) / MAX( 1, current - get_since_time() );
 }
 
 
@@ -316,20 +316,19 @@ std::string ArticleBase::get_res_str( int number, bool ref )
 //
 // 更新時刻
 //
-time_t ArticleBase::get_time_modified()
+std::time_t ArticleBase::get_time_modified() const
 {
-    time_t time_out;
-    time_out = MISC::datetotime( m_date_modified );
-    if( time_out == 0 ) time_out = time( nullptr ) - 600;
+    std::time_t time_out = MISC::datetotime( m_date_modified );
+    if( time_out == 0 ) time_out = std::time( nullptr ) - 600;
     return time_out; 
 }
 
 
 
 // スレが立ってからの経過時間( 時間 )
-int ArticleBase::get_hour()
+int ArticleBase::get_hour() const
 {
-    return ( time( nullptr ) - get_since_time() ) / ( 60 * 60 );
+    return ( std::time( nullptr ) - get_since_time() ) / ( 60 * 60 );
 }
 
 
@@ -388,7 +387,7 @@ void ArticleBase::set_org_host( const std::string& host )
 //
 // access_time を 文字列に変換して返す
 //
-std::string ArticleBase::get_access_time_str()
+std::string ArticleBase::get_access_time_str() const
 {
     struct timeval buf{};
     buf.tv_sec = m_access_time;

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -150,7 +150,7 @@ namespace DBTREE
         void set_number_max( const int number ){ m_number_max = number; }
 
         // スレ速度
-        int get_speed();
+        int get_speed() const;
 
         // キャッシュにあるdatファイルのサイズ
         size_t get_lng_dat();
@@ -237,7 +237,7 @@ namespace DBTREE
         virtual std::string url_subbbscgi() const { return {}; }
 
         // 最終アクセス時間
-        std::string get_access_time_str();
+        std::string get_access_time_str() const;
         time_t get_access_time() const noexcept { return m_access_time; } // 秒
         const std::string& get_access_date(); // string型
         void reset_access_date(){ m_access_date = std::string(); }
@@ -268,12 +268,12 @@ namespace DBTREE
         void reset_since_date(){ m_since_date = std::string(); }
 
         // 更新時間
-        time_t get_time_modified();
-        const std::string& get_date_modified() { return m_date_modified; }
+        std::time_t get_time_modified() const;
+        const std::string& get_date_modified() const { return m_date_modified; }
         void set_date_modified( const std::string& date ){ m_date_modified = date; }
 
         // スレが立ってからの経過時間( 時間 )
-        int get_hour();
+        int get_hour() const;
 
         // http コード
         int get_code() const { return m_code; }


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

- `ArticleBase::get_date_modified()`
- `ArticleBase::get_hour()`
- `ArticleBase::get_time_modified()`
- `ArticleBase::get_access_time_str()`
- `ArticleBase::get_speed()`

関連のpull request: #682 
