### PR TITLE
ICON_Manager: Fix icon loading to prevent crash on start

### DIFF
--- a/src/icons/iconmanager.cpp
+++ b/src/icons/iconmanager.cpp
@@ -9,6 +9,8 @@
 
 #include "cache.h"
 
+#include "jdlib/miscmsg.h"
+
 #include "jd16.h"
 #include "jd32.h"
 #include "jd48.h"
@@ -50,7 +52,6 @@
 #include "link.h"
 #include "info.h"
 
-#include <cstring>
 
 ICON::ICON_Manager* instance_icon_manager = nullptr;
 
@@ -75,6 +76,101 @@ Glib::RefPtr< Gdk::Pixbuf > ICON::get_icon( int id )
 {
     return get_icon_manager()->get_icon( id );
 }
+
+
+namespace {
+
+/// アイコンを読み込むヘルパークラス
+struct NamedIconLoader
+{
+    Glib::RefPtr<Gtk::IconTheme> m_icon_theme = Gtk::IconTheme::get_default();
+    Glib::RefPtr<Gdk::Pixbuf> m_missing_icon;
+
+    explicit NamedIconLoader( int size );
+    Glib::RefPtr<Gdk::Pixbuf> load_icon( const Glib::ustring& icon_name, int size ) const;
+    Glib::RefPtr<Gdk::Pixbuf> choose_icon( const std::vector<Glib::ustring>& icon_names, int size ) const;
+};
+
+
+/** @brief コンストラクタ
+ *
+ * @param[in] size 見つからないときかわりに返すアイコンのサイズ
+ */
+NamedIconLoader::NamedIconLoader( int size )
+{
+    // GTKテーマのforeground colorを取得して矩形枠の色に使う
+    Gdk::RGBA rgba;
+
+    Gtk::WidgetPath path;
+    path.path_append_type( Gtk::Window::get_type() );
+    path.path_append_type( Gtk::Label::get_type() );
+    auto context = Gtk::StyleContext::create();
+    context->set_path( path );
+    if( ! context->lookup_color( "theme_fg_color", rgba ) ) {
+        rgba.set_red( 0 );
+        rgba.set_green( 0 );
+        rgba.set_blue( 0 );
+        rgba.set_alpha( 1 );
+    }
+
+    // アイコンの読み込みに失敗したときかわりに表示するイメージ (点線の矩形で薄赤色)
+    auto surface = Cairo::ImageSurface::create( Cairo::FORMAT_ARGB32, size, size );
+    auto cr = Cairo::Context::create( surface );
+    cr->rectangle( 0, 0 , size, size );
+    cr->set_source_rgba( 1, 0, 0, 0.0625 );
+    cr->fill_preserve();
+    cr->set_source_rgba( rgba.get_red(), rgba.get_green(), rgba.get_blue(), rgba.get_alpha() );
+    cr->set_line_width( 1 );
+    const std::vector<double> dashes = { 1 };
+    cr->set_dash( dashes, 0 );
+    cr->stroke();
+    m_missing_icon = Gdk::Pixbuf::create( surface, 0, 0, size, size );
+}
+
+
+/** @brief アイコンを読み込んで Gdk::Pixbuf を返す
+ *
+ * アイコンが見つからないときは同名のsymbolic iconを探す。
+ * @param[in] icon_name アイコン名
+ * @param[in] size アイコンのサイズ
+ * @return 読み込んだアイコン。見つからないときはかわりに表示するイメージを返す。
+ */
+Glib::RefPtr<Gdk::Pixbuf> NamedIconLoader::load_icon( const Glib::ustring& icon_name, int size ) const
+{
+    Gtk::IconInfo icon_info = m_icon_theme->lookup_icon( icon_name, size );
+    if( icon_info ) return icon_info.load_icon();
+
+    icon_info = m_icon_theme->lookup_icon( icon_name, size, Gtk::ICON_LOOKUP_FORCE_SYMBOLIC );
+    if( icon_info ) return icon_info.load_icon();
+
+    MISC::MSG( "Icon \"" + icon_name + "\" is not found... "
+               "Please make sure that icon theme is installed on your desktop." );
+    return m_missing_icon;
+}
+
+
+/** @brief アイコンを読み込んで Gdk::Pixbuf を返す
+ *
+ * アイコンが見つからないときは同名のsymbolic iconを探す。
+ * @param[in] icon_names アイコン名のリスト (1つ以上必須)
+ * @param[in] size アイコンのサイズ
+ * @return リストから最初に見つけたアイコン。見つからないときはかわりに表示するイメージを返す。
+ */
+Glib::RefPtr<Gdk::Pixbuf> NamedIconLoader::choose_icon( const std::vector<Glib::ustring>& icon_names, int size ) const
+{
+    assert( ! icon_names.empty() );
+    Gtk::IconInfo icon_info = m_icon_theme->choose_icon( icon_names, size );
+    if( icon_info ) return icon_info.load_icon();
+
+    icon_info = m_icon_theme->choose_icon( icon_names, size, Gtk::ICON_LOOKUP_FORCE_SYMBOLIC );
+    if( icon_info ) return icon_info.load_icon();
+
+    MISC::MSG( "Icon \"" + icon_names[0] + "\" is not found... "
+               "Please make sure that icon theme is installed on your desktop." );
+    return m_missing_icon;
+}
+
+} // namespace
 
 
 ///////////////////////////////////////////////
@@ -140,32 +236,24 @@ ICON_Manager::ICON_Manager()
     // https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html
     // https://gitlab.gnome.org/GNOME/adwaita-icon-theme
 
-    const auto icon_theme = Gtk::IconTheme::get_default();
     constexpr int size_menu = 16; // Gtk::ICON_SIZE_MENU
+    const NamedIconLoader icon_loader{ size_menu };
+    std::vector<Glib::ustring> icon_names;
 
     // 共通
-    m_list_icons[ ICON::SEARCH_PREV ] = icon_theme->load_icon( "go-up", size_menu );
-    m_list_icons[ ICON::SEARCH_NEXT ] = icon_theme->load_icon( "go-down", size_menu );
-    m_list_icons[ ICON::STOPLOADING ] = icon_theme->load_icon( "process-stop", size_menu );
+    m_list_icons[ ICON::SEARCH_PREV ] = icon_loader.load_icon( "go-up", size_menu );
+    m_list_icons[ ICON::SEARCH_NEXT ] = icon_loader.load_icon( "go-down", size_menu );
+    m_list_icons[ ICON::STOPLOADING ] = icon_loader.load_icon( "process-stop", size_menu );
     m_list_icons[ ICON::WRITE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_write ), icon_write );
-    m_list_icons[ ICON::RELOAD ] = icon_theme->load_icon( "view-refresh", size_menu );
-    try {
-        m_list_icons[ ICON::APPENDFAVORITE ] = icon_theme->load_icon( "bookmark-new", size_menu );
-    }
-    catch( Gtk::IconThemeError& ) {
-        m_list_icons[ ICON::APPENDFAVORITE ] = icon_theme->load_icon( "edit-copy", size_menu );
-    }
-    m_list_icons[ ICON::DELETE ] = icon_theme->load_icon( "edit-delete", size_menu );
-    m_list_icons[ ICON::QUIT ] = icon_theme->load_icon( "window-close", size_menu );
-    m_list_icons[ ICON::BACK ] = icon_theme->load_icon( "go-previous", size_menu );
-    m_list_icons[ ICON::FORWARD ] = icon_theme->load_icon( "go-next", size_menu );
-    try {
-        // changes-prevent is not a standard icon name.
-        m_list_icons[ ICON::LOCK ] = icon_theme->load_icon( "changes-prevent-symbolic", size_menu );
-    }
-    catch( Gtk::IconThemeError& ) {
-        m_list_icons[ ICON::LOCK ] = icon_theme->load_icon( "window-close", size_menu );
-    }
+    m_list_icons[ ICON::RELOAD ] = icon_loader.load_icon( "view-refresh", size_menu );
+    icon_names.assign( { "bookmark-new", "edit-copy" } );
+    m_list_icons[ ICON::APPENDFAVORITE ] = icon_loader.choose_icon( icon_names, size_menu );
+    m_list_icons[ ICON::DELETE ] = icon_loader.load_icon( "edit-delete", size_menu );
+    m_list_icons[ ICON::QUIT ] = icon_loader.load_icon( "window-close", size_menu );
+    m_list_icons[ ICON::BACK ] = icon_loader.load_icon( "go-previous", size_menu );
+    m_list_icons[ ICON::FORWARD ] = icon_loader.load_icon( "go-next", size_menu );
+    icon_names.assign( { "changes-prevent-symbolic", "window-close" } );
+    m_list_icons[ ICON::LOCK ] = icon_loader.choose_icon( icon_names, size_menu );
 
     // メイン
     m_list_icons[ ICON::BBSLISTVIEW ] = m_list_icons[ ICON::DIR ];
@@ -178,27 +266,27 @@ ICON_Manager::ICON_Manager()
     m_list_icons[ ICON::BOARDVIEW ] = m_list_icons[ ICON::BOARD ];
     m_list_icons[ ICON::ARTICLEVIEW ] = m_list_icons[ ICON::THREAD ];
     m_list_icons[ ICON::IMAGEVIEW ] = m_list_icons[ ICON::IMAGE ];
-    m_list_icons[ ICON::GO ] = icon_theme->load_icon( "go-jump", size_menu );
-    m_list_icons[ ICON::UNDO ] = icon_theme->load_icon( "edit-undo", size_menu );
-    m_list_icons[ ICON::REDO ] = icon_theme->load_icon( "edit-redo", size_menu );
+    m_list_icons[ ICON::GO ] = icon_loader.load_icon( "go-jump", size_menu );
+    m_list_icons[ ICON::UNDO ] = icon_loader.load_icon( "edit-undo", size_menu );
+    m_list_icons[ ICON::REDO ] = icon_loader.load_icon( "edit-redo", size_menu );
 
     // サイドバー
-    m_list_icons[ ICON::CHECK_UPDATE_ROOT ] = icon_theme->load_icon( "view-refresh", size_menu );
+    m_list_icons[ ICON::CHECK_UPDATE_ROOT ] = icon_loader.load_icon( "view-refresh", size_menu );
     m_list_icons[ ICON::CHECK_UPDATE_OPEN_ROOT ]  = Gdk::Pixbuf::create_from_inline( sizeof( icon_thread ), icon_thread );
 
     // スレビュー
-    m_list_icons[ ICON::SEARCH ] = icon_theme->load_icon( "edit-find", size_menu );
-    m_list_icons[ ICON::LIVE ] = icon_theme->load_icon( "media-playback-start", size_menu );
+    m_list_icons[ ICON::SEARCH ] = icon_loader.load_icon( "edit-find", size_menu );
+    m_list_icons[ ICON::LIVE ] = icon_loader.load_icon( "media-playback-start", size_menu );
 
     // 検索バー
-    m_list_icons[ ICON::CLOSE_SEARCH ] = icon_theme->load_icon( "edit-undo", size_menu );
-    m_list_icons[ ICON::CLEAR_SEARCH ] = icon_theme->load_icon( "edit-clear", size_menu );
-    m_list_icons[ ICON::SEARCH_AND ] = icon_theme->load_icon( "edit-cut", size_menu );
-    m_list_icons[ ICON::SEARCH_OR ] = icon_theme->load_icon( "list-add", size_menu );
+    m_list_icons[ ICON::CLOSE_SEARCH ] = icon_loader.load_icon( "edit-undo", size_menu );
+    m_list_icons[ ICON::CLEAR_SEARCH ] = icon_loader.load_icon( "edit-clear", size_menu );
+    m_list_icons[ ICON::SEARCH_AND ] = icon_loader.load_icon( "edit-cut", size_menu );
+    m_list_icons[ ICON::SEARCH_OR ] = icon_loader.load_icon( "list-add", size_menu );
 
     // 書き込みビュー
     m_list_icons[ ICON::PREVIEW ] = m_list_icons[ ICON::THREAD ];
-    m_list_icons[ ICON::INSERTTEXT ] = icon_theme->load_icon( "document-open", size_menu );
+    m_list_icons[ ICON::INSERTTEXT ] = icon_loader.load_icon( "document-open", size_menu );
 
     load_theme();
 }


### PR DESCRIPTION
アイコンの読み込みを修正して起動時にクラッシュしないようにします。
アイコンが見つからないときは同名のsymbolic iconを探してsymbolicも見つからないときは代替のアイコン(点線の矩形)を表示するようにします。

#### 背景
JDimで使用するアイコンはGNOME(GTK3)のデフォルトテーマで使われている[Adwaita Icon Theme][1]を参照しています。
新しいバージョンのGNOMEでは[symbolic icon][2]を使うように更新されたためテーマから[color iconが削除][3]されました。
そのため最新のGNOME環境(v42)ではアイコンの読み込みに失敗してJDimが起動しない問題がありました。

[1]: https://gitlab.gnome.org/GNOME/adwaita-icon-theme/
[2]: https://developer.gnome.org/hig/guidelines/ui-icons.html
[3]: https://www.spinics.net/lists/fedora-devel/msg298835.html

関連のissue: #954 