### PR TITLE
Use std::string_view for NodeTreeBase::create_node_anc() part2

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -896,11 +896,11 @@ NODE* NodeTreeBase::create_node_link( std::string_view text, const char* link, c
 //
 // アンカーノード作成
 //
-NODE* NodeTreeBase::create_node_anc( std::string_view text, const char* link, const int n_link,
+NODE* NodeTreeBase::create_node_anc( std::string_view text, std::string_view link,
                                      const int color_text,  const bool bold,
                                      const ANCINFO* ancinfo, const int lng_ancinfo, const char fontid )
 {
-    NODE* tmpnode = create_node_link( text, link, n_link, color_text, bold, fontid );
+    NODE* tmpnode = create_node_link( text, link.data(), link.size(), color_text, bold, fontid );
     if( tmpnode ){
 
         tmpnode->linkinfo->ancinfo = m_heap.heap_alloc<ANCINFO>( lng_ancinfo + 1 );
@@ -2303,7 +2303,8 @@ void NodeTreeBase::parse_html( const char* str, const int lng, const int color_t
             }
 
             std::string_view tmp_view( tmpstr, lng_str );
-            create_node_anc( tmp_view, tmplink, lng_link, COLOR_CHAR_LINK, bold, ancinfo, lng_anc, fontid );
+            std::string_view view_tmplink( tmplink, lng_link );
+            create_node_anc( tmp_view, view_tmplink, COLOR_CHAR_LINK, bold, ancinfo, lng_anc, fontid );
 
             // forのところで++されるので--しておく
             --pos;

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -306,7 +306,7 @@ namespace DBTREE
         NODE* create_node_htab();
         NODE* create_node_link( std::string_view text, const char* link, const int n_link,
                                 const int color_text, const bool bold, const char fontid = FONT_MAIN );
-        NODE* create_node_anc( std::string_view text, const char* link, const int n_link,
+        NODE* create_node_anc( std::string_view text, std::string_view link,
                                const int color_text, const bool bold,
                                const ANCINFO* ancinfo, const int lng_ancinfo, const char fontid = FONT_MAIN );
         NODE* create_node_sssp( std::string_view link );


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡しているメンバ関数の引数を`std::string_view`に交換して整理します。

関連のpull request: #905 