### PR TITLE
Update documents

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -40,7 +40,7 @@
   ・oniguruma (--with-regex=oniguruma)
   ・migemo (--with-migemo)
 
-  OSやディストリビューション別の解説は"OS/ディストリビューション別インストール方法 [https://ja.osdn.net/projects/jd4linux/wiki/OS%2f%E3%83%87%E3%82%A3%E3%82%B9%E3%83%88%E3%83%AA%E3%83%93%E3%83%A5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E5%88%A5%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95]"(wiki) を参照。
+  OSやディストリビューション別の解説は https://github.com/JDimproved/JDim/discussions/592 を参照。
 
   configure のかわりに meson を使ってビルドする方法は https://github.com/JDimproved/JDim/discussions/556 を参照。
   (v0.4.0+から暫定サポート)

--- a/INSTALL
+++ b/INSTALL
@@ -40,10 +40,19 @@
   ・oniguruma (--with-regex=oniguruma)
   ・migemo (--with-migemo)
 
+  画像表示に必要なパッケージ
+  インストールされていない環境では`.webp`や`.avif`で終わるURLは通常リンクになる。
+
+  ・libwebp, webp-pixbuf-loader (WebP)
+  ・libavif (AVIF)
+
   OSやディストリビューション別の解説は https://github.com/JDimproved/JDim/discussions/592 を参照。
 
   configure のかわりに meson を使ってビルドする方法は https://github.com/JDimproved/JDim/discussions/556 を参照。
   (v0.4.0+から暫定サポート)
+
+  GTKがデフォルトでサポートしていないWebPやAVIF形式の画像を表示する方法は
+  https://github.com/JDimproved/JDim/discussions/737 を参照。(v0.5.0+からサポート)
 
 * ビルド方法( configure + make の場合 )
 

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -52,10 +52,18 @@ layout: default
 - oniguruma (`--with-regex=oniguruma`)
 - migemo (`--with-migemo`)
 
+#### 画像表示に必要なパッケージ
+インストールされていない環境では`.webp`や`.avif`で終わるURLは通常リンクになる。
+- libwebp, webp-pixbuf-loader (WebP)
+- libavif (AVIF)
+
 OSやディストリビューション別の解説は [#592][dis592] を参照。
 
 configure のかわりに [meson] を使ってビルドする方法は [GitHub][dis556] を参照。
 <small>(v0.4.0+から暫定サポート)</small>
+
+WebPやAVIF形式の画像を表示する方法は [#737][dis737] を参照。
+<small>(v0.5.0+からサポート)</small>
 
 
 <a name="make-configure"></a>
@@ -153,3 +161,4 @@ configure のかわりに [meson] を使ってビルドする方法は [GitHub][
 [meson]: https://mesonbuild.com
 [dis556]: https://github.com/JDimproved/JDim/discussions/556 "Mesonを使ってJDimをビルドする方法 - Discussions #556"
 [dis592]: https://github.com/JDimproved/JDim/discussions/592 "OS/ディストリビューション別インストール方法 - Discussions #592"
+[dis737]: https://github.com/JDimproved/JDim/discussions/737 "[v0.5.0+] WebPやAVIF形式の画像を表示する方法 - Discussions #737"

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -52,7 +52,7 @@ layout: default
 - oniguruma (`--with-regex=oniguruma`)
 - migemo (`--with-migemo`)
 
-OSやディストリビューション別の解説は[OS/ディストリビューション別インストール方法][wiki-install] (JD wiki) を参照。
+OSやディストリビューション別の解説は [#592][dis592] を参照。
 
 configure のかわりに [meson] を使ってビルドする方法は [GitHub][dis556] を参照。
 <small>(v0.4.0+から暫定サポート)</small>
@@ -150,6 +150,6 @@ configure のかわりに [meson] を使ってビルドする方法は [GitHub][
 以上の操作でmakeが通らなかったり動作が変な時は configure のオプションを変更する。
 
 
-[wiki-install]: https://ja.osdn.net/projects/jd4linux/wiki/OS%2F%E3%83%87%E3%82%A3%E3%82%B9%E3%83%88%E3%83%AA%E3%83%93%E3%83%A5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E5%88%A5%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95
 [meson]: https://mesonbuild.com
 [dis556]: https://github.com/JDimproved/JDim/discussions/556 "Mesonを使ってJDimをビルドする方法 - Discussions #556"
+[dis592]: https://github.com/JDimproved/JDim/discussions/592 "OS/ディストリビューション別インストール方法 - Discussions #592"

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -47,6 +47,7 @@ layout: default
 - zlib
 
 #### オプション
+- meson 0.49.0 以上
 - alsa-lib (`--with-alsa`)
 - openssl (`--with-tls=openssl`)
 - oniguruma (`--with-regex=oniguruma`)
@@ -59,7 +60,7 @@ layout: default
 
 OSやディストリビューション別の解説は [#592][dis592] を参照。
 
-configure のかわりに [meson] を使ってビルドする方法は [GitHub][dis556] を参照。
+configure のかわりに [meson] を使ってビルドする方法は [#556][dis556] を参照。
 <small>(v0.4.0+から暫定サポート)</small>
 
 WebPやAVIF形式の画像を表示する方法は [#737][dis737] を参照。


### PR DESCRIPTION
#### docs: Update URL which how to build JDim by OS/Distribution
OS/ディストリビューション別インストール方法のwebページをJD projectのWikiからJDimporovedの[GitHub Discussions][#592]に変更します。
JD本家の内容はディストロの更新など環境が変化して内容が合わなくなってきたため新たにページを作成しました。

[#592]: https://github.com/JDimproved/JDim/discussions/592

#### docs: Add descriptions for supporting WebP and AVIF
WebPやAVIFを表示するために必要なパッケージをドキュメントに記載します。

#### manual: Update notes about Meson
オプションのビルドツールMesonの記載が漏れていたので追加します。
Mesonを使ってビルドする方法を載せたページヘのリンクテキストをGitHubの[ページ番号][#556]に変更します。

[#556]: https://github.com/JDimproved/JDim/discussions/556
