### PR TITLE
skeleton: Optimize finding start string

### DIFF
--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -878,7 +878,7 @@ void Admin::update_url( const std::string& url_old, const std::string& url_new )
 
         for( int i = 0; i < pages; ++i ){
             SKELETON::View* view = dynamic_cast< View* >( m_notebook->get_nth_page( i ) );
-            if( view && view->get_url().find( url_old ) == 0 ){
+            if( view && view->get_url().rfind( url_old, 0 ) == 0 ){
 
                 std::list< std::string >::iterator it
                     = std::find( m_list_switchhistory.begin(), m_list_switchhistory.end(), view->get_url() );
@@ -904,7 +904,7 @@ void Admin::update_boardname( const std::string& url )
 
         for( int i = 0; i < pages; ++i ){
             SKELETON::View* view = dynamic_cast< View* >( m_notebook->get_nth_page( i ) );
-            if( view && view->get_url().find( url ) == 0 ) view->update_boardname();
+            if( view && view->get_url().rfind( url, 0 ) == 0 ) view->update_boardname();
         }
 
         redraw_toolbar();
@@ -1088,7 +1088,7 @@ void Admin::open_view( const COMMAND_ARGS& command )
         else if( open_method == "left" ) openpage = page;
 
         // 指定した位置に表示
-        else if( open_method.find( "page" ) == 0 ) openpage = atoi( open_method.c_str() + 4 );
+        else if( open_method.rfind( "page", 0 ) == 0 ) openpage = atoi( open_method.c_str() + 4 );
 
         // ロックされていたら右に表示
         else if( open_method == "false" && page != -1 && is_locked( page ) ) openpage = page +1;

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -556,7 +556,7 @@ void DragTreeView::slot_cell_data( Gtk::CellRenderer* cell, const Gtk::TreeModel
     int rownum = atoi( path_str.c_str() );
     if( rownum %2 ) even = true;
 
-    size_t pos = path_str.find( ":" );
+    size_t pos = path_str.find( ':' );
     while( pos != std::string::npos ){
         path_str = path_str.substr( pos+1 );
         rownum = atoi( path_str.c_str() );
@@ -564,7 +564,7 @@ void DragTreeView::slot_cell_data( Gtk::CellRenderer* cell, const Gtk::TreeModel
         if( ( even && ( rownum %2 ) ) || ( ! even && !( rownum %2 ) ) ) even = true;
         else even = false;
 
-        pos = path_str.find( ":" );
+        pos = path_str.find( ':' );
     }
 
     // 偶数行に色を塗る

--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -56,7 +56,7 @@ void View::set_url( const std::string& url_new )
 //
 void View::update_url( const std::string& url_old, const std::string& url_new )
 {
-    if( m_url.find( url_old ) != 0 ) return;
+    if( m_url.rfind( url_old, 0 ) != 0 ) return;
 
     std::string url = url_new + m_url.substr( url_old.length() );
 


### PR DESCRIPTION
文字列先頭が一致するか検索する処理を`std::string::rfind()`を使って最適化します。

関連のpull request: #756 
