### PR TITLE
board: Update iterator for loop

### DIFF
--- a/src/board/boardadmin.cpp
+++ b/src/board/boardadmin.cpp
@@ -391,9 +391,7 @@ void BoardAdmin::command_local( const COMMAND_ARGS& command )
     if( command.command == "update_columns" ){
 
         std::list< SKELETON::View* > list_view = get_list_view( command.url );
-        std::list< SKELETON::View* >::iterator it = list_view.begin();
-        for( ; it != list_view.end(); ++it ){
-            SKELETON::View* view = ( *it );
+        for( SKELETON::View* view : list_view ) {
             if( view ) view->set_command( "update_columns" );
         }
     }

--- a/src/board/boardviewnext.cpp
+++ b/src/board/boardviewnext.cpp
@@ -17,6 +17,8 @@
 
 #include "session.h"
 
+#include <algorithm>
+
 using namespace BOARD;
 
 
@@ -68,8 +70,8 @@ void BoardViewNext::update_view()
     update_by_tfidf( next_items );
 
     std::vector< DBTREE::ArticleBase* >list_article;
-    std::vector< NEXT_ITEM >::iterator it_next_items = next_items.begin();
-    for( ; it_next_items != next_items.end(); ++it_next_items ) list_article.push_back( ( *it_next_items ).article );
+    std::transform( next_items.cbegin(), next_items.cend(), std::back_inserter( list_article ),
+                    []( const NEXT_ITEM& i ) { return i.article; } );
 
     const bool loading_fin = true;
     update_view_impl( list_article, loading_fin );
@@ -111,13 +113,12 @@ void BoardViewNext::update_by_tfidf( std::vector< NEXT_ITEM >& next_items )
     MISC::tfidf_calc_vec_tfifd( vec_tfidf_src, subject_src, vec_idf, vec_words );
 
     // 類似度検索
-    std::vector< DBTREE::ArticleBase* >::const_iterator it = list_subject.begin();
-    for( ; it != list_subject.end(); ++it ){
+    for( DBTREE::ArticleBase* article : list_subject ) {
 
         NEXT_ITEM item;
 
         // 読み込み済みのスレは除外
-        item.article = ( *it );
+        item.article = article;
         if( item.article->get_number_load() ) continue;
 
         item.since = item.article->get_since_time();

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -250,29 +250,22 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     set_activate_entry( m_proxy_frame_w.entry_port );
 
     // あぼーん
-    std::string str_id, str_name, str_word, str_regex;
-    std::string str_thread, str_word_thread, str_regex_thread;
-    std::list< std::string >::iterator it;
 
     // ID
     std::list< std::string > list_id = DBTREE::get_abone_list_id_board( get_url() );
-    for( it = list_id.begin(); it != list_id.end(); ++it ) if( ! ( *it ).empty() ) str_id += ( *it ) + "\n";
-    m_edit_id.set_text( str_id );
+    m_edit_id.set_text( MISC::concat_with_suffix( list_id, '\n' ) );
 
     // name
     std::list< std::string > list_name = DBTREE::get_abone_list_name_board( get_url() );
-    for( it = list_name.begin(); it != list_name.end(); ++it ) if( ! ( *it ).empty() ) str_name += ( *it ) + "\n";
-    m_edit_name.set_text( str_name );
+    m_edit_name.set_text( MISC::concat_with_suffix( list_name, '\n' ) );
 
     // word
     std::list< std::string > list_word = DBTREE::get_abone_list_word_board( get_url() );
-    for( it = list_word.begin(); it != list_word.end(); ++it ) if( ! ( *it ).empty() ) str_word += ( *it ) + "\n";
-    m_edit_word.set_text( str_word );
+    m_edit_word.set_text( MISC::concat_with_suffix( list_word, '\n' ) );
 
     // regex
     std::list< std::string > list_regex = DBTREE::get_abone_list_regex_board( get_url() );
-    for( it = list_regex.begin(); it != list_regex.end(); ++it ) if( ! ( *it ).empty() ) str_regex += ( *it ) + "\n";
-    m_edit_regex.set_text( str_regex );
+    m_edit_regex.set_text( MISC::concat_with_suffix( list_regex, '\n' ) );
 
     m_label_warning.set_text(
         "ここでのあぼーん設定は「" +  DBTREE::board_name( get_url() ) + "」板の全スレに適用されます。\n\n"
@@ -320,8 +313,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
 
     // スレあぼーん
     std::list< std::string > list_thread = DBTREE::get_abone_list_thread( get_url() );
-    for( it = list_thread.begin(); it != list_thread.end(); ++it ) if( ! ( *it ).empty() ) str_thread += ( *it ) + "\n";
-    m_edit_thread.set_text( str_thread );
+    m_edit_thread.set_text( MISC::concat_with_suffix( list_thread, '\n' ) );
 
     m_button_remove_old_title.signal_clicked().connect( sigc::mem_fun(*this, &Preferences::slot_remove_old_title ) );
     m_vbox_abone_title.pack_start( m_edit_thread );
@@ -329,13 +321,11 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
 
     // スレwordあぼーん
     std::list< std::string > list_word_thread = DBTREE::get_abone_list_word_thread( get_url() );
-    for( it = list_word_thread.begin(); it != list_word_thread.end(); ++it ) if( ! ( *it ).empty() ) str_word_thread += ( *it ) + "\n";
-    m_edit_word_thread.set_text( str_word_thread );
+    m_edit_word_thread.set_text( MISC::concat_with_suffix( list_word_thread, '\n' ) );
 
     // スレregexあぼーん
     std::list< std::string > list_regex_thread = DBTREE::get_abone_list_regex_thread( get_url() );
-    for( it = list_regex_thread.begin(); it != list_regex_thread.end(); ++it ) if( ! ( *it ).empty() ) str_regex_thread += ( *it ) + "\n";
-    m_edit_regex_thread.set_text( str_regex_thread );
+    m_edit_regex_thread.set_text( MISC::concat_with_suffix( list_regex_thread, '\n' ) );
 
     m_notebook_abone_thread.append_page( m_vbox_abone_thread, "一般" );
     m_notebook_abone_thread.append_page( m_vbox_abone_title, "NG スレタイトル" );
@@ -444,10 +434,7 @@ void Preferences::slot_remove_old_title()
     }
 
     const std::list< std::string > list_thread = DBTREE::get_abone_list_thread_remove( get_url() );
-    std::list< std::string >::const_iterator it = list_thread.begin();
-    std::string str;
-    for( ; it != list_thread.end(); ++it ) if( ! ( *it ).empty() ) str += ( *it ) + "\n";
-    m_edit_thread.set_text( str );
+    m_edit_thread.set_text( MISC::concat_with_suffix( list_thread, '\n' ) );
 }
 
 


### PR DESCRIPTION
#### BoardAdmin: Update iterator for loop
for文によるイテレーターの走査処理をSTLアルゴリズム関数や範囲ベースfor文に更新して保守性を向上させます。

#### BoardViewNext: Update iterator for loop
for文によるイテレーターの走査処理をSTLアルゴリズム関数や範囲ベースfor文に更新して保守性を向上させます。

#### BOARD::Preferences: Update iterator for loop
for文によるイテレーターの走査処理をSTLアルゴリズム関数や範囲ベースfor文に更新して保守性を向上させます。

関連のpull request: #783 

