### PR TITLE
DrawAreaBase: Fix known condition true/false

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -2976,7 +2976,7 @@ void DrawAreaBase::wheelscroll( GdkEventScroll* event )
 
         m_wheel_scroll_time = event->time;
 
-        if( m_vscrbar && ( m_scrollinfo.mode == SCROLL_NOT || m_scrollinfo.mode == SCROLL_NORMAL ) ){
+        if( m_scrollinfo.mode == SCROLL_NOT || m_scrollinfo.mode == SCROLL_NORMAL ){
 
             const auto adjust = m_vscrbar->get_adjustment();
 


### PR DESCRIPTION
既に条件が判明している比較があるとcppcheck 2.7.1に指摘されたため条件文を修正します。直前のif文で条件をチェックしています。

cppcheckのレポート
```
src/article/drawareabase.cpp:2979:13: style: Condition 'm_vscrbar' is always true [knownConditionTrueFalse]
        if( m_vscrbar && ( m_scrollinfo.mode == SCROLL_NOT || m_scrollinfo.mode == SCROLL_NORMAL ) ){
            ^
```