### PR TITLE
Use std::string_view for Loader::analyze_header_option_list()

### DIFF
--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -1286,7 +1286,7 @@ std::string Loader::analyze_header_option( std::string_view option ) const
 //
 // analyze_header() から呼ばれるオプションの値を取り出す関数(リスト版)
 //
-std::list< std::string > Loader::analyze_header_option_list( const std::string& option ) const
+std::list< std::string > Loader::analyze_header_option_list( std::string_view option ) const
 {
     std::list< std::string > str_list;
 

--- a/src/jdlib/loader.h
+++ b/src/jdlib/loader.h
@@ -97,7 +97,7 @@ namespace JDLIB
         int receive_header( char* buf, size_t& read_size );
         bool analyze_header();
         std::string analyze_header_option( std::string_view option ) const;
-        std::list< std::string > analyze_header_option_list( const std::string& option ) const;
+        std::list< std::string > analyze_header_option_list( std::string_view option ) const;
 
         // chunk用
         bool skip_chunk( char* buf, size_t& read_size );


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡している関数の引数を`std::string_view`に交換して整理します。

関連のpull request: #905

