### PR TITLE
Use std::string_view for NodeTreeBase::create_node_link() part2

### DIFF
--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -302,7 +302,7 @@ namespace DBTREE
         NODE* create_node_space( const int type );
         NODE* create_node_multispace( std::string_view text, const char fontid = FONT_MAIN );
         NODE* create_node_htab();
-        NODE* create_node_link( std::string_view text, const char* link, const int n_link,
+        NODE* create_node_link( std::string_view text, std::string_view link,
                                 const int color_text, const bool bold, const char fontid = FONT_MAIN );
         NODE* create_node_anc( std::string_view text, std::string_view link,
                                const int color_text, const bool bold,


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡しているメンバ関数の引数を`std::string_view`に交換して整理します。

関連のpull request: #905 