### PR TITLE
dbimg: Update iterator for loop

### DIFF
--- a/src/dbimg/img.cpp
+++ b/src/dbimg/img.cpp
@@ -527,11 +527,6 @@ void Img::receive_finish()
               << "total byte = " << total_length() << std::endl
               << "contenttype = " << get_contenttype() << std::endl
               << "cookies : " << std::endl;
-
-//    if( cookies().size() ){
-//        std::list< std::string >::iterator it = cookies().begin();
-//        for( ; it != cookies().end() ; ++it ) std::cout << *it << std::endl;
-//    }
 #endif
 
     if( m_fout ) fclose( m_fout );

--- a/src/dbimg/imgroot.cpp
+++ b/src/dbimg/imgroot.cpp
@@ -53,8 +53,7 @@ void ImgRoot::clock_in()
 {
     if( m_list_wait.size() ){
 
-        std::list< Img* >::iterator it = m_list_wait.begin();
-        for( ; it != m_list_wait.end(); ++it ) ( *it )->clock_in();
+        for( Img* img : m_list_wait ) img->clock_in();
 
         remove_clock_in();
     }
@@ -82,12 +81,11 @@ void ImgRoot::remove_clock_in()
         std::cout << "ImgRoot::remove_clock_in\n";
 #endif
 
-        std::list< Img* >::iterator it = m_list_delwait.begin();
-        for( ; it != m_list_delwait.end(); ++it ){
+        for( Img* img : m_list_delwait ) {
 #ifdef _DEBUG
-            std::cout << ( *it )->url() << std::endl;
+            std::cout << img->url() << std::endl;
 #endif
-            m_list_wait.remove( *it );
+            m_list_wait.remove( img );
         }
 
         m_list_delwait.clear();


### PR DESCRIPTION
#### Img: Remove codes which are comment out
コメントアウトされているfor文を削除します。

#### ImgRoot: Update iterator for loop
for文によるイテレーターの走査処理をSTLアルゴリズム関数や範囲ベースfor文に更新して保守性を向上させます。

関連のpull request: #783 

