### PR TITLE
Loader: Fix HTTP header analyzing to ignoring case

### DIFF
--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -1262,7 +1262,7 @@ bool Loader::analyze_header()
 //
 std::string Loader::analyze_header_option( const std::string& option ) const
 {
-    const std::size_t i = m_data.str_header.find( option, 0 );
+    const std::size_t i = MISC::ascii_ignore_case_find( m_data.str_header, option );
     if( i != std::string::npos ){
         const std::size_t option_length = option.length();
         std::size_t i2 = m_data.str_header.find( "\r\n", i );
@@ -1287,7 +1287,7 @@ std::list< std::string > Loader::analyze_header_option_list( const std::string& 
     std::size_t i2 = 0;
     for(;;){
 
-        const std::size_t i = m_data.str_header.find( option, i2 );
+        const std::size_t i = MISC::ascii_ignore_case_find( m_data.str_header, option, i2 );
         if( i == std::string::npos ) break;
 
         i2 = m_data.str_header.find( "\r\n", i );

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -12,6 +12,8 @@
 #include "dbtree/spchar_decoder.h"
 #include "dbtree/node.h"
 
+#include <glib.h>
+
 #include <sstream>
 #include <cstring>
 #include <cstdio>
@@ -2055,4 +2057,24 @@ std::string MISC::parse_html_form_action( const std::string& html )
         path = "/test" + regex.str( 2 );
     }
     return path;
+}
+
+
+// haystack の pos 以降から最初に needle と一致する位置を返す (ASCIIだけignore case)
+// 見つからない場合は std::string::npos を返す、needle が空文字列なら pos を返す
+std::size_t MISC::ascii_ignore_case_find( const std::string& haystack, const std::string& needle, std::size_t pos )
+{
+    if( haystack.size() < pos ) return std::string::npos;
+    if( needle.empty() ) return pos;
+
+    const char head[3] = { g_ascii_toupper( needle[0] ), g_ascii_tolower( needle[0] ) };
+    std::size_t i = pos;
+    while( true ) {
+        i = haystack.find_first_of( head, i );
+        if( i == std::string::npos ) break;
+        // ヌル終端文字列が要件なので注意
+        if( g_ascii_strncasecmp( haystack.c_str() + i, needle.c_str(), needle.size() ) == 0 ) break;
+        ++i;
+    }
+    return i;
 }

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -304,6 +304,10 @@ namespace MISC
     // 2ch互換板に特化して実装しているため他の掲示板で期待した結果を返す保証はない
     // 詳細は実装やテストコードを参照
     std::string parse_html_form_action( const std::string& html );
+
+    // haystack の pos 以降から最初に needle と一致する位置を返す (ASCIIだけignore case)
+    // 見つからない場合は std::string::npos を返す、needle が空文字列なら pos を返す
+    std::size_t ascii_ignore_case_find( const std::string& haystack, const std::string& needle, std::size_t pos = 0 );
 }
 
 

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -842,4 +842,60 @@ TEST_F(ChrefDecodeTest, escape_html_char_keeping)
     EXPECT_EQ( result, "&lt;&gt;&amp;&quot; &lt;&gt;&amp;&quot; &lt;&gt;&amp;&quot;" );
 }
 
+
+class AsciiIgnoreCaseFindTest : public ::testing::Test {};
+
+TEST_F(AsciiIgnoreCaseFindTest, empty)
+{
+    EXPECT_EQ( 0, MISC::ascii_ignore_case_find( std::string{}, std::string{} ) );
+    EXPECT_EQ( std::string::npos, MISC::ascii_ignore_case_find( std::string{}, std::string{}, 10 ) );
+}
+
+TEST_F(AsciiIgnoreCaseFindTest, not_match)
+{
+    const std::string haystack = "spam ham eggs";
+    EXPECT_EQ( std::string::npos, MISC::ascii_ignore_case_find( haystack, "foo bar" ) );
+}
+
+TEST_F(AsciiIgnoreCaseFindTest, out_of_bounds)
+{
+    const std::string haystack = "out of bounds";
+    EXPECT_EQ( std::string::npos, MISC::ascii_ignore_case_find( haystack, "needle", haystack.size() + 1 ) );
+}
+
+TEST_F(AsciiIgnoreCaseFindTest, match_same_case)
+{
+    const std::string haystack = "helloworld";
+    EXPECT_EQ( 0, MISC::ascii_ignore_case_find( haystack, "hello" ) );
+    EXPECT_EQ( 5, MISC::ascii_ignore_case_find( haystack, "world" ) );
+}
+
+TEST_F(AsciiIgnoreCaseFindTest, match_lowercase)
+{
+    const std::string haystack_lower = "helloworld";
+    EXPECT_EQ( 0, MISC::ascii_ignore_case_find( haystack_lower, "HELLO" ) );
+    EXPECT_EQ( 5, MISC::ascii_ignore_case_find( haystack_lower, "WORLD" ) );
+}
+
+TEST_F(AsciiIgnoreCaseFindTest, match_uppercase)
+{
+    const std::string haystack_upper = "HELLOWORLD";
+    EXPECT_EQ( 0, MISC::ascii_ignore_case_find( haystack_upper, "hello" ) );
+    EXPECT_EQ( 5, MISC::ascii_ignore_case_find( haystack_upper, "world" ) );
+}
+
+TEST_F(AsciiIgnoreCaseFindTest, match_mix_case)
+{
+    const std::string haystack_mix = "HeLlOwOrLd";
+    EXPECT_EQ( 0, MISC::ascii_ignore_case_find( haystack_mix, "hElLo" ) );
+    EXPECT_EQ( 5, MISC::ascii_ignore_case_find( haystack_mix, "WoRlD" ) );
+}
+
+TEST_F(AsciiIgnoreCaseFindTest, match_lead_word)
+{
+    const std::string haystack = "foo bar baz bar";
+    EXPECT_EQ( 4, MISC::ascii_ignore_case_find( haystack, "bar" ) );
+    EXPECT_EQ( 12, MISC::ascii_ignore_case_find( haystack, "BAR", 5 ) );
+}
+
 } // namespace


### PR DESCRIPTION
Fixes #791 

#### Add MISC::ascii_ignore_case_find()
HTTPヘッダーの解析を改良するため文字列を走査して最初に検索語句と一致する位置を返す関数を追加します。ASCIIの文字は大文字小文字の違いを無視します。見つからない場合は`std::string::npos`を返します。

#### Loader: Fix HTTP header analyzing to ignoring case
HTTPヘッダーのフィールド名は大文字小文字関係なく受け付けるように変更します。HTTPのRFCでは大文字小文字を区別しない([HTTP/1.1][1])、小文字のみ([HTTP/2.0][2])と定義されていますがこれまでの実装では区別してたためヘッダーの解析に失敗して正常に表示できないサイトがありました。

[1]: https://datatracker.ietf.org/doc/html/rfc2616#section-4.2
[2]: https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2

