### PR TITLE
Implement MISC::utf8bytes()

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -16,6 +16,7 @@
 #include "embeddedimage.h"
 
 #include "jdlib/jdregex.h"
+#include "jdlib/misccharcode.h"
 #include "jdlib/miscgtk.h"
 #include "jdlib/miscmsg.h"
 #include "jdlib/miscutil.h"
@@ -1515,8 +1516,7 @@ bool DrawAreaBase::set_init_wide_mode( const char* str, const int pos_start, con
     int i = pos_start;
     while( i < pos_to ){
 
-        int byte_tmp;
-        MISC::utf8toucs2( str + i, byte_tmp );
+        const int byte_tmp = MISC::utf8bytes( str + i );
 
         // 文字列に全角が含まれていたら全角モードで開始
         if( byte_tmp != 1 ) break;

--- a/src/jdlib/misccharcode.h
+++ b/src/jdlib/misccharcode.h
@@ -22,8 +22,11 @@ namespace MISC
     bool is_euc( const char* input, size_t read_byte );
     bool is_jis( const char* input, size_t& read_byte );
     bool is_sjis( const char* input, size_t read_byte );
-    bool is_utf( const char* input, size_t read_byte );
+    bool is_utf8( const char* input, size_t read_byte );
     int judge_char_code( const std::string& str );
+
+    /// utf-8文字のbyte数を返す
+    int utf8bytes( const char* utf8str );
 }
 
 #endif

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -3,11 +3,12 @@
 //#define _DEBUG
 #include "jddebug.h"
 
-#include "miscutil.h"
-#include "miscmsg.h"
+#include "hkana.h"
 #include "jdiconv.h"
 #include "jdregex.h"
-#include "hkana.h"
+#include "misccharcode.h"
+#include "miscmsg.h"
+#include "miscutil.h"
 
 #include "dbtree/spchar_decoder.h"
 #include "dbtree/node.h"
@@ -677,7 +678,7 @@ std::string MISC::cut_str( const std::string& str, const unsigned int maxsize )
     const size_t outstr_length = outstr.length();
 
     for( pos = 0, lng_str = 0; pos < outstr_length; pos += byte ){
-        MISC::utf8toucs2( outstr.c_str()+pos, byte );
+        byte = MISC::utf8bytes( outstr.c_str() + pos );
         if( byte > 1 ) lng_str += 2;
         else ++lng_str;
         if( lng_str >= maxsize ) break;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -111,6 +111,7 @@ gtest_jdim_SOURCES = \
 	gtest_jdlib_cookiemanager.cpp \
 	gtest_jdlib_jdiconv.cpp \
 	gtest_jdlib_jdregex.cpp \
+	gtest_jdlib_misccharcode.cpp \
 	gtest_jdlib_misctime.cpp \
 	gtest_jdlib_misctrip.cpp \
 	gtest_jdlib_miscutil.cpp \

--- a/test/gtest_jdlib_misccharcode.cpp
+++ b/test/gtest_jdlib_misccharcode.cpp
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "jdlib/misccharcode.h"
+
+#include "gtest/gtest.h"
+
+
+namespace {
+
+class Utf8BytesTest : public ::testing::Test {};
+
+TEST_F(Utf8BytesTest, null_data)
+{
+    EXPECT_EQ( 0, MISC::utf8bytes( nullptr ) );
+    EXPECT_EQ( 0, MISC::utf8bytes( "" ) );
+}
+
+TEST_F(Utf8BytesTest, ascii)
+{
+    char ascii_seq[2]{};
+    for( int i = 1; i < 0x80; ++i ) {
+        ascii_seq[0] = i;
+        EXPECT_EQ( 1, MISC::utf8bytes( ascii_seq ) );
+    }
+}
+
+TEST_F(Utf8BytesTest, two_bytes)
+{
+    EXPECT_EQ( 2, MISC::utf8bytes( "\xC2\x80" ) ); // U+0080
+    EXPECT_EQ( 2, MISC::utf8bytes( "\xDF\xBF" ) ); // U+07FF
+}
+
+TEST_F(Utf8BytesTest, three_bytes)
+{
+    EXPECT_EQ( 3, MISC::utf8bytes( "\xE0\xA0\x80" ) ); // U+0800
+    EXPECT_EQ( 3, MISC::utf8bytes( "\xEF\xBF\xBF" ) ); // U+FFFF
+}
+
+TEST_F(Utf8BytesTest, four_bytes)
+{
+    EXPECT_EQ( 4, MISC::utf8bytes( "\xF0\x90\x80\x80" ) ); // U+10000
+    EXPECT_EQ( 4, MISC::utf8bytes( "\xF4\x8F\xBF\xBF" ) ); // U+10FFFF
+}
+
+TEST_F(Utf8BytesTest, obsolete_four_bytes)
+{
+    // 廃止された RFC2279
+    // 簡易的なチェックのため先頭が F4 のシーケンスは4(バイト)が返る
+    EXPECT_EQ( 4, MISC::utf8bytes( "\xF4\x90\x80\x80" ) ); // U+110000
+    EXPECT_EQ( 4, MISC::utf8bytes( "\xF4\xBF\xBF\xBF" ) ); // U+13FFFF
+
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xF5\x80\x80\x80" ) ); // U+140000
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xF6\x80\x80\x80" ) ); // U+180000
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xF7\x80\x80\x80" ) ); // U+1C0000
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xF7\xBF\xBF\xBF" ) ); // U+1FFFFF
+}
+
+TEST_F(Utf8BytesTest, obsolete_five_bytes)
+{
+    // 廃止された RFC2279
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xF8\x88\x80\x80\x80" ) ); // U+200000
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xF9\x80\x80\x80\x80" ) ); // U+1000000
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xFA\x80\x80\x80\x80" ) ); // U+2000000
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xFB\x80\x80\x80\x80" ) ); // U+3000000
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xFB\xBF\xBF\xBF\xBF" ) ); // U+3FFFFFF
+}
+
+TEST_F(Utf8BytesTest, obsolete_six_bytes)
+{
+    // 廃止された RFC2279
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xFC\x84\x80\x80\x80\x80" ) ); // U+4000000
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xFD\x80\x80\x80\x80\x80" ) ); // U+40000000
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xFD\xBF\xBF\xBF\xBF\xBF" ) ); // U+7FFFFFFF
+}
+
+TEST_F(Utf8BytesTest, invalid_byte)
+{
+    // マルチバイトの後続部分
+    char invalid_seq[2]{};
+    for( int i = 0x80; i < 0xC0; ++i ) {
+        invalid_seq[0] = i;
+        EXPECT_EQ( 0, MISC::utf8bytes( invalid_seq ) );
+    }
+
+    // 最少のバイト数による表現以外は不正
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xC0" ) );
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xC1" ) );
+
+    // UTF-16, UTF-32 で使われるバイトオーダーマーク
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xFE" ) );
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xFF" ) );
+}
+
+TEST_F(Utf8BytesTest, invalid_seq)
+{
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xC2\x7F" ) );
+    EXPECT_EQ( 0, MISC::utf8bytes( "\xC2\xC0" ) );
+
+    // 簡易的なチェックのため非ゼロが返る (右コメントは正しい範囲)
+    EXPECT_EQ( 3, MISC::utf8bytes( "\xE0\x9F\x80" ) ); // E0 A0-BF 80-BF
+    EXPECT_EQ( 3, MISC::utf8bytes( "\xED\xA0\x80" ) ); // ED 80-9F 80-BF
+    EXPECT_EQ( 4, MISC::utf8bytes( "\xF0\x8F\x80\x80" ) ); // F0 90-BF 80-BF 80-BF
+}
+
+} // namespace

--- a/test/meson.build
+++ b/test/meson.build
@@ -3,6 +3,7 @@ sources = [
   'gtest_jdlib_cookiemanager.cpp',
   'gtest_jdlib_jdiconv.cpp',
   'gtest_jdlib_jdregex.cpp',
+  'gtest_jdlib_misccharcode.cpp',
   'gtest_jdlib_misctime.cpp',
   'gtest_jdlib_misctrip.cpp',
   'gtest_jdlib_miscutil.cpp',


### PR DESCRIPTION
#### [Implement MISC::utf8bytes()](https://github.com/JDimproved/JDim/commit/26aed31e563b82e6d7fb197c3ea268308da07521)

UTF-8で符号化された文字のバイト数を返す関数を追加する。
また、バイト数を取得するコードを実装した関数に更新する。

#### [Add test cases for MISC::utf8bytes()](https://github.com/JDimproved/JDim/commit/4dbdb92776732ea10857c69706b37d4709197e9c)
