### PR TITLE
AAManager: Optimize finding start string

### DIFF
--- a/src/aamanager.cpp
+++ b/src/aamanager.cpp
@@ -84,13 +84,13 @@ void AAManager::load_label()
 #endif
 
             // 先頭に"**"がある場合は、"*"を一つ取り除いて一行AAとして扱う
-            if( asciiart.find( "**", 0 ) == 0 )
+            if( asciiart.rfind( "**", 0 ) == 0 )
             {
                 // **example -> *example
                 asciiart.erase( 0, 1 );
             }
             // "*"が一つだけある場合は、"*"を取り除いてファイル名とみなす
-            else if( asciiart.find( "*", 0 ) == 0 )
+            else if( asciiart.rfind( '*', 0 ) == 0 )
             {
                 // *example -> example
                 asciiart.erase( 0, 1 );


### PR DESCRIPTION
文字列先頭が一致するか検索する処理を`std::string::rfind()`を使って最適化します。

文字列の末尾から先頭へ逆順に検索する関数を使い検索開始の位置を0(先頭)に指定することで検索の試行を1回にします。
```
int position = 0;
bool found{ haystack.rfind(needle, position) == 0 };
```

##### 参考文献
<https://stackoverflow.com/questions/1878001/>