### PR TITLE
Replace lambda with sigc::mem_fun() for signal connection

### DIFF
--- a/src/bbslist/selectdialog.cpp
+++ b/src/bbslist/selectdialog.cpp
@@ -138,7 +138,7 @@ void SelectListDialog::slot_show_tree()
 
         m_selectview->set_parent_win( this );
         m_selectview->copy_treestore( m_treestore );
-        m_selectview->sig_close_dialog().connect( [this] { hide(); } );
+        m_selectview->sig_close_dialog().connect( sigc::mem_fun( *this, &SelectListDialog::hide ) );
 
         get_content_area()->pack_start( *m_selectview );
         m_selectview->set_size_request( -1, SELECTDIAG_TREEHEIGHT );

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -631,7 +631,7 @@ void BoardViewBase::update_columns()
         // ヘッダをクリックしたときに呼ぶslot
         column->signal_clicked().connect( sigc::bind< int >( sigc::mem_fun( *this, &BoardViewBase::slot_col_clicked ), id ) );
         // 列の幅が変わったらセッション情報に記憶する
-        column->connect_property_changed( "width", [this]{ save_column_width(); } );
+        column->connect_property_changed( "width", sigc::mem_fun( *this, &BoardViewBase::save_column_width ) );
 
         // ヘッダの位置
         switch( id ){

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -690,7 +690,7 @@ void Core::run( const bool init, const bool skip_setupdiag )
     m_action_group->add( Gtk::Action::create( "LivePref", "実況設定(_L)..." ), sigc::mem_fun( *this, &Core::slot_setup_live ) );
     m_action_group->add( Gtk::Action::create( "UsrCmdPref", "ユーザコマンドの編集(_U)..." ), sigc::mem_fun( *this, &Core::slot_usrcmd_pref ) );
     m_action_group->add( Gtk::Action::create( "FilterPref", "リンクフィルタの編集(_F)..." ), sigc::mem_fun( *this, &Core::slot_filter_pref ) );
-    m_action_group->add( Gtk::Action::create( "ReplacePref", "置換文字列の編集(_R)..." ), [this] { slot_replace_pref(); } );
+    m_action_group->add( Gtk::Action::create( "ReplacePref", "置換文字列の編集(_R)..." ), sigc::mem_fun( *this, &Core::slot_replace_pref ) );
     m_action_group->add( Gtk::Action::create( "AboutConfig", "about:config 高度な設定(_C)..." ), sigc::mem_fun( *this, &Core::slot_aboutconfig ) );
 
 

--- a/src/replacestrpref.cpp
+++ b/src/replacestrpref.cpp
@@ -33,8 +33,8 @@ ReplaceStrDiag::ReplaceStrDiag( Gtk::Window* parent, ReplaceStrCondition conditi
 {
     resize( 600, 1 );
 
-    m_button_copy.signal_clicked().connect( [this] { slot_copy(); } );
-    m_check_regex.signal_clicked().connect( [this] { slot_sens(); } );
+    m_button_copy.signal_clicked().connect( sigc::mem_fun( *this, &ReplaceStrDiag::slot_copy ) );
+    m_check_regex.signal_clicked().connect( sigc::mem_fun( *this, &ReplaceStrDiag::slot_sens ) );
 
     m_check_active.set_active( condition.active );
     m_check_icase.set_active( condition.icase );
@@ -135,12 +135,12 @@ ReplaceStrPref::ReplaceStrPref( Gtk::Window* parent, const std::string& url )
     m_button_down.set_image_from_icon_name( "go-down" );
     m_button_bottom.set_image_from_icon_name( "go-bottom" );
 
-    m_button_top.signal_clicked().connect( [this] { slot_top(); } );
-    m_button_up.signal_clicked().connect( [this] { slot_up(); } );
-    m_button_down.signal_clicked().connect( [this] { slot_down(); } );
-    m_button_bottom.signal_clicked().connect( [this] { slot_bottom(); } );
-    m_button_delete.signal_clicked().connect( [this] { slot_delete(); } );
-    m_button_add.signal_clicked().connect( [this] { slot_add(); } );
+    m_button_top.signal_clicked().connect( sigc::mem_fun( *this, &ReplaceStrPref::slot_top ) );
+    m_button_up.signal_clicked().connect( sigc::mem_fun( *this, &ReplaceStrPref::slot_up ) );
+    m_button_down.signal_clicked().connect( sigc::mem_fun( *this, &ReplaceStrPref::slot_down ) );
+    m_button_bottom.signal_clicked().connect( sigc::mem_fun( *this, &ReplaceStrPref::slot_bottom ) );
+    m_button_delete.signal_clicked().connect( sigc::mem_fun( *this, &ReplaceStrPref::slot_delete ) );
+    m_button_add.signal_clicked().connect( sigc::mem_fun( *this, &ReplaceStrPref::slot_add ) );
 
     std::generate( m_store.begin(), m_store.end(), [this] { return Gtk::ListStore::create( m_columns ); } );
     m_current_store = m_store.back();
@@ -191,7 +191,7 @@ ReplaceStrPref::ReplaceStrPref( Gtk::Window* parent, const std::string& url )
     // スレタイトルは未実装のため省略する
     std::for_each( kReplStrTargetLabels.begin() + kReplStrTargetReserved_0, kReplStrTargetLabels.end(),
                    [this]( const char* target ) { m_menu_target.append( target ); } );
-    m_menu_target.signal_changed().connect( [this] { slot_target_changed(); } );
+    m_menu_target.signal_changed().connect( sigc::mem_fun( *this, &ReplaceStrPref::slot_target_changed ) );
     m_menu_target.set_active_text( kReplStrTargetLabels.back() );
     m_label_target.set_mnemonic_widget( m_menu_target );
 

--- a/src/skeleton/menubutton.cpp
+++ b/src/skeleton/menubutton.cpp
@@ -54,7 +54,7 @@ MenuButton::MenuButton( const bool show_arrow, Gtk::Widget* label, Gtk::PackOpti
         Glib::RefPtr< Gtk::Action > action = Gtk::Action::create( "menu" + std::to_string( i ), "dummy" );
         action->set_accel_group( agroup );
         Gtk::MenuItem* item = Gtk::manage( action->create_menu_item() );
-        actiongroup->add( action, [this, i] { slot_menu_selected( i ); } );
+        actiongroup->add( action, sigc::bind( sigc::mem_fun( *this, &MenuButton::slot_menu_selected ), i ) );
         m_menuitems.push_back( item );
     }
 


### PR DESCRIPTION
`sigc::mem_fun()`を使ってメンバー関数をシグナルに接続するように変更します。
`sigc::trackable`を継承したオブジェクトが破棄されるとき接続が解除されます。

https://developer-old.gnome.org/libsigc++/2.10/group__mem__fun.html#details