### PR TITLE
Set signal action to ignore SIGPIPE for preventing crash

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -382,6 +382,13 @@ int main( int argc, char **argv )
         fprintf( stderr, "sigaction failed\n" );
         exit( 1 );
     }
+    // 接続が切れたソケットに書き込むと SIGPIPE が発生して強制終了するので無視するように設定する
+    std::memset( &sigact, 0, sizeof(struct sigaction) );
+    sigact.sa_handler = SIG_IGN;
+    if( sigaction( SIGPIPE, &sigact, nullptr ) != 0 ) {
+        std::cerr << "sigaction failed (SIGPIPE)\n";
+        std::exit( 1 );
+    }
 
     Gtk::Main m( &argc, &argv );
 


### PR DESCRIPTION
接続が閉じられたソケットに書き込むと強制終了するため原因となるシグナル(SIGPIPE)を無視するように設定します。