### PR TITLE
meson: Change current directory to get build information

### DIFF
--- a/src/buildinfo.h.sh
+++ b/src/buildinfo.h.sh
@@ -7,7 +7,11 @@ GIT_HASH=""
 GIT_DATE=""
 GIT_DIRTY=0
 
-if test -n "$GIT" ; then
+if test -x "$GIT" ; then
+  # Change current directory to execute git commands in source directory.
+  if test -d "$1"; then
+    cd "$1"
+  fi
   GIT_HASH="$($GIT log --pretty=format:%h --abbrev=10 -n 1 2>/dev/null)"
   GIT_DATE="$($GIT log  --pretty=format:%ad --date=format:%Y%m%d -n 1 2>/dev/null)"
   GIT_STATUS="$($GIT status -uno -s 2>/dev/null | head -n 1)"

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,7 +5,7 @@ config_h = configure_file(output : 'config.h',
 buildinfo_h = custom_target('buildinfo.h',
                             build_always_stale : true,
                             capture : true,
-                            command : ['sh', '@INPUT@'],
+                            command : ['sh', '@INPUT@', '@SOURCE_ROOT@'],
                             input : 'buildinfo.h.sh',
                             output : 'buildinfo.h')
 


### PR DESCRIPTION
ビルドディレクトリをソースディレクトリ(gitリポジトリ)の外に作った場合gitを使ったビルド情報の取得に失敗します。
そのためソースディレクトリに移動してgitコマンドを実行するようにスクリプトを修正します。