### PR TITLE
dbtree: Update iterator for loop part1

### DIFF
--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -357,10 +357,8 @@ void Board2chCompati::regist_article( const bool is_online )
 
     const std::string datbase = url_datbase();
 
-    for( unsigned int i = 0; i < get_list_artinfo().size(); ++i ){
+    for( const ARTICLE_INFO& artinfo : get_list_artinfo() ) {
 
-        const ARTICLE_INFO& artinfo = get_list_artinfo()[ i ];
-        
         // DBに登録されてるならarticle クラスの情報更新
         ArticleBase* article = get_article( datbase, artinfo.id );
 

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -334,9 +334,7 @@ void BoardJBBS::regist_article( const bool is_online )
 
     const std::string datbase = url_datbase();
 
-    for( unsigned int i = 0; i < get_list_artinfo().size(); ++i ){
-
-        const ARTICLE_INFO& artinfo = get_list_artinfo()[ i ];
+    for( const ARTICLE_INFO& artinfo : get_list_artinfo() ) {
 
         // DBに登録されてるならarticle クラスの情報更新
         ArticleBase* article = get_article( datbase, artinfo.id );

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -294,9 +294,7 @@ void BoardMachi::regist_article( const bool is_online )
 
     const std::string datbase = url_datbase();
 
-    for( unsigned int i = 0; i < get_list_artinfo().size(); ++i ){
-
-        const ARTICLE_INFO& artinfo = get_list_artinfo()[ i ];
+    for( const ARTICLE_INFO& artinfo : get_list_artinfo() ) {
 
         // DBに登録されてるならarticle クラスの情報更新
         ArticleBase* article = get_article( datbase, artinfo.id );


### PR DESCRIPTION
#### Board2chCompati: Update iterator for loop

for文によるイテレーターの走査処理をSTLアルゴリズム関数や範囲ベースfor文に更新して保守性を向上させます。

#### BoardJBBS: Update iterator for loop

for文によるイテレーターの走査処理をSTLアルゴリズム関数や範囲ベースfor文に更新して保守性を向上させます。

#### BoardMachi: Update iterator for loop

for文によるイテレーターの走査処理をSTLアルゴリズム関数や範囲ベースfor文に更新して保守性を向上させます。

関連のpull request: #783 

