### PR TITLE
Update requirements for dependencies (gcc >= 7)

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -18,18 +18,12 @@ jobs:
     strategy:
       matrix:
         sets:
-          - cc: gcc-6
-            cxx: g++-6
-            package: g++-6
           - cc: gcc-7
             cxx: g++-7
             package: g++-7
           - cc: gcc-8
             cxx: g++-8
             package: g++-8
-          - cc: clang-5.0
-            cxx: clang++-5.0
-            package: clang-5.0
           - cc: clang-6.0
             cxx: clang++-6.0
             package: clang-6.0
@@ -85,6 +79,12 @@ jobs:
           - cc: clang-10
             cxx: clang++-10
             package: clang-10
+          - cc: clang-11
+            cxx: clang++-11
+            package: clang-11
+          - cc: clang-12
+            cxx: clang++-12
+            package: clang-12
     steps:
       - uses: actions/checkout@v2
       - name: dependencies installation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,12 +50,25 @@ Pull requestは`master`ブランチに対してお願いいたします。
 
 #### :pencil: C++ソースコードを修正するときの注意
 
-* C++14の機能を使う。迷ったときは[C++ Core Guidelines][isocpp]を参考にする。
-* C++17の機能はgcc-6が[サポート][support] [\[1\]][lang] [\[2\]][lib]していれば使ってもよい。(メンテナーと相談)
+* C++17の機能を使う。迷ったときは[C++ Core Guidelines][isocpp]を参考にする。
+* CIのビルドで失敗する機能は使わなくてもビルドできるようにする。(下記参照)
 * コーディングスタイルは周囲のコードになるべく合わせる。
 * ソースコードを修正したときはビルド可能なことチェックする。
 * 修正前よりコンパイル時警告を増やさないように気をつける。
 
+C++17で追加された標準ライブラリのうちg++ 7またはclang++ 6.0が[サポート][support]していないものに注意
+
+| JDimの動作環境に合わない標準ライブラリ | ヘッダー | gcc | clang |
+| --- | --- | ---:| ---:|
+| [Standardization of Parallelism TS][cpp17exe] | `<execution>` | 9 | n/a |
+| [Hardware interference size][cpp17his]  | | 12 | n/a |
+| [File system library][cpp17fs] | `<filesystem>` | 8 | 7 |
+| [Polymorphic memory resources][cpp17pmr] | `<memory_resources>` | 9 | n/a |
+| [Mathematical special functions][cpp17math] | | 7 | n/a |
+| Splicing [Maps][cpp17maps] and [Sets][cpp17sets] | | 7 | 8 |
+| [Elementary string conversions][cpp17conv] (integer support) | `<charconv>` | 8 | 7 |
+| [Elementary string conversions][cpp17conv] (floating-point support) | `<charconv>` | 11 | n/a |
+| `std::shared_ptr` and `std::weak_ptr` with array support | | 7 | 11 |
 
 [readme-md]: https://github.com/JDimproved/JDim/tree/master/README.md
 [issues]: https://github.com/JDimproved/JDim/issues
@@ -69,6 +82,12 @@ Pull requestは`master`ブランチに対してお願いいたします。
 [docs-readme]: https://github.com/JDimproved/JDim/tree/master/docs/README.md
 [test-readme]: https://github.com/JDimproved/JDim/tree/master/test/README.md
 [isocpp]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines
-[support]: https://en.cppreference.com/w/Template:cpp/compiler_support/17
-[lang]: https://gcc.gnu.org/projects/cxx-status.html#cxx17
-[lib]: https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html#status.iso.2017
+[support]: https://en.cppreference.com/w/cpp/compiler_support/17
+[cpp17exe]: https://en.cppreference.com/w/cpp/header/execution
+[cpp17his]: https://en.cppreference.com/w/cpp/thread/hardware_destructive_interference_size
+[cpp17fs]: https://en.cppreference.com/w/cpp/filesystem
+[cpp17pmr]: https://en.cppreference.com/w/cpp/header/memory_resource
+[cpp17math]: https://en.cppreference.com/w/cpp/numeric/special_functions
+[cpp17maps]: https://en.cppreference.com/w/cpp/container/map/merge
+[cpp17sets]: https://en.cppreference.com/w/cpp/container/set/merge
+[cpp17conv]: https://en.cppreference.com/w/cpp/header/charconv

--- a/INSTALL
+++ b/INSTALL
@@ -6,13 +6,13 @@
   必須環境
 
   ・gtkmm 3.22.0 以上
-  ・glibmm 2.50.0 以上 ( 2.56.0 未満のサポートは将来のリリースで廃止される )
+  ・glibmm 2.56.0 以上
   ・zlib 1.2 以上
-  ・gnutls 3.5.8 以上 ( 3.5.18 未満のサポートは将来のリリースで廃止される )
+  ・gnutls 3.5.18 以上
 
   推奨環境
 
-  ・Linux Kernel 3.10 以上 ( 4.4.0 未満は将来のリリースで推奨環境から外れる )
+  ・Linux Kernel 4.4.0 以上
   ・gtkmm 3.24.0 以上
   ・UTF-8環境 ( EUC環境では LANG="ja_JP.UTF-8" を指定する必要がある )
 
@@ -25,7 +25,7 @@
   ・autoconf
   ・autoconf-archive
   ・automake
-  ・g++ 6 以上、または clang++ 5.0 以上 ( 将来のリリースで g++ 7 以上、または clang++ 6.0 以上になる )
+  ・g++ 7 以上、または clang++ 6.0 以上
   ・gnutls
   ・gtkmm
   ・libtool
@@ -36,7 +36,7 @@
 
   ・meson 0.49.0 以上
   ・alsa-lib (--with-alsa)
-  ・openssl (--with-tls=openssl, バージョン 1.1.0 未満のサポートは将来のリリースで廃止される )
+  ・openssl 1.1.0 以上 (--with-tls=openssl)
   ・oniguruma (--with-regex=oniguruma, 廃止予定)
   ・migemo (--with-migemo)
   ・googletest (`test/RADME.md`を参照)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ JDim は GPLv2 の下で公開されている [JD][jd-project] からforkした�
 LinuxなどのUnixライクなOS(FreeBSD,OpenBSD,Nexenta,MacOSXでも動作報告例があります)。
 
 ##### サポートの最新情報
-gccのバージョンが7未満のプラットフォームはサポートを終了する予定となりました。
+gccのバージョンが7未満のプラットフォームはサポートを終了しました。
 Ubuntu 18.04(2018年)より前にリリースされたディストリビューションを利用されている場合は更新をお願いいたします。
 
 メンテナンスの都合によりWindows(MinGW)版のサポートは[終了][#445]しました。
@@ -73,16 +73,16 @@ configure のかわりに meson を使ってビルドする方法は [Discussion
 dnf install gtkmm30-devel gnutls-devel libSM-devel libtool automake autoconf-archive git
 ```
 
-#### Debian (stretch-backportsあるいはbuster以降)
+#### Debian (buster以降)
 ```sh
 sudo apt install libc6-dev make gcc g++ git
 sudo vi /etc/apt/sources.list
-# ↑エディタは何でも良い。deb-src行でstretch-backportsあるいはbuster以降を有効にする
+# ↑エディタは何でも良い。deb-src行でbuster以降を有効にする
 sudo apt update
 sudo apt build-dep jdim
 ```
 
-#### Ubuntu 18.04
+#### Ubuntu (18.04以降)
 開発環境が入っていない場合は、
 
 ```sh
@@ -151,7 +151,7 @@ yay -S jdim-git
 
   1. `configure.ac` の `AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])` の行を削除する。
   2. `autoreconf -i` で `configure` を作りconfigureチェックをやり直す。
-  3. `make CXXFLAGS+="-std=c++1z"` でビルドする。
+  3. `make CXXFLAGS+="-std=c++17"` でビルドする。
 
   もしこれで駄目な場合はgccのversionが古すぎるので、
   gccのバージョンアップをするか、ディストリをバージョンアップしてください。

--- a/configure.ac
+++ b/configure.ac
@@ -165,13 +165,13 @@ AC_MSG_RESULT($with_tls)
 
 AS_IF(
   [test "x$with_tls" = xgnutls],
-  [PKG_CHECK_MODULES(GNUTLS, [gnutls >= 3.5.8])
+  [PKG_CHECK_MODULES(GNUTLS, [gnutls >= 3.5.18])
    AC_DEFINE(USE_GNUTLS, , [use gnutls])
    AC_SUBST(GNUTLS_CFLAGS)
    AC_SUBST(GNUTLS_LIBS)],
 
   [test "x$with_tls" = xopenssl],
-  [PKG_CHECK_MODULES(OPENSSL, [openssl >= 0.9])
+  [PKG_CHECK_MODULES(OPENSSL, [openssl >= 1.1.0])
    AC_DEFINE(USE_OPENSSL, , [use openssl])
    AC_SUBST(OPENSSL_CFLAGS)
    AC_SUBST(OPENSSL_LIBS)],

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -20,12 +20,12 @@ layout: default
 
 #### 必須環境
 - gtkmm 3.22.0 以上
-- glibmm 2.50.0 以上 ( 2.56.0 未満のサポートは将来のリリースで廃止される )
+- glibmm 2.56.0 以上
 - zlib 1.2 以上
-- gnutls 3.5.8 以上 ( 3.5.18 未満のサポートは将来のリリースで廃止される )
+- gnutls 3.5.18 以上
 
 #### 推奨環境
-- Linux Kernel 3.10 以上 ( 4.4.0 未満は将来のリリースで推奨環境から外れる )
+- Linux Kernel 4.4.0 以上
 - gtkmm 3.24.0 以上
 - UTF-8環境 ( EUC環境では `LANG="ja_JP.UTF-8"` を指定する必要がある )
 
@@ -39,7 +39,7 @@ layout: default
 - autoconf
 - autoconf-archive
 - automake
-- g++ 6 以上、または clang++ 5.0 以上 ( 将来のリリースで g++ 7 以上、または clang++ 6.0 以上になる )
+- g++ 7 以上、または clang++ 6.0 以上
 - gnutls
 - gtkmm
 - libtool
@@ -49,7 +49,7 @@ layout: default
 #### オプション
 - meson 0.49.0 以上
 - alsa-lib (`--with-alsa`)
-- openssl (`--with-tls=openssl`, バージョン 1.1.0 未満のサポートは将来のリリースで廃止される )
+- openssl 1.1.0 以上 (`--with-tls=openssl`)
 - oniguruma (`--with-regex=oniguruma`, 廃止予定)
 - migemo (`--with-migemo`)
 - googletest ([test/RADME.md][testreadme]を参照)

--- a/meson.build
+++ b/meson.build
@@ -20,7 +20,7 @@
 #   sudo apt install libgnutls28-dev libgtkmm-3.0-dev libltdl-dev
 #   ```
 #
-# Debian Stretch, Ubuntu 18.04
+# Ubuntu 18.04
 #   ディストロのmesonパッケージはバージョンが古いためpypiからインストールする
 #   $HOME/.local/bin にパスを通す
 #   ```
@@ -47,7 +47,7 @@ project('jdim', 'cpp',
         version : '0.7.0',
         license : 'GPL2',
         meson_version : '>= 0.49.0',
-        default_options : ['warning_level=3', 'cpp_std=c++1z'])
+        default_options : ['warning_level=3', 'cpp_std=c++17'])
 
 # 追加コンパイルオプション
 add_project_arguments('-DHAVE_CONFIG_H=1', language : 'cpp')
@@ -137,10 +137,10 @@ endif
 # TLS
 tls_opt = get_option('tls')
 if tls_opt == 'gnutls'
-  tls_dep = dependency('gnutls', version : '>= 3.5.8')
+  tls_dep = dependency('gnutls', version : '>= 3.5.18')
   conf.set('USE_GNUTLS', 1)
 elif tls_opt == 'openssl'
-  tls_dep = dependency('openssl', version : '>= 0.9.0')
+  tls_dep = dependency('openssl', version : '>= 1.1.0')
   conf.set('USE_OPENSSL', 1)
   configure_args += '\'--with-tls=openssl\''
 endif


### PR DESCRIPTION
#### Update requirements for dependencies (gcc >= 7) 

2018年以降にリリースされたディストロでは使われていない古いgcc(バージョン7未満)のサポートを終了します。
合わせてgnutlsやopensslのバージョン要件とLinuxの推奨環境も更新します。
また、CI設定からサポートしなくなったコンパイラを利用するビルドを取り除いて整理します。

- glibmm >= 2.56.0
- gnutls >= 3.5.18
- openssl >= 1.1.0
- gcc >= 7 または clang >= 6.0
- Linux Kernel >= 4.4.0 (推奨環境)

##### 互換性に関する注意
Ubuntu 18.04より古いプラットフォームではビルドと実行が困難になります。

#### Update CONTRIBUTING.md to allow C++17

CONTRIBUTING.mdの"C++ソースコードを修正するときの注意"を更新してC++17を使うように案内します。また注意する点としてJDimの動作環境に合わない標準ライブラリをリストします。

関連のissue: #777
