### PR TITLE
Log_Manager: Fix iterator loop

### DIFF
--- a/src/message/logmanager.cpp
+++ b/src/message/logmanager.cpp
@@ -123,8 +123,7 @@ void Log_Manager::remove_items( const std::string& url )
               << "size = " << m_logitems.size() << std::endl;
 #endif 
 
-    std::list<LogItem>::iterator it = m_logitems.begin();
-    for( ; it != m_logitems.end(); ++it ){
+    for( auto it = m_logitems.begin(); it != m_logitems.end(); ) {
 
         if( it->url == url
             || ( it->newthread && url.rfind( it->url, 0 ) == 0 )
@@ -143,8 +142,10 @@ void Log_Manager::remove_items( const std::string& url )
                 std::cout << "removed url = " << it->url << std::endl;
 #endif
                 it = m_logitems.erase( it );
+                continue;
             }
         }
+        ++it;
     }
 
 #ifdef _DEBUG

--- a/src/message/logmanager.cpp
+++ b/src/message/logmanager.cpp
@@ -370,10 +370,9 @@ int Log_Manager::get_max_num_of_log()
     const std::string path = CACHE::path_postlog() + "-";
 
     int maxno = 0;
-    std::list< std::string >::iterator it = filelist.begin();
-    for( ; it != filelist.end(); ++it ){
+    for( const std::string& filename : filelist ) {
 
-        const std::string target = CACHE::path_logroot() + (*it);
+        const std::string target = CACHE::path_logroot() + filename;
 #ifdef _DEBUG
         std::cout << target << std::endl;
 #endif


### PR DESCRIPTION
####  Log_Manager: Fix iterator loop 
for文のイテレーターインクリメントを修正します。
リストの要素を削除する処理で返り値をイテレーターに代入していますがループ周回時のインクリメントで余計にすすめていました。

#### Log_Manager: Update iterator for loop
for文によるイテレーターの走査処理をSTLアルゴリズム関数や範囲ベースfor文に更新して保守性を向上させます。

関連のpull request: #783 