### PR TITLE
Use std::string_view for MISC::replace_str_list()

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -473,15 +473,19 @@ std::string MISC::replace_str( std::string_view str, std::string_view pattern, s
 }
 
 
-//
-// list_inから str1 を str2 に置き換えてリストを返す
-//
-std::list< std::string > MISC::replace_str_list( const std::list< std::string >& list_in,
-                                                 const std::string& str1, const std::string& str2 )
+/** @brief list_inから pattern を replacement に置き換えてリストを返す
+ *
+ * @param[in] list_in 置き換えを実行する文字列のリスト
+ * @param[in] pattern 置き換える文字列のパターン
+ * @param[in] replacement マッチした文字列を置き換える内容
+ * @return 置き換えを実行したリスト。
+ */
+std::list<std::string> MISC::replace_str_list( const std::list<std::string>& list_in,
+                                               std::string_view pattern, std::string_view replacement )
 {
     std::list< std::string > list_out;
     std::transform( list_in.cbegin(), list_in.cend(), std::back_inserter( list_out ),
-                    [&]( const std::string& s ) { return replace_str( s, str1, str2 ); } );
+                    [&]( const std::string& s ) { return replace_str( s, pattern, replacement ); } );
     return list_out;
 }
 

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -112,9 +112,9 @@ namespace MISC
     /// pattern を replacement に置き換える
     std::string replace_str( std::string_view str, std::string_view pattern, std::string_view replacement );
 
-    // list_inから str1 を str2 に置き換えてリストを返す
-    std::list< std::string > replace_str_list( const std::list< std::string >& list_in,
-                                               const std::string& str1, const std::string& str2 );
+    /// list_inから pattern を replacement に置き換えてリストを返す
+    std::list<std::string> replace_str_list( const std::list<std::string>& list_in,
+                                             std::string_view pattern, std::string_view replacement );
 
     // str_in に含まれる改行文字を replace に置き換え
     std::string replace_newlines_to_str( const std::string& str_in, const std::string& replace );

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -181,6 +181,23 @@ TEST_F(ReplaceStrTest, multi_match)
 }
 
 
+class ReplaceStrListTest : public ::testing::Test {};
+
+TEST_F(ReplaceStrListTest, empty_data)
+{
+    std::list<std::string> empty;
+    std::list<std::string> expect;
+    EXPECT_EQ( expect, MISC::replace_str_list( empty, "AA", "BB" ) );
+}
+
+TEST_F(ReplaceStrListTest, sample_match)
+{
+    std::list<std::string> input = { "hello", "world", "sample" };
+    std::list<std::string> expect = { "hell123", "w123rld", "sample" };
+    EXPECT_EQ( expect, MISC::replace_str_list( input, "o", "123" ) );
+}
+
+
 class IsUrlSchemeTest : public ::testing::Test {};
 
 TEST_F(IsUrlSchemeTest, url_none)


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡している関数の引数を`std::string_view`に交換して整理します。

- テストを追加して動作をチェックします

関連のpull request: #905