### PR TITLE
ICON_Manager: Change APPENDFAVIRITE icon (retake)

### DIFF
--- a/src/icons/iconmanager.cpp
+++ b/src/icons/iconmanager.cpp
@@ -150,7 +150,7 @@ ICON_Manager::ICON_Manager()
     m_list_icons[ ICON::WRITE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_write ), icon_write );
     m_list_icons[ ICON::RELOAD ] = icon_theme->load_icon( "view-refresh", size_menu );
     try {
-        m_list_icons[ ICON::APPENDFAVORITE ] = icon_theme->load_icon( "emblem-favorite", size_menu );
+        m_list_icons[ ICON::APPENDFAVORITE ] = icon_theme->load_icon( "bookmark-new", size_menu );
     }
     catch( Gtk::IconThemeError& ) {
         m_list_icons[ ICON::APPENDFAVORITE ] = icon_theme->load_icon( "edit-copy", size_menu );


### PR DESCRIPTION
前のアイコン変更(571af0f3fd)ではテーマごとにアイコンの意味合いが違っていました（星は重要性、ハートはポジティブ感情）。
そのため再度「お気に入りに追加」ボタンのアイコンを変更し"bookmark-new"にします（星や栞にプラス記号が付いて表示される）。
読み込み失敗したときは変更前の"edit-copy"を使います。

https://next2ch.net/test/read.cgi/linux/1613035222/694-697