### PR TITLE
BoardViewBase: Remove unused member function redraw_scrollbar()

### DIFF
--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -1220,19 +1220,6 @@ void BoardViewBase::show_view()
 
 
 //
-// スクロールバー再描画
-//
-void BoardViewBase::redraw_scrollbar()
-{
-#ifdef _DEBUG
-    std::cout << "BoardViewBase::redraw_scrollbar\n";
-#endif
-
-    m_scrwin.queue_draw();
-}
-
-
-//
 // 色、フォント、表示内容の更新
 //
 void BoardViewBase::relayout()

--- a/src/board/boardviewbase.h
+++ b/src/board/boardviewbase.h
@@ -129,7 +129,6 @@ namespace BOARD
         void write() override;
         void stop() override;
         void show_view() override;
-        void redraw_scrollbar() override;
         void relayout() override;
         void focus_view() override;
         void focus_out() override;

--- a/src/skeleton/view.h
+++ b/src/skeleton/view.h
@@ -278,7 +278,6 @@ namespace SKELETON
         virtual void stop(){}
         virtual void show_view(){}
         virtual void redraw_view(){}
-        virtual void redraw_scrollbar(){}
         virtual void relayout(){}
         virtual void update_view(){}
         virtual void update_finish(){}        

--- a/src/skeleton/viewnote.h
+++ b/src/skeleton/viewnote.h
@@ -3,7 +3,6 @@
 // DragableNoteBookを構成するview表示用の Notebook
 //
 // TODO: 使われなくなったコンストラクタの引数を整理する
-// TODO: 使われなくなった SKELETON::View::redraw_scrollbar() を整理する
 
 #ifndef _VIEWNOTE_H
 #define _VIEWNOTE_H


### PR DESCRIPTION
`BoardViewBase::redraw_scrollbar()`が使われていないとcppcheck 2.6.2に指摘されたため整理します。

commit c67716bef729d8f88ac5df9e1c61da29ab785ec6 (2020-07)で削除されてから使われていませんでした。

cppcheckのレポート
```
src/board/boardviewbase.cpp:1225:0: style: The function 'redraw_scrollbar' is never used. [unusedFunction]
```

関連のpull request: #865 