### PR TITLE
SKELETON::Toolbar: Update close button flat style

### DIFF
--- a/src/skeleton/toolbar.h
+++ b/src/skeleton/toolbar.h
@@ -174,10 +174,6 @@ namespace SKELETON
         // 書き込みボタン関係
         bool slot_focusout_write_button( GdkEventFocus* event );
 
-        // 閉じるボタン関係
-        static constexpr const char* s_css_leave = u8"jd-leave";
-        void setup_manual_styling( Gtk::ToolButton& toolbutton );
-
         // 検索関係
         void slot_toggle_searchbar();
         void slot_changed_search();


### PR DESCRIPTION
ツールバーにある閉じるボタンを押すと再びツールバーを表示したときボタンがフォーカスされたままになっている問題があり、これを回避する修正で廃止予定の機能が使われています。
このため修正を更新してGTK4で廃止される`Gtk::StyleContext::get_border_color()`と`Gtk::StyleContext::get_background_color()`を使わない方法に変更します。

コンパイラのレポート
```
../src/skeleton/toolbar.cpp:996:45: error: 'class Gtk::StyleContext' has no member named 'get_border_color'; did you mean 'get_border'?
 1036 |     const Gdk::RGBA border_color = context->get_border_color( Gtk::STATE_FLAG_NORMAL );
      |                                             ^~~~~~~~~~~~~~~~
      |                                             get_border
../src/skeleton/toolbar.cpp:997:41: error: 'class Gtk::StyleContext' has no member named 'get_background_color'
 1037 |     const Gdk::RGBA bg_color = context->get_background_color( Gtk::STATE_FLAG_NORMAL );
      |                                         ^~~~~~~~~~~~~~~~~~~~
```