### PR TITLE
Implement User-Agent configuration for board

### DIFF
--- a/src/board/preference.h
+++ b/src/board/preference.h
@@ -81,9 +81,17 @@ namespace BOARD
         Gtk::CheckButton m_check_live;
         Gtk::SpinButton m_spin_live;
 
+        // ネットワーク設定
+        Gtk::Box m_vbox_network;
+
+        // ユーザーエージェント
+        Gtk::Label m_comment_agent;
+        Gtk::Box m_hbox_agent;
+        Gtk::Label m_label_agent;
+        Gtk::Entry m_entry_agent;
+
         // プロキシ
-        Gtk::VBox m_vbox_proxy;
-        Gtk::Label m_label_proxy;
+        Gtk::Label m_comment_proxy;
         ProxyFrame m_proxy_frame;
         ProxyFrame m_proxy_frame_w;
 

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -42,13 +42,23 @@ Board2ch::~Board2ch() noexcept
 // ダウンロード用
 const std::string& Board2ch::get_agent() const
 {
-    return CONFIG::get_agent_for2ch();
+    if( get_board_agent().empty() ) {
+        return CONFIG::get_agent_for2ch();
+    }
+    else {
+        return get_board_agent();
+    }
 }
 
 // 書き込み用
 const std::string& Board2ch::get_agent_w() const
 {
-    return CONFIG::get_agent_for2ch();
+    if( get_board_agent().empty() ) {
+        return CONFIG::get_agent_for2ch();
+    }
+    else {
+        return get_board_agent();
+    }
 }
 
 

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -133,7 +133,12 @@ void BoardBase::update_name( const std::string& name )
 // ダウンロード用
 const std::string& BoardBase::get_agent() const
 {
-    return CONFIG::get_agent_for_data();
+    if( get_board_agent().empty() ) {
+        return CONFIG::get_agent_for_data();
+    }
+    else {
+        return get_board_agent();
+    }
 }
 
 // 書き込み用
@@ -2062,6 +2067,9 @@ void BoardBase::read_board_info()
     // 最大レス数
     m_number_max_res = cf.get_option_int( "max_res", get_default_number_max_res(), 0, CONFIG::get_max_resnumber() );
 
+    // 板のユーザーエージェント設定
+    m_board_agent = cf.get_option_str( "user_agent", std::string{} );
+
 #ifdef _DEBUG
     std::cout << "modified = " << get_date_modified() << std::endl;
 #endif
@@ -2152,6 +2160,7 @@ void BoardBase::save_jdboard_info()
          << "last_access_time = " << m_last_access_time << std::endl
          << "status = " << m_status << std::endl
          << "max_res = " << m_number_max_res << std::endl
+         << "user_agent = " << m_board_agent << std::endl
     ;
 
     CACHE::save_rawdata( path_info, sstr.str() );

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -210,6 +210,9 @@ namespace DBTREE
         // Null artice クラス
         std::unique_ptr<ArticleBase> m_article_null;
 
+        /// 板のユーザーエージェント設定 (空のときは全体設定を使う)
+        std::string m_board_agent;
+
       protected:
 
         ARTICLE_INFO_LIST& get_list_artinfo(){ return m_list_artinfo; }
@@ -540,6 +543,10 @@ namespace DBTREE
 
         // 最終アクセス時刻
         time_t get_last_access_time() const{ return m_last_access_time; }
+
+        // 板のユーザーエージェント設定
+        const std::string& get_board_agent() const { return m_board_agent; }
+        void set_board_agent( const std::string& user_agent ) { m_board_agent = user_agent; }
 
         // 最大レス数
         int get_number_max_res() const { return m_number_max_res; }

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -705,6 +705,16 @@ time_t DBTREE::board_last_access_time( const std::string& url )
     return DBTREE::get_board( url )->get_last_access_time();
 }
 
+const std::string& DBTREE::board_get_board_agent( const std::string& url )
+{
+    return DBTREE::get_board( url )->get_board_agent();
+}
+
+void DBTREE::board_set_board_agent( const std::string& url, const std::string& user_agent )
+{
+    DBTREE::get_board( url )->set_board_agent( user_agent );
+}
+
 
 /////////////////////////////////////////////////
 

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -191,6 +191,10 @@ namespace DBTREE
     void board_set_live_sec( const std::string& url, time_t sec );
     time_t board_last_access_time( const std::string& url );
 
+    // 板のユーザーエージェント設定
+    const std::string& board_get_board_agent( const std::string& url );
+    void board_set_board_agent( const std::string& url, const std::string& user_agent );
+
     // 全スレの書き込み履歴のリセット
     void clear_all_post_history();
 


### PR DESCRIPTION
Fixes #872 

###    BoardBase: Implement User-Agent configuration for board 

板設定にUser-Agent(UA)設定を実装します。UAが板に設定されているときは全体設定(about:config)のUAにかわって板のアクセスで使います。設定したUAはキャッシュに保存され次回起動時に読み込まれます。

##### 互換性に関する注意
板のUA設定が未実装のバージョンで起動すると設定が失われます。

### board: Add User-Agent config to preferences dialog

板のプロパティにUser-Agent(UA)の設定を追加して板にアクセスするとき使う
UAを変更できるようにします。

##### ユーザーインターフェース
- 板のプロパティの"プロキシ設定"タブを"ネットワーク設定"に名称変更する
- ネットワーク設定にUAを設定する入力欄を追加する
- ダイアログのOKボタンを押すと入力したUAが適用される

##### 設定のルール
- 空欄または不適切な文字(non-ASCII)がある状態でOKを押すと設定が消去される
- 入力可能な長さは200文字に制限される

##### 通信
- プロパティで設定したUAは対象の板にアクセスするとき使われる
