### PR TITLE
ICON_Manager: Change APPENDFAVORITE icon

### DIFF
--- a/src/icons/iconmanager.cpp
+++ b/src/icons/iconmanager.cpp
@@ -149,7 +149,12 @@ ICON_Manager::ICON_Manager()
     m_list_icons[ ICON::STOPLOADING ] = icon_theme->load_icon( "process-stop", size_menu );
     m_list_icons[ ICON::WRITE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_write ), icon_write );
     m_list_icons[ ICON::RELOAD ] = icon_theme->load_icon( "view-refresh", size_menu );
-    m_list_icons[ ICON::APPENDFAVORITE ] = icon_theme->load_icon( "edit-copy", size_menu );
+    try {
+        m_list_icons[ ICON::APPENDFAVORITE ] = icon_theme->load_icon( "emblem-favorite", size_menu );
+    }
+    catch( Gtk::IconThemeError& ) {
+        m_list_icons[ ICON::APPENDFAVORITE ] = icon_theme->load_icon( "edit-copy", size_menu );
+    }
     m_list_icons[ ICON::DELETE ] = icon_theme->load_icon( "edit-delete", size_menu );
     m_list_icons[ ICON::QUIT ] = icon_theme->load_icon( "window-close", size_menu );
     m_list_icons[ ICON::BACK ] = icon_theme->load_icon( "go-previous", size_menu );


### PR DESCRIPTION
「お気に入りに追加」ボタンのアイコンが分かりにくいためXDGアイコンを"emblem-favorite"に変更します（テーマによって異なるが星やハートマークなどが表示される）。
読み込み失敗したときは変更前の"edit-copy"を使います。

https://next2ch.net/test/read.cgi/linux/1613035222/678-680