### PR TITLE
Update histories

### DIFF
--- a/docs/manual/2022.md
+++ b/docs/manual/2022.md
@@ -9,7 +9,112 @@ layout: default
 
 
 <a name="0.8.0-unreleased"></a>
-### [0.8.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.7.0...master) (unreleased)
+### [0.8.0-unreleased](https://github.com/JDimproved/JDim/compare/b06a6a6fe71...master) (unreleased)
+
+<a name="0.7.0-20220402"></a>
+### [0.7.0-20220402](https://github.com/JDimproved/JDim/compare/JDim-v0.7.0...b06a6a6fe71) (2022-04-02)
+- Update histories
+  ([#952](https://github.com/JDimproved/JDim/pull/952))
+- Use `std::string_view` for `MISC::replace_str_list()`
+  ([#950](https://github.com/JDimproved/JDim/pull/950))
+- Use `std::string_view` for `MISC::replace_str()`
+  ([#949](https://github.com/JDimproved/JDim/pull/949))
+- Use `std::string_view` for `MISC::remove_str(str, start, end)`
+  ([#948](https://github.com/JDimproved/JDim/pull/948))
+- Implement `MISC::utf8toutf32()`
+  ([#947](https://github.com/JDimproved/JDim/pull/947))
+- Use `std::string_view` for `Loader::analyze_header_option_list()`
+  ([#946](https://github.com/JDimproved/JDim/pull/946))
+- Use `std::string_view` for `Loader::analyze_header_option()`
+  ([#945](https://github.com/JDimproved/JDim/pull/945))
+- readme: Add information about crash with asan
+  ([#944](https://github.com/JDimproved/JDim/pull/944))
+- Update function parameters for font width caching
+  ([#942](https://github.com/JDimproved/JDim/pull/942))
+- `DrawAreaBase`: Fix known condition true/false
+  ([#941](https://github.com/JDimproved/JDim/pull/941))
+- Use `std::string_view` for `MISC::ascii_ignore_case_find()`
+  ([#940](https://github.com/JDimproved/JDim/pull/940))
+- Use `std::string_view` for `ReplaceStr_Manager::replace()`
+  ([#939](https://github.com/JDimproved/JDim/pull/939))
+- Use `std::string_view` for `MISC::chref_decode()`
+  ([#938](https://github.com/JDimproved/JDim/pull/938))
+- `IOMonitor`: Refactor parameter type of member function
+  ([#937](https://github.com/JDimproved/JDim/pull/937))
+- Set signal action to ignore SIGPIPE for preventing crash
+  ([#936](https://github.com/JDimproved/JDim/pull/936))
+- Use `std::string_view` for `NodeTreeBase::parse_html()`
+  ([#935](https://github.com/JDimproved/JDim/pull/935))
+- Use `std::string_view` for `NodeTreeBase::parse_write()`
+  ([#934](https://github.com/JDimproved/JDim/pull/934))
+- Use `std::string_view` for `NodeTreeBase::parse_date_id()`
+  ([#933](https://github.com/JDimproved/JDim/pull/933))
+- Use `std::string_view` for `NodeTreeBase::parse_mail()`
+  ([#932](https://github.com/JDimproved/JDim/pull/932))
+- Use `std::string_view` for `NodeTreeBase::parse_name()`
+  ([#931](https://github.com/JDimproved/JDim/pull/931))
+- Implement `MISC::utf8bytes()`
+  ([#930](https://github.com/JDimproved/JDim/pull/930))
+- `IOMonitor`: Remove quit command for debug build
+  ([#929](https://github.com/JDimproved/JDim/pull/929))
+- `NodeTreeBase`: Use `std::string_view` instead of const pointer and size
+  ([#928](https://github.com/JDimproved/JDim/pull/928))
+- Use `std::string_view` for `NodeTreeBase::create_node_text()`
+  ([#927](https://github.com/JDimproved/JDim/pull/927))
+- Use `std::string_view` for `NodeTreeBase::create_node_link()` part2
+  ([#926](https://github.com/JDimproved/JDim/pull/926))
+- `AboutDiag`: Use `Pango::Attribute` to show version number bigger
+  ([#925](https://github.com/JDimproved/JDim/pull/925))
+- Merge implementation of `NodeTreeBase::check_link()`
+  ([#924](https://github.com/JDimproved/JDim/pull/924))
+- Use `std::string_view` for `NodeTreeBase::create_node_anc()` part2
+  ([#923](https://github.com/JDimproved/JDim/pull/923))
+- Use `std::string_view` for `NodeTreeBase::create_node_img()` part2
+  ([#922](https://github.com/JDimproved/JDim/pull/922))
+- Use `std::string_view` for `NodeTreeBase::create_node_sssp()`
+  ([#921](https://github.com/JDimproved/JDim/pull/921))
+- Core: Disable virtual board for non-thread's histories
+  ([#920](https://github.com/JDimproved/JDim/pull/920))
+- `ICON_Manager`: Adjust size of loaded icon from file
+  ([#919](https://github.com/JDimproved/JDim/pull/919))
+- Use `std::string_view` for `NodeTreeBase::create_node_thumbnail()` part2 part3
+  ([#918](https://github.com/JDimproved/JDim/pull/918))
+- `NodeTreeBase`: Refactor local variable for urlreplace
+  ([#917](https://github.com/JDimproved/JDim/pull/917))
+- `Admin`: Add append-favorite to tab context menu
+  ([#915](https://github.com/JDimproved/JDim/pull/915))
+- `ICON_Manager`: Change APPENDFAVIRITE icon (retake)
+  ([#914](https://github.com/JDimproved/JDim/pull/914))
+- Use `std::string_view` for `NodeTreeBase::create_node_link()`
+  ([#913](https://github.com/JDimproved/JDim/pull/913))
+- Use `std::string_view` for `NodeTreeBase::create_node_img()`
+  ([#912](https://github.com/JDimproved/JDim/pull/912))
+- Implement `JDLIB::span<T>` class
+  ([#911](https://github.com/JDimproved/JDim/pull/911))
+- `BoardViewBase`: Add accelerator keys to dialog
+  ([#909](https://github.com/JDimproved/JDim/pull/909))
+- `ICON_Manager`: Change APPENDFAVORITE icon
+  ([#908](https://github.com/JDimproved/JDim/pull/908))
+- Use `std::string_view` for `NodeTreeBase::create_node_thumbnail()`
+  ([#907](https://github.com/JDimproved/JDim/pull/907))
+- Use `std::string_view` for `NodeTreeBase::create_node_anc()`
+  ([#906](https://github.com/JDimproved/JDim/pull/906))
+- Use `std::string_view` for `NodeTreeBase::create_node_multispace()`
+  ([#905](https://github.com/JDimproved/JDim/pull/905))
+- `Regex`: Implement named captures
+  ([#904](https://github.com/JDimproved/JDim/pull/904))
+- Replace lambda with `sigc::mem_fun()` for signal connection
+  ([#903](https://github.com/JDimproved/JDim/pull/903))
+- Change first argument of `sigc::mem_fun()` to reference value `*this`
+  ([#902](https://github.com/JDimproved/JDim/pull/902))
+- `Admin`: Add null pointer check
+  ([#901](https://github.com/JDimproved/JDim/pull/901))
+- Replace fallthrough comments with C++17 attribute
+  ([#900](https://github.com/JDimproved/JDim/pull/900))
+- Remove deprecated build option for regex
+  ([#899](https://github.com/JDimproved/JDim/pull/899))
+- Update requirements for dependencies (gcc >= 7)
+  ([#898](https://github.com/JDimproved/JDim/pull/898))
 
 
 <a name="JDim-v0.7.0"></a>

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -17,7 +17,7 @@
 #define MAJORVERSION 0
 #define MINORVERSION 7
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20220115"
+#define JDDATE_FALLBACK    "20220402"
 #define JDTAG     ""
 
 //---------------------------------


### PR DESCRIPTION
#### [Update histories](https://github.com/JDimproved/JDim/commit/441612ad8f418f59052579cc2946f011c2f2ac6b)

更新履歴の項目が長くなったため分割します。

#### [Update JDDATE_FALLBACK macro to 20220402](https://github.com/JDimproved/JDim/commit/918de19696aa78d04229a586c269894da43beb17)

関連のissue: #951 