### PR TITLE
MouseKeyPref: Use set_value function instead of operator[]

### DIFF
--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -554,8 +554,7 @@ void MouseKeyPref::append_row( const int id, const std::string& label )
         }
         row[ get_colums().m_col_motions ] = motions;
         row[ get_colums().m_col_id ] = id;
-        if( motions != get_default_motions( id ) ) row[ get_colums().m_col_drawbg ] = true;
-        else row[ get_colums().m_col_drawbg ] = false;
+        row.set_value( get_colums().m_col_drawbg, motions != get_default_motions( id ) );
     }
 }
 
@@ -622,8 +621,7 @@ void MouseKeyPref::slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::Tr
         const std::string motions = diag->get_str_motions();
 
         row[ get_colums().m_col_motions ] = motions;
-        if( motions != get_default_motions( id ) ) row[ get_colums().m_col_drawbg ] = true;
-        else row[ get_colums().m_col_drawbg ] = false;
+        row.set_value( get_colums().m_col_drawbg, motions != get_default_motions( id ) );
 
         remove_motions( id );
         set_motions( id, motions );


### PR DESCRIPTION
値を代入した後使っていないとcppcheck 2.6.2に指摘されたため値をセットするメンバー関数に置き換えます。

cppcheckのレポート
```
src/control/mousekeypref.cpp:557:85: style: Variable 'row[get_colums().m_col_drawbg]' is assigned a value that is never used. [unreadVariable]
        if( motions != get_default_motions( id ) ) row[ get_colums().m_col_drawbg ] = true;
                                                                                    ^
src/control/mousekeypref.cpp:558:47: style: Variable 'row[get_colums().m_col_drawbg]' is assigned a value that is never used. [unreadVariable]
        else row[ get_colums().m_col_drawbg ] = false;
                                              ^
src/control/mousekeypref.cpp:625:85: style: Variable 'row[get_colums().m_col_drawbg]' is assigned a value that is never used. [unreadVariable]
        if( motions != get_default_motions( id ) ) row[ get_colums().m_col_drawbg ] = true;
                                                                                    ^
src/control/mousekeypref.cpp:626:47: style: Variable 'row[get_colums().m_col_drawbg]' is assigned a value that is never used. [unreadVariable]
        else row[ get_colums().m_col_drawbg ] = false;
                                              ^
```

関連のpull request: #865 
