### PR TITLE
miscutil: Fix dereference invalid iterator

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -594,20 +594,23 @@ int MISC::str_to_uint( const char* str, size_t& dig, size_t& n )
 //
 std::string MISC::intlisttostr( const std::list< int >& list_num )
 {
+    assert( ! list_num.empty() );
+
     std::ostringstream comment;
 
     std::list < int >::const_iterator it = list_num.begin();
 
     bool comma = false;
     int num_from = *it;
-    int num_to = -1;
-    int i = 0;
+    int num_to = -1; // -1 は番兵
+    int i = 0; // 連番判定に使う
     for(;;){
 
         ++i;
         ++it;
-        const int num = *it;
-        if( num_from + i != num || it == list_num.end() ){
+        const bool loop_end{ it == list_num.end() };
+        const int num{ loop_end ? -1 : *it };
+        if( num_from + i != num || loop_end ) {
 
             if( comma ) comment << ",";
             comment << num_from;
@@ -617,8 +620,9 @@ std::string MISC::intlisttostr( const std::list< int >& list_num )
             i = 0;
             comma = true;
 
-            if( it == list_num.end() ) break;
+            if( loop_end ) break;
         }
+        // 数字が連番のときは記録しておく
         else num_to = num;
     }
 


### PR DESCRIPTION
イテレーターを終端チェックする前にデリファレンスしているとcppcheck 2.6.2に指摘されたため修正します。

cppcheckのレポート
```
src/jdlib/miscutil.cpp:609:26: warning: Either the condition 'it==list_num.end()' is redundant or there is possible dereference of an invalid iterator: it. [derefInvalidIteratorRedundantCheck]
        const int num = *it;
                         ^
src/jdlib/miscutil.cpp:610:39: note: Assuming that condition 'it==list_num.end()' is not redundant
        if( num_from + i != num || it == list_num.end() ){
                                      ^
src/jdlib/miscutil.cpp:609:26: note: Dereference of an invalid iterator
        const int num = *it;
                         ^
```

関連のpull request: #865 