### PR TITLE
Implement MISC::utf8toutf32()

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -1550,7 +1550,7 @@ int DrawAreaBase::get_width_of_one_char( const char* utfstr, int& byte, char& pr
     int width = 0;
     int width_wide = 0;
 
-    const char32_t code = MISC::utf8toucs2( utfstr, byte );
+    const char32_t code = MISC::utf8toutf32( utfstr, byte );
 
     if( ! byte ){
 #ifdef _DEBUG
@@ -3991,41 +3991,41 @@ LAYOUT* DrawAreaBase::set_caret( CARET_POSITION& caret_pos, int x, int y )
 //
 
 // 区切り文字
-bool is_separate_char( const int ucs2 )
+bool is_separate_char( const char32_t unich )
 {
-    if( ucs2 == ' '
+    if( unich == ' '
 
-        || ucs2 == '.'
-        || ucs2 == ','
+        || unich == '.'
+        || unich == ','
 
-        || ucs2 == '('
-        || ucs2 == ')'
+        || unich == '('
+        || unich == ')'
 
-        || ucs2 == '='
+        || unich == '='
 
         // 全角空白
-        || ucs2 == 0x3000
+        || unich == 0x3000
 
         // 。、
-        || ucs2 == 0x3001
-        || ucs2 == 0x3002
+        || unich == 0x3001
+        || unich == 0x3002
 
         // ．，
-        || ucs2 == 0xff0c
-        || ucs2 == 0xff0e
+        || unich == 0xFF0C
+        || unich == 0xFF0E
 
         // 全角()
-        || ucs2 == 0xff08
-        || ucs2 == 0xff09
+        || unich == 0xFF08
+        || unich == 0xFF09
 
         // 全角 =
-        || ucs2 == 0xff1d
+        || unich == 0xFF1D
 
         // 「」
-        || ucs2 == 0x300c
-        || ucs2 == 0x300d
-        || ucs2 == 0x300e
-        || ucs2 == 0x300f
+        || unich == 0x300C
+        || unich == 0x300D
+        || unich == 0x300E
+        || unich == 0x300F
 
         ) return true;
 
@@ -4103,15 +4103,15 @@ bool DrawAreaBase::set_carets_dclick( CARET_POSITION& caret_left, CARET_POSITION
                 }
 
                 int byte_char_pointer;
-                const int ucs2_pointer = MISC::utf8toucs2( layout->text + pos, byte_char_pointer );
-                const int ucs2mode_pointer = MISC::get_ucs2mode( ucs2_pointer );
+                const char32_t uch_pointer = MISC::utf8toutf32( layout->text + pos, byte_char_pointer );
+                const int ucstype_pointer = MISC::get_ucs2mode( uch_pointer );
 #ifdef _DEBUG
-                std::cout << "ucs2 = " << std::hex << ucs2_pointer << std::dec
-                          << " mode = " << ucs2mode_pointer << " pos = " << pos << std::endl;
+                std::cout << "utf32 = " << std::hex << uch_pointer << std::dec
+                          << " type = " << ucstype_pointer << " pos = " << pos << std::endl;
 #endif
 
                 // 区切り文字をダブルクリックした
-                if( is_separate_char( ucs2_pointer ) ){
+                if( is_separate_char( uch_pointer ) ){
                     caret_left.set( layout, pos );
                     caret_right.set( layout, pos + byte_char_pointer );
                     return true;
@@ -4123,20 +4123,17 @@ bool DrawAreaBase::set_carets_dclick( CARET_POSITION& caret_left, CARET_POSITION
                 while( pos_tmp < pos ){
 
                     int byte_char;
-                    const int ucs2 = MISC::utf8toucs2( layout->text + pos_tmp, byte_char );
-                    const int ucs2mode = MISC::get_ucs2mode( ucs2 );
+                    const char32_t uch = MISC::utf8toutf32( layout->text + pos_tmp, byte_char );
+                    const int ucstype = MISC::get_ucs2mode( uch );
 
                     int byte_char_next;
-                    const int ucs2_next = MISC::utf8toucs2( layout->text + pos_tmp + byte_char, byte_char_next );
-                    const int ucs2mode_next = MISC::get_ucs2mode( ucs2_next );
+                    const char32_t uch_next = MISC::utf8toutf32( layout->text + pos_tmp + byte_char, byte_char_next );
+                    const int ucstype_next = MISC::get_ucs2mode( uch_next );
 
                     // 区切り文字が来たら左位置を移動する
-                    if( ucs2_next == '\0'
-
-                        || is_separate_char( ucs2 )
-
+                    if( uch_next == '\0' || is_separate_char( uch )
                         // 文字種が変わった
-                        || ( ucs2mode != ucs2mode_pointer && ucs2mode_next == ucs2mode_pointer )
+                        || ( ucstype != ucstype_pointer && ucstype_next == ucstype_pointer )
 
                         ) pos_left = pos_tmp + byte_char;
 
@@ -4148,21 +4145,21 @@ bool DrawAreaBase::set_carets_dclick( CARET_POSITION& caret_left, CARET_POSITION
                 while( pos_right < layout->lng_text ){
 
                     int byte_char;
-                    const int ucs2 = MISC::utf8toucs2( layout->text + pos_right, byte_char );
-                    const int ucs2mode = MISC::get_ucs2mode( ucs2 );
+                    const char32_t uch = MISC::utf8toutf32( layout->text + pos_right, byte_char );
+                    const int ucstype = MISC::get_ucs2mode( uch );
 
                     int byte_char_next;
-                    const int ucs2_next = MISC::utf8toucs2( layout->text + pos_right + byte_char, byte_char_next );
-                    const int ucs2mode_next = MISC::get_ucs2mode( ucs2_next );
+                    const char32_t uch_next = MISC::utf8toutf32( layout->text + pos_right + byte_char, byte_char_next );
+                    const int ucstype_next = MISC::get_ucs2mode( uch_next );
 
                     // 区切り文字が来たらbreak
-                    if( is_separate_char( ucs2 ) ) break;
+                    if( is_separate_char( uch ) ) break;
 
                     pos_right += ( byte_char ? byte_char : 1 );
 
                     // 文字種が変わった
-                    if( ucs2_next == '\0'
-                        || ( ucs2mode == ucs2mode_pointer && ucs2mode_next != ucs2mode_pointer )
+                    if( uch_next == '\0'
+                        || ( ucstype == ucstype_pointer && ucstype_next != ucstype_pointer )
                         ) break;
                 }
 

--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -311,3 +311,45 @@ int MISC::utf8bytes( const char* utf8str )
 
     return byte;
 }
+
+
+/** @brief UTF-8 バイト列から UTF-32 コードポイント に変換
+ *
+ * @param[in] utf8str 入力文字 (UTF-8)
+ * @param[out] byte 長さ(バイト数). utf8str が ASCII なら 1, UTF-8 なら 2 or 3 or 4, NULまたは不正な文字なら 0 を返す
+ * @return Unicode コードポイント
+ */
+char32_t MISC::utf8toutf32( const char* utf8str, int& byte )
+{
+    char32_t unich = 0;
+    byte = MISC::utf8bytes( utf8str );
+
+    switch( byte ){
+    case 1:
+        unich = utf8str[0];
+        break;
+
+    case 2:
+        unich = utf8str[0] & 0x1F;
+        unich = ( unich << 6 ) + ( utf8str[1] & 0x3F );
+        break;
+
+    case 3:
+        unich = utf8str[0] & 0x0F;
+        unich = ( unich << 6 ) + ( utf8str[1] & 0x3F );
+        unich = ( unich << 6 ) + ( utf8str[2] & 0x3F );
+        break;
+
+    case 4:
+        unich = utf8str[0] & 0x07;
+        unich = ( unich << 6 ) + ( utf8str[1] & 0x3F );
+        unich = ( unich << 6 ) + ( utf8str[2] & 0x3F );
+        unich = ( unich << 6 ) + ( utf8str[3] & 0x3F );
+        break;
+
+    default:
+        break;
+    }
+
+    return unich;
+}

--- a/src/jdlib/misccharcode.h
+++ b/src/jdlib/misccharcode.h
@@ -27,6 +27,12 @@ namespace MISC
 
     /// utf-8文字のbyte数を返す
     int utf8bytes( const char* utf8str );
+
+    // UTF-8 -> UTF-32 変換
+    // 入力 : utf8str 入力文字 (UTF-8)
+    // 出力 :  byte  長さ(バイト) utf8str が ASCII なら 1, UTF-8 なら 2 or 3 or 4, それ以外は 0 を入れて返す
+    // 戻り値 : unicode code point
+    char32_t utf8toutf32( const char* utf8str, int& byte );
 }
 
 #endif

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1523,61 +1523,6 @@ std::string MISC::decode_spchar_number( const std::string& str )
 
 
 //
-// utf-8 -> ucs2 変換
-//
-// 入力 : utfstr 入力文字 (UTF-8)
-//
-// 出力 :  byte  長さ(バイト) utfstr が ascii なら 1, UTF-8 なら 2 or 3 or 4 を入れて返す
-//
-// 戻り値 : ucs2
-//
-int MISC::utf8toucs2( const char* utfstr, int& byte )
-{
-    int ucs2 = 0;
-    byte = 0;
-
-    if( utfstr[ 0 ] == '\0' ) return '\0';
-    
-    else if( ( ( unsigned char ) utfstr[ 0 ] & 0xf0 ) == 0xe0 ){
-        byte = 3;
-        ucs2 = utfstr[ 0 ] & 0x0f;
-        ucs2 = ( ucs2 << 6 ) + ( utfstr[ 1 ] & 0x3f );
-        ucs2 = ( ucs2 << 6 ) + ( utfstr[ 2 ] & 0x3f );        
-    }
-
-    else if( ( ( unsigned char ) utfstr[ 0 ] & 0x80 ) == 0 ){ // ascii
-        byte = 1;
-        ucs2 =  utfstr[ 0 ];
-    }
-
-    else if( ( ( unsigned char ) utfstr[ 0 ] & 0xe0 ) == 0xc0 ){
-        byte = 2;
-        ucs2 = utfstr[ 0 ] & 0x1f;
-        ucs2 = ( ucs2 << 6 ) + ( utfstr[ 1 ] & 0x3f );
-    }
-
-    else if( ( ( unsigned char ) utfstr[ 0 ] & 0xf8 ) == 0xf0 ){
-        byte = 4;
-        ucs2 = utfstr[ 0 ] & 0x07;
-        ucs2 = ( ucs2 << 6 ) + ( utfstr[ 1 ] & 0x3f );
-        ucs2 = ( ucs2 << 6 ) + ( utfstr[ 2 ] & 0x3f );
-        ucs2 = ( ucs2 << 6 ) + ( utfstr[ 3 ] & 0x3f );        
-    }
-
-    // 不正なUTF8
-    else {
-        byte = 1;
-        ucs2 =  utfstr[ 0 ];
-        ERRMSG( "MISC::utf8toucs2 : invalid code = " + std::to_string( ucs2 ) );
-    }
-
-    return ucs2;
-}
-
-
-
-
-//
 // ucs2 -> utf8 変換
 //
 // 出力 : utfstr 変換後の文字

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -231,12 +231,6 @@ namespace MISC
     // str に含まれる「&#数字;」形式の数字参照文字列を全てユニーコード文字に変換する
     std::string decode_spchar_number( const std::string& str );
 
-    // utf-8 -> ucs2 変換
-    // 入力 : utfstr 入力文字 (UTF-8)
-    // 出力 :  byte  長さ(バイト) utfstr が ascii なら 1, UTF-8 なら 2 or 3 or 4 を入れて返す
-    // 戻り値 : ucs2
-    int utf8toucs2( const char* utfstr, int& byte );
-
     // ucs2 の種類
     int get_ucs2mode( const int ucs2 );
 

--- a/test/gtest_jdlib_misccharcode.cpp
+++ b/test/gtest_jdlib_misccharcode.cpp
@@ -102,4 +102,66 @@ TEST_F(Utf8BytesTest, invalid_seq)
     EXPECT_EQ( 4, MISC::utf8bytes( "\xF0\x8F\x80\x80" ) ); // F0 90-BF 80-BF 80-BF
 }
 
+
+class Utf8ToUtf32Test : public ::testing::Test {};
+
+TEST_F(Utf8ToUtf32Test, null_data)
+{
+    int byte;
+    EXPECT_EQ( 0, MISC::utf8toutf32( nullptr, byte ) );
+    EXPECT_EQ( 0, byte );
+    EXPECT_EQ( 0, MISC::utf8toutf32( "", byte ) );
+    EXPECT_EQ( 0, byte );
+}
+
+TEST_F(Utf8ToUtf32Test, ascii)
+{
+    int byte;
+    EXPECT_EQ( 0x0001, MISC::utf8toutf32( "\x01", byte ) );
+    EXPECT_EQ( 1, byte );
+    EXPECT_EQ( 0x007F, MISC::utf8toutf32( "\x7F", byte ) );
+    EXPECT_EQ( 1, byte );
+}
+
+TEST_F(Utf8ToUtf32Test, two_bytes)
+{
+    int byte;
+    EXPECT_EQ( 0x0080, MISC::utf8toutf32( "\xC2\x80", byte ) );
+    EXPECT_EQ( 2, byte );
+    EXPECT_EQ( 0x07FF, MISC::utf8toutf32( "\xDF\xBF", byte ) );
+    EXPECT_EQ( 2, byte );
+}
+
+TEST_F(Utf8ToUtf32Test, three_bytes)
+{
+    int byte;
+    EXPECT_EQ( 0x0800, MISC::utf8toutf32( "\xE0\xA0\x80", byte ) );
+    EXPECT_EQ( 3, byte );
+    EXPECT_EQ( 0xFFFF, MISC::utf8toutf32( "\xEF\xBF\xBF", byte ) );
+    EXPECT_EQ( 3, byte );
+}
+
+TEST_F(Utf8ToUtf32Test, four_bytes)
+{
+    int byte;
+    EXPECT_EQ( 0x00010000, MISC::utf8toutf32( "\xF0\x90\x80\x80", byte ) );
+    EXPECT_EQ( 4, byte );
+    EXPECT_EQ( 0x0010FFFF, MISC::utf8toutf32( "\xF4\x8F\xBF\xBF", byte ) );
+    EXPECT_EQ( 4, byte );
+}
+
+TEST_F(Utf8ToUtf32Test, invalid_bytes)
+{
+    // 範囲外のうち一部の4バイトシーケンスは 0 にならない
+    // Utf8BytesTest::obsolete_four_bytes を参照
+    int byte;
+    EXPECT_EQ( 0x00110000, MISC::utf8toutf32( "\xF4\x90\x80\x80", byte ) );
+    EXPECT_EQ( 4, byte );
+    EXPECT_EQ( 0x0013FFFF, MISC::utf8toutf32( "\xF4\xBF\xBF\xBF", byte ) );
+    EXPECT_EQ( 4, byte );
+
+    EXPECT_EQ( 0, MISC::utf8toutf32( "\xF5\x80\x80\x80", byte ) ); // U+140000
+    EXPECT_EQ( 0, byte );
+}
+
 } // namespace


### PR DESCRIPTION
#### [Implement MISC::utf8toutf32()](https://github.com/JDimproved/JDim/commit/ab6eef8bdf4bb18e5598cbe22098dcbf54b534ed) 

jdlib/miscutil.h の`MISC::utf8toucs2()` のかわりに jdlib/misccharcode.h にUTF-8バイト列からUTF-32のコードポイントを返す関数を実装する。

#### [Add test cases for MISC::utf8toutf32()](https://github.com/JDimproved/JDim/commit/5451509f5b8906c8e8a86f2a23652cf202ec7905)

関連のissue: #76 