### PR TITLE
Use std::string_view for Loader::analyze_header_option()

### DIFF
--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -1268,7 +1268,7 @@ bool Loader::analyze_header()
 //
 // analyze_header() から呼ばれるオプションの値を取り出す関数
 //
-std::string Loader::analyze_header_option( const std::string& option ) const
+std::string Loader::analyze_header_option( std::string_view option ) const
 {
     const std::size_t i = MISC::ascii_ignore_case_find( m_data.str_header, option );
     if( i != std::string::npos ){

--- a/src/jdlib/loader.h
+++ b/src/jdlib/loader.h
@@ -12,11 +12,12 @@
 #include "loaderdata.h"
 #include "jdthread.h"
 
-#include <string>
-#include <list>
+#include <netdb.h>
 #include <zlib.h>
 
-#include <netdb.h>
+#include <list>
+#include <string>
+#include <string_view>
 
 
 namespace SKELETON
@@ -95,7 +96,7 @@ namespace JDLIB
         // ヘッダ用
         int receive_header( char* buf, size_t& read_size );
         bool analyze_header();
-        std::string analyze_header_option( const std::string& option ) const;
+        std::string analyze_header_option( std::string_view option ) const;
         std::list< std::string > analyze_header_option_list( const std::string& option ) const;
 
         // chunk用


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡している関数の引数を`std::string_view`に交換して整理します。

関連のpull request: #905 