### PR TITLE
SettingLoader: Set max res number by BBS_THREAD_STOP from SETTING.TXT

### DIFF
--- a/src/dbtree/settingloader.cpp
+++ b/src/dbtree/settingloader.cpp
@@ -86,6 +86,14 @@ void SettingLoader::parse_data()
     m_line_number = cf.get_option_int( "BBS_LINE_NUMBER", 0, 0, 8192 );
     m_message_count = cf.get_option_int( "BBS_MESSAGE_COUNT", 0, 0, 81920 );
     m_unicode = cf.get_option_str( "BBS_UNICODE", "" );
+    const int num_stop = cf.get_option_int( "BBS_THREAD_STOP", 0, 0, CONFIG::get_max_resnumber() );
+    if( num_stop ) {
+        // 板設定の最大レス数がデフォルト(0:未設定)でないときは BBS_THREAD_STOP の値に上書きする
+        const int max_res = DBTREE::board_get_number_max_res( m_url_boadbase );
+        if( !max_res && max_res != num_stop ) {
+            DBTREE::board_set_number_max_res( m_url_boadbase, num_stop );
+        }
+    }
     DBTREE::board_set_modified_setting( m_url_boadbase, get_date_modified() );
 
 #ifdef _DEBUG


### PR DESCRIPTION
板の設定情報(SETTING.TXT)に[`BBS_THREAD_STOP`][1]があり板設定の
最大レス数がデフォルト(`0`:未設定)でないときは`BBS_THREAD_STOP`の値に
上書きするように変更します。

[1]: http://blog.livedoor.jp/bbsnews/archives/51024405.html

関連のissue: #76 
