### PR TITLE
Release 0.6.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ layout: default
 - [JDimについて]({{ site.baseurl }}/about/)
 - [make、実行方法について]({{ site.baseurl }}/make/)
 - [起動について]({{ site.baseurl }}/start/)
-- [OS/ディストリビューション別インストール方法][wiki-install] (JD wiki)
+- [OS/ディストリビューション別インストール方法][dis592] (GitHub discussions)
 - [datファイルのインポート、エクスポートについて]({{ site.baseurl }}/dat/)
 - [バックアップ、アンインストールについて]({{ site.baseurl }}/backup/)
 
@@ -29,6 +29,7 @@ layout: default
 - [更新履歴]({{ site.baseurl }}/history/)
 
 ### 前のバージョンのマニュアル (GitHubリンク)
+- [JDim 0.6.0-20210710](./link-20210710)
 - [JDim 0.5.0-20210109](./link-20210109)
 - [JDim 0.4.0-20200718](./link-20200718)
 - [JDim 0.3.0-20200118](./link-20200118)
@@ -38,7 +39,7 @@ layout: default
 
 © 2019-2021 JDimproved project
 
-[wiki-install]: https://ja.osdn.net/projects/jd4linux/wiki/OS%2F%E3%83%87%E3%82%A3%E3%82%B9%E3%83%88%E3%83%AA%E3%83%93%E3%83%A5%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E5%88%A5%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95
+[dis592]: https://github.com/JDimproved/JDim/discussions/592
 [wiki-faq]: https://ja.osdn.net/projects/jd4linux/wiki/FAQ
 [wiki-tips]: https://ja.osdn.net/projects/jd4linux/wiki/Tips
 [wiki-rfcs]: https://github.com/JDimproved/rfcs/wiki/rfc-index "Request for Comments"

--- a/docs/manual/2021.md
+++ b/docs/manual/2021.md
@@ -23,6 +23,22 @@ layout: default
 
 <a name="0.6.0-20210710"></a>
 ### [0.6.0-20210710](https://github.com/JDimproved/JDim/compare/948a10e9b44...JDim-v0.6.0) (2021-07-10)
+- Release 0.6.0
+  ([#775](https://github.com/JDimproved/JDim/pull/775))
+- Deprecate command-line option `--norestore`
+  ([#774](https://github.com/JDimproved/JDim/pull/774))
+- Restore snapcraft configuration (2021-06)
+  ([#773](https://github.com/JDimproved/JDim/pull/773))
+- Set snapcraft config for i386 (2021-06)
+  ([#771](https://github.com/JDimproved/JDim/pull/771))
+- Optimize finding start string part11
+  ([#770](https://github.com/JDimproved/JDim/pull/770))
+- skeleton: Optimize finding start string
+  ([#769](https://github.com/JDimproved/JDim/pull/769))
+- message: Optimize finding start string
+  ([#768](https://github.com/JDimproved/JDim/pull/768))
+- jdlib: Optimize finding start string
+  ([#767](https://github.com/JDimproved/JDim/pull/767))
 - Bump version to 0.6.0-beta
   ([#766](https://github.com/JDimproved/JDim/pull/766))
 - message: Improve error messages for incomplete input

--- a/docs/manual/2021.md
+++ b/docs/manual/2021.md
@@ -8,8 +8,21 @@ layout: default
 ## {{ page.title }}
 
 
-<a name="0.6.0-unreleased"></a>
-### [0.6.0-unreleased](https://github.com/JDimproved/JDim/compare/948a10e9b44...master) (unreleased)
+<a name="0.7.0-unreleased"></a>
+### [0.7.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.6.0...master) (unreleased)
+
+
+<a name="JDim-v0.6.0"></a>
+### [**JDim-v0.6.0** Release](https://github.com/JDimproved/JDim/releases/tag/JDim-v0.6.0) (2021-07-10)
+主な変更点
+- ダイアログにClient-Side Decoration(CSD)のサポートを追加した
+- スレ一覧にソートの優先順を変更するショートカットキーを追加した (設定が必要)
+- 画像フォーマット _WebP_ と _AVIF_ に対応した (対応するローダーのインストールが必要)
+- 正規表現ライブラリPOSIX regex(`--with-regex=posix`)のサポートを廃止した
+
+
+<a name="0.6.0-20210710"></a>
+### [0.6.0-20210710](https://github.com/JDimproved/JDim/compare/948a10e9b44...JDim-v0.6.0) (2021-07-10)
 - Bump version to 0.6.0-beta
   ([#766](https://github.com/JDimproved/JDim/pull/766))
 - message: Improve error messages for incomplete input

--- a/docs/manual/link-20210710.md
+++ b/docs/manual/link-20210710.md
@@ -1,0 +1,87 @@
+---
+title: JDim 0.6.0-20210710
+layout: default
+---
+
+&gt; [Top](../) &gt; 前のバージョンのマニュアル (GitHubリンク) &gt; {{ page.title }}
+
+
+## 前のバージョンのマニュアル ( {{ page.title }} )
+
+括弧書きのないリンクは[GitHubリポジトリ][gh]のページです。<br>
+**注意**: 原稿のMarkdownはHTMLに変換する前提で書かれているので一部の表示やリンクが機能しません。
+
+- [リリースノート][release-note] (GitHub Releases)
+- [README.md][readme]
+- [COPYING][copying]
+- [INSTALL][install]
+- [docs/README.md][docs-readme]
+- [test/README.md][test-readme]
+- [CONTRIBUTING.md][contributing]
+
+---
+
+- [JDimについて][about]
+- [make、実行方法について][make]
+- [OS/ディストリビューション別インストール方法][dis592] (GitHub discussions)
+- [起動について][start]
+- [datファイルのインポート、エクスポートについて][dat]
+- [バックアップ、アンインストールについて][backup]
+
+- [操作方法について][operation]
+- [マウスジェスチャについて][mouse]
+
+- [お気に入りについて][favorite]
+- [外部板について][external]
+- [実況モードについて][live]
+- [ユーザーコマンド、リンクフィルタについて][usrcmd]
+- [アスキーアート(AA)の入力について][asciiart]
+- [次スレ検索について][next]
+
+- [FAQ][jdwiki-faq] (JD wiki)
+- [Tips][jdwiki-tips] (JD wiki)
+- その他
+  - [板移転について][move]
+  - [ユーザーコマンド設定集][jdwiki-usrcmd] (JD wiki)
+  - [テーマについて][skin]
+  - [動作環境の記入について][environment]
+  - [効果音の再生について][sound]
+  - [URL変換について][urlreplace]
+  - [置換文字列の設定(ReplaceStr)][replacestr]
+
+[gh]: https://github.com/JDimproved/JDim/tree/JDim-v0.6.0
+
+[release-note]: https://github.com/JDimproved/JDim/releases/tag/JDim-v0.6.0
+[readme]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/README.md
+[copying]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/COPYING
+[install]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/INSTALL
+[docs-readme]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/README.md
+[test-readme]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/test/README.md
+[contributing]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/CONTRIBUTING.md
+
+[about]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/about.md
+[make]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/make.md
+[dis592]: https://github.com/JDimproved/JDim/discussions/592
+[start]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/start.md
+[dat]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/dat.md
+[backup]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/backup.md
+
+[operation]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/operation.md
+[mouse]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/mouse.md
+
+[favorite]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/favorite.md
+[external]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/external.md
+[live]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/live.md
+[usrcmd]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/usrcmd.md
+[asciiart]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/asciiart.md
+[next]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/next.md
+
+[jdwiki-faq]: https://ja.osdn.net/projects/jd4linux/wiki/FAQ
+[jdwiki-tips]: https://ja.osdn.net/projects/jd4linux/wiki/Tips
+[move]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/move.md
+[jdwiki-usrcmd]: https://ja.osdn.net/projects/jd4linux/wiki/%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89%E8%A8%AD%E5%AE%9A%E9%9B%86
+[skin]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/skin.md
+[environment]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/environment.md
+[sound]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/sound.md
+[urlreplace]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/urlreplace.md
+[replacestr]: https://github.com/JDimproved/JDim/blob/JDim-v0.6.0/docs/manual/replacestr.md

--- a/jdim.metainfo.xml
+++ b/jdim.metainfo.xml
@@ -30,8 +30,8 @@
       <image>https://user-images.githubusercontent.com/15698961/72191765-39568200-33fb-11ea-9b2d-f8a997cf9ae8.png</image>
     </screenshot>
     <screenshot>
-      <caption>Extracting a keyword (highlight "外来")</caption>
-      <image>https://user-images.githubusercontent.com/15698961/103151663-7e69f480-47c3-11eb-882c-a8af33e6674b.png</image>
+      <caption>Extracting a keyword (highlight "フェリー")</caption>
+      <image>https://user-images.githubusercontent.com/15698961/124387371-5383ce80-dd19-11eb-97ee-6ad6861368bc.png</image>
     </screenshot>
     <screenshot>
       <caption>Editing message to post</caption>
@@ -39,7 +39,7 @@
     </screenshot>
     <screenshot>
       <caption>Extracting posts which have much referenced</caption>
-      <image>https://user-images.githubusercontent.com/15698961/103151693-b2ddb080-47c3-11eb-9201-32e2ec910246.png</image>
+      <image>https://user-images.githubusercontent.com/15698961/124387374-54b4fb80-dd19-11eb-8a8f-c272d627fdc0.png</image>
     </screenshot>
   </screenshots>
 

--- a/jdim.metainfo.xml
+++ b/jdim.metainfo.xml
@@ -53,6 +53,12 @@
   </provides>
 
   <releases>
+    <release version="0.6.0" date="2021-07-10">
+      <description>
+        <p>Add initial support for Client-Side Decoration</p>
+      </description>
+      <url>https://github.com/JDimproved/JDim/releases/tag/JDim-v0.6.0</url>
+    </release>
     <release version="0.5.0" date="2021-01-09">
       <description>
         <p>End-of-life for GTK2 support</p>

--- a/meson.build
+++ b/meson.build
@@ -44,7 +44,7 @@
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 
 project('jdim', 'cpp',
-        version : '0.6.0-beta',
+        version : '0.6.0',
         license : 'GPL2',
         meson_version : '>= 0.49.0',
         default_options : ['warning_level=3', 'cpp_std=c++1z'])

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -17,8 +17,8 @@
 #define MAJORVERSION 0
 #define MINORVERSION 6
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20210619"
-#define JDTAG     "beta"
+#define JDDATE_FALLBACK    "20210710"
+#define JDTAG     ""
 
 //---------------------------------
 


### PR DESCRIPTION
0.6.0リリースのために変更履歴やバージョン番号を修正します。

- バージョン番号の更新
- メタデータを更新
- 前のマニュアルへのリンクに0.6.0を追加する
- 更新履歴に0.6.0リリースの項目を追加する

TODO

- [ ] PRのマージ
- [ ] タグ付け JDim-v0.6.0
- [ ] [Releaseページ](https://github.com/JDimproved/JDim/releases/tag/JDim-v0.6.0)の更新
- [ ] Projectページの更新
- [ ] 関連のissueを更新


関連のissue: #657
