### PR TITLE
Use std::string_view for NodeTreeBase::create_node_thumbnail()

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -951,9 +951,11 @@ NODE* NodeTreeBase::create_node_img( const char* text, const int n, const char* 
 //
 // サムネイル画像ノード ( youtubeなどのサムネイル表示用 )
 //
-NODE* NodeTreeBase::create_node_thumbnail( const char* text, const int n, const char* link, const int n_link, const char* thumb, const int n_thumb, const int color_text, const bool bold, const char fontid )
+NODE* NodeTreeBase::create_node_thumbnail( std::string_view text, const char* link, const int n_link,
+                                           const char* thumb, const int n_thumb, const int color_text, const bool bold,
+                                           const char fontid )
 {
-    NODE* tmpnode = create_node_link( text, n, link, n_link, color_text, bold, fontid );
+    NODE* tmpnode = create_node_link( text.data(), text.size(), link, n_link, color_text, bold, fontid );
 
     if( tmpnode ){
         // サムネイル画像のURLをセット
@@ -2368,12 +2370,14 @@ void NodeTreeBase::parse_html( const char* str, const int lng, const int color_t
             }
 
             else {
+                std::string_view tmp_view( tmpstr, lng_str );
+
                 // Urlreplaceによる画像コントロールを取得する
                 int imgctrl = CORE::get_urlreplace_manager()->get_imgctrl( std::string( tmpreplace, lng_replace ) );
 
                 // youtubeなどのサムネイル画像リンク
                 if( imgctrl & CORE::IMGCTRL_THUMBNAIL ){
-                    create_node_thumbnail( tmpstr, lng_str, tmplink , lng_link, tmpreplace, lng_replace, COLOR_CHAR_LINK, bold, fontid );
+                    create_node_thumbnail( tmp_view, tmplink , lng_link, tmpreplace, lng_replace, COLOR_CHAR_LINK, bold, fontid );
                 }
 
                 // 画像リンク

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -313,7 +313,7 @@ namespace DBTREE
                                const bool bold, const char fontid = FONT_MAIN );
         NODE* create_node_text( const char* text, const int color_text, const bool bold = false, const char fontid = FONT_MAIN );
         NODE* create_node_ntext( const char* text, const int n, const int color_text, const bool bold = false, const char fontid = FONT_MAIN );
-        NODE* create_node_thumbnail( const char* text, const int n, const char* link, const int n_link, const char* thumb, const int n_thumb,
+        NODE* create_node_thumbnail( std::string_view text, const char* link, const int n_link, const char* thumb, const int n_thumb,
                                      const int color_text, const bool bold, const char fontid = FONT_MAIN );
 
         // 以下、構文解析用関数


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡しているメンバ関数の引数を`std::string_view`に交換して整理します。

関連のpull request: #905