### PR TITLE
NodeTreeBase: Update NodeTreeBase::get_imglinks()

### DIFF
--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -1590,12 +1590,9 @@ void ArticleBase::delete_cache( const bool cache_only )
         // スレ内の画像キャッシュ削除
         if( CONFIG::get_delete_img_in_thread() != 2 ){
 
-            const auto has_cache = []( const std::string& url ) {
-                return DBIMG::get_type_ext( url ) != DBIMG::T_UNKNOWN && DBIMG::is_cached( url );
-            };
+            const std::list<std::string> list_urls = get_nodetree()->get_imglinks();
 
-            std::list< std::string > list_urls = get_nodetree()->get_urls();
-            bool delete_img_cache = std::any_of( list_urls.cbegin(), list_urls.cend(), has_cache );
+            bool delete_img_cache = std::any_of( list_urls.cbegin(), list_urls.cend(), &DBIMG::is_cached );
 
             if( delete_img_cache ){
 
@@ -1624,7 +1621,7 @@ void ArticleBase::delete_cache( const bool cache_only )
 
                     for( const std::string& url : list_urls ) {
 
-                        if( has_cache( url ) ) {
+                        if( DBIMG::is_cached( url ) ){
 
 #ifdef _DEBUG
                             std::cout << "delete " << url << std::endl;

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -360,11 +360,11 @@ std::list< int > NodeTreeBase::get_res_with_url() const
 
 
 //
-// 含まれる URL をリストにして取得
+// ツリーに含まれてる 画像URL をリストにして取得
 //
-std::list< std::string > NodeTreeBase::get_urls() const
+std::list<std::string> NodeTreeBase::get_imglinks() const
 {
-    std::list< std::string > list_urls;
+    std::list<std::string> list_urls;
     for( int i = 1; i <= m_id_header; ++i ){
 
         const NODE* head = res_header( i );
@@ -375,7 +375,9 @@ std::list< std::string > NodeTreeBase::get_urls() const
                 const NODE* node = head->headinfo->block[ block ];
 
                 while( node ){
-                    if( IS_URL( node ) ) list_urls.push_back( node->linkinfo->link );
+                    if( IS_URL( node ) && node->linkinfo->imglink ) {
+                        list_urls.emplace_back( node->linkinfo->imglink );
+                    }
                     node = node->next_node;
                 }
             }

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -203,8 +203,8 @@ namespace DBTREE
         // URL を含むレス番号をリストにして取得
         std::list< int > get_res_with_url() const;
 
-        // 含まれる URL をリストにして取得
-        std::list< std::string > get_urls() const;
+        // ツリーに含まれてる 画像URL をリストにして取得
+        std::list<std::string> get_imglinks() const;
 
         // number番のレスを参照しているレス番号をリストにして取得
         std::list< int > get_res_reference( const int number ) const;


### PR DESCRIPTION
`NodeTreeBase::get_urls()`を画像URL用に更新してコードを整理します。

関連のissue: #76 
