### PR TITLE
playsound: Remove __has_include macro for <alsa/asoundlib.h> 

### DIFF
--- a/src/sound/playsound.cpp
+++ b/src/sound/playsound.cpp
@@ -9,14 +9,12 @@
 
 #include "jdlib/miscmsg.h"
 
+#include <alsa/asoundlib.h>
+
 #include <algorithm>
 #include <string>
 #include <vector>
-#if __has_include(<alsa/asoundlib.h>)
-#include <alsa/asoundlib.h>
-#else
-#include <asoundlib.h>
-#endif
+
 
 using namespace SOUND;
 

--- a/src/sound/playsound.cpp
+++ b/src/sound/playsound.cpp
@@ -12,6 +12,7 @@
 #include <alsa/asoundlib.h>
 
 #include <algorithm>
+#include <cstdio>
 #include <string>
 #include <vector>
 

--- a/src/sound/playsound.h
+++ b/src/sound/playsound.h
@@ -14,8 +14,6 @@
 #include "skeleton/dispatchable.h"
 #include "jdlib/jdthread.h"
 
-#include <gtkmm.h>
-
 #include <cstdint>
 
 


### PR DESCRIPTION
#### playsound: Remove `__has_include` macro for `<alsa/asoundlib.h>`
alsa-libのヘッダーファイル `alsa/asoundlib.h` は[2001年][1]から導入されているため現状サポートしているディストロでは利用可能です。
そのためヘッダーのチェックを整理してcppcheckのレポート(誤検知?)を解消します。

cppcheck 2.3のレポート
```
src/sound/playsound.cpp:15:0: error: failed to evaluate #if condition, division/modulo by zero [preprocessorErrorDirective]
#if __has_include(<alsa/asoundlib.h>)
^
```

[1]: https://github.com/alsa-project/alsa-lib/commit/0a8749a8026976e85ff486aa7872a05c2f0e150b

#### playsound: Organize header files 