### PR TITLE
DrawAreaBase: Remove unused member function is_separator_on_screen()

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -502,25 +502,6 @@ void DrawAreaBase::hide_separator_new()
 }
 
 
-// セパレータが画面に表示されているか
-bool DrawAreaBase::is_separator_on_screen() const
-{
-    if( ! m_layout_tree ) return false;
-
-    const int separator_new = m_layout_tree->get_separator_new();
-    if( ! separator_new ) return false;
-
-    const RECTANGLE* rect = m_layout_tree->get_separator()->rect;
-    if( ! rect ) return false;
-
-    const int height_view = m_view.get_height();
-    const int pos_y = get_vscr_val();
-    if( rect->y + rect->height <= pos_y || rect->y > pos_y + height_view ) return false;
-
-    return true;
-}
-
-
 // 現在のポインタの下にあるレス番号取得
 int DrawAreaBase::get_current_res_num() const
 {

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -279,9 +279,6 @@ namespace ARTICLE
         void set_separator_new( int num );
         void hide_separator_new();
 
-        // セパレータが画面に表示されているか
-        bool is_separator_on_screen() const;
-
         // 現在のポインタの下にあるレス番号取得
         int get_current_res_num() const;
 


### PR DESCRIPTION
`DrawAreaBase::is_separator_on_screen()`が使われていないとcppcheck 2.6.2に指摘されたため整理します。

commit 327b431a1b6726f94ece668cba4264d3d32a1c9a (2008-11)で削除されてから使われていませんでした。

cppcheckのレポート
```
src/article/drawareabase.cpp:506:0: style: The function 'is_separator_on_screen' is never used. [unusedFunction]
```

関連のpull request: #865 