### PR TITLE
Use std::string_view for MISC::remove_str(str, pattern)

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -377,12 +377,15 @@ std::string MISC::remove_spaces( const std::string& str )
 
 
 
-//
-// str1からstr2で示された文字列を除く
-//
-std::string MISC::remove_str( const std::string& str1, const std::string& str2 )
+/** @brief strからpatternで示された文字列を除く
+ *
+ * @param[in] str 処理する文字列
+ * @param[in] pattern 取り除く文字列
+ * @return 取り除いた結果
+ */
+std::string MISC::remove_str( std::string_view str, std::string_view pattern )
 {
-    return MISC::replace_str( str1, str2, "" );
+    return MISC::replace_str( str, pattern, "" );
 }
 
 

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -87,8 +87,8 @@ namespace MISC
     // str前後の改行、タブ、スペースを削除
     std::string remove_spaces( const std::string& str );
 
-    // str1からstr2で示された文字列を除く
-    std::string remove_str( const std::string& str1, const std::string& str2 );
+    /// strからpatternで示された文字列を除く
+    std::string remove_str( std::string_view str, std::string_view pattern );
 
     /// start 〜 end の範囲をstrから取り除く ( /* コメント */ など )
     std::string remove_str( std::string_view str, std::string_view start, std::string_view end );


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡している関数の引数を`std::string_view`に交換して整理します。

関連のpull request: #905 