### PR TITLE
Bump version to 0.6.0-beta

### DIFF
--- a/docs/manual/2021.md
+++ b/docs/manual/2021.md
@@ -10,6 +10,200 @@ layout: default
 
 <a name="0.6.0-unreleased"></a>
 ### [0.6.0-unreleased](https://github.com/JDimproved/JDim/compare/948a10e9b44...master) (unreleased)
+- Bump version to 0.6.0-beta
+  ([#766](https://github.com/JDimproved/JDim/pull/766))
+- message: Improve error messages for incomplete input
+  ([#765](https://github.com/JDimproved/JDim/pull/765))
+- environment: Optimize finding start string
+  ([#764](https://github.com/JDimproved/JDim/pull/764))
+- dbtree: Optimize finding start string
+  ([#763](https://github.com/JDimproved/JDim/pull/763))
+- `Css_Manager`: Optimize finding start string
+  ([#762](https://github.com/JDimproved/JDim/pull/762))
+- `Core`: Optimize finding start string
+  ([#760](https://github.com/JDimproved/JDim/pull/760))
+- Optimize finding start string part3
+  ([#759](https://github.com/JDimproved/JDim/pull/759))
+- `DrawAreaBase`: Optimize finding start string
+  ([#758](https://github.com/JDimproved/JDim/pull/758))
+- `ArticleViewBase`: Optimize finding start string
+  ([#757](https://github.com/JDimproved/JDim/pull/757))
+- `AAManager`: Optimize finding start string
+  ([#756](https://github.com/JDimproved/JDim/pull/756))
+- `EditTextView`: Replace space conversion `&nbsp;` with `&#160;`
+  ([#755](https://github.com/JDimproved/JDim/pull/755))
+- Update documents
+  ([#754](https://github.com/JDimproved/JDim/pull/754))
+- Convert line separator to whitespace for drawing thread view tidily
+  ([#753](https://github.com/JDimproved/JDim/pull/753))
+- `Img`: Add error message for unsupported image with fake extension
+  ([#752](https://github.com/JDimproved/JDim/pull/752))
+- `Img`: Add image/webp, image/avif to Accept header for genuine URL if supported
+  ([#751](https://github.com/JDimproved/JDim/pull/751))
+- `MouseKeyConf`: Use member variables to backup instead of global vars
+  ([#750](https://github.com/JDimproved/JDim/pull/750))
+- `SKELETON::Toolbar`: Update close button flat style
+  ([#747](https://github.com/JDimproved/JDim/pull/747))
+- `Img`: Get rid of image/webp from Accept header for requesting image
+  ([#746](https://github.com/JDimproved/JDim/pull/746))
+- `ArticleBase`: Add noexcept qualifier to member function
+  ([#745](https://github.com/JDimproved/JDim/pull/745))
+- `ArticleBase`: Add const qualifier to member function part7
+  ([#744](https://github.com/JDimproved/JDim/pull/744))
+- `ArticleBase`: Add const qualifier to member function part6
+  ([#743](https://github.com/JDimproved/JDim/pull/743))
+- `ArticleBase`: Add const qualifier to member function part5
+  ([#742](https://github.com/JDimproved/JDim/pull/742))
+- `ArticleBase`: Add const qualifier to member function part4
+  ([#741](https://github.com/JDimproved/JDim/pull/741))
+- `ArticleBase`: Add const qualifier to member function part3
+  ([#740](https://github.com/JDimproved/JDim/pull/740))
+- `ArticleBase`: Add const qualifier to member function part2
+  ([#739](https://github.com/JDimproved/JDim/pull/739))
+- `ArticleBase`: Add const qualifier to member function part1
+  ([#738](https://github.com/JDimproved/JDim/pull/738))
+- Add WebP and AVIF support
+  ([#736](https://github.com/JDimproved/JDim/pull/736))
+- `NodeTreeBase`: Add const qualifier to member function part5
+  ([#735](https://github.com/JDimproved/JDim/pull/735))
+- `NodeTreeBase`: Add const qualifier to member function part4
+  ([#734](https://github.com/JDimproved/JDim/pull/734))
+- `NodeTreeBase`: Add const qualifier to member function part3
+  ([#733](https://github.com/JDimproved/JDim/pull/733))
+- `NodeTreeBase`: Add const qualifier to member function part2
+  ([#732](https://github.com/JDimproved/JDim/pull/732))
+- `BBSListViewBase`: Add const qualifier to member function argument
+  ([#731](https://github.com/JDimproved/JDim/pull/731))
+- `NodeTreeBase`: Add const qualifier to member function part1
+  ([#730](https://github.com/JDimproved/JDim/pull/730))
+- `NodeTreeBase`: Add static keyword to member function
+  ([#729](https://github.com/JDimproved/JDim/pull/729))
+- `NodeTreeBase`: Add delete declaration to unimplemented member function
+  ([#728](https://github.com/JDimproved/JDim/pull/728))
+- `NodeTreeBase`: Add noexcept qualifier to member function
+  ([#726](https://github.com/JDimproved/JDim/pull/726))
+- `Play_Sound`: Fix loading WAV file on big endian machine
+  ([#725](https://github.com/JDimproved/JDim/pull/725))
+- misctrip: Add configure check for thread-safe crypt_r
+  ([#724](https://github.com/JDimproved/JDim/pull/724))
+- image: Add const qualifier member function
+  ([#723](https://github.com/JDimproved/JDim/pull/723))
+- message: Add const qualifier member function
+  ([#722](https://github.com/JDimproved/JDim/pull/722))
+- `SKELETON::ToolBar`: Remove unused member function
+  ([#721](https://github.com/JDimproved/JDim/pull/721))
+- `TreeViewBase`: Add const qualifier to member function
+  ([#720](https://github.com/JDimproved/JDim/pull/720))
+- `PaneControl`: Add const qualifier to member function
+  ([#719](https://github.com/JDimproved/JDim/pull/719))
+- `DragableNoteBook`: Add const qualifier to member function
+  ([#718](https://github.com/JDimproved/JDim/pull/718))
+- `AboutDiag`: Add const qualifier to member function
+  ([#717](https://github.com/JDimproved/JDim/pull/717))
+- `MessageAdmin`: Fix unexpected mouse cursor on text selection
+  ([#716](https://github.com/JDimproved/JDim/pull/716))
+- skeleton: Add const qualifier member function part1
+  ([#715](https://github.com/JDimproved/JDim/pull/715))
+- `Loader`: Get rid of DNT: 1 from HTTP request header
+  ([#713](https://github.com/JDimproved/JDim/pull/713))
+- `JDWindow`: Add const qualifier to member function
+  ([#712](https://github.com/JDimproved/JDim/pull/712))
+- `MISC::get_pointer_at_window()`: Add const qualifier to argument
+  ([#711](https://github.com/JDimproved/JDim/pull/711))
+- `ArticleHash`: Add const qualifier to member function
+  ([#710](https://github.com/JDimproved/JDim/pull/710))
+- filtering: Add const qualifier member function
+  ([#709](https://github.com/JDimproved/JDim/pull/709))
+- jdlib: Add const qualifier member function
+  ([#708](https://github.com/JDimproved/JDim/pull/708))
+- `IOMonitor`: Add const qualifier to member function
+  ([#707](https://github.com/JDimproved/JDim/pull/707))
+- `Root`: Add const qualifier to member function
+  ([#706](https://github.com/JDimproved/JDim/pull/706))
+- `TextLoader`: Add const qualifier to member function
+  ([#705](https://github.com/JDimproved/JDim/pull/705))
+- `ImgRoot`: Add const qualifier to member function
+  ([#704](https://github.com/JDimproved/JDim/pull/704))
+- `Img`: Add const qualifier to member function
+  ([#703](https://github.com/JDimproved/JDim/pull/703))
+- `DelImgCacheDiag`: Add static keyword to member function
+  ([#702](https://github.com/JDimproved/JDim/pull/702))
+- `Core`: Add const qualifier to member function
+  ([#701](https://github.com/JDimproved/JDim/pull/701))
+- `InputDiag`: Add const qualifier to member function
+  ([#700](https://github.com/JDimproved/JDim/pull/700))
+- `KeyConfig`: Add const qualifier to member function
+  ([#699](https://github.com/JDimproved/JDim/pull/699))
+- `ButtonConfig`: Add const qualifier to member function
+  ([#698](https://github.com/JDimproved/JDim/pull/698))
+- Add shortcut key configurations for switching board view column sort
+  ([#696](https://github.com/JDimproved/JDim/pull/696))
+- `MouseKeyConf`: Add const qualifier to member function part2
+  ([#695](https://github.com/JDimproved/JDim/pull/695))
+- `MouseKeyConf`: Add const qualifier to member function part1
+  ([#694](https://github.com/JDimproved/JDim/pull/694))
+- `LayoutTree`: Set font IDs for abone layout nodes
+  ([#693](https://github.com/JDimproved/JDim/pull/693))
+- `MouseKeyItem`: Add const qualifier to member function
+  ([#692](https://github.com/JDimproved/JDim/pull/692))
+- `BoardViewBase`: Add const qualifier to member function
+  ([#691](https://github.com/JDimproved/JDim/pull/691))
+- `BoardViewBase`: Remove not implemented member function
+  ([#690](https://github.com/JDimproved/JDim/pull/690))
+- `SelectListDialog`: Add const qualifier to member function
+  ([#689](https://github.com/JDimproved/JDim/pull/689))
+- `BBSListViewBase`: Add const qualifier to member function
+  ([#688](https://github.com/JDimproved/JDim/pull/688))
+- `ArticleToolBar`: Remove not implemented member functions
+  ([#687](https://github.com/JDimproved/JDim/pull/687))
+- `DrawAreaBase`: Add const qualifier to member function
+  ([#686](https://github.com/JDimproved/JDim/pull/686))
+- `LayoutTree`: Add const qualifier to member function
+  ([#685](https://github.com/JDimproved/JDim/pull/685))
+- `CARET_POSITION`: Add const qualifier to member function
+  ([#684](https://github.com/JDimproved/JDim/pull/684))
+- `ArticleViewBase`: Add const qualifier to member function
+  ([#683](https://github.com/JDimproved/JDim/pull/683))
+- `AAManager`: Add const qualifier to member function
+  ([#682](https://github.com/JDimproved/JDim/pull/682))
+- Fix initial settings for thread title search (2021-04)
+  ([#680](https://github.com/JDimproved/JDim/pull/680))
+- `DragableNoteBook`: Fix DnD destination mark position on Wayland
+  ([#678](https://github.com/JDimproved/JDim/pull/678))
+- `Post`: Fix error message for HTTP response
+  ([#677](https://github.com/JDimproved/JDim/pull/677))
+- Add several missing headers to HTTP request
+  ([#676](https://github.com/JDimproved/JDim/pull/676))
+- `BoardViewBase`: Simplify if statement condition
+  ([#673](https://github.com/JDimproved/JDim/pull/673))
+- Replace `Gtk::Menu::popup()` with new API
+  ([#672](https://github.com/JDimproved/JDim/pull/672))
+- Refactor `Dom` part3
+  ([#671](https://github.com/JDimproved/JDim/pull/671))
+- `Dom`: Implement member function `size()`
+  ([#670](https://github.com/JDimproved/JDim/pull/670))
+- dialog: Add Client-Side Decoration support
+  ([#668](https://github.com/JDimproved/JDim/pull/668))
+- Remove `ConstPtr` which represents unowned pointer
+  ([#667](https://github.com/JDimproved/JDim/pull/667))
+- `BoardFactory`: Use `std::unique_ptr` instead of raw pointer
+  ([#666](https://github.com/JDimproved/JDim/pull/666))
+- `Root`: Use `std::find_if()` instead of range based for statement
+  ([#665](https://github.com/JDimproved/JDim/pull/665))
+- `Root`: Use `std::unique_ptr` instead of raw pointer
+  ([#664](https://github.com/JDimproved/JDim/pull/664))
+- `ImageAdmin`: Use `std::unique_ptr` instead of raw pointer
+  ([#663](https://github.com/JDimproved/JDim/pull/663))
+- `ArticleHash`: Use `std::unique_ptr` instead of raw pointer
+  ([#662](https://github.com/JDimproved/JDim/pull/662))
+- `BoardBase`: Use concrete type member instead of dynamic allocation
+  ([#661](https://github.com/JDimproved/JDim/pull/661))
+- notebook: Use `Gtk::manage()` instead of operator delete
+  ([#660](https://github.com/JDimproved/JDim/pull/660))
+- `PopupWinBase`: Uss css setting instead of drawing border lines
+  ([#659](https://github.com/JDimproved/JDim/pull/659))
+- Switch css class name instead of reload css
+  ([#658](https://github.com/JDimproved/JDim/pull/658))
 
 
 <a name="0.5.0-20210404"></a>

--- a/meson.build
+++ b/meson.build
@@ -44,7 +44,7 @@
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 
 project('jdim', 'cpp',
-        version : '0.5.0',
+        version : '0.6.0-beta',
         license : 'GPL2',
         meson_version : '>= 0.49.0',
         default_options : ['warning_level=3', 'cpp_std=c++1z'])

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -15,10 +15,10 @@
 // SEE ALSO: ENVIRONMENT::get_jdversion()
 
 #define MAJORVERSION 0
-#define MINORVERSION 5
+#define MINORVERSION 6
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20210404"
-#define JDTAG     ""
+#define JDDATE_FALLBACK    "20210619"
+#define JDTAG     "beta"
 
 //---------------------------------
 


### PR DESCRIPTION
機能フリーズ期間に入るためバージョン番号をベータ版に更新します。

関連のissue: #657 
