### PR TITLE
IOMonitor: Remove quit command for debug build

### DIFF
--- a/src/iomonitor.cpp
+++ b/src/iomonitor.cpp
@@ -188,11 +188,6 @@ bool IOMonitor::slot_ioin( Glib::IOCondition io_condition )
         MISC::ERRMSG( "IOMonitor::slot_ioin(): read error." );
     }
 
-#ifdef _DEBUG
-    std::cout << "入力文字: " << buffer << std::endl;
-    if( buffer == "Q" ) Gtk::Main::quit();
-#endif // _DEBUG
-
     // FIFOに書き込まれたURLを開く
     // "現在のタブ/新しいタブ"など、開き方を選ぶ必要があるかも知れない
     //core_set_command( "open_article", buffer, "left", "auto" );

--- a/src/iomonitor.cpp
+++ b/src/iomonitor.cpp
@@ -11,10 +11,11 @@
 #include "cache.h"
 #include "jdlib/miscmsg.h"
 
-#include <fcntl.h>
-#include <errno.h>
 #include <cstring>
+#include <errno.h>
+#include <fcntl.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 
 using namespace CORE;

--- a/src/iomonitor.h
+++ b/src/iomonitor.h
@@ -6,7 +6,7 @@
 #ifndef _IOMONITOR_H
 #define _IOMONITOR_H
 
-#include <gtkmm.h>
+#include <glibmm.h>
 
 
 namespace CORE


### PR DESCRIPTION
デバッグビルドで使えるFIFOを介した終了コマンドを削除します。
デフォルトのビルドではデバッグビルドが無効になっているためコマンドを使う機会がほとんどありませんでした。