### PR TITLE
font: Fix known condition true/false

### DIFF
--- a/src/article/font.cpp
+++ b/src/article/font.cpp
@@ -79,7 +79,7 @@ bool ARTICLE::get_width_of_char( const char* utfstr, int& byte, const char pre_c
     }
 
     const int c32 = MISC::utf8toucs2( utfstr, byte );
-    if( byte && c32 < kMaxCacheCodePoint ){
+    if( byte > 0 && c32 < kMaxCacheCodePoint ){
 
         // 全角モードの幅
         width_wide = width_of_char[ mode ][ c32 ].width_wide;


### PR DESCRIPTION
既に条件が判明している比較があるとcppcheck 2.6.1に指摘されたため条件文を修正します。
0がfalseの条件になっているif文があるためツールがintで真偽値を扱っていると診断したようです。

cppcheckのレポート
```
src/article/font.cpp:91:18: style: Condition 'byte==1' is always true [knownConditionTrueFalse]
        if( byte == 1 && strict_of_char ){
                 ^
src/article/font.cpp:82:9: note: Assuming condition 'byte' is true
    if( byte && c32 < kMaxCacheCodePoint ){
        ^
src/article/font.cpp:91:18: note: Condition 'byte==1' is always true
        if( byte == 1 && strict_of_char ){
                 ^
```