### PR TITLE
Admin: Add null pointer check

### DIFF
--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -1436,7 +1436,7 @@ void Admin::redraw_views( const std::string& url )
     std::list< SKELETON::View* > list_view = get_list_view( url );
 
     for( SKELETON::View* view : list_view ) {
-        if( view == current_view ) view->redraw_view();
+        if( view && view == current_view ) view->redraw_view();
     }
 }
 


### PR DESCRIPTION
null pointerにアクセスしているとscan-build(llvm-13)に指摘されたためチェックを追加します。

scan-buildのレポート
```
[202/318] Compiling C++ object src/skeleton/libskeleton.a.p/admin.cpp.o
../../../src/skeleton/admin.cpp:1439:36: warning: Called C++ object pointer is null [core.CallAndMessage]
        if( view == current_view ) view->redraw_view();
                                   ^~~~~~~~~~~~~~~~~~~
1 warning generated.
```