### PR TITLE
EditColumns: Remove unused member function copy_row()

### DIFF
--- a/src/skeleton/editcolumns.cpp
+++ b/src/skeleton/editcolumns.cpp
@@ -44,15 +44,3 @@ void EditColumns::setup_row( Gtk::TreeModel::Row& row,
     row[ m_underline ] = false;
     row[ m_dirid ] = dirid;
 }
-
-
-void EditColumns::copy_row( const Gtk::TreeModel::Row& row_src, Gtk::TreeModel::Row& row_dest )
-{
-    const Glib::ustring url = row_src[ m_url ];
-    const Glib::ustring name = row_src[ m_name ];
-    const Glib::ustring data = row_src[ m_data ];
-    const int type = row_src[ m_type ];
-    const size_t dirid = row_src[ m_dirid ];
-
-    setup_row( row_dest, url, name, data, type, dirid );
-}

--- a/src/skeleton/editcolumns.h
+++ b/src/skeleton/editcolumns.h
@@ -53,7 +53,6 @@ namespace SKELETON
 
         virtual void setup_row( Gtk::TreeModel::Row& row,
                                 const Glib::ustring url, const Glib::ustring name, const Glib::ustring data, const int type, const size_t dirid );
-        virtual void copy_row( const Gtk::TreeModel::Row& row_src, Gtk::TreeModel::Row& row_dest );
     };
 }
 


### PR DESCRIPTION
`EditColumns::copy_row()`が使われていないとcppcheck 2.6.2に指摘されたため整理します。

commit 94c0d66bf11bb86ed160a1511448c69e38c95101 (2008-12) で呼び出し元が削除されてから使われていませんでした。

cppcheckのレポート
```
src/skeleton/editcolumns.cpp:49:0: style: The function 'copy_row' is never used. [unusedFunction]
```