### PR TITLE
Remove unused MISC::count_str()

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -536,24 +536,6 @@ std::string MISC::recover_quot( const std::string& str )
 
 
 //
-// str 中に含まれている str2 の 数を返す
-//
-int MISC::count_str( const std::string& str, const std::string& str2  )
-{
-    int count = 0;
-    size_t found, pos = 0;
-
-    while( ( found = str.find( str2, pos ) ) != std::string::npos )
-    {
-        ++count;
-        pos = found + 1;
-    }
-
-    return count;
-}
-
-
-//
 // 文字列(utf-8も) -> 整数変換
 //
 // (例) "12３" -> 123

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -115,9 +115,6 @@ namespace MISC
     // \" を " に置き換え
     std::string recover_quot( const std::string& str );
 
-    // str 中に含まれている str2 の 数を返す
-    int count_str( const std::string& str, const std::string& str2 );
-
     // 文字列(utf-8も) -> 整数変換
     // (例) "12３" -> 123
     // 入力: str


### PR DESCRIPTION
`MISC::count_str()`が使われていないとcppcheck 2.6.2に指摘されたため整理します。

commit 548112fe697b38fdcdb403ebb7f99c8839fb6790 (2008-08)
で呼び出し元が削除されてから使われていませんでした。

cppcheckのレポート
```
src/jdlib/miscutil.cpp:525:0: style: The function 'count_str' is never used. [unusedFunction]
```