### PR TITLE
Optimize finding start string part11

### DIFF
--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1154,7 +1154,7 @@ void BoardBase::receive_finish()
             if( regex.exec( query, m_rawdata, offset, icase, newline, usemigemo, wchar ) ){
 
                 std::string new_url = regex.str( 1 );
-                if( new_url.compare( 0, 2, "//" ) == 0 ){
+                if( new_url.rfind( "//", 0 ) == 0 ){
                     std::string tmp_url = url_boardbase();
                     size_t pos = tmp_url.find("://");
                     if( pos != std::string::npos )

--- a/src/dbtree/boardlocal.cpp
+++ b/src/dbtree/boardlocal.cpp
@@ -32,7 +32,7 @@ BoardLocal::~BoardLocal() noexcept = default;
 //
 bool BoardLocal::equal( const std::string& url ) const
 {
-    return url.size() >= 7 && url.compare( 0, 7, "file://" ) == 0;
+    return url.rfind( "file://", 0 ) == 0;
 }
 
 

--- a/src/icons/iconmanager.cpp
+++ b/src/icons/iconmanager.cpp
@@ -243,8 +243,7 @@ void ICON_Manager::load_theme()
 
         while( iconfiles[ id ][ 0 ] != '\0' ){
 
-            if( iconfiles[ id ][ 0 ] == filename[ 0 ]
-                && filename.compare( iconfiles[ id ] ) == 0 ){
+            if( filename == iconfiles[ id ] ){
 #ifdef _DEBUG
                 std::cout << "hit : " << iconfiles[ id ] << " id = " << id << std::endl;
 #endif

--- a/src/login2ch.cpp
+++ b/src/login2ch.cpp
@@ -156,14 +156,14 @@ void Login2ch::receive_finish()
         // SID 取得
         std::string sid = m_rawdata;
 
-        if( sid.find( "SESSION-ID=" ) == 0 ){
+        if( sid.rfind( "SESSION-ID=", 0 ) == 0 ){
 
             sid = sid.substr( strlen( "SESSION-ID=" ) );
 
 #ifdef _DEBUG
 //            std::cout << "sid = " << sid << std::endl;
 #endif
-            if( sid.find( "ERROR" ) != 0 ){
+            if( sid.rfind( "ERROR", 0 ) != 0 ){
                 SKELETON::Login::set_login_now( true );
                 SKELETON::Login::set_sessionid( sid );
                 show_err = false;

--- a/src/usrcmdmanager.cpp
+++ b/src/usrcmdmanager.cpp
@@ -189,14 +189,14 @@ void Usrcmd_Manager::exec( const std::string& command, // コマンド
 #endif
 
     bool use_browser = false;
-    if( cmd.find( "$VIEW" ) == 0 ){
+    if( cmd.rfind( "$VIEW", 0 ) == 0 ){
         use_browser = true;
         cmd = cmd.substr( 5 );
         cmd = MISC::remove_space( cmd );
     }
 
     bool show_dialog = false;
-    if( cmd.find( "$DIALOG" ) == 0 ){
+    if( cmd.rfind( "$DIALOG", 0 ) == 0 ){
         show_dialog = true;
         cmd = cmd.substr( 7 );
         cmd = MISC::remove_space( cmd );

--- a/src/xml/dom.cpp
+++ b/src/xml/dom.cpp
@@ -197,8 +197,8 @@ void Dom::parse( const std::string& str )
                     }
 
                     // 空要素でない同名の開始タグを見つけたらカウントを増やす
-                    if( close_tag.compare( 0, name.length(), name ) == 0
-                     && close_tag.compare( close_tag.length() - 1, 1, "/" ) != 0 ) ++count;
+                    if( close_tag.rfind( name, 0 ) == 0
+                        && close_tag.compare( close_tag.size() - 1, 1, "/" ) != 0 ) ++count;
                     // 終了タグを見つけたらカウントを減らす
                     else if( close_tag.compare( 0, name.length() + 1, "/" + name ) == 0 ) --count;
 


### PR DESCRIPTION
#### Login2ch: Optimize finding start string
文字列先頭が一致するか検索する処理を`std::string::rfind()`を使って最適化します。

#### Usrcmd_Manager: Optimize finding start string
文字列先頭が一致するか検索する処理を`std::string::rfind()`を使って最適化します。

#### dbtree: Optimize finding start string more
文字列先頭が一致するか検索する処理を`std::string::rfind()`を使って最適化します。

#### ICON_Manager: Optimize comparing strings
文字列が一致するか比較する処理を`std::string::operator ==()`を使って最適化します。

#### Dom: Optimize finding start string
文字列先頭が一致するか検索する処理を`std::string::rfind()`を使って最適化します。

関連のpull request: #756 
