### PR TITLE
Admin: Add append-favorite to tab context menu

### DIFF
--- a/src/article/articleadmin.cpp
+++ b/src/article/articleadmin.cpp
@@ -787,3 +787,23 @@ void ArticleAdmin::slot_drag_data_get( Gtk::SelectionData& selection_data, const
 
     selection_data.set( DNDTARGET_FAVORITE, get_url() );
 }
+
+
+/**
+ * @brief page をお気に入りに追加するダイアログを開く
+ */
+void ArticleAdmin::append_favorite_impl( const std::string& url )
+{
+    CORE::DATA_INFO info;
+    info.type = TYPE_THREAD;
+    info.url = DBTREE::url_readcgi( url, 0, 0 );
+    info.name = DBTREE::article_subject( info.url );
+    info.path = Gtk::TreePath( "0" ).to_string();
+
+    if( info.url.empty() ) return;
+
+    CORE::DATA_INFO_LIST list_info;
+    list_info.push_back( std::move( info ) );
+    CORE::SBUF_set_list( list_info );
+    CORE::core_set_command( "append_favorite", URL_FAVORITEVIEW );
+}

--- a/src/article/articleadmin.h
+++ b/src/article/articleadmin.h
@@ -77,6 +77,7 @@ namespace ARTICLE
 
         // タブをお気に入りにドロップした時にお気に入りがデータ送信を要求してきた
         void slot_drag_data_get( Gtk::SelectionData& selection_data, const int page ) override;
+        void append_favorite_impl( const std::string& url ) override;
     };
     
     ARTICLE::ArticleAdmin* get_admin();

--- a/src/board/boardadmin.cpp
+++ b/src/board/boardadmin.cpp
@@ -449,3 +449,24 @@ void BoardAdmin::slot_drag_data_get( Gtk::SelectionData& selection_data, const i
 
     selection_data.set( DNDTARGET_FAVORITE, get_url() );
 }
+
+
+
+/**
+ * @brief page をお気に入りに追加するダイアログを開く
+ */
+void BoardAdmin::append_favorite_impl( const std::string& url )
+{
+    CORE::DATA_INFO info;
+    info.type = TYPE_BOARD;
+    info.url = DBTREE::url_boardbase( url );
+    info.name = DBTREE::board_name( info.url );
+    info.path = Gtk::TreePath( "0" ).to_string();
+
+    if( info.url.empty() ) return;
+
+    CORE::DATA_INFO_LIST list_info;
+    list_info.push_back( std::move( info ) );
+    CORE::SBUF_set_list( list_info );
+    CORE::core_set_command( "append_favorite", URL_FAVORITEVIEW );
+}

--- a/src/board/boardadmin.h
+++ b/src/board/boardadmin.h
@@ -56,6 +56,7 @@ namespace BOARD
 
         // タブをお気に入りにドロップした時にお気に入りがデータ送信を要求してきた
         void slot_drag_data_get( Gtk::SelectionData& selection_data, const int page ) override;
+        void append_favorite_impl( const std::string& url ) override;
     };
     
     BoardAdmin* get_admin();

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -299,6 +299,8 @@ namespace SKELETON
         virtual void slot_open_by_browser();
         virtual void slot_copy_url();
         virtual void slot_copy_title_url();
+        void slot_append_favorite();
+        virtual void append_favorite_impl( const std::string& url ) {}
 
         // ページがロックされているかリストで取得
         virtual std::list< bool > get_locked();


### PR DESCRIPTION
タブの右クリックメニューに「お気に入りに追加」を実装します。
メニュー項目を選択すると追加先を選択するダイアログを呼び出します。
また、仮想板や抽出ビューのタブはお気に入りに追加を選択不可にします。

XXX: 選択不可の条件は誤判定になる可能性がある (ソースを参照)

https://next2ch.net/test/read.cgi/linux/1613035222/676

関連のissue: #910