### PR TITLE
Fix URL redirection for bbsmenu and board to handle 302 Found

### DIFF
--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1126,7 +1126,7 @@ void BoardBase::receive_finish()
         send_update_board();
 
         // Locationヘッダーで移転先を指定された場合
-        if( get_code() == HTTP_MOVED_PERM && ! location().empty() ) {
+        if( ( get_code() == HTTP_MOVED_PERM || get_code() == HTTP_REDIRECT ) && ! location().empty() ) {
 
             // location() は url_boardbase() の移転先 (start_checkking_if_board_moved() を参照)
             if( DBTREE::move_board( url_boardbase(), location() ) ) {

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -372,7 +372,7 @@ void Root::receive_finish()
         return;
     }
 
-    if( get_code() == HTTP_MOVED_PERM && ! location().empty() ){
+    if( ( get_code() == HTTP_MOVED_PERM || get_code() == HTTP_REDIRECT ) && ! location().empty() ){
 
         const std::string msg = get_str_code() + "\n\n板一覧が " + location() + " に移転しました。更新しますか？";
         SKELETON::MsgDiag mdiag( nullptr, msg, false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );


### PR DESCRIPTION
Fixes #848 

bbsmenuや板のサーバー移転処理で302 Foundを受信したときリダイレクト先に移転するよう修正します。
302が処理できず不完全な状態で移転が止まり板が開けないことがありした。

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1613107502/916-919n