### PR TITLE
Convert line separator to whitespace for drawing thread view tidily

### DIFF
--- a/src/dbtree/spchar_decoder.cpp
+++ b/src/dbtree/spchar_decoder.cpp
@@ -61,6 +61,12 @@ int decode_char_number( const char* in_char, int& n_in,  char* out_char, int& n_
             ret = DBTREE::NODE_ZWSP;
             break;
 
+        // U+2028 LINE SEPARATOR を描画処理に渡すと改行が乱れるため空白に置き換える (webブラウザと同じ挙動)
+        case CP_LINE_SEPARATOR:
+            out_char[0] = ' ';
+            n_out = 1;
+            break;
+
         default:
             n_out = MISC::ucs2toutf8( num, out_char );
             if( ! n_out ) return DBTREE::NODE_NONE;

--- a/src/dbtree/spchar_tbl.h
+++ b/src/dbtree/spchar_tbl.h
@@ -283,6 +283,7 @@ enum
     UCS_ZWJ     = 8205,
     UCS_LRM     = 8206,
     UCS_RLM     = 8207,
+    CP_LINE_SEPARATOR = 8232,
 };
 
 


### PR DESCRIPTION
Fixes #749 

U+2028 LINE SEPARATOR をDAT読み込み時に半角空白 U+0020 に変換します。

U+2028を描画処理に渡すと改行とレイアウトが乱れます。
webブラウザはU+2028を空白として表示するためJDimも挙動を合わせます。