### PR TITLE
Change first argument of sigc::mem_fun() to reference value *this

### DIFF
--- a/src/bbslist/editlistwin.cpp
+++ b/src/bbslist/editlistwin.cpp
@@ -33,15 +33,15 @@ EditListWin::EditListWin( const std::string& url, const Glib::RefPtr< Gtk::TreeS
     m_toolbar->show_toolbar();
 
     // Adminクラスが無いのでツールバーのボタン等のシグナルを直接つなぐ
-    m_toolbar->get_button_close()->signal_clicked().connect( sigc::mem_fun( this, &EditListWin::slot_close ) );
+    m_toolbar->get_button_close()->signal_clicked().connect( sigc::mem_fun( *this, &EditListWin::slot_close ) );
 
     m_toolbar->get_entry_search()->signal_changed().connect( sigc::mem_fun( *this, &EditListWin::slot_changed_search ) );
     m_toolbar->get_entry_search()->signal_activate().connect( sigc::mem_fun( *this, &EditListWin::slot_active_search ) );
     m_toolbar->get_entry_search()->signal_operate().connect( sigc::mem_fun( *this, &EditListWin::slot_operate_search ) );
-    m_toolbar->get_button_up_search()->signal_clicked().connect( sigc::mem_fun( this, &EditListWin::slot_up_search ) );
-    m_toolbar->get_button_down_search()->signal_clicked().connect( sigc::mem_fun( this, &EditListWin::slot_down_search ) );
-    m_toolbar->get_button_undo()->signal_clicked().connect( sigc::mem_fun( this, &EditListWin::slot_undo ) );
-    m_toolbar->get_button_redo()->signal_clicked().connect( sigc::mem_fun( this, &EditListWin::slot_redo ) );
+    m_toolbar->get_button_up_search()->signal_clicked().connect( sigc::mem_fun( *this, &EditListWin::slot_up_search ) );
+    m_toolbar->get_button_down_search()->signal_clicked().connect( sigc::mem_fun( *this, &EditListWin::slot_down_search ) );
+    m_toolbar->get_button_undo()->signal_clicked().connect( sigc::mem_fun( *this, &EditListWin::slot_undo ) );
+    m_toolbar->get_button_redo()->signal_clicked().connect( sigc::mem_fun( *this, &EditListWin::slot_redo ) );
 
     // ラベル
     m_vbox.pack_start( m_label, Gtk::PACK_SHRINK );

--- a/src/bbslist/selectdialog.cpp
+++ b/src/bbslist/selectdialog.cpp
@@ -83,7 +83,7 @@ SelectListDialog::SelectListDialog( Gtk::Window* parent, const std::string& url,
 
     get_content_area()->pack_start( m_label_name, Gtk::PACK_SHRINK );
     get_content_area()->pack_start( m_hbox_dirs, Gtk::PACK_SHRINK );
-    m_bt_show_tree.signal_clicked().connect( sigc::mem_fun( this, &SelectListDialog::slot_show_tree ) );
+    m_bt_show_tree.signal_clicked().connect( sigc::mem_fun( *this, &SelectListDialog::slot_show_tree ) );
 
     set_title( "お気に入り追加先選択" );
     resize( SELECTDIAG_WIDTH, 1 );

--- a/src/iomonitor.cpp
+++ b/src/iomonitor.cpp
@@ -118,7 +118,7 @@ void IOMonitor::init()
         m_main_process = true;
 
         // Glib::IOChannel
-        Glib::signal_io().connect( sigc::mem_fun( this, &IOMonitor::slot_ioin ), m_fifo_fd, Glib::IO_IN );
+        Glib::signal_io().connect( sigc::mem_fun( *this, &IOMonitor::slot_ioin ), m_fifo_fd, Glib::IO_IN );
         m_iochannel = Glib::IOChannel::create_from_fd( m_fifo_fd );
     }
 }

--- a/src/skeleton/aboutdiag.cpp
+++ b/src/skeleton/aboutdiag.cpp
@@ -217,7 +217,7 @@ void AboutDiag::set_website( const Glib::ustring& website )
 {
     if( m_button_website.get_label().empty() ) m_button_website.set_label( website );
     m_button_website.set_relief( Gtk::RELIEF_NONE );
-    m_button_website.signal_clicked().connect( sigc::mem_fun( this, &AboutDiag::slot_button_website_clicked ) );
+    m_button_website.signal_clicked().connect( sigc::mem_fun( *this, &AboutDiag::slot_button_website_clicked ) );
 
     m_website_url = website;
 }


### PR DESCRIPTION
`sigc::mem_fun()`に渡す`this`をポインターから参照(`*this`)に変更します。
ポインター版のオーバーロードは廃止予定になっています。