### PR TITLE
Add thread abone config for low number of res

### DIFF
--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -2962,10 +2962,11 @@ void BoardViewBase::slot_abone_thread()
     // あぼーん情報更新
     std::list< std::string > words = DBTREE::get_abone_list_word_thread( get_url_board() );
     std::list< std::string > regexs = DBTREE::get_abone_list_regex_thread( get_url_board() );
-    const int number = DBTREE::get_abone_number_thread( get_url_board() );
+    const int low_number = DBTREE::get_abone_low_number_thread( get_url_board() );
+    const int high_number = DBTREE::get_abone_high_number_thread( get_url_board() );
     const int hour = DBTREE::get_abone_hour_thread( get_url_board() );
     const bool redraw = false; // 板の再描画はしない
-    DBTREE::reset_abone_thread( get_url_board(), threads, words, regexs, number, hour, redraw );
+    DBTREE::reset_abone_thread( get_url_board(), threads, words, regexs, low_number, high_number, hour, redraw );
 
     m_treeview.delete_selected_rows( true );
 }

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -53,6 +53,8 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     , m_label_samba( false, "書き込み規制秒数 (Samba24) ：" )
     , m_button_clearsamba( "秒数クリア" )
     , m_check_oldlog( "過去ログを表示する" )
+    , m_hbox_low_number{ Gtk::ORIENTATION_HORIZONTAL, 4 }
+    , m_hbox_high_number{ Gtk::ORIENTATION_HORIZONTAL, 4 }
     , m_button_remove_old_title( "dat落ちしたスレのタイトルを削除する" )
 {
     m_edit_cookies.set_editable( false );
@@ -283,16 +285,25 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     // スレ数、時間
     m_label_abone_thread.set_text( "以下の数字が0の時は、設定メニューの全体あぼ〜ん設定で指定した数字が用いられます。\nまたキャッシュにログがあるスレはあぼ〜んされません。\n\n" );
 
-    m_label_number.set_text( "レス以上のスレをあぼ〜ん" );
-    m_spin_number.set_range( 0, 9999 );
-    m_spin_number.set_increments( 1, 1 );
-    m_spin_number.set_value( DBTREE::get_abone_number_thread( get_url() ) );
-            
-    m_hbox_number.set_spacing( 4 );
-    m_hbox_number.pack_start( m_spin_number, Gtk::PACK_SHRINK );
-    m_hbox_number.pack_start( m_label_number, Gtk::PACK_SHRINK );
+    m_label_low_number.set_text( "レス以下のスレをあぼ〜ん" );
+    m_spin_low_number.set_range( 0, CONFIG::get_max_resnumber() );
+    m_spin_low_number.set_increments( 1, 1 );
+    m_spin_low_number.set_value( DBTREE::get_abone_low_number_thread( get_url() ) );
 
-    set_activate_entry( m_spin_number );
+    m_hbox_low_number.pack_start( m_spin_low_number, Gtk::PACK_SHRINK );
+    m_hbox_low_number.pack_start( m_label_low_number, Gtk::PACK_SHRINK );
+
+    set_activate_entry( m_spin_low_number );
+
+    m_label_high_number.set_text( "レス以上のスレをあぼ〜ん" );
+    m_spin_high_number.set_range( 0, CONFIG::get_max_resnumber() );
+    m_spin_high_number.set_increments( 1, 1 );
+    m_spin_high_number.set_value( DBTREE::get_abone_high_number_thread( get_url() ) );
+
+    m_hbox_high_number.pack_start( m_spin_high_number, Gtk::PACK_SHRINK );
+    m_hbox_high_number.pack_start( m_label_high_number, Gtk::PACK_SHRINK );
+
+    set_activate_entry( m_spin_high_number );
 
     m_label_hour.set_text( "時間以上スレ立てから経過したスレをあぼ〜ん" );
     m_spin_hour.set_range( 0, 9999 );
@@ -308,7 +319,8 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     m_vbox_abone_thread.set_border_width( 16 );
     m_vbox_abone_thread.set_spacing( 8 );
     m_vbox_abone_thread.pack_start( m_label_abone_thread, Gtk::PACK_SHRINK );
-    m_vbox_abone_thread.pack_start( m_hbox_number, Gtk::PACK_SHRINK );
+    m_vbox_abone_thread.pack_start( m_hbox_low_number, Gtk::PACK_SHRINK );
+    m_vbox_abone_thread.pack_start( m_hbox_high_number, Gtk::PACK_SHRINK );
     m_vbox_abone_thread.pack_start( m_hbox_hour, Gtk::PACK_SHRINK );
 
     // スレあぼーん
@@ -505,11 +517,13 @@ void Preferences::slot_ok_clicked()
     std::list< std::string > list_thread = MISC::get_lines( m_edit_thread.get_text() );
     std::list< std::string > list_word_thread = MISC::get_lines( m_edit_word_thread.get_text() );
     std::list< std::string > list_regex_thread = MISC::get_lines( m_edit_regex_thread.get_text() );
-    const int number = m_spin_number.get_value_as_int();
+    const int low_number = m_spin_low_number.get_value_as_int();
+    const int high_number = m_spin_high_number.get_value_as_int();
     const int hour = m_spin_hour.get_value_as_int();
 
     const bool redraw = true; // ここでスレ一覧の再描画指定をする
-    DBTREE::reset_abone_thread( get_url(), list_thread, list_word_thread, list_regex_thread, number, hour, redraw );  
+    DBTREE::reset_abone_thread( get_url(), list_thread, list_word_thread, list_regex_thread,
+                                low_number, high_number, hour, redraw );
 
     DBTREE::board_save_info( get_url() );
 }

--- a/src/board/preference.h
+++ b/src/board/preference.h
@@ -128,9 +128,13 @@ namespace BOARD
         Gtk::VBox m_vbox_abone_thread;
         Gtk::Label m_label_abone_thread;
 
-        Gtk::HBox m_hbox_number;
-        Gtk::Label m_label_number;
-        Gtk::SpinButton m_spin_number;
+        Gtk::Box m_hbox_low_number;
+        Gtk::Label m_label_low_number;
+        Gtk::SpinButton m_spin_low_number;
+
+        Gtk::Box m_hbox_high_number;
+        Gtk::Label m_label_high_number;
+        Gtk::SpinButton m_spin_high_number;
 
         Gtk::HBox m_hbox_hour;
         Gtk::Label m_label_hour;

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -9,6 +9,7 @@
 
 #include "configitems.h"
 #include "defaultconf.h"
+#include "globalconf.h"
 
 #include "jdlib/confloader.h"
 #include "jdlib/miscutil.h"
@@ -490,7 +491,11 @@ bool ConfigItems::load( const bool restore )
     remove_old_abone_thread = cf.get_option_int( "remove_old_abone_thread", CONF_REMOVE_OLD_ABONE_THREAD, 0, 2 );
 
     // スレ あぼーん( レス数 )
-    abone_number_thread = cf.get_option_int( "abone_number_thread", CONF_ABONE_NUMBER_THREAD, 0, 9999 );
+    // abone_number_thread は変数や関数と名前が異なるが互換性のため維持する
+    abone_low_number_thread = cf.get_option_int( "abone_low_number_thread", CONF_ABONE_LOW_NUMBER_THREAD, 0,
+                                                 CONFIG::get_max_resnumber() );
+    abone_high_number_thread = cf.get_option_int( "abone_number_thread", CONF_ABONE_HIGH_NUMBER_THREAD, 0,
+                                                  CONFIG::get_max_resnumber() );
 
     // スレ あぼーん( スレ立てからの経過時間 )
     abone_hour_thread = cf.get_option_int( "abone_hour_thread", CONF_ABONE_HOUR_THREAD, 0, 9999 );
@@ -877,7 +882,8 @@ void ConfigItems::save_impl( const std::string& path )
 
     cf.update( "remove_old_abone_thread", remove_old_abone_thread );
 
-    cf.update( "abone_number_thread", abone_number_thread );
+    cf.update( "abone_low_number_thread", abone_low_number_thread );
+    cf.update( "abone_number_thread", abone_high_number_thread );
     cf.update( "abone_hour_thread", abone_hour_thread );
 
     // あぼーん情報

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -442,7 +442,8 @@ namespace CONFIG
         int remove_old_abone_thread{};
 
         // スレ あぼーん レス数
-        int abone_number_thread{};
+        int abone_low_number_thread{};
+        int abone_high_number_thread{};
 
         // スレ あぼーん スレ立てからの経過時間
         int abone_hour_thread{};

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -134,7 +134,8 @@ namespace CONFIG
         CONF_USE_LINK_AS_BOARD = 0,     // bbsmenu.html内にあるリンクは全て板とみなす
         CONF_SHOW_MOVEDIAG = 1,    // 板移転時に確認ダイアログを表示する
         CONF_REMOVE_OLD_ABONE_THREAD = 0, // dat落ちしたスレをNGスレタイトルリストから取り除くか( 0: ダイアログ表示 1: 取り除く 2: 除かない )
-        CONF_ABONE_NUMBER_THREAD = 0, // スレあぼーん( レス数 )
+        CONF_ABONE_LOW_NUMBER_THREAD = 0,  // nレス以下のスレをあぼーんする
+        CONF_ABONE_HIGH_NUMBER_THREAD = 0, // nレス以上のスレをあぼーんする
         CONF_ABONE_HOUR_THREAD = 0,   // スレあぼーん( スレ立てからの経過時間 )
         CONF_ABONE_TRANSPARENT = 0, // デフォルトで透明あぼーんをする
         CONF_ABONE_CHAIN = 0,       // デフォルトで連鎖あぼーんをする

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -489,8 +489,11 @@ void CONFIG::set_list_abone_regex_thread( std::list< std::string >& regex )
 int CONFIG::get_remove_old_abone_thread(){ return get_confitem()->remove_old_abone_thread; }
 void CONFIG::set_remove_old_abone_thread( const int remove ){ get_confitem()->remove_old_abone_thread = remove; }
 
-int CONFIG::get_abone_number_thread(){ return get_confitem()->abone_number_thread; }
-void CONFIG::set_abone_number_thread( const int number ){ get_confitem()->abone_number_thread = number; }
+int CONFIG::get_abone_low_number_thread(){ return get_confitem()->abone_low_number_thread; }
+void CONFIG::set_abone_low_number_thread( int number ){ get_confitem()->abone_low_number_thread = number; }
+
+int CONFIG::get_abone_high_number_thread(){ return get_confitem()->abone_high_number_thread; }
+void CONFIG::set_abone_high_number_thread( int number ){ get_confitem()->abone_high_number_thread = number; }
 
 int CONFIG::get_abone_hour_thread(){ return get_confitem()->abone_hour_thread; }
 void CONFIG::set_abone_hour_thread( const int hour ){ get_confitem()->abone_hour_thread = hour; }

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -504,8 +504,11 @@ namespace CONFIG
     int get_remove_old_abone_thread(); // dat落ちしたスレをNGスレタイトルリストから取り除くか( 0: ダイアログ表示 1: 取り除く 2: 除かない )
     void set_remove_old_abone_thread( const int remove ); 
 
-    int get_abone_number_thread();
-    void set_abone_number_thread( const int number );
+    int get_abone_low_number_thread();
+    void set_abone_low_number_thread( int number );
+
+    int get_abone_high_number_thread();
+    void set_abone_high_number_thread( int number );
 
     int get_abone_hour_thread();
     void set_abone_hour_thread( const int hour );

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -516,9 +516,17 @@ void Board2chCompati::download_rule_setting()
 
 
 //
-// レス数であぼーん(グローバル)
+// レス数以下であぼーん(グローバル)
 //
-int Board2chCompati::get_abone_number_global() const
+int Board2chCompati::get_abone_low_number_global() const
 {
-    return CONFIG::get_abone_number_thread();
+    return CONFIG::get_abone_low_number_thread();
+}
+
+//
+// レス数以上であぼーん(グローバル)
+//
+int Board2chCompati::get_abone_high_number_global() const
+{
+    return CONFIG::get_abone_high_number_thread();
 }

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -72,7 +72,8 @@ namespace DBTREE
         void download_rule_setting() override;
 
         // レス数であぼーん(グローバル)
-        int get_abone_number_global() const override;
+        int get_abone_low_number_global() const override;
+        int get_abone_high_number_global() const override;
 
         // htmlからキーワードを解析する
         std::string analyze_keyword_impl( const std::string& html, bool full_parse );

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -139,7 +139,8 @@ namespace DBTREE
         std::list< std::string > m_list_abone_thread_remove; // あぼーんするスレのタイトル( dat 落ち判定用、remove_old_abone_thread()を参照せよ )
         std::list< std::string > m_list_abone_word_thread; // あぼーんする文字列
         std::list< std::string > m_list_abone_regex_thread; // あぼーんする正規表現
-        int m_abone_number_thread{}; // レスの数
+        int m_abone_low_number_thread{};  // nレス以下をあぼーんする
+        int m_abone_high_number_thread{}; // nレス以上をあぼーんする
         int m_abone_hour_thread{}; // スレ立てからの経過時間
 
         // 読み込み用ローカルプロキシ設定
@@ -468,7 +469,8 @@ namespace DBTREE
         const std::list< std::string >& get_abone_list_thread_remove(){ return m_list_abone_thread_remove; }
         const std::list< std::string >& get_abone_list_word_thread(){ return m_list_abone_word_thread; }
         const std::list< std::string >& get_abone_list_regex_thread(){ return m_list_abone_regex_thread; }
-        int get_abone_number_thread() const noexcept { return m_abone_number_thread; }
+        int get_abone_low_number_thread() const noexcept { return m_abone_low_number_thread; }
+        int get_abone_high_number_thread() const noexcept { return m_abone_high_number_thread; }
         int get_abone_hour_thread() const noexcept { return m_abone_hour_thread; }
 
         // subject.txtのロード後にdat落ちしたスレッドをスレあぼーんのリストから取り除く
@@ -484,7 +486,8 @@ namespace DBTREE
         void reset_abone_thread( const std::list< std::string >& threads,
                                  const std::list< std::string >& words,
                                  const std::list< std::string >& regexs,
-                                 const int number,
+                                 const int low_number,
+                                 const int high_number,
                                  const int hour,
                                  const bool redraw
             );
@@ -613,7 +616,8 @@ namespace DBTREE
 
         // レス数であぼーん(グローバル)
         // 2ch以外の板ではキャンセルする
-        virtual int get_abone_number_global() const { return 0; }
+        virtual int get_abone_low_number_global() const { return 0; }
+        virtual int get_abone_high_number_global() const { return 0; }
     };
 }
 

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -778,9 +778,14 @@ const std::list< std::string >& DBTREE::get_abone_list_regex_thread( const std::
     return DBTREE::get_board( url )->get_abone_list_regex_thread();
 }
 
-int DBTREE::get_abone_number_thread( const std::string& url )
+int DBTREE::get_abone_low_number_thread( const std::string& url )
 {
-    return DBTREE::get_board( url )->get_abone_number_thread();
+    return DBTREE::get_board( url )->get_abone_low_number_thread();
+}
+
+int DBTREE::get_abone_high_number_thread( const std::string& url )
+{
+    return DBTREE::get_board( url )->get_abone_high_number_thread();
 }
 
 int DBTREE::get_abone_hour_thread( const std::string& url )
@@ -803,12 +808,13 @@ void DBTREE::reset_abone_thread( const std::string& url,
                                  const std::list< std::string >& threads,
                                  const std::list< std::string >& words,
                                  const std::list< std::string >& regexs,
-                                 const int number,
+                                 const int low_number,
+                                 const int high_number,
                                  const int hour,
                                  const bool redraw
     )
 {
-    DBTREE::get_board( url )->reset_abone_thread( threads, words, regexs, number, hour, redraw );
+    DBTREE::get_board( url )->reset_abone_thread( threads, words, regexs, low_number, high_number, hour, redraw );
 }
 
 /////////////////////////////////////////////////

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -338,7 +338,8 @@ namespace DBTREE
     const std::list< std::string >& get_abone_list_word_thread( const std::string& url );
     const std::list< std::string >& get_abone_list_regex_thread( const std::string& url );
     const std::unordered_set< int >& get_abone_reses( const std::string& url );
-    int get_abone_number_thread( const std::string& url );
+    int get_abone_low_number_thread( const std::string& url );
+    int get_abone_high_number_thread( const std::string& url );
     int get_abone_hour_thread( const std::string& url );
 
     // subject.txtのロード後にdat落ちしたスレッドをスレあぼーんのリストから取り除く
@@ -354,7 +355,8 @@ namespace DBTREE
                              const std::list< std::string >& threads,
                              const std::list< std::string >& words,
                              const std::list< std::string >& regexs,
-                             const int number, const int hour, const bool redraw );
+                             const int low_number, const int high_number,
+                             const int hour, const bool redraw );
 
     //
     // 各articlebase別のあぼーん情報

--- a/src/globalabonethreadpref.h
+++ b/src/globalabonethreadpref.h
@@ -26,9 +26,13 @@ namespace CORE
         Gtk::VBox m_vbox_abone_thread;
         Gtk::Label m_label_abone_thread;
 
-        Gtk::HBox m_hbox_number;
-        Gtk::Label m_label_number;
-        Gtk::SpinButton m_spin_number;
+        Gtk::Box m_hbox_low_number;
+        Gtk::Label m_label_low_number;
+        Gtk::SpinButton m_spin_low_number;
+
+        Gtk::Box m_hbox_high_number;
+        Gtk::Label m_label_high_number;
+        Gtk::SpinButton m_spin_high_number;
 
         Gtk::HBox m_hbox_hour;
         Gtk::Label m_label_hour;
@@ -41,7 +45,8 @@ namespace CORE
             // 全体あぼーん再設定
 
             // スレ数、時間
-            CONFIG::set_abone_number_thread( m_spin_number.get_value_as_int() );
+            CONFIG::set_abone_low_number_thread( m_spin_low_number.get_value_as_int() );
+            CONFIG::set_abone_high_number_thread( m_spin_high_number.get_value_as_int() );
             CONFIG::set_abone_hour_thread( m_spin_hour.get_value_as_int() );
 
             // word
@@ -60,7 +65,9 @@ namespace CORE
       public:
 
         GlobalAboneThreadPref( Gtk::Window* parent, const std::string& url )
-        : SKELETON::PrefDiag( parent, url )
+            : SKELETON::PrefDiag( parent, url )
+            , m_hbox_low_number{ Gtk::ORIENTATION_HORIZONTAL, 4 }
+            , m_hbox_high_number{ Gtk::ORIENTATION_HORIZONTAL, 4 }
         {
             std::string str_word, str_regex;
             std::list< std::string >::iterator it;
@@ -68,16 +75,25 @@ namespace CORE
             // スレ数、時間
             m_label_abone_thread.set_text( "以下の数字が0の時は未設定になります。\nまたキャッシュにログがあるスレはあぼ〜んされません。\n\n" );
 
-            m_label_number.set_text( "レス以上のスレをあぼ〜ん" );
-            m_spin_number.set_range( 0, 9999 );
-            m_spin_number.set_increments( 1, 1 );
-            m_spin_number.set_value( CONFIG::get_abone_number_thread() );
-            
-            m_hbox_number.set_spacing( 4 );
-            m_hbox_number.pack_start( m_spin_number, Gtk::PACK_SHRINK );
-            m_hbox_number.pack_start( m_label_number, Gtk::PACK_SHRINK );
+            m_label_low_number.set_text( "レス以下のスレをあぼ〜ん" );
+            m_spin_low_number.set_range( 0, CONFIG::get_max_resnumber() );
+            m_spin_low_number.set_increments( 1, 1 );
+            m_spin_low_number.set_value( CONFIG::get_abone_low_number_thread() );
 
-            set_activate_entry( m_spin_number );
+            m_hbox_low_number.pack_start( m_spin_low_number, Gtk::PACK_SHRINK );
+            m_hbox_low_number.pack_start( m_label_low_number, Gtk::PACK_SHRINK );
+
+            set_activate_entry( m_spin_low_number );
+
+            m_label_high_number.set_text( "レス以上のスレをあぼ〜ん" );
+            m_spin_high_number.set_range( 0, CONFIG::get_max_resnumber() );
+            m_spin_high_number.set_increments( 1, 1 );
+            m_spin_high_number.set_value( CONFIG::get_abone_high_number_thread() );
+
+            m_hbox_high_number.pack_start( m_spin_high_number, Gtk::PACK_SHRINK );
+            m_hbox_high_number.pack_start( m_label_high_number, Gtk::PACK_SHRINK );
+
+            set_activate_entry( m_spin_high_number );
 
             m_label_hour.set_text( "時間以上スレ立てから経過したスレをあぼ〜ん" );
             m_spin_hour.set_range( 0, 9999 );
@@ -93,7 +109,8 @@ namespace CORE
             m_vbox_abone_thread.set_border_width( 16 );
             m_vbox_abone_thread.set_spacing( 8 );
             m_vbox_abone_thread.pack_start( m_label_abone_thread, Gtk::PACK_SHRINK );
-            m_vbox_abone_thread.pack_start( m_hbox_number, Gtk::PACK_SHRINK );
+            m_vbox_abone_thread.pack_start( m_hbox_low_number, Gtk::PACK_SHRINK );
+            m_vbox_abone_thread.pack_start( m_hbox_high_number, Gtk::PACK_SHRINK );
             m_vbox_abone_thread.pack_start( m_hbox_hour, Gtk::PACK_SHRINK );
 
             // word


### PR DESCRIPTION
板にある未取得スレッドの内、nレス以下のものをあぼ〜んにする機能を追加します。
また、設定の上限を定数から最大表示可能レス数の値に変更します。

元となった玉葱版パッチを元に改変しています。
設定ファイルのnレス以下の項目は名前を変更したため互換性がありません。
- `abone_min_number_thread` -> `abone_low_number_thread`
- `aboneminnumberthread` -> `abonelownumberthread`

関連のissue: #76 
