### PR TITLE
ArticleBase: Add const qualifier to member function part7

### DIFF
--- a/src/dbtree/article2ch.cpp
+++ b/src/dbtree/article2ch.cpp
@@ -76,7 +76,7 @@ NodeTreeBase* Article2ch::create_nodetree()
 //
 // dat落ちしたスレをロードするか
 //
-bool Article2ch::is_load_olddat()
+bool Article2ch::is_load_olddat() const
 {
     // 2chにログインしている場合
     return CORE::get_login2ch()->login_now();

--- a/src/dbtree/article2ch.h
+++ b/src/dbtree/article2ch.h
@@ -25,7 +25,7 @@ namespace DBTREE
       protected:
 
         // dat落ちしたスレをロードするか
-        bool is_load_olddat() override;
+        bool is_load_olddat() const override;
 
       private:
         

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -96,7 +96,7 @@ ArticleBase::~ArticleBase()
 
 
 // ID がこのスレのものかどうか
-bool ArticleBase::equal( const std::string& datbase, const std::string& id )
+bool ArticleBase::equal( const std::string& datbase, const std::string& id ) const
 {
     return ( id == m_id );
 }

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -114,7 +114,7 @@ namespace DBTREE
         void set_is_924( const bool is924 ){ m_924 = is924; }
 
         // dat落ちしたスレをロードするか
-        virtual bool is_load_olddat(){ return false; }
+        virtual bool is_load_olddat() const { return false; }
 
       public:
 
@@ -126,7 +126,7 @@ namespace DBTREE
         const std::string& get_url() const { return m_url; }
 
         // ID がこのスレのものかどうか
-        virtual bool equal( const std::string& datbase, const std::string& id );
+        virtual bool equal( const std::string& datbase, const std::string& id ) const;
 
         // 移転があったときなどにdatファイルのベースアドレスを更新
         void update_datbase( const std::string& datbase );
@@ -404,7 +404,7 @@ namespace DBTREE
       private:
 
         // 更新チェック可能
-        virtual bool enable_check_update() { return true; }
+        virtual bool enable_check_update() const { return true; }
 
         // NodeTree作成
         // もしNodeTreeが作られていなかったら作成

--- a/src/dbtree/articlejbbs.h
+++ b/src/dbtree/articlejbbs.h
@@ -33,7 +33,7 @@ namespace DBTREE
       private:
         
         // 更新チェック不可能
-        bool enable_check_update() override { return false; }
+        bool enable_check_update() const override { return false; }
 
         NodeTreeBase* create_nodetree() override;
     };

--- a/src/dbtree/articlelocal.cpp
+++ b/src/dbtree/articlelocal.cpp
@@ -30,7 +30,7 @@ ArticleLocal::~ArticleLocal()
 
 
 // ID がこのスレのものかどうか
-bool ArticleLocal::equal( const std::string& datbase, const std::string& id )
+bool ArticleLocal::equal( const std::string& datbase, const std::string& id ) const
 {
     return ( get_url() == datbase + id );
 }

--- a/src/dbtree/articlelocal.h
+++ b/src/dbtree/articlelocal.h
@@ -19,7 +19,7 @@ namespace DBTREE
         ~ArticleLocal();
 
         // ID がこのスレのものかどうか
-        bool equal( const std::string& datbase, const std::string& id ) override;
+        bool equal( const std::string& datbase, const std::string& id ) const override;
 
         // キャッシュの削除をしない
         void delete_cache( const bool cache_only ) override {}

--- a/src/dbtree/articlemachi.cpp
+++ b/src/dbtree/articlemachi.cpp
@@ -88,7 +88,7 @@ std::string ArticleMachi::url_subbbscgi() const
 
 
 // offlawモードなら更新チェック可能
-bool ArticleMachi::enable_check_update()
+bool ArticleMachi::enable_check_update() const
 {
     return CONFIG::get_use_machi_offlaw();
 }

--- a/src/dbtree/articlemachi.h
+++ b/src/dbtree/articlemachi.h
@@ -33,7 +33,7 @@ namespace DBTREE
       private:
         
         // offlawモードなら更新チェック可能
-        bool enable_check_update() override;
+        bool enable_check_update() const override;
 
         NodeTreeBase* create_nodetree() override;
     };


### PR DESCRIPTION
メンバーの更新がない＆更新処理が入る可能性が低いメンバー関数をconstにして保守性を向上させます。

- `ArticleBase::enable_check_update()`
- `ArticleBase::equal()`
- `ArticleBase::is_load_olddat()`

関連のpull request: #682 
