### PR TITLE
BoardViewLog: Fix known condition true/false

### DIFF
--- a/src/board/boardviewlog.cpp
+++ b/src/board/boardviewlog.cpp
@@ -168,7 +168,7 @@ void BoardViewLog::update_item( const std::string& url, const std::string& id )
     if( id.empty() || row ) BoardViewBase::update_item( url, id );
 
     // もし row が無く、かつキャッシュがあるならば行を追加
-    else if( ! id.empty() ){ 
+    else {
 
         DBTREE::ArticleBase* art = DBTREE::get_article( url_dat );
         if( art && art->is_cached() ){


### PR DESCRIPTION
既に条件が判明している比較があるとcppcheck 2.6.2に指摘されたため条件文を修正します。直前のif文で条件をチェックしています。

cppcheckのレポート
```
src/board/boardviewlog.cpp:171:14: style: Condition '!id.empty()' is always true [knownConditionTrueFalse]
    else if( ! id.empty() ){
             ^
src/board/boardviewlog.cpp:168:17: note: Assuming that condition 'id.empty()' is not redundant
    if( id.empty() || row ) BoardViewBase::update_item( url, id );
                ^
src/board/boardviewlog.cpp:171:14: note: Condition '!id.empty()' is always true
    else if( ! id.empty() ){
             ^
```

関連のpull request: #865 