### PR TITLE
Remove deprecated build option for regex

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -146,12 +146,12 @@ jobs:
     strategy:
       matrix:
         deps:
-          - config_args: --with-tls=gnutls --with-regex=oniguruma --with-sessionlib=xsmp --with-migemo --with-alsa --with-pangolayout
-            packages: libgnutls28-dev libonig-dev libmigemo-dev libasound2-dev
-          - config_args: --with-tls=openssl --with-regex=glib --with-sessionlib=no --with-migemo --disable-compat-cache-dir
+          - config_args: --with-tls=gnutls --with-sessionlib=xsmp --with-migemo --with-alsa --with-pangolayout
+            packages: libgnutls28-dev libmigemo-dev libasound2-dev
+          - config_args: --with-tls=openssl --with-sessionlib=no --with-migemo --disable-compat-cache-dir
             packages: libssl-dev libmigemo-dev
-          - config_args: --with-tls=openssl --with-regex=oniguruma --with-sessionlib=xsmp --with-alsa --with-pangolayout
-            packages: libssl-dev libonig-dev libasound2-dev
+          - config_args: --with-tls=openssl --with-sessionlib=xsmp --with-alsa --with-pangolayout
+            packages: libssl-dev libasound2-dev
     steps:
       - uses: actions/checkout@v2
       - name: dependencies installation (${{ matrix.deps.packages }})
@@ -178,12 +178,12 @@ jobs:
     strategy:
       matrix:
         deps:
-          - config_args: -Dtls=gnutls -Dregex=oniguruma -Dsessionlib=xsmp -Dmigemo=enabled -Dalsa=enabled -Dpangolayout=enabled
-            packages: libgnutls28-dev libonig-dev libmigemo-dev libasound2-dev
-          - config_args: -Dtls=openssl -Dregex=glib -Dsessionlib=no -Dmigemo=enabled -Dcompat_cache_dir=disabled
+          - config_args: -Dtls=gnutls -Dsessionlib=xsmp -Dmigemo=enabled -Dalsa=enabled -Dpangolayout=enabled
+            packages: libgnutls28-dev libmigemo-dev libasound2-dev
+          - config_args: -Dtls=openssl -Dsessionlib=no -Dmigemo=enabled -Dcompat_cache_dir=disabled
             packages: libssl-dev libmigemo-dev
-          - config_args: -Dtls=openssl -Dregex=oniguruma -Dsessionlib=xsmp -Dalsa=enabled -Dpangolayout=enabled
-            packages: libssl-dev libonig-dev libasound2-dev
+          - config_args: -Dtls=openssl -Dsessionlib=xsmp -Dalsa=enabled -Dpangolayout=enabled
+            packages: libssl-dev libasound2-dev
     steps:
       - uses: actions/checkout@v2
       - name: dependencies installation (${{ matrix.deps.packages }})

--- a/INSTALL
+++ b/INSTALL
@@ -37,7 +37,6 @@
   ・meson 0.49.0 以上
   ・alsa-lib (--with-alsa)
   ・openssl 1.1.0 以上 (--with-tls=openssl)
-  ・oniguruma (--with-regex=oniguruma, 廃止予定)
   ・migemo (--with-migemo)
   ・googletest (`test/RADME.md`を参照)
 
@@ -69,7 +68,7 @@
     3. 起動は ./builddir/src/jdim
 
     mesonのビルドオプション
-    - meson builddir -Dregex=glib のように指定する。
+    - meson builddir -Dpangolayout=enabled のように指定する。
     - オプションの一覧は meson configure を実行してProject optionsの段落を参照する。
 
 * configureオプション
@@ -115,23 +114,6 @@
 
        gprofによるプロファイリングを行う。コンパイルオプションに -pg が付き、JDimを実行すると
        gmon.out が出来るのでgprof./jdgmon.out で解析できる。CPUの最適化は効かなくなるので注意する。
-
-    --with-regex=oniguruma|glib
-
-       使用する正規表現ライブラリを設定する。
-       デフォルトでは Glib Regex(GRegex) を使用する。(v0.4.0+から変更)
-       非推奨: 正規表現ライブラリを選択するオプションは将来廃止される。
-       https://github.com/JDimproved/JDim/issues/697 を参照すること。
-
-    --with-regex=oniguruma
-
-       非推奨: GRegex のかわりに鬼車を使用する。
-       鬼車はBSDライセンスなのでJDimをバイナリ配布する場合には注意すること(ライセンスはGPLになる)。
-
-    --with-regex=glib
-
-       Perl互換の正規表現なので、従来の POSIX 拡張の正規表現から設定変更が必要になる場合がある。
-       (v0.3.0+から追加)
 
     --disable-compat-cache-dir
 

--- a/configure.ac
+++ b/configure.ac
@@ -130,28 +130,11 @@ AS_IF(
 
 
 dnl
-dnl 正規表現ライブラリ
+dnl 正規表現ライブラリのオプションは廃止された
 dnl
-AC_MSG_CHECKING(for --with-regex)
 AC_ARG_WITH(regex,
-AS_HELP_STRING([--with-regex=oniguruma|glib],[use regular expression library @<:@default=glib@:>@]),
-[], [with_regex=glib])
-AC_MSG_RESULT($with_regex)
-
-AS_IF(
-  [test "x$with_regex" = xoniguruma],
-  [PKG_CHECK_MODULES(ONIG, [oniguruma])
-   AC_SUBST(ONIG_CFLAGS)
-   AC_SUBST(ONIG_LIBS)
-   AC_CHECK_HEADERS([onigposix.h], , [AC_MSG_ERROR([onigposix.h not found])])
-   AC_CHECK_LIB([onig], [regexec], , [AC_MSG_ERROR([libonig.a not found])])
-   AC_MSG_WARN([--with-regex=onigruma is deprecated. See https://github.com/JDimproved/JDim/issues/697])],
-
-  [test "x$with_regex" = xglib],
-  [PKG_CHECK_MODULES(GLIB, [glib-2.0 >= 2.14.0])],
-
-  [AC_MSG_ERROR([regular expression library not found])]
-)
+AS_HELP_STRING([--with-regex], [NO LONGER AVAILABLE]),
+[AC_MSG_ERROR([regex library options have been removed. see https://github.com/JDimproved/JDim/issues/697])])
 
 
 dnl

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -50,7 +50,6 @@ layout: default
 - meson 0.49.0 以上
 - alsa-lib (`--with-alsa`)
 - openssl 1.1.0 以上 (`--with-tls=openssl`)
-- oniguruma (`--with-regex=oniguruma`, 廃止予定)
 - migemo (`--with-migemo`)
 - googletest ([test/RADME.md][testreadme]を参照)
 
@@ -85,7 +84,7 @@ WebPやAVIF形式の画像を表示する方法は [#737][dis737] を参照。
 3. 起動は `./builddir/src/jdim`
 
 #### mesonのビルドオプション
-- `meson builddir -Dregex=glib` のように指定する。
+- `meson builddir -Dpangolayout=enabled` のように指定する。
 - オプションの一覧は `meson configure` を実行してProject optionsの段落を参照する。
 
 
@@ -128,24 +127,6 @@ WebPやAVIF形式の画像を表示する方法は [#737][dis737] を参照。
     gprof によるプロファイリングを行う。
     コンパイルオプションに <code>-pg</code> が付き、JDimを実行すると <code>gmon.out</code> が出来るので
     <code>gprof  ./jdim  gmon.out</code> で解析できる。CPUの最適化は効かなくなるので注意する。
-  </dd>
-
-  <dt>--with-regex=oniguruma|glib</dt>
-  <dd>
-    使用する正規表現ライブラリを設定する。
-    デフォルトでは Glib Regex(GRegex) を使用する。<small>(v0.4.0+から変更)</small><br>
-    <strong>非推奨</strong>: 正規表現ライブラリを選択するオプションは将来廃止される。
-    <a href="https://github.com/JDimproved/JDim/issues/697">#697</a> を参照すること。
-  </dd>
-  <dt>--with-regex=oniguruma</dt>
-  <dd>
-    <strong>非推奨</strong>: GRegex のかわりに鬼車を使用する。
-    鬼車はBSDライセンスなのでJDimをバイナリ配布する場合には注意すること(ライセンスはGPLになる)。
-  </dd>
-  <dt>--with-regex=glib</dt>
-  <dd>
-    Perl互換の正規表現なので、従来の POSIX 拡張の正規表現から設定変更が必要になる場合がある。
-    <small>(v0.3.0+から追加)</small>
   </dd>
 
   <dt>--disable-compat-cache-dir</dt>

--- a/meson.build
+++ b/meson.build
@@ -40,7 +40,7 @@
 # Tips
 #   - JDimのビルドオプションは `meson configure` を実行してProject optionsの段落を確認する
 #     または meson_options.txt を見る
-#   - ビルドオプションは `meson builddir -Dregex=glib` のように指定する
+#   - ビルドオプションは `meson builddir -Dpangolayout=enabled` のように指定する
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 
 project('jdim', 'cpp',
@@ -120,18 +120,10 @@ elif sessionlib_opt == 'no'
   configure_args += '\'--with-sessionlib=no\''
 endif
 
-# 正規表現ライブラリ
+# 正規表現ライブラリのオプションは廃止された
 regex_opt = get_option('regex')
-if regex_opt == 'oniguruma'
-  regex_dep = dependency('oniguruma')
-  if not cpp_compiler.has_header('onigposix.h')
-    error('onigposix.h not found')
-  endif
-  conf.set('HAVE_ONIGPOSIX_H', 1)
-  configure_args += '\'--with-regex=oniguruma\''
-  warning('-Dregex=oniguruma is deprecated. See https://github.com/JDimproved/JDim/issues/697')
-elif regex_opt == 'glib'
-  regex_dep = dependency('glib-2.0', version : '>= 2.14.0')
+if regex_opt != ''
+  error('regex library options have been removed. see https://github.com/JDimproved/JDim/issues/697')
 endif
 
 # TLS
@@ -259,7 +251,6 @@ message('migemo = @0@'.format(migemo_dep.found()))
 message('migemodict = @0@'.format(migemodict))
 message('native = @0@'.format(native))
 message('pangolayout = @0@'.format(pangolayout))
-message('regex = @0@'.format(regex_opt))
 message('sessionlib = @0@'.format(sessionlib_opt))
 message('tls = @0@'.format(tls_opt))
 message('*********************')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,6 @@ option('migemo', type : 'feature', value : 'disabled', description : 'Use text s
 option('migemodict', type : 'string', value : '', description : 'Default path for migemo dictionary file')
 option('native', type : 'feature', value : 'disabled', description : 'Optimize to your machine')
 option('pangolayout', type : 'feature', value : 'disabled', description : 'Render text by PangoLayout')
-option('regex', type : 'combo', choices : ['oniguruma', 'glib'], value : 'glib', description : 'Regex library to use')
+option('regex', type : 'string', value : '', description : 'NO LONGER AVAILABLE')
 option('sessionlib', type : 'combo', choices : ['xsmp', 'no'], value : 'xsmp', description : 'Use Session Management Protocol')
 option('tls', type : 'combo', choices : ['gnutls', 'openssl'], value : 'gnutls', description : 'SSL/TLS library to use')

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,7 +18,7 @@ jdim_LDADD = \
 	./sound/libsound.a \
 	./xml/libxml.a \
 	./control/libcontrol.a \
-	@LIBS@ @GTKMM_LIBS@ @GNUTLS_LIBS@ @OPENSSL_LIBS@ @LIBSM_LIBS@ @ALSA_LIBS@ @ONIG_LIBS@ @X11_LIBS@
+	@LIBS@ @GTKMM_LIBS@ @GNUTLS_LIBS@ @OPENSSL_LIBS@ @LIBSM_LIBS@ @ALSA_LIBS@ @X11_LIBS@
 
 
 jdim_SOURCES = \

--- a/src/jdlib/jdregex.h
+++ b/src/jdlib/jdregex.h
@@ -10,15 +10,7 @@
 #include "config.h"
 #endif
 
-#if defined(HAVE_ONIGPOSIX_H)
-#include <onigposix.h>
-#else
 #include <glib.h>
-#endif
-
-#if defined(HAVE_ONIGPOSIX_H)
-#define POSIX_STYLE_REGEX_API 1
-#endif
 
 
 namespace JDLIB
@@ -29,21 +21,11 @@ namespace JDLIB
     {
         friend class Regex;
 
-#ifdef POSIX_STYLE_REGEX_API
-        // onigurumaではregexec()の引数regex_t*がconst修飾されていない
-        // そのためRegex::match()のコンパイルエラーを回避するためmutable修飾が必要
-        mutable regex_t m_regex;
-#else
         GRegex* m_regex{};
-#endif
         bool m_compiled{};
         bool m_newline{};
         bool m_wchar{};
-#ifdef POSIX_STYLE_REGEX_API
-        int m_error{};
-#else
         GError *m_error{};
-#endif
 
     public:
         RegexPattern() noexcept = default;

--- a/src/meson.build
+++ b/src/meson.build
@@ -83,7 +83,6 @@ jdim_deps = [
   gtkmm_dep,
   ice_dep,
   migemo_dep,
-  regex_dep,
   sm_dep,
   socket_dep,
   threads_dep,

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -102,7 +102,7 @@ gtest_jdim_LDADD = \
 	$(top_builddir)/src/winmain.o \
 \
 	$(GTEST_MAIN_LIB) \
-	@LIBS@ @GTKMM_LIBS@ @GNUTLS_LIBS@ @OPENSSL_LIBS@ @LIBSM_LIBS@ @ALSA_LIBS@ @ONIG_LIBS@ @X11_LIBS@ @GTEST_LIBS@
+	@LIBS@ @GTKMM_LIBS@ @GNUTLS_LIBS@ @OPENSSL_LIBS@ @LIBSM_LIBS@ @ALSA_LIBS@ @X11_LIBS@ @GTEST_LIBS@
 
 
 # テストコードのファイルを追加したらここにリストします


### PR DESCRIPTION
#### Remove deprecated build option for regex

廃止予定の正規表現ライブラリのビルドオプション`--with-regex`を削除します。
削除されたオプションを指定すると./configureがエラーになり中断されます。
また、CI設定から正規表現ライブラリを指定するテストを取り除いて整理します。

#### Remove obsolete oniguruma codes
Onigurumaのサポート終了により使われなくなったコードを削除します。

関連のissue: #697 
