### PR TITLE
Update function parameters for font width caching

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -1550,8 +1550,22 @@ int DrawAreaBase::get_width_of_one_char( const char* utfstr, int& byte, char& pr
     int width = 0;
     int width_wide = 0;
 
+    const char32_t code = MISC::utf8toucs2( utfstr, byte );
+
+    if( ! byte ){
+#ifdef _DEBUG
+        std::cout << "DrawAreaBase::get_width_of_one_char "
+                  << "invalid char " << (unsigned char)utfstr[ 0 ]
+                  << " " << (unsigned char)utfstr[ 1 ]
+                  << " " << (unsigned char)utfstr[ 2 ]
+                  << " " << (unsigned char)utfstr[ 3 ] << std::endl;
+#endif
+        byte = 1;
+        return 0;
+    }
+
     // キャッシュに無かったら幅を調べてキャッシュに登録
-    if( ! ARTICLE::get_width_of_char( utfstr, byte, pre_char, width, width_wide, mode ) ){
+    if( ! ARTICLE::get_width_of_char( code, pre_char, width, width_wide, mode ) ){
 
         const std::string tmpchar( utfstr, byte );
 

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -1627,26 +1627,26 @@ int DrawAreaBase::get_width_of_one_char( const char* utfstr, int& byte, char& pr
         // フォントが無い
         if( width_wide <= 0 ){
 
-            int byte_tmp;
-            const unsigned int code = MISC::utf8toucs2( tmpchar.c_str(), byte_tmp );
-
-            std::stringstream ss_err;
-            ss_err << "unknown font byte = " << byte_tmp << " ucs2 = " << code << " width = " << width;
-
 #ifdef _DEBUG
             std::cout << "DrawAreaBase::get_width_of_one_char "
                       << "byte = " << byte
-                      << " byte_tmp = " << byte_tmp
                       << " code = " << code
                       << " [" << tmpchar << "]\n";
 #endif
 
-            MISC::ERRMSG( ss_err.str() );
+            if( ( code < 0xE000 || code > 0xF8FF ) // 基本面私用領域ではない
+                && ( code < 0xF0000 || code > 0x10FFFF ) // 私用面ではない
+              ){
+                std::stringstream ss_err;
+                ss_err << "unknown font byte = " << byte << " ucs = " << code << " width = " << width;
 
-            ARTICLE::set_width_of_char( utfstr, byte, pre_char, -1, -1, mode );
+                MISC::ERRMSG( ss_err.str() );
+            }
+
+            ARTICLE::set_width_of_char( code, pre_char, -1, -1, mode );
             width = width_wide = 0;
         }
-        else ARTICLE::set_width_of_char( utfstr, byte, pre_char, width, width_wide, mode );
+        else ARTICLE::set_width_of_char( code, pre_char, width, width_wide, mode );
     }
 
     int ret = 0;

--- a/src/article/font.cpp
+++ b/src/article/font.cpp
@@ -5,8 +5,6 @@
 
 #include "font.h"
 
-#include "jdlib/miscutil.h"
-
 #include "fontid.h"
 #include "config/globalconf.h"
 
@@ -131,24 +129,27 @@ bool ARTICLE::get_width_of_char( const char32_t code, const char pre_char, int& 
 
 
 
-//
-// 文字幅を登録する関数
-//
-// width == -1 はフォント幅の取得に失敗した場合
-//
-void ARTICLE::set_width_of_char( const char* utfstr, int& byte, const char pre_char, const int width, const int width_wide, const int mode )
-{    
-    const int c32 = MISC::utf8toucs2( utfstr, byte );
-    if( ! byte ) return;
-    if( c32 >= kMaxCacheCodePoint ) return;
+/** @brief 文字幅を登録する関数
+ *
+ * width == -1 はフォント幅の取得に失敗した場合
+ * @param[in] code      入力文字 (コードポイント)
+ * @param[in] pre_char  ひとつ前の文字 ( 前の文字が全角の場合は 0 )
+ * @param[in] width     半角モードでの幅
+ * @param[in] width_wide  全角モードでの幅
+ * @param[in] mode      fontid.h で定義されているフォントのID
+ */
+void ARTICLE::set_width_of_char( const char32_t code, const char pre_char, const int width, const int width_wide,
+                                 const int mode )
+{
+    if( code >= kMaxCacheCodePoint ) return;
 
     // 半角モードの幅を厳密に求める場合
-    if( byte == 1 && strict_of_char ){
+    if( code < 128 && strict_of_char ){
 
-        const int pre_char_num = ( int ) pre_char;
-        if( pre_char_num < 128 ) width_of_char[ mode ][ c32 ].width[ pre_char_num ] = width;
+        const int pre_char_num = pre_char;
+        if( pre_char_num < 128 ) width_of_char[ mode ][ code ].width[ pre_char_num ] = width;
     }
 
     // 全角モードの幅
-    width_of_char[ mode ][ c32 ].width_wide = width_wide;
+    width_of_char[ mode ][ code ].width_wide = width_wide;
 }

--- a/src/article/font.cpp
+++ b/src/article/font.cpp
@@ -30,7 +30,7 @@ static bool strict_of_char = false;
 
 // UnicodeのPlane 0 基本多言語面(BMP)からPlane 3 第三漢字面(TIP)までキャッシュを持つ。
 // 現状のメモリ消費を抑えるためPlane 4からPlane 13は将来割り当てられたときにキャッシュ対応する。
-constexpr int kMaxCacheCodePoint{ 0x40000 };
+constexpr char32_t kMaxCacheCodePoint{ 0x40000 };
 
 
 //
@@ -45,7 +45,7 @@ void ARTICLE::init_font()
 
         if( char_data ) {
 
-            for( int j = 0; j < kMaxCacheCodePoint; ++j ){
+            for( char32_t j = 0; j < kMaxCacheCodePoint; ++j ){
 
                 if( char_data[ j ].width ) delete[] char_data[ j ].width;
             }
@@ -57,61 +57,74 @@ void ARTICLE::init_font()
 
 
 
-//
-// 登録された文字の幅を返す関数
-//
-// utfstr : 入力文字 (UTF-8)
-// byte   : 長さ(バイト) utfstr が ascii なら 1, UTF-8 なら 2 or 3 or 4 を入れて返す
-// pre_char : ひとつ前の文字 ( 前の文字が全角の場合は 0 )
-// width  : 半角モードでの幅
-// width_wide : 全角モードでの幅
-// mode   : fontid.h で定義されているフォントのID
-// 戻り値 : 登録されていればtrue
-// 
-bool ARTICLE::get_width_of_char( const char* utfstr, int& byte, const char pre_char, int& width, int& width_wide, const int mode )
+/** @brief 登録された文字の幅を返す関数
+ *
+ * @param[in]  code      入力文字 (コードポイント)
+ * @param[in]  pre_char  ひとつ前の文字 ( 前の文字が全角の場合は 0 )
+ * @param[out] width     半角モードでの幅
+ * @param[out] width_wide  全角モードでの幅
+ * @param[in]  mode      fontid.h で定義されているフォントのID
+ * @return     登録されていればtrue
+ */
+bool ARTICLE::get_width_of_char( const char32_t code, const char pre_char, int& width, int& width_wide, const int mode )
 {
-    byte = 0;
     width = 0;
     width_wide = 0;
 
     if( ! width_of_char[ mode ] ){
-        width_of_char[ mode ] = new WIDTH_DATA[ kMaxCacheCodePoint ]{} ;
+        width_of_char[ mode ] = new WIDTH_DATA[ kMaxCacheCodePoint ]{};
+
+        // 合成文字や制御文字や異字体セレクタの初期化
+        constexpr const int blocks[][2] = {
+            { 0x0300, 0x036F }, // Combining Diacritical Marks
+            { 0x180B, 0x180D }, // Mongolian Free Variation Selector
+            { 0x200B, 0x200F }, // ZWSP,ZWNJ,ZWJ,LRM,RLM
+            { 0x202A, 0x202E }, // LRE,RLE,PDF,LRO,RLO
+            { 0x20D0, 0x20FF }, // Combining Diacritical Marks for Symbols
+            { 0x3099, 0x309A }, // COMBINING KATAKANA-HIRAGANA (SEMI-)VOICED SOUND MARK
+            { 0xFE00, 0xFE0F }, // VS1-VS16
+        };
+        for( const auto [start, end] : blocks ) {
+            for( int i = start; i <= end; ++i ) {
+                width_of_char[ mode ][ i ].width_wide = -1;
+            }
+        }
+        width_of_char[ mode ][ 0xFEFF ].width_wide = -1; // ZERO WIDTH NO-BREAK SPACE
     }
 
-    const int c32 = MISC::utf8toucs2( utfstr, byte );
-    if( byte > 0 && c32 < kMaxCacheCodePoint ){
+    if( code > 0 && code < kMaxCacheCodePoint ){
 
         // 全角モードの幅
-        width_wide = width_of_char[ mode ][ c32 ].width_wide;
+        width_wide = width_of_char[ mode ][ code ].width_wide;
 
         // 半角モードの幅
         width = width_wide;
 
         // 厳密に求める場合
-        if( byte == 1 && strict_of_char ){
+        if( code < 128 && strict_of_char ){
 
-            if( ! width_of_char[ mode ][ c32 ].width ){
-                width_of_char[ mode ][ c32 ].width = new unsigned int[ 128 ]{} ;
+            if( ! width_of_char[ mode ][ code ].width ){
+                width_of_char[ mode ][ code ].width = new unsigned int[ 128 ]{};
             }
 
             const int pre_char_num = ( int ) pre_char;
-            if( pre_char_num < 128 ) width = width_of_char[ mode ][ c32 ].width[ pre_char_num ];
+            if( pre_char_num < 128 ) width = width_of_char[ mode ][ code ].width[ pre_char_num ];
         }
     }
+    // キャッシュ範囲外のコードポイントは個別に幅を設定する
     // Plane 14 追加特殊用途面(SSP)
-    // 制御コードが追加されたら条件を追加する
-    else if( 0xE0001 == c32 || ( 0xE0020 <= c32 && c32 <= 0xE007F ) // タグ文字
-             || ( 0xE0100 <= c32 && c32 <= 0xE01EF )                // 異字体セレクタ
+    else if( 0xE0001 == code || ( 0xE0020 <= code && code <= 0xE007F ) // タグ文字
+             || ( 0xE0100 <= code && code <= 0xE01EF )                 // 異字体セレクタ
     ) {
         width = width_wide = 0;
         return true;
     }
 
-    if( width && width_wide ) return true;
-    else if( width == -1 ){ // フォント幅の取得に失敗した場合
+    if( width == -1 ){ // フォント幅の取得に失敗した場合
         width = width_wide = 0;
         return true;
     }
+    else if( width && width_wide ) return true;
 
     return false;
 }

--- a/src/article/font.h
+++ b/src/article/font.h
@@ -10,14 +10,13 @@ namespace ARTICLE
     void init_font();
 
     // 登録された文字の幅を返す関数
-    // utfstr : 入力文字 (UTF-8)
-    // byte   : 長さ(バイト) utfstr が ascii なら 1, UTF-8 なら 2 or 3 or 4 を入れて返す
+    // code   : 入力文字 (コードポイント)
     // pre_char : ひとつ前の文字 ( 前の文字が全角の場合は 0 )
     // width  : 半角モードでの幅
     // width_wide : 全角モードでの幅
     // mode   : fontid.h で定義されているフォントのID
     // 戻り値 : 登録されていればtrue
-    bool get_width_of_char( const char* utfstr, int& byte, const char pre_char, int& width, int& width_wide, const int mode );
+    bool get_width_of_char( const char32_t code, const char pre_char, int& width, int& width_wide, const int mode );
 
     // 文字幅を登録する関数
     // width == -1 はフォント幅の取得に失敗した場合

--- a/src/article/font.h
+++ b/src/article/font.h
@@ -20,7 +20,8 @@ namespace ARTICLE
 
     // 文字幅を登録する関数
     // width == -1 はフォント幅の取得に失敗した場合
-    void set_width_of_char( const char* utfstr, int& byte, const char pre_char, const int width, const int width_wide, const int mode );
+    void set_width_of_char( const char32_t code, const char pre_char, const int width, const int width_wide,
+                            const int mode );
 }
 
 #endif


### PR DESCRIPTION
#### [Update function parameters for ARTICLE::get_width_of_char()](https://github.com/JDimproved/JDim/commit/172ef7f1194bc55e1c51a740ff6edd1f6762c612) 

フォントの文字幅を取得するUnicode文字をUTF-8バイト列＆長さ渡しからUTF-32コードポイント渡しに変更してエンコーディングの変換処理を整理します。

#### [Update function parameters for ARTICLE::set_width_of_char()](https://github.com/JDimproved/JDim/commit/783d181eeedf8bcc4cc211f5cb2eba0b8089f33a)

フォントの文字幅を登録するUnicode文字をUTF-8バイト列＆長さ渡しからUTF-32コードポイント渡しに変更してエンコーディングの変換処理を整理します。
