### PR TITLE
EditTreeView: Add const qualifier to function parameter

### DIFF
--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -1107,7 +1107,7 @@ CORE::DATA_INFO_LIST EditTreeView::append_info( const CORE::DATA_INFO_LIST& list
 //
 // force = true なら m_editable が false でも削除
 //
-void EditTreeView::delete_path( std::list< Gtk::TreePath >& list_path, const bool force )
+void EditTreeView::delete_path( const std::list<Gtk::TreePath>& list_path, const bool force )
 {
     if( ! list_path.size() ) return;
     if( ! force && ! m_editable ) return;

--- a/src/skeleton/edittreeview.h
+++ b/src/skeleton/edittreeview.h
@@ -161,7 +161,7 @@ namespace SKELETON
 
         // pathをまとめて削除
         // force = true なら m_editable が false でも削除
-        void delete_path( std::list< Gtk::TreePath >& list_path, const bool force );
+        void delete_path( const std::list<Gtk::TreePath>& list_path, const bool force );
 
         // 選択した行をまとめて削除
         // force = true なら m_editable が false でも削除


### PR DESCRIPTION
メンバー関数の引数にconstを付けれるとcppcheck 2.6.2に指摘されたため修正します。

cppcheckのレポート
```
src/skeleton/edittreeview.cpp:1110:61: style: Parameter 'list_path' can be declared with const [constParameter]
void EditTreeView::delete_path( std::list< Gtk::TreePath >& list_path, const bool force )
                                                            ^
```

関連のpull request: #865 