### PR TITLE
Replace fallthrough comments with C++17 attribute

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -951,7 +951,7 @@ bool DrawAreaBase::exec_layout_impl( const bool is_popup, const int offset_y )
                 case DBTREE::NODE_IDNUM: // 発言数ノード
 
                     if( ! set_num_id( layout ) ) break;
-                    // fallthrough
+                    [[fallthrough]];
 
                 case DBTREE::NODE_TEXT: // テキスト
                 case DBTREE::NODE_LINK: // リンク
@@ -996,7 +996,7 @@ bool DrawAreaBase::exec_layout_impl( const bool is_popup, const int offset_y )
 
                     y += 2; // 水平線1px + 余白1px
 
-                    // fallthrough
+                    [[fallthrough]];
 
                     //////////////////////////////////////////
 
@@ -1989,7 +1989,7 @@ bool DrawAreaBase::draw_one_node( LAYOUT* layout, const CLIPINFO& ci )
                     else node->color_text = COLOR_IMG_ERR;
                 }
             }
-            // fallthrough
+            [[fallthrough]];
 
 
             //////////////////////////////////////////

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -1872,7 +1872,7 @@ bool BBSListViewBase::open_row( Gtk::TreePath& path, const bool tab )
 
         case TYPE_THREAD_OLD:
             toggle_articleicon( url ); // break;しない
-            // fallthrough
+            [[fallthrough]];
         case TYPE_THREAD:
         case TYPE_THREAD_UPDATE:
             CORE::core_set_command( "open_article", url, str_tab, str_mode );

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -1416,7 +1416,7 @@ bool BoardViewBase::operate_view( const int control )
             // スレを開く
         case CONTROL::OpenArticleTab:
             open_tab = true;
-            // fallthrough
+            [[fallthrough]];
         case CONTROL::OpenArticle:
             if( ! path.empty() ) open_row( path, open_tab, false );
             break;
@@ -2887,7 +2887,7 @@ void BoardViewBase::slot_save_dat()
                             // 名前変更
                         case Gtk::RESPONSE_YES:
                             if( ! art->save_dat( path_to ) ) continue;
-                            // fallthrough
+                            [[fallthrough]];
 
                         default:
                             copy_file = false;


### PR DESCRIPTION
switch文にあるfallthrough箇所のコンパイラ警告を抑制するため書いていたコメントをC++17の属性`[[fallthrough]]`に置き換えます。