### PR TITLE
dbtree: Optimize finding start string

### DIFF
--- a/src/dbtree/article2chcompati.cpp
+++ b/src/dbtree/article2chcompati.cpp
@@ -22,7 +22,7 @@ Article2chCompati::Article2chCompati( const std::string& datbase, const std::str
     assert( ! get_id().empty() );
 
     // key (idから拡張子を除いたもの)を取得
-    size_t i = get_id().rfind( "." ); // 拡張子は取り除く
+    size_t i = get_id().rfind( '.' ); // 拡張子は取り除く
     if( i != std::string::npos ) set_key( get_id().substr( 0, i ) );
 
     // key から since 計算

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -428,7 +428,7 @@ void ArticleBase::set_subject( const std::string& subject )
     if( subject.empty() ) return;
 
     // 特殊文字の置き換え
-    if( subject.find( "&" ) != std::string::npos ){
+    if( subject.find( '&' ) != std::string::npos ){
 
         std::string subject_tmp = MISC::html_unescape( subject );
 

--- a/src/dbtree/articlejbbs.cpp
+++ b/src/dbtree/articlejbbs.cpp
@@ -38,7 +38,7 @@ std::string ArticleJBBS::create_write_message( const std::string& name, const st
 
     // DIR と BBS を分離する( ID = DIR/BBS )
     std::string boardid = DBTREE::board_id( get_url() );
-    int i = boardid.find( "/" );
+    int i = boardid.find( '/' );
     std::string dir = boardid.substr( 0, i );
     std::string bbs = boardid.substr( i + 1 );
 

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -107,7 +107,7 @@ bool BoardBase::empty() const
 //
 bool BoardBase::equal( const std::string& url ) const
 {
-    if( url.find( get_root() ) == 0
+    if( url.rfind( get_root(), 0 ) == 0
         && url.find( get_path_board() + "/" ) != std::string::npos ) return true;
 
     return false;
@@ -669,7 +669,7 @@ std::string BoardBase::url_dat( const std::string& url, int& num_from, int& num_
 
     // もしurl(スレッドのURL)が移転前の旧URLのものだったら対応するarticlebaseクラスに旧ホスト名を教えてあげる
     // ( offlaw による dat落ちスレの読み込み時に使用する )
-    if( m_root.find( MISC::get_hostname( url ) ) != 0 ){
+    if( m_root.rfind( MISC::get_hostname( url ), 0 ) != 0 ){
 #ifdef _DEBUG
         std::cout << "org_host : " << MISC::get_hostname( url ) << std::endl;
 #endif

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -109,7 +109,7 @@ std::string BoardJBBS::create_newarticle_message( const std::string& subject, co
 
     // DIR と BBS を分離する( ID = DIR/BBS )
     std::string boardid = get_id();
-    int i = boardid.find( "/" );
+    int i = boardid.find( '/' );
     std::string dir = boardid.substr( 0, i );
     std::string bbs = boardid.substr( i + 1 );
 

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -44,7 +44,7 @@ BoardMachi::BoardMachi( const std::string& root, const std::string& path_board, 
 //
 bool BoardMachi::equal( const std::string& url ) const
 {
-    if( url.find( get_root() ) == 0 ){
+    if( url.rfind( get_root(), 0 ) == 0 ){
 
         if( url.find( get_path_board() + "/" ) != std::string::npos ) return true;
         if( url.find( "BBS=" + get_id() ) != std::string::npos ) return true;

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -298,7 +298,7 @@ std::list< int > NodeTreeBase::get_res_str_num( const std::string& str_num, std:
 
                     int num_to = 0;
                     size_t i;
-                    if( ( i = ( *it_pl ).find( "-" ) ) != std::string::npos ) num_to = atol( ( *it_pl ).substr( i +1 ).c_str() );
+                    if( ( i = ( *it_pl ).find( '-' ) ) != std::string::npos ) num_to = atol( ( *it_pl ).substr( i +1 ).c_str() );
                     num_to = MIN( MAX( num_to, num_from ), m_id_header );
 
                     for( int i2 = num_from; i2 <= num_to ; ++i2 ) {

--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -171,7 +171,7 @@ char* NodeTreeMachi::process_raw_lines( char* rawlines )
 
         if( m_tmp_buffer.empty() ){
 
-            if( line.find( "<dt>" ) == 0 ){
+            if( line.rfind( "<dt>", 0 ) == 0 ){
 
                 // 既に読み込んでいる場合は飛ばす
                 char num_tmp[ 8 ];

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -1432,7 +1432,7 @@ std::string Root::is_board_moved( const std::string& url,
     std::list< MOVETABLE >::iterator it_move = m_movetable.begin();
     for( ; it_move != m_movetable.end(); ++it_move ){
 
-        if( url.find( ( *it_move ).old_root ) == 0
+        if( url.rfind( ( *it_move ).old_root, 0 ) == 0
             && url.find( ( *it_move ).old_path_board + "/" ) != std::string::npos ){
 
             const std::string new_url = ( *it_move ).new_root + ( *it_move ).new_path_board + "/";


### PR DESCRIPTION
#### ArticleBase: Optimize finding start string
文字列先頭が一致するか検索する関数の引数をcharに変更して最適化します。

#### BoardBase: Optimize finding start string
文字列先頭が一致するか検索する処理を`std::string::rfind()`を使って最適化します。

#### NodeTreeBase: Optimize finding start string
文字列先頭が一致するか検索する処理を`std::string::rfind()`を使って最適化します。

関連のpull request: #756 

