### PR TITLE
Deprecate command-line option --norestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ NOTE:
 -n, --norestore | ~~前回異常終了した時にバックアップファイルを復元しない~~ **廃止予定** ([#772])
 -s, --skip-setup | 初回起動時の設定ダイアログを表示しない
 -l, --logfile | エラーなどのメッセージをファイル(キャッシュディレクトリのlog/msglog)に出力する
--g, --geometry WxH-X+Y | 幅(W)高さ(H)横位置(X)縦位置(Y)の指定。WxHは省略化(例: -g 100x40-10+30, -g -20+100 )
+-g, --geometry WxH-X+Y | 幅(W)高さ(H)横位置(X)縦位置(Y)の指定。WxHは省略可能(例: -g 100x40-10+30, -g -20+100 )
 -V, --version | バージョン及びconfigureオプションを全て表示
 
 [#772]: https://github.com/JDimproved/JDim/issues/772 "コマンドラインオプション --norestore を廃止する- Issue #772"

--- a/README.md
+++ b/README.md
@@ -220,11 +220,13 @@ NOTE:
 --- | ---
 -h, --help | ヘルプを表示
 -m, --multi | 多重起動時のサブプロセスであっても終了しない
--n, --norestore | 前回異常終了した時にバックアップファイルを復元しない
+-n, --norestore | ~~前回異常終了した時にバックアップファイルを復元しない~~ **廃止予定** ([#772])
 -s, --skip-setup | 初回起動時の設定ダイアログを表示しない
 -l, --logfile | エラーなどのメッセージをファイル(キャッシュディレクトリのlog/msglog)に出力する
 -g, --geometry WxH-X+Y | 幅(W)高さ(H)横位置(X)縦位置(Y)の指定。WxHは省略化(例: -g 100x40-10+30, -g -20+100 )
 -V, --version | バージョン及びconfigureオプションを全て表示
+
+[#772]: https://github.com/JDimproved/JDim/issues/772 "コマンドラインオプション --norestore を廃止する- Issue #772"
 
 
 ## 多重起動について

--- a/docs/manual/start.md
+++ b/docs/manual/start.md
@@ -63,7 +63,10 @@ NOTE:
 <dl>
   <dt>-h, --help</dt><dd>ヘルプを表示</dd>
   <dt>-m, --multi</dt><dd>多重起動時のサブプロセスであっても終了しない</dd>
-  <dt>-n, --norestore</dt><dd>前回異常終了した時にバックアップファイルを復元しない</dd>
+  <dt>-n, --norestore</dt><dd><s>前回異常終了した時にバックアップファイルを復元しない</s>
+    <strong>廃止予定</strong> (<a href="https://github.com/JDimproved/JDim/issues/772"
+      title="コマンドラインオプション --norestore を廃止する - Issue #772">#772</a>)
+  </dd>
   <dt>-s, --skip-setup</dt><dd>初回起動時の設定ダイアログを表示しない</dd>
   <dt>-l, --logfile</dt>
   <dd>エラーなどのメッセージをファイル(キャッシュディレクトリの<code>log/msglog</code>)に出力する</dd>

--- a/docs/manual/start.md
+++ b/docs/manual/start.md
@@ -72,7 +72,7 @@ NOTE:
   <dd>エラーなどのメッセージをファイル(キャッシュディレクトリの<code>log/msglog</code>)に出力する</dd>
   <dt>-g, --geometry WxH-X+Y</dt>
   <dd>幅(W)高さ(H)横位置(X)縦位置(Y)の指定。
-  WxHは省略化(例: <code>-g 100x40-10+30</code>, <code>-g -20+100</code> )</dd>
+  WxHは省略可能(例: <code>-g 100x40-10+30</code>, <code>-g -20+100</code> )</dd>
   <dt>-V, --version</dt><dd>バージョン及びconfigureオプションを全て表示</dd>
 </dl>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -282,7 +282,7 @@ void usage( const int status )
     "-m, --multi\n"
     "        Do not quit even if multiple sub-process\n"
     "-n, --norestore\n"
-    "        Do not restore backup files\n"
+    "        **DEPRECATED** Do not restore backup files\n"
     "-s, --skip-setup\n"
     "        Skip the setup dialog\n"
     "-l, --logfile\n"


### PR DESCRIPTION
コマンドラインオプションの`--norestore`は"前回異常終了した時にバックアップファイルを復元しない"と[説明][2]されていますが[前の修正][1]でセッションの保存処理が変更されたため実際には何もしません。
オプションはもう不要であるため廃止予定にして機能を整理する準備をします。

関連のissue: #772

[1]: https://github.com/JDimproved/JDim/commit/58df294f91a7dacf2b80b9497265869bdb37353f
[2]: https://jdimproved.github.io/JDim/start/#run