### PR TITLE
History_Manager: Remove unused replace_current_url_viewhistory()

### DIFF
--- a/src/history/historymanager.cpp
+++ b/src/history/historymanager.cpp
@@ -426,25 +426,6 @@ void History_Manager::delete_viewhistory( const std::string& url )
 
 
 //
-// 現在表示中のViewのURL( url_old) を新しいURL( url_new )に変更
-//
-bool History_Manager::replace_current_url_viewhistory( const std::string& url_old, const std::string& url_new )
-{
-#ifdef _DEBUG
-    std::cout << "History_Manager::replace_current_url_viewhistory\n"
-              << "old = " << url_old << std::endl
-              << "new = " << url_new << std::endl;
-#endif
-
-    ViewHistory* history = get_viewhistory( url_old );
-    if( !history ) return false;
-
-    history->replace_current_url( url_new );
-    return true;
-}
-
-
-//
 // 履歴全体で url_old を url_new に変更
 //
 void History_Manager::replace_url_viewhistory( const std::string& url_old, const std::string& url_new )

--- a/src/history/historymanager.h
+++ b/src/history/historymanager.h
@@ -76,9 +76,6 @@ namespace HISTORY
         void create_viewhistory( const std::string& url );
         void delete_viewhistory( const std::string& url );
 
-        // 現在表示中のViewのURL( url_old) を新しいURL( url_new )に変更
-        bool replace_current_url_viewhistory( const std::string& url_old, const std::string& url_new ); 
-
         // 履歴全体で url_old を url_new に変更
         void replace_url_viewhistory( const std::string& url_old, const std::string& url_new ); 
 


### PR DESCRIPTION
`History_Manager::replace_current_url_viewhistory()`が使われていないとcppcheck 2.6.2に指摘されたため整理します。

commit db8adb132a82fe5c4b024e1691f2e0d6995564b3 (2010-09)で呼び出し元が削除されてから使われていませんでした。

cppcheckのレポート
```
src/history/historymanager.cpp:431:0: style: The function 'replace_current_url_viewhistory' is never used. [unusedFunction]
```

関連のpull request: #865 