### PR TITLE
Deprecate oniguruma regex option

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -119,10 +119,12 @@
 
        使用する正規表現ライブラリを設定する。
        デフォルトでは Glib Regex(GRegex) を使用する。(v0.4.0+から変更)
+       非推奨: 正規表現ライブラリを選択するオプションは将来廃止される。
+       https://github.com/JDimproved/JDim/issues/697 を参照すること。
 
     --with-regex=oniguruma
 
-       GRegex のかわりに鬼車を使用する。
+       非推奨: GRegex のかわりに鬼車を使用する。
        鬼車はBSDライセンスなのでJDimをバイナリ配布する場合には注意すること(ライセンスはGPLになる)。
 
     --with-regex=glib

--- a/configure.ac
+++ b/configure.ac
@@ -147,7 +147,8 @@ AS_IF(
    AC_SUBST(ONIG_CFLAGS)
    AC_SUBST(ONIG_LIBS)
    AC_CHECK_HEADERS([onigposix.h], , [AC_MSG_ERROR([onigposix.h not found])])
-   AC_CHECK_LIB([onig], [regexec], , [AC_MSG_ERROR([libonig.a not found])])],
+   AC_CHECK_LIB([onig], [regexec], , [AC_MSG_ERROR([libonig.a not found])])
+   AC_MSG_WARN([--with-regex=onigruma is deprecated. See https://github.com/JDimproved/JDim/issues/697])],
 
   [test "x$with_regex" = xglib],
   [PKG_CHECK_MODULES(GLIB, [glib-2.0 >= 2.14.0])],

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 gem 'jekyll-redirect-from'
+gem 'jekyll-theme-cayman', '~> 0.1.1'

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,15 @@
 theme: jekyll-theme-cayman
 plugins:
   - jekyll-redirect-from
-exclude: [ Gemfile*, Makefile, README.md ]
+exclude:
+  - Gemfile*
+  - Makefile
+  - README.md
+  - backup_bund/ruby
+  - vendor/bundle
+  - vendor/cache
+  - vendor/gems
+  - vendor/ruby
 lang: ja
 baseurl: /JDim
 defaults:

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -50,7 +50,7 @@ layout: default
 - meson 0.49.0 以上
 - alsa-lib (`--with-alsa`)
 - openssl (`--with-tls=openssl`)
-- oniguruma (`--with-regex=oniguruma`)
+- oniguruma (`--with-regex=oniguruma`, 廃止予定)
 - migemo (`--with-migemo`)
 
 #### 画像表示に必要なパッケージ
@@ -132,11 +132,13 @@ WebPやAVIF形式の画像を表示する方法は [#737][dis737] を参照。
   <dt>--with-regex=oniguruma|glib</dt>
   <dd>
     使用する正規表現ライブラリを設定する。
-    デフォルトでは Glib Regex(GRegex) を使用する。<small>(v0.4.0+から変更)</small>
+    デフォルトでは Glib Regex(GRegex) を使用する。<small>(v0.4.0+から変更)</small><br>
+    <strong>非推奨</strong>: 正規表現ライブラリを選択するオプションは将来廃止される。
+    <a href="https://github.com/JDimproved/JDim/issues/697">#697</a> を参照すること。
   </dd>
   <dt>--with-regex=oniguruma</dt>
   <dd>
-    GRegex のかわりに鬼車を使用する。
+    <strong>非推奨</strong>: GRegex のかわりに鬼車を使用する。
     鬼車はBSDライセンスなのでJDimをバイナリ配布する場合には注意すること(ライセンスはGPLになる)。
   </dd>
   <dt>--with-regex=glib</dt>

--- a/meson.build
+++ b/meson.build
@@ -129,6 +129,7 @@ if regex_opt == 'oniguruma'
   endif
   conf.set('HAVE_ONIGPOSIX_H', 1)
   configure_args += '\'--with-regex=oniguruma\''
+  warning('-Dregex=oniguruma is deprecated. See https://github.com/JDimproved/JDim/issues/697')
 elif regex_opt == 'glib'
   regex_dep = dependency('glib-2.0', version : '>= 2.14.0')
 endif


### PR DESCRIPTION
正規表現ライブラリOnigurumaのサポートを廃止予定にします。
Onigurumaは名前付きキャプチャなど正規表現の拡張機能に対応していますがライブラリAPIがGlib regexと異なるため両方に対応するとコードが複雑になりメンテナンスが難しくなります。そのため両対応を断念し正規表現をGTKに付属しているGlib regexにまとめます。

関連のissue: #697