### PR TITLE
Remove obsolete --with-regex=posix for ./configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,9 +142,6 @@ AC_HELP_STRING([--with-regex=oniguruma|glib],
 AC_MSG_RESULT($with_regex)
 
 AS_IF(
-  [test "x$with_regex" = xposix],
-  [AC_MSG_ERROR([--with-regex=posix has been removed. Use --with-regex=glib instead.])],
-
   [test "x$with_regex" = xoniguruma],
   [PKG_CHECK_MODULES(ONIG, [oniguruma])
    AC_SUBST(ONIG_CFLAGS)


### PR DESCRIPTION
Fixes #521

廃止されたPOSIX regexを選択するconfigureオプションを削除します。
~~削除されたオプションは指定しても無視されてエラーは出なくなります。~~
削除されたオプションを指定すると一般的なエラー(regular expression library not found)が表示されます。

- `--with-regex=posix`

