### PR TITLE
Loader: Use reinterpret_cast instead of C-style pointer casting

### DIFF
--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -1032,11 +1032,22 @@ struct addrinfo* Loader::get_addrinfo( const std::string& hostname, const int po
         MISC::ERRMSG( m_data.str_code );
         return nullptr;
     }
-    
-#ifdef _DEBUG    
-    std::cout << "host = " << hostname
-              << " ipv6 = " << m_data.use_ipv6
-              << ", ip =" << inet_ntoa( (  ( sockaddr_in* )( res->ai_addr ) )->sin_addr ) << std::endl;
+
+#ifdef _DEBUG
+    const auto family = res->ai_addr->sa_family;
+    const void* src;
+    if( family == AF_INET ) {
+        src = &reinterpret_cast<sockaddr_in*>( res->ai_addr )->sin_addr;
+    }
+    else {
+        src = &reinterpret_cast<sockaddr_in6*>( res->ai_addr )->sin6_addr;
+    }
+    char buf[ INET6_ADDRSTRLEN ]{};
+    if( inet_ntop( family, src, buf, sizeof(buf) ) ) {
+        std::cout << "host = " << hostname
+                  << ", ipv6 = " << m_data.use_ipv6
+                  << ", ip = " << buf << std::endl;
+    }
 #endif
 
     return res;


### PR DESCRIPTION
C言語スタイルのキャストを使っているとcppcheck 2.6.2に指摘されたため修正します。また、IPアドレスのデバッグプリントをIPv6に対応します。

参考文献
https://man7.org/linux/man-pages/man3/inet_ntop.3.html

cppcheckのレポート
```
src/jdlib/loader.cpp:1039:44: style: C-style pointer casting detected. C++ offers four different kinds of casts as
replacements: static_cast, const_cast, dynamic_cast and reinterpret_cast. A C-style cast could evaluate to any of
those automatically, thus it is considered safer if the programmer explicitly states which kind of cast is expected.
See also: https://www.securecoding.cert.org/confluence/display/cplusplus/EXP05-CPP.+Do+not+use+C-style+casts. [cstyleCast]
              << ", ip =" << inet_ntoa( (  ( sockaddr_in* )( res->ai_addr ) )->sin_addr ) << std::endl;
                                           ^
```

関連のpull request: #865 