### PR TITLE
Use std::string_view for NodeTreeBase::create_node_link()

### DIFF
--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -304,7 +304,8 @@ namespace DBTREE
         NODE* create_node_space( const int type );
         NODE* create_node_multispace( std::string_view text, const char fontid = FONT_MAIN );
         NODE* create_node_htab();
-        NODE* create_node_link( const char* text, const int n, const char* link, const int n_link, const int color_text, const bool bold, const char fontid = FONT_MAIN );
+        NODE* create_node_link( std::string_view text, const char* link, const int n_link,
+                                const int color_text, const bool bold, const char fontid = FONT_MAIN );
         NODE* create_node_anc( std::string_view text, const char* link, const int n_link,
                                const int color_text, const bool bold,
                                const ANCINFO* ancinfo, const int lng_ancinfo, const char fontid = FONT_MAIN );


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡しているメンバ関数の引数を`std::string_view`に交換して整理します。

関連のpull request: #905 