### PR TITLE
miscutil: Fix heap buffer overflow

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -570,11 +570,11 @@ int MISC::str_to_uint( const char* str, size_t& dig, size_t& n )
 
         else{
 
-            const unsigned char in2 = (* ( str +1 ));
-            const unsigned char in3 = (* ( str +2 ));
+            const auto in2 = static_cast<unsigned char>( in == 0xEF ? *( str + 1 ) : 0 );
+            const auto in3 = static_cast<unsigned char>( in2 == 0xBC ? *( str + 2 ) : 0 );
 
             // utf-8
-            if( in == 0xef && in2 == 0xbc && ( 0x90 <= in3 && in3 <= 0x99 ) ){
+            if( 0x90 <= in3 && in3 <= 0x99 ){
                 out = out*10 + ( in3 - 0x90 );
                 ++dig;
                 str += 3;
@@ -1816,8 +1816,8 @@ bool MISC::has_widechar( const char* str )
 
             if( in == 0xef ){
 
-                const unsigned char in2 = * ( str + 1 );
-                const unsigned char in3 = * ( str + 2 );
+                const auto in2 = static_cast<unsigned char>( *( str + 1 ) );
+                const auto in3 = static_cast<unsigned char>( in2 != '\0' ? *( str + 2 ) : 0 );
 
                 if( in2 == 0xbc ){
 


### PR DESCRIPTION
AddressSanitizerでバッファオーバーフローを検知した箇所にヌル終端のチェックを追加します。また、同様のコードがあったためそれも修正します。

バックトレースから抜粋
```
AddressSanitizer: heap-buffer-overflow on address 0x603000dcff4a at pc 0x559327b6d0ee bp 0x7ffff20d0510 sp 0x7ffff20d0500
0x559327b6d0ed in MISC::str_to_uint(char const*, unsigned long&, unsigned long&) ../src/jdlib/miscutil.cpp:637
```