### PR TITLE
miscutil: Fix percent encoding to use uppercase

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1195,7 +1195,7 @@ std::string MISC::url_encode( const char* str, const size_t n )
             ( c != '@' ) &&
             ( c != '_' )){
 
-            snprintf( str_tmp, tmplng , "%%%02x", c );
+            std::snprintf( str_tmp, tmplng, "%%%02X", c );
         }
         else {
             str_tmp[ 0 ] = c;


### PR DESCRIPTION
文字列をパーセントエンコーディングに変換する処理で16進数表記のA-Fを小文字から大文字に変更します。
[RFC3986][1]では大文字を使うべきと書かれています。

> For consistency, URI producers and normalizers should use uppercase hexadecimal digits for all percent-encodings.

修正にあたり不具合報告をしていただきありがとうございました。
https://next2ch.net/test/read.cgi/linux/1613035222/557
https://mao.5ch.net/test/read.cgi/linux/1615781919/869

[1]: https://datatracker.ietf.org/doc/html/rfc3986#section-2.1