### PR TITLE
Admin: Drop virtual function from SKELETON::Admin::close_view(View*)

### DIFF
--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -206,7 +206,6 @@ namespace SKELETON
         virtual void update_item( const std::string& url,  const std::string& id );
         virtual void update_finish( const std::string& url );        
         virtual void close_view( const std::string& url );
-        virtual void close_view( View* view );
         virtual void unlock_all_view( const std::string& url );
         virtual void close_all_view( const std::string& url );
         virtual void close_other_views( const std::string& url );
@@ -343,6 +342,8 @@ namespace SKELETON
         void append_switchhistory( const std::string& url );
         void remove_switchhistory( const std::string& url );
         std::string get_valid_switchhistory();
+
+        void close_view( View* view );
     };
 }
 


### PR DESCRIPTION
仮想関数として使われていない`SKELETON::Admin::close_view(View*)`を非仮想のメンバー関数にします。

関連のissue: #76 