### PR TITLE
Use std::string_view for NodeTreeBase::create_node_img()

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -936,9 +936,10 @@ NODE* NodeTreeBase::create_node_sssp( const char* link, const int n_link )
 //
 // 画像ノード作成
 //
-NODE* NodeTreeBase::create_node_img( const char* text, const int n, const char* link, const int n_link, const int color_text,  const bool bold, const char fontid )
+NODE* NodeTreeBase::create_node_img( std::string_view text, const char* link, const int n_link, const int color_text,
+                                     const bool bold, const char fontid )
 {
-    NODE* tmpnode = create_node_link( text, n, link, n_link, color_text, bold, fontid );
+    NODE* tmpnode = create_node_link( text.data(), text.size(), link, n_link, color_text, bold, fontid );
     if( tmpnode ){
         tmpnode->linkinfo->image = true;
         tmpnode->linkinfo->imglink = tmpnode->linkinfo->link;
@@ -2382,7 +2383,7 @@ void NodeTreeBase::parse_html( const char* str, const int lng, const int color_t
 
                 // 画像リンク
                 else if( DBIMG::get_type_ext( tmpreplace, lng_replace ) != DBIMG::T_UNKNOWN ){
-                    node = create_node_img( tmpstr, lng_str, tmpreplace , lng_replace, COLOR_IMG_NOCACHE, bold );
+                    node = create_node_img( tmp_view, tmpreplace , lng_replace, COLOR_IMG_NOCACHE, bold );
                     if ( fontid != FONT_MAIN ) node->fontid = fontid;
                 }
     

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -309,7 +309,7 @@ namespace DBTREE
                                const int color_text, const bool bold,
                                const ANCINFO* ancinfo, const int lng_ancinfo, const char fontid = FONT_MAIN );
         NODE* create_node_sssp( const char* link, const int n_link );
-        NODE* create_node_img( const char* text, const int n, const char* link, const int n_link, const int color_text,
+        NODE* create_node_img( std::string_view text, const char* link, const int n_link, const int color_text,
                                const bool bold, const char fontid = FONT_MAIN );
         NODE* create_node_text( const char* text, const int color_text, const bool bold = false, const char fontid = FONT_MAIN );
         NODE* create_node_ntext( const char* text, const int n, const int color_text, const bool bold = false, const char fontid = FONT_MAIN );


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡しているメンバ関数の引数を`std::string_view`に交換して整理します。

関連のpull request: #905 