### PR TITLE
Regex: Implement named captures

### DIFF
--- a/docs/manual/operation.md
+++ b/docs/manual/operation.md
@@ -671,6 +671,28 @@ layout: default
 
 検索ビューの操作方法はスレビューの操作方法と同じである。
 
+#### スレタイ検索の設定
+about:configの設定 `スレタイ検索時にアドレスとスレタイを取得する正規表現`
+はグループ番号のかわりに名前付きキャプチャを利用することができる。<small>( v0.7.0+から暫定的にサポート )</small>
+
+正規表現パターン中にグループ名が有れば名前付きキャプチャ、無ければグループ番号で対象を取得する。
+
+取得対象 | グループ番号 | グループ名 | 備考
+--- | --- | --- | ---
+スレURL | 1 | `url` | 必須
+スレタイトル | 2 | `subject` | 必須
+レス数 | 3 | `number` | オプション
+
+グループ番号は順序固定のため取得対象が番号順に並んでいないときは名前付きキャプチャを使うと分かりやすい。
+(下の例はスレタイ、レス数、URLの順に並んでいるデータにマッチする)
+
+設定例 | 正規表現パターン
+--- | ---
+グループ番号 | `^(?=[^\t\n]+\t[^\t\n]+\t([^\t\n]+))([^\t\n]+)\t([^\t\n]+)`
+名前付きキャプチャ | `^(?<subject>[^\t\n]+)\t(?<number>[^\t\n]+)\t(?<url>[^\t\n]+)`
+
+正規表現の構文は[Glib公式][gregex]など外部サイトを参照する。
+
 
 <a name="checkupdate"></a>
 ### 更新チェック
@@ -739,3 +761,4 @@ layout: default
 [thread_old]: ../assets/thread_old.png
 [thread_update]: ../assets/thread_update.png
 [thread_updated]: ../assets/thread_updated.png
+[gregex]: https://developer-old.gnome.org/glib/stable/glib-regex-syntax.html

--- a/src/jdlib/jdregex.cpp
+++ b/src/jdlib/jdregex.cpp
@@ -232,6 +232,20 @@ bool Regex::match( const RegexPattern& creg, const std::string& target,
 }
 
 
+bool Regex::match( const RegexPattern& creg, const std::string& target,
+                   const std::size_t offset, const bool notbol, const bool noteol,
+                   const std::vector<std::string>& named_captures )
+{
+    m_named_numbers.clear();
+    for( const std::string& name : named_captures ) {
+        const int num = g_regex_get_string_number( creg.m_regex, name.c_str() );
+        if( num != -1 ) m_named_numbers.emplace( name, num );
+    }
+
+    return match( creg, target, offset, notbol, noteol );
+}
+
+
 //
 // マッチした文字列と \0〜\9 を置換する
 //
@@ -282,4 +296,20 @@ std::string Regex::str( std::size_t num ) const
     if( m_results.size() > num ) return m_results[num];
 
     return {};
+}
+
+
+/**
+ * @brief パターン中にグループ名が有れば名前付きキャプチャ、無ければグループ番号でマッチした部分を取得する。
+ *
+ * どちらにもマッチしなかったときは空文字列を返す
+ * @param[in] name グループ名
+ * @param[in] fallback_num パターン中にグループ名が無かったときに取得するグループ番号
+ */
+std::string Regex::named_or_num( const std::string& name, std::size_t fallback_num ) const
+{
+    const auto it = m_named_numbers.find( name );
+    if( it != m_named_numbers.end() ) return m_results[it->second];
+
+    return str( fallback_num );
 }

--- a/src/jdlib/jdregex.h
+++ b/src/jdlib/jdregex.h
@@ -3,6 +3,7 @@
 #ifndef _JDREGEX_H
 #define _JDREGEX_H
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -52,6 +53,7 @@ namespace JDLIB
     {
         std::vector<int> m_pos;
         std::vector<std::string> m_results;
+        std::map<std::string, int> m_named_numbers; // グループ名(名前付きキャプチャ)からグループ番号を取得する
 
         // 全角半角を区別しないときに使う変換用バッファ
         // 処理可能なバッファ長は regoff_t (= int) のサイズに制限される
@@ -67,6 +69,11 @@ namespace JDLIB
         // noteol : 行末マッチは必ず失敗する
         bool match( const RegexPattern& creg, const std::string& target, const std::size_t offset,
                     const bool notbol = false, const bool noteol = false );
+
+        // named_captures : 後で利用する名前付きキャプチャを登録する
+        bool match( const RegexPattern& creg, const std::string& target, const std::size_t offset,
+                    const bool notbol, const bool noteol,
+                    const std::vector<std::string>& named_captures );
 
         // icase : 大文字小文字区別しない
         // newline :  . に改行をマッチさせない
@@ -85,6 +92,11 @@ namespace JDLIB
         int length( std::size_t num ) const noexcept;
         int pos( std::size_t num ) const noexcept;
         std::string str( std::size_t num ) const;
+        // 名前付きキャプチャ版の取得APIは実際に使う箇所がないため未実装
+
+        // パターン中に名前が有れば名前付きキャプチャ、無ければグループ番号で取得する
+        // どちらにもマッチしなかったときは空文字列を返す
+        std::string named_or_num( const std::string& name, std::size_t fallback_num ) const;
     };
 }
 

--- a/src/searchmanager.cpp
+++ b/src/searchmanager.cpp
@@ -257,14 +257,16 @@ void Search_Manager::search_fin_title()
         const bool usemigemo = false;
         const bool wchar = false;
         const JDLIB::RegexPattern regexptn( pattern, icase, newline, usemigemo, wchar );
+        const std::vector<std::string> named_caps = { "url", "subject", "number" };
 
         std::size_t offset = 0;
-        while( regex.match( regexptn, source, offset ) ){
+        while( regex.match( regexptn, source, offset, false, false, named_caps ) ){
 
             SEARCHDATA data;
-            data.url_readcgi = DBTREE::url_readcgi( regex.str( 1 ), 0, 0 );
-            data.subject = MISC::html_unescape( regex.str( 2 ) );
-            data.num = std::atoi( regex.str( 3 ).c_str() ); // マッチしていなければ 0 になる
+            // パターン中にグループ名が有れば名前付きキャプチャ、無ければグループ番号で取得する
+            data.url_readcgi = DBTREE::url_readcgi( regex.named_or_num( named_caps[0], 1 ), 0, 0 );
+            data.subject = MISC::html_unescape( regex.named_or_num( named_caps[1], 2 ) );
+            data.num = std::atoi( regex.named_or_num( named_caps[2], 3 ).c_str() ); // マッチしていなければ 0 になる
             data.bookmarked = false;
             data.num_bookmarked = 0;
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -110,6 +110,7 @@ gtest_jdim_LDADD = \
 gtest_jdim_SOURCES = \
 	gtest_jdlib_cookiemanager.cpp \
 	gtest_jdlib_jdiconv.cpp \
+	gtest_jdlib_jdregex.cpp \
 	gtest_jdlib_misctime.cpp \
 	gtest_jdlib_misctrip.cpp \
 	gtest_jdlib_miscutil.cpp \

--- a/test/gtest_jdlib_jdregex.cpp
+++ b/test/gtest_jdlib_jdregex.cpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "jdlib/jdregex.h"
+
+#include "gtest/gtest.h"
+
+
+namespace {
+
+constexpr bool icase = false;
+constexpr bool newline = false;
+constexpr bool notbol = false;
+constexpr bool noteol = false;
+
+class Regex_NamedOrNumTest : public ::testing::Test {};
+
+TEST_F(Regex_NamedOrNumTest, invalid_both_arguments)
+{
+    const JDLIB::RegexPattern pattern( "(?<name>foobar)", icase, newline );
+    JDLIB::Regex regex;
+    const std::vector<std::string> named_caps = { "name" };
+    EXPECT_TRUE( regex.match( pattern, "foobar", 0, notbol, noteol, named_caps ) );
+    constexpr std::size_t invalid_group = 10;
+    EXPECT_EQ( regex.named_or_num( "invalid_name", invalid_group ), "" );
+}
+
+TEST_F(Regex_NamedOrNumTest, prioritize_named_capture)
+{
+    const JDLIB::RegexPattern pattern( "(?<name>foobar) (fallback)", icase, newline );
+    JDLIB::Regex regex;
+    const std::vector<std::string> named_caps = { "name" };
+    EXPECT_TRUE( regex.match( pattern, "foobar fallback", 0, notbol, noteol, named_caps ) );
+    constexpr std::size_t valid_group = 2;
+    EXPECT_EQ( regex.named_or_num( "name", valid_group ), "foobar" );
+}
+
+TEST_F(Regex_NamedOrNumTest, unregistered_name)
+{
+    const JDLIB::RegexPattern pattern( "(?<name>foobar) (fallback)", icase, newline );
+    JDLIB::Regex regex;
+    EXPECT_TRUE( regex.match( pattern, "foobar fallback", 0, notbol, noteol ) );
+    constexpr std::size_t valid_group = 2;
+    EXPECT_EQ( regex.named_or_num( "name", valid_group ), "fallback" );
+}
+
+TEST_F(Regex_NamedOrNumTest, register_invalid_name)
+{
+    JDLIB::RegexPattern pattern( "(fallback) (?<name>foobar)", icase, newline );
+    JDLIB::Regex regex;
+    const std::vector<std::string> named_caps = { "invalid_name" };
+    EXPECT_TRUE( regex.match( pattern, "fallback foobar", 0, notbol, noteol, named_caps ) );
+    constexpr std::size_t valid_group = 1;
+    EXPECT_EQ( regex.named_or_num( "name", valid_group ), "fallback" );
+}
+
+} // namespace

--- a/test/meson.build
+++ b/test/meson.build
@@ -2,6 +2,7 @@
 sources = [
   'gtest_jdlib_cookiemanager.cpp',
   'gtest_jdlib_jdiconv.cpp',
+  'gtest_jdlib_jdregex.cpp',
   'gtest_jdlib_misctime.cpp',
   'gtest_jdlib_misctrip.cpp',
   'gtest_jdlib_miscutil.cpp',


### PR DESCRIPTION
#### Regex: Implement named captures

正規表現の名前付きキャプチャ機能をラッパークラスに実装します。
グループ名またはグループ番号でマッチした文字列を取得する関数を追加します。
グループ名のみの取得APIは実際に使う箇所がないため今回は実装しません。

#### Add test cases for JDLIB::Regex::named_or_num()

#### Add provisional support for named captures to thread title search

about:configの `スレタイ検索時にアドレスとスレタイを取得する正規表現`に名前付きキャプチャ対応を追加します。(暫定サポート)
設定した正規表現パターンにグループ名が有れば名前付きキャプチャ、無ければグループ番号で対象を取得します。また、互換性のためグループ番号は現状を維持します。

取得対象     | グループ番号 | グループ名 | 備考
---          | ---          | ---        | ---
スレURL      | 1            | url        | 必須
スレタイトル | 2            | subject    | 必須
レス数       | 3            | number     | オプション

関連のissue: #697