### PR TITLE
Root: Fix known condition true/false

### DIFF
--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -1123,7 +1123,6 @@ void Root::load_etc()
 
             // board id
             info.boardid = *( it );
-            if( it == list_etc.end() ) break;
 
 #ifdef _DEBUG
             std::cout << "etc board : name = " << info.name << std::endl


### PR DESCRIPTION
既に条件が判明している比較があるとcppcheck 2.6.2に指摘されたため条件文を修正します。イテレーターをデリファレンスした後に比較しています。

cppcheckのレポート
```
src/dbtree/root.cpp:1126:20: style: Condition 'it==list_etc.end()' is always false [knownConditionTrueFalse]
            if( it == list_etc.end() ) break;
                   ^
```

関連のpull request: #865 