### PR TITLE
Remove deprecated command-line option --norestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,13 +220,10 @@ NOTE:
 --- | ---
 -h, --help | ヘルプを表示
 -m, --multi | 多重起動時のサブプロセスであっても終了しない
--n, --norestore | ~~前回異常終了した時にバックアップファイルを復元しない~~ **廃止予定** ([#772])
 -s, --skip-setup | 初回起動時の設定ダイアログを表示しない
 -l, --logfile | エラーなどのメッセージをファイル(キャッシュディレクトリのlog/msglog)に出力する
 -g, --geometry WxH-X+Y | 幅(W)高さ(H)横位置(X)縦位置(Y)の指定。WxHは省略可能(例: -g 100x40-10+30, -g -20+100 )
 -V, --version | バージョン及びconfigureオプションを全て表示
-
-[#772]: https://github.com/JDimproved/JDim/issues/772 "コマンドラインオプション --norestore を廃止する- Issue #772"
 
 
 ## 多重起動について

--- a/docs/manual/start.md
+++ b/docs/manual/start.md
@@ -63,10 +63,6 @@ NOTE:
 <dl>
   <dt>-h, --help</dt><dd>ヘルプを表示</dd>
   <dt>-m, --multi</dt><dd>多重起動時のサブプロセスであっても終了しない</dd>
-  <dt>-n, --norestore</dt><dd><s>前回異常終了した時にバックアップファイルを復元しない</s>
-    <strong>廃止予定</strong> (<a href="https://github.com/JDimproved/JDim/issues/772"
-      title="コマンドラインオプション --norestore を廃止する - Issue #772">#772</a>)
-  </dd>
   <dt>-s, --skip-setup</dt><dd>初回起動時の設定ダイアログを表示しない</dd>
   <dt>-l, --logfile</dt>
   <dd>エラーなどのメッセージをファイル(キャッシュディレクトリの<code>log/msglog</code>)に出力する</dd>

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -114,21 +114,11 @@ std::string CACHE::path_xml_listmain()
     return CACHE::path_root() +  "boards.xml";
 }
 
-std::string CACHE::path_xml_listmain_bkup()
-{
-    return CACHE::path_xml_listmain() + ".bkup";
-}
-
 
 // お気に入り
 std::string CACHE::path_xml_favorite()
 {
     return CACHE::path_root() +  "bookmark.xml";
-}
-
-std::string CACHE::path_xml_favorite_bkup()
-{
-    return CACHE::path_xml_favorite() + ".bkup";
 }
 
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -51,11 +51,11 @@ namespace CACHE
 
     // 板
     std::string path_xml_listmain();
-    std::string path_xml_listmain_bkup();
+    std::string path_xml_listmain_bkup() = delete; // Removed in v0.6.0 (2021-07)
 
     // お気に入り
     std::string path_xml_favorite();
-    std::string path_xml_favorite_bkup();
+    std::string path_xml_favorite_bkup() = delete; // Removed in v0.6.0 (2021-07)
 
     // 外部板設定ファイル( navi2ch 互換 )
     std::string path_etcboard();


### PR DESCRIPTION
Fixes #772

#### Remove deprecated command-line option --norestore

`--norestore`は"前回異常終了した時にバックアップファイルを復元しない"ようにするオプションですが[以前の修正][1]でセッションの保存処理が変更されバックアップを作成しなくなったため実際には何もしません。
そのためオプションを削除してバックアップの復元処理を整理します。

[1]: https://github.com/JDimproved/JDim/commit/58df294f91a7dacf2b80b9497265869bdb37353f

#### Remove unused functions for cache backup file path
コマンドラインオプションの整理により使わなくなったバックアップ用のファイルパスを返す関数を削除します。

- `CACHE::path_xml_listmain_bkup()`
- `CACHE::path_xml_favorite_bkup()`

