### PR TITLE
Img: Add error message for unsupported image with fake extension

### DIFF
--- a/src/dbimg/img.cpp
+++ b/src/dbimg/img.cpp
@@ -496,9 +496,13 @@ void Img::receive_data( const char* data, size_t size )
             std::cout << data << std::endl;
 #endif
         }
+        else if( m_type == T_NOT_SUPPORT ) {
+            // GdkPixbufが未対応で表示できない画像なら読み込みを中止する
+            stop_load();
+        }
     }
 
-    if( m_fout && m_type != T_NOIMG && m_type != T_NOT_FOUND ){
+    if( m_fout && m_type != T_NOIMG && m_type != T_NOT_FOUND && m_type != T_NOT_SUPPORT ) {
 
         if( fwrite( data, 1, size, m_fout ) != size ){
             m_type = T_WRITEFAILED; // 書き込み失敗
@@ -608,6 +612,13 @@ void Img::receive_finish()
 
         set_code( HTTP_ERR );
         set_str_code( "画像サイズを取得出来ません" );
+        set_current_length( 0 );
+    }
+
+    else if( m_type == T_NOT_SUPPORT ) {
+        set_code( HTTP_ERR );
+        set_str_code( "拡張子が偽装されています…" + get_contenttype()
+                      + "の表示にはGdkPixbufローダーのインストールが必要です" );
         set_current_length( 0 );
     }
 

--- a/src/dbimg/imginterface.h
+++ b/src/dbimg/imginterface.h
@@ -33,6 +33,7 @@ namespace DBIMG
         T_WRITEFAILED,
         T_NOT_FOUND,
         T_NODATA,
+        T_NOT_SUPPORT, // 読み込みに対応していない画像
 
         T_UNKNOWN,    // 画像ではない
         T_FORCEIMAGE, // 拡張子がなくても画像として扱う

--- a/src/dbimg/imgroot.cpp
+++ b/src/dbimg/imgroot.cpp
@@ -116,6 +116,9 @@ Img* ImgRoot::get_img( const std::string& url )
 // 画像データの先頭のシグネチャを見て画像のタイプを取得
 // 画像ではない場合は T_NOIMG を返す
 //
+// また、拡張子が偽装されていると未対応の画像が読み込まれる場合がある
+// 読み込みが未対応の場合は T_NOT_SUPPORT を返す
+//
 int ImgRoot::get_image_type( const unsigned char *sign ) const
 {
     int type = T_NOIMG;
@@ -152,7 +155,7 @@ int ImgRoot::get_image_type( const unsigned char *sign ) const
              && sign[ 8 ] == 'W'
              && sign[ 9 ] == 'E'
              && sign[ 10 ] == 'B'
-             && sign[ 11 ] == 'P' ) type = T_WEBP;
+             && sign[ 11 ] == 'P' ) type = m_webp_support ? T_WEBP : T_NOT_SUPPORT;
 
     // avif
     else if( sign[ 4 ] == 'f'
@@ -162,7 +165,7 @@ int ImgRoot::get_image_type( const unsigned char *sign ) const
              && sign[ 8 ] == 'a'
              && sign[ 9 ] == 'v'
              && sign[ 10 ] == 'i'
-             && sign[ 11 ] == 'f' ) type = T_AVIF;
+             && sign[ 11 ] == 'f' ) type = m_avif_support ? T_AVIF : T_NOT_SUPPORT;
 
     return type;
 }

--- a/src/dbimg/imgroot.h
+++ b/src/dbimg/imgroot.h
@@ -46,6 +46,7 @@ namespace DBIMG
 
         // 画像データの先頭のシグネチャを見て画像のタイプを取得
         // 画像ではない場合は T_NOIMG を返す
+        // 読み込みが未対応の場合は T_NOT_SUPPORT を返す
         int get_image_type( const unsigned char *sign ) const;
 
         // 拡張子から画像タイプを取得


### PR DESCRIPTION
GdkPixbufローダーが対応していない画像URLは拡張子のチェックで通常リンクになります。しかし拡張子が偽装されていると画像として読み込みが行われ分かりにくいエラーメッセージが表示されます。(画像サイズを取得出来ません)

そのため画像データのシグネチャ確認を修正し読み込みが未対応のときのエラーメッセージを追加します。

修正にあたり不具合報告をしていただきありがとうございました。
https://next2ch.net/test/read.cgi/linux/1613035222/273