### PR TITLE
Use std::string_view for NodeTreeBase::parse_html()

### DIFF
--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -328,7 +328,7 @@ namespace DBTREE
         //             false なら数字の前に >> がついてるときだけアンカーにする
         // bold : ボールド表示
         // ahref : <a href=～></a> からリンクノードを作成する
-        void parse_html( const char* str, const int lng, const int color_text,
+        void parse_html( std::string_view str, const int color_text,
                          bool digitlink, const bool bold, const bool ahref, const char fontid = FONT_MAIN );
 
         // 書き込みログ比較用文字列作成


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡しているメンバ関数の引数を`std::string_view`に交換して整理します。

関連のpull request: #905 