### PR TITLE
Use std::string_view for ReplaceStr_Manager::replace()

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1599,7 +1599,7 @@ const char* NodeTreeBase::add_one_dat_line( const char* datline )
         // 文字列置換
         const CORE::ReplaceStr_Manager* const mgr = CORE::get_replacestr_manager();
         if( mgr->list_get_active( CORE::REPLACETARGET_MESSAGE ) ) {
-            str_msg = mgr->replace( str.data(), str.size(), CORE::REPLACETARGET_MESSAGE );
+            str_msg = mgr->replace( str, CORE::REPLACETARGET_MESSAGE );
             str = str_msg;
         }
 
@@ -1694,7 +1694,7 @@ void NodeTreeBase::parse_name( NODE* header, std::string_view str, const int col
     std::string str_name;
     const CORE::ReplaceStr_Manager* const mgr = CORE::get_replacestr_manager();
     if( mgr->list_get_active( CORE::REPLACETARGET_NAME ) ) {
-        str_name = mgr->replace( str.data(), str.size(), CORE::REPLACETARGET_NAME );
+        str_name = mgr->replace( str, CORE::REPLACETARGET_NAME );
         str = str_name;
     }
 
@@ -1805,7 +1805,7 @@ void NodeTreeBase::parse_mail( NODE* header, std::string_view str )
     std::string str_mail;
     const CORE::ReplaceStr_Manager* const mgr = CORE::get_replacestr_manager();
     if( mgr->list_get_active( CORE::REPLACETARGET_MAIL ) ) {
-        str_mail = mgr->replace( str.data(), str.size(), CORE::REPLACETARGET_MAIL );
+        str_mail = mgr->replace( str, CORE::REPLACETARGET_MAIL );
         str = str_mail;
     }
 
@@ -1835,7 +1835,7 @@ void NodeTreeBase::parse_date_id( NODE* header, std::string_view str )
     // 文字列置換
     const CORE::ReplaceStr_Manager* const mgr = CORE::get_replacestr_manager();
     if( mgr->list_get_active( CORE::REPLACETARGET_DATE ) ) {
-        str_date = mgr->replace( str.data(), str.size(), CORE::REPLACETARGET_DATE );
+        str_date = mgr->replace( str, CORE::REPLACETARGET_DATE );
         str = str_date;
     }
 

--- a/src/replacestrmanager.cpp
+++ b/src/replacestrmanager.cpp
@@ -235,14 +235,14 @@ std::string ReplaceStr_Manager::target_name( const int id )
 //
 // 実行
 //
-std::string ReplaceStr_Manager::replace( const char* str, const int lng, const int id ) const
+std::string ReplaceStr_Manager::replace( std::string_view str, const int id ) const
 {
-    if( id >= REPLACETARGET_MAX || ( m_list[id].empty() && ! m_chref[id] ) ) return std::string( str, lng );
+    if( id >= REPLACETARGET_MAX || ( m_list[id].empty() && ! m_chref[id] ) ) return std::string{ str };
 
     std::string buffer;
 
-    if( m_chref[id] ) buffer = MISC::chref_decode( std::string_view( str, lng ), false );
-    else buffer.assign( str, lng );
+    if( m_chref[id] ) buffer = MISC::chref_decode( str, false );
+    else buffer.assign( str );
 
 #ifdef _DEBUG
     std::cout << "ReplaceStr_Manager::replace str=" << buffer << std::endl;

--- a/src/replacestrmanager.h
+++ b/src/replacestrmanager.h
@@ -12,6 +12,7 @@
 #include <array>
 #include <list>
 #include <string>
+#include <string_view>
 
 namespace XML
 {
@@ -81,7 +82,7 @@ namespace CORE
         void save_xml();
 
         // 文字列を置換
-        std::string replace( const char* str, const int lng, const int id ) const;
+        std::string replace( std::string_view str, const int id ) const;
 
         static XML::Dom* dom_append( XML::Dom* node, const int id, const bool chref );
         static XML::Dom* dom_append( XML::Dom* node, ReplaceStrCondition condition,


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡しているメンバー関数の引数を`std::string_view`に交換して整理します。

関連のpull request: #905 