### PR TITLE
Use std::string_view for MISC::chref_decode()

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -987,18 +987,18 @@ static std::string chref_decode_one( const char* str, int& n_in, const bool comp
 //
 // completely = true の時は'"' '&' '<' '>'もデコードする
 //
-std::string MISC::chref_decode( const char* str, const int lng, const bool completely )
+std::string MISC::chref_decode( std::string_view str, const bool completely )
 {
     std::string str_out;
 
-    if( lng <= 0 ) return str_out;
-    if( std::memchr( str, '&', lng ) == nullptr ) {
-        str_out.assign( str, lng );
+    if( str.empty() ) return str_out;
+    if( str.find( '&' ) == std::string_view::npos ) {
+        str_out.assign( str );
         return str_out;
     }
 
-    const char* pos = str;
-    const char* pos_end = str + lng;
+    const char* pos = str.data();
+    const char* pos_end = str.data() + str.size();
 
     while( pos < pos_end ) {
 

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -5,11 +5,14 @@
 #ifndef _MISCUTIL_H
 #define _MISCUTIL_H
 
-#include <string>
+
+#include <glibmm.h>
+
 #include <cstring>
 #include <list>
+#include <string>
+#include <string_view>
 #include <vector>
-#include <glibmm.h>
 
 namespace MISC
 {
@@ -164,11 +167,7 @@ namespace MISC
     std::string html_unescape( const std::string& str );
 
     // HTML文字参照をデコード( completely=trueの場合は '&' '<' '>' '"' を含める )
-    std::string chref_decode( const char* str, const int lng, const bool completely = true );
-    inline std::string chref_decode( const std::string& str, const bool completely = true )
-    {
-        return MISC::chref_decode( str.c_str(), str.size(), completely );
-    }
+    std::string chref_decode( std::string_view str, const bool completely );
 
     // URL中のスキームを判別する
     // 戻り値 : スキームタイプ

--- a/src/replacestrmanager.cpp
+++ b/src/replacestrmanager.cpp
@@ -241,7 +241,7 @@ std::string ReplaceStr_Manager::replace( const char* str, const int lng, const i
 
     std::string buffer;
 
-    if( m_chref[id] ) buffer = MISC::chref_decode( str, lng, false );
+    if( m_chref[id] ) buffer = MISC::chref_decode( std::string_view( str, lng ), false );
     else buffer.assign( str, lng );
 
 #ifdef _DEBUG


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡している関数の引数を`std::string_view`に交換して整理します。

関連のpull request: #905 
