### PR TITLE
Add const qualifier to local variable found by cppcheck

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1248,7 +1248,7 @@ std::string MISC::charset_url_encode_split( const std::string& str, const std::s
 //
 std::string MISC::base64( const std::string& str )
 {
-    char table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    constexpr const char table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
     int lng = str.length();
 

--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -131,7 +131,7 @@ LinkFilterPref::LinkFilterPref( Gtk::Window* parent, const std::string& url )
 
 void LinkFilterPref::append_rows()
 {
-    std::vector< LinkFilterItem >& list_item = CORE::get_linkfilter_manager()->get_list();
+    const std::vector<LinkFilterItem>& list_item = CORE::get_linkfilter_manager()->get_list();
     if( list_item.empty() ) return;
     for( const LinkFilterItem& item : list_item ) append_row( item.url, item.cmd );
 

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -91,7 +91,7 @@ class compare_path
 
     int type_to_order( const int type ) const
     {
-        int order[]={
+        constexpr const int order[] = {
 
             TYPE_DIR,
 


### PR DESCRIPTION
####    LinkFilterPref: Add const qualifier to local variable 
ローカル変数にconstを付けれるとcppcheck 2.6.2に指摘されたため修正します。

cppcheckのレポート
```
src/linkfilterpref.cpp:134:36: style: Variable 'list_item' can be declared with const [constVariable]
    std::vector< LinkFilterItem >& list_item = CORE::get_linkfilter_manager()->get_list();
                                   ^
```

#### miscutil: Add const qualifier to local variable

ローカル変数にconstを付けれるとcppcheck 2.6.2に指摘されたため修正します。

cppcheckのレポート
```
src/jdlib/miscutil.cpp:1251:10: style: Variable 'table' can be declared with const [constVariable]
    char table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
         ^
```

#### EditTreeView: Add const qualifier to local variable

ローカル変数にconstを付けれるとcppcheck 2.6.2に指摘されたため修正します。

cppcheckのレポート
```
src/skeleton/edittreeview.cpp:94:13: style: Variable 'order' can be declared with const [constVariable]
        int order[]={
            ^
```

関連のpull request: #865 