### PR TITLE
Use std::string_view for MISC::remove_str(str, start, end)

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -386,12 +386,17 @@ std::string MISC::remove_str( const std::string& str1, const std::string& str2 )
 }
 
 
-//
-// start 〜 end の範囲をstrから取り除く ( /* コメント */ など )
-//
-std::string MISC::remove_str( const std::string& str, const std::string& start, const std::string& end )
+/// @brief start 〜 end の範囲をstrから取り除く ( /* コメント */ など )
+/**
+ * @param[in] str 処理する文字列
+ * @param[in] start 取り除く範囲の先頭
+ * @param[in] end 取り除く範囲の末尾
+ * @return 取り除いた結果。
+ */
+std::string MISC::remove_str( std::string_view str, std::string_view start, std::string_view end )
 {
-    std::string str_out = str;
+    std::string str_out{ str };
+    if( str_out.empty() || start.empty() || end.empty() ) return str_out;
 
     size_t l_pos = 0, r_pos = 0;
     const size_t start_length = start.length();

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -100,8 +100,8 @@ namespace MISC
     // str1からstr2で示された文字列を除く
     std::string remove_str( const std::string& str1, const std::string& str2 );
 
-    // start 〜 end の範囲をstrから取り除く ( /* コメント */ など )
-    std::string remove_str( const std::string& str, const std::string& start, const std::string& end );
+    /// start 〜 end の範囲をstrから取り除く ( /* コメント */ など )
+    std::string remove_str( std::string_view str, std::string_view start, std::string_view end );
 
     // 正規表現を使ってstr1からqueryで示された文字列を除く
     std::string remove_str_regex( const std::string& str1, const std::string& query );

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -109,6 +109,47 @@ TEST_F(RemoveSpaceTest, remove_doublequote)
 }
 
 
+class RemoveStrStartEndTest : public ::testing::Test {};
+
+TEST_F(RemoveStrStartEndTest, empty_data)
+{
+    EXPECT_EQ( "", MISC::remove_str( "", "", "" ) );
+    EXPECT_EQ( "", MISC::remove_str( "", "<<", "" ) );
+    EXPECT_EQ( "", MISC::remove_str( "", "<<", ">>" ) );
+    EXPECT_EQ( "", MISC::remove_str( "", "", ">>" ) );
+}
+
+TEST_F(RemoveStrStartEndTest, empty_start)
+{
+    EXPECT_EQ( "Quick<<Brown>>Fox", MISC::remove_str( "Quick<<Brown>>Fox", "", ">>" ) );
+}
+
+TEST_F(RemoveStrStartEndTest, empty_end)
+{
+    EXPECT_EQ( "Quick<<Brown>>Fox", MISC::remove_str( "Quick<<Brown>>Fox", "<<", "" ) );
+}
+
+TEST_F(RemoveStrStartEndTest, different_marks)
+{
+    EXPECT_EQ( "QuickFox", MISC::remove_str( "Quick<<Brown>>Fox", "<<", ">>" ) );
+}
+
+TEST_F(RemoveStrStartEndTest, same_marks)
+{
+    EXPECT_EQ( "QuickFox", MISC::remove_str( "Quick!!Brown!!Fox", "!!", "!!" ) );
+}
+
+TEST_F(RemoveStrStartEndTest, much_start_marks)
+{
+    EXPECT_EQ( "TheFox", MISC::remove_str( "The(Quick(Brown)Fox", "(", ")" ) );
+}
+
+TEST_F(RemoveStrStartEndTest, much_end_marks)
+{
+    EXPECT_EQ( "TheBrown)Fox", MISC::remove_str( "The(Quick)Brown)Fox", "(", ")" ) );
+}
+
+
 class IsUrlSchemeTest : public ::testing::Test {};
 
 TEST_F(IsUrlSchemeTest, url_none)


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡している関数の引数を`std::string_view`に交換して整理します。

- テストを追加して動作をチェックします
- 無限ループしないように引数のチェックを追加します

関連のpull request: #905 