### PR TITLE
Img: Get rid of image/webp from Accept header for requesting image

### DIFF
--- a/src/dbimg/img.cpp
+++ b/src/dbimg/img.cpp
@@ -306,6 +306,11 @@ void Img::download_img( const std::string& refurl, const bool mosaic, const int 
     std::string referer;
     if( CORE::get_urlreplace_manager()->referer( m_url, referer ) ) data.referer = referer;
 
+    // 効率がよい画像形式を受け入れる(Accept)クライアントに対して
+    // URLの拡張子と異なる画像形式でデータを送信するサイトがある
+    // 現状の実装では拡張子の偽装チェックが誤検知するため画像の軽量化は利用しない
+    data.accept = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
+
     if( !start_load( data ) ) receive_finish();
     else CORE::core_set_command( "redraw", m_url );
 }

--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -476,6 +476,7 @@ bool Loader::run( SKELETON::Loadable* cb, const LOADERDATA& data_in )
     m_data.agent = data_in.agent;
     m_data.origin = data_in.origin;
     m_data.referer = data_in.referer;
+    m_data.accept = data_in.accept;
     m_data.cookie_for_request = data_in.cookie_for_request;
     m_data.timeout = MAX( TIMEOUT_MIN, data_in.timeout );
     m_data.ex_field = data_in.ex_field;
@@ -1080,7 +1081,8 @@ std::string Loader::create_msg_send() const
 
     if( ! m_data.modified.empty() ) msg << "If-Modified-Since: " << m_data.modified << "\r\n";
 
-    msg << "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\r\n";
+    if( ! m_data.accept.empty() ) msg << "Accept: " << m_data.accept << "\r\n";
+    else msg << "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\r\n";
     msg << "Accept-Language: ja,en-US;q=0.7,en;q=0.3\r\n";
 
     // レジュームするときは gzip は受け取らない

--- a/src/jdlib/loaderdata.h
+++ b/src/jdlib/loaderdata.h
@@ -40,6 +40,7 @@ namespace JDLIB
         std::string agent;
         std::string origin;
         std::string referer;
+        std::string accept;
         std::string ex_field;  // 送信時にヘッダに追加するフィールド
         std::string str_header;
         long code;


### PR DESCRIPTION
HTTPリクエストの`Accept`ヘッダーに`image/webp`があるとWebP対応の有無に関係なくWebPデータが送られてきて画像が表示できない問題がありました。
そのため画像をリクエストするときは`Accept`から`image/webp`を外します。画像以外のリクエストは変更しません。

背景
効率がよい画像形式を受け入れる(Accept)クライアントに対してURLの拡張子と異なる画像形式でデータを送信するサイトがあります。
現状の実装では拡張子の偽装チェックが誤検知するためコンテントネゴシエーションによる画像の軽量化は利用しません。

修正にあたり不具合報告をしていただきありがとうございました。
https://next2ch.net/test/read.cgi/linux/1613035222/273-280

関連のissue: #727
関連のpull request: #736