### PR TITLE
board: Improve dialog layout for displaying cookie and keyword

### DIFF
--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -122,16 +122,17 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     keyword = DBTREE::board_keyword_for_newarticle( get_url() );
     if( ! keyword.empty() ) str_cookies.append( "\nスレ立て用キーワード: " + keyword + "\n" );
 
+    m_edit_cookies.set_hexpand( true );
+    m_edit_cookies.set_propagate_natural_height( true );
     m_edit_cookies.set_text( str_cookies );
 
-    m_hbox_cookie.set_border_width( 8 );
-    m_hbox_cookie.set_spacing( 8 );
-    m_hbox_cookie.pack_start( m_edit_cookies );
-    m_hbox_cookie.pack_start( m_vbox_cookie, Gtk::PACK_SHRINK );
-    m_vbox_cookie.pack_end( m_button_cookie, Gtk::PACK_SHRINK );
+    m_grid_cookie.property_margin() = 8;
+    m_grid_cookie.attach( m_edit_cookies, 0, 0, 1, 1 );
+    m_grid_cookie.attach( m_button_cookie, 1, 0, 1, 1 );
+    m_button_cookie.set_valign( Gtk::ALIGN_END );
     m_button_cookie.signal_clicked().connect( sigc::mem_fun(*this, &Preferences::slot_delete_cookie ) );
 
-    m_frame_cookie.add( m_hbox_cookie );
+    m_frame_cookie.add( m_grid_cookie );
 
     // 実況
     const int live_sec = DBTREE::board_get_live_sec( get_url() );

--- a/src/board/preference.h
+++ b/src/board/preference.h
@@ -70,9 +70,8 @@ namespace BOARD
 
         // クッキー と キーワード表示
         Gtk::Frame m_frame_cookie;
-        Gtk::HBox m_hbox_cookie;
+        Gtk::Grid m_grid_cookie;
         SKELETON::EditView m_edit_cookies;
-        Gtk::VBox m_vbox_cookie;
         Gtk::Button m_button_cookie;
 
         // 実況の更新間隔


### PR DESCRIPTION
板のプロパティのクッキーとキーワードを表示する欄をサイズ調整します。
欄が小さくスクロールバーが表示されて見づらくなっていました。