### PR TITLE
Use std::string_view for NodeTreeBase::create_node_multispace()

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -847,9 +847,9 @@ NODE* NodeTreeBase::create_node_space( const int type )
 //
 // 連続半角スペース
 //
-NODE* NodeTreeBase::create_node_multispace( const char* text, const int n, const char fontid )
+NODE* NodeTreeBase::create_node_multispace( std::string_view text, const char fontid )
 {
-    NODE* tmpnode = create_node_ntext( text, n, COLOR_CHAR, false, fontid );
+    NODE* tmpnode = create_node_ntext( text.data(), text.size(), COLOR_CHAR, false, fontid );
     tmpnode->type = NODE_MULTISP;
     return tmpnode;
 }
@@ -2031,7 +2031,7 @@ void NodeTreeBase::parse_html( const char* str, const int lng, const int color_t
             while( *pos == ' ' ) {
                 m_parsed_text.push_back( *(pos++) );
             }
-            create_node_multispace( m_parsed_text.c_str(), m_parsed_text.size(), fontid );
+            create_node_multispace( m_parsed_text, fontid );
             m_parsed_text.clear();
         }
     }
@@ -2247,7 +2247,7 @@ void NodeTreeBase::parse_html( const char* str, const int lng, const int color_t
                         while( *pos == ' ' ) {
                             m_parsed_text.push_back( *(pos++) );
                         }
-                        create_node_multispace( m_parsed_text.c_str(), m_parsed_text.size(), fontid );
+                        create_node_multispace( m_parsed_text, fontid );
                         m_parsed_text.clear();
                     }
                 }
@@ -2454,7 +2454,7 @@ void NodeTreeBase::parse_html( const char* str, const int lng, const int color_t
             while( *pos == ' ' ) {
                 m_parsed_text.push_back( *(pos++) );
             }
-            create_node_multispace( m_parsed_text.c_str(), m_parsed_text.size(), fontid );
+            create_node_multispace( m_parsed_text, fontid );
             m_parsed_text.clear();
 
             // forのところで++されるので--しておく

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -16,8 +16,9 @@
 #include "jdlib/miscutil.h"
 #include "jdlib/jdregex.h"
 
-#include <map>
 #include <cstring>
+#include <map>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -301,7 +302,7 @@ namespace DBTREE
         NODE* create_node_br();
         NODE* create_node_hr();
         NODE* create_node_space( const int type );
-        NODE* create_node_multispace( const char* text, const int n, const char fontid = FONT_MAIN );
+        NODE* create_node_multispace( std::string_view text, const char fontid = FONT_MAIN );
         NODE* create_node_htab();
         NODE* create_node_link( const char* text, const int n, const char* link, const int n_link, const int color_text, const bool bold, const char fontid = FONT_MAIN );
         NODE* create_node_anc( const char* text, const int n, const char* link, const int n_link,


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡しているメンバ関数の引数を`std::string_view`に交換して整理します。