### PR TITLE
Use std::string_view for NodeTreeBase::create_node_thumbnail() part2 part3

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -954,16 +954,16 @@ NODE* NodeTreeBase::create_node_img( std::string_view text, const char* link, co
 // サムネイル画像ノード ( youtubeなどのサムネイル表示用 )
 //
 NODE* NodeTreeBase::create_node_thumbnail( std::string_view text, std::string_view link,
-                                           const char* thumb, const int n_thumb, const int color_text, const bool bold,
+                                           std::string_view thumb, const int color_text, const bool bold,
                                            const char fontid )
 {
     NODE* tmpnode = create_node_link( text, link.data(), link.size(), color_text, bold, fontid );
 
     if( tmpnode ){
         // サムネイル画像のURLをセット
-        char *tmpthumb = m_heap.heap_alloc<char>( n_thumb + 1 );
-        memcpy( tmpthumb, thumb, n_thumb );
-        tmpthumb[ n_thumb ] = '\0';
+        char *tmpthumb = m_heap.heap_alloc<char>( thumb.size() + 1 );
+        thumb.copy( tmpthumb, thumb.size() );
+        tmpthumb[ thumb.size() ] = '\0';
 
         tmpnode->linkinfo->imglink = tmpthumb;
     }
@@ -2374,7 +2374,7 @@ void NodeTreeBase::parse_html( const char* str, const int lng, const int color_t
                 // youtubeなどのサムネイル画像リンク
                 if( imgctrl & CORE::IMGCTRL_THUMBNAIL ){
                     std::string_view view_tmplink( tmplink, lng_link );
-                    create_node_thumbnail( tmp_view, view_tmplink, tmpreplace.c_str(), tmpreplace.size(), COLOR_CHAR_LINK, bold, fontid );
+                    create_node_thumbnail( tmp_view, view_tmplink, tmpreplace, COLOR_CHAR_LINK, bold, fontid );
                 }
 
                 // 画像リンク

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -953,11 +953,11 @@ NODE* NodeTreeBase::create_node_img( std::string_view text, const char* link, co
 //
 // サムネイル画像ノード ( youtubeなどのサムネイル表示用 )
 //
-NODE* NodeTreeBase::create_node_thumbnail( std::string_view text, const char* link, const int n_link,
+NODE* NodeTreeBase::create_node_thumbnail( std::string_view text, std::string_view link,
                                            const char* thumb, const int n_thumb, const int color_text, const bool bold,
                                            const char fontid )
 {
-    NODE* tmpnode = create_node_link( text, link, n_link, color_text, bold, fontid );
+    NODE* tmpnode = create_node_link( text, link.data(), link.size(), color_text, bold, fontid );
 
     if( tmpnode ){
         // サムネイル画像のURLをセット
@@ -2373,7 +2373,8 @@ void NodeTreeBase::parse_html( const char* str, const int lng, const int color_t
 
                 // youtubeなどのサムネイル画像リンク
                 if( imgctrl & CORE::IMGCTRL_THUMBNAIL ){
-                    create_node_thumbnail( tmp_view, tmplink , lng_link, tmpreplace.c_str(), tmpreplace.size(), COLOR_CHAR_LINK, bold, fontid );
+                    std::string_view view_tmplink( tmplink, lng_link );
+                    create_node_thumbnail( tmp_view, view_tmplink, tmpreplace.c_str(), tmpreplace.size(), COLOR_CHAR_LINK, bold, fontid );
                 }
 
                 // 画像リンク

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -314,7 +314,7 @@ namespace DBTREE
                                const bool bold, const char fontid = FONT_MAIN );
         NODE* create_node_text( const char* text, const int color_text, const bool bold = false, const char fontid = FONT_MAIN );
         NODE* create_node_ntext( const char* text, const int n, const int color_text, const bool bold = false, const char fontid = FONT_MAIN );
-        NODE* create_node_thumbnail( std::string_view text, std::string_view link, const char* thumb, const int n_thumb,
+        NODE* create_node_thumbnail( std::string_view text, std::string_view link, std::string_view thumb,
                                      const int color_text, const bool bold, const char fontid = FONT_MAIN );
 
         // 以下、構文解析用関数

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -314,7 +314,7 @@ namespace DBTREE
                                const bool bold, const char fontid = FONT_MAIN );
         NODE* create_node_text( const char* text, const int color_text, const bool bold = false, const char fontid = FONT_MAIN );
         NODE* create_node_ntext( const char* text, const int n, const int color_text, const bool bold = false, const char fontid = FONT_MAIN );
-        NODE* create_node_thumbnail( std::string_view text, const char* link, const int n_link, const char* thumb, const int n_thumb,
+        NODE* create_node_thumbnail( std::string_view text, std::string_view link, const char* thumb, const int n_thumb,
                                      const int color_text, const bool bold, const char fontid = FONT_MAIN );
 
         // 以下、構文解析用関数


### PR DESCRIPTION
#### [Use std::string_view for NodeTreeBase::create_node_thumbnail() part2](https://github.com/JDimproved/JDim/commit/b6de6c2ee9a3c1f8ded41d43f6e55dde47db26b8) 

変更不可の文字列のポインターと長さを渡しているメンバ関数の引数を`std::string_view`に交換して整理します。

#### [Use std::string_view for NodeTreeBase::create_node_thumbnail() part3](https://github.com/JDimproved/JDim/commit/1b1e3b7ba7e4c4d7e0a21568a0053e5e60600b63)[](https://github.com/JDimproved/JDim/commits?author=ma8ma)

変更不可の文字列のポインターと長さを渡しているメンバ関数の引数を
`std::string_view`に交換して整理します。

関連のpull request: #905 