### PR TITLE
Core update iter for loop

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -3062,7 +3062,6 @@ void Core::exec_command()
         if( ! CONFIG::get_restore_image() ){
             std::list< bool > list_locked = SESSION::get_image_locked();
             img_locked = std::any_of( list_locked.cbegin(), list_locked.cend(), []( bool b ) { return b; } );
-
         }
 
         if( SESSION::image_URLs().size() &&


### PR DESCRIPTION
for文によるイテレーターの走査処理をSTLアルゴリズム関数や範囲ベースfor文に更新して保守性を向上させます。

関連のpull request: #783 