### PR TITLE
Use set_value function instead of operator[] part2

### DIFF
--- a/src/replacestrpref.cpp
+++ b/src/replacestrpref.cpp
@@ -349,11 +349,11 @@ void ReplaceStrPref::slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::
 
     ReplaceStrDiag dlg( this, condition, row[ m_columns.m_col_pattern ], row[ m_columns.m_col_replace ] );
     if( dlg.run() == Gtk::RESPONSE_OK ) {
-        row[ m_columns.m_col_active ] = dlg.get_active();
-        row[ m_columns.m_col_icase ] = dlg.get_icase();
-        row[ m_columns.m_col_regex ] = dlg.get_regex();
-        row[ m_columns.m_col_pattern ] = dlg.get_pattern();
-        row[ m_columns.m_col_replace ] = dlg.get_replace();
+        row.set_value( m_columns.m_col_active, dlg.get_active() );
+        row.set_value( m_columns.m_col_icase, dlg.get_icase() );
+        row.set_value( m_columns.m_col_regex, dlg.get_regex() );
+        row.set_value( m_columns.m_col_pattern, dlg.get_pattern() );
+        row.set_value( m_columns.m_col_replace, dlg.get_replace() );
 
         if( dlg.get_regex() ) {
             JDLIB::RegexPattern ptn;

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -595,7 +595,7 @@ void EditTreeView::slot_ren_text_on_edited( const Glib::ustring& path, const Gli
     if( row ){
 
         const Glib::ustring text_before = row[ m_columns.m_name ];
-        row[ m_columns.m_name ] = text;
+        row.set_value( m_columns.m_name, text );
 
         if( m_editable && m_undo_buffer ) m_undo_buffer->set_name( Gtk::TreePath( path ), text, text_before );
     }


### PR DESCRIPTION
#### ReplaceStrPref: Use set_value function instead of operator[]

値を代入した後使っていないとcppcheck 2.6.2に指摘されたため値をセットするメンバー関数に置き換えます。

cppcheckのレポート
```
src/replacestrpref.cpp:356:40: style: Variable 'row[m_columns.m_col_replace]' is assigned a value that is never used. [unreadVariable]
        row[ m_columns.m_col_replace ] = dlg.get_replace();
                                       ^
```

#### EditTreeView: Use set_value function instead of operator[]

値を代入した後使っていないとcppcheck 2.6.2に指摘されたため値をセットするメンバー関数に置き換えます。

cppcheckのレポート
```
src/skeleton/edittreeview.cpp:598:33: style: Variable 'row[m_columns.m_name]' is assigned a value that is never used. [unreadVariable]
        row[ m_columns.m_name ] = text;
                                ^
```

関連のpull request: #865
