### PR TITLE
Use std::string_view for MISC::cut_str()

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -432,15 +432,21 @@ std::string MISC::remove_str_regex( const std::string& str1, const std::string& 
 }
 
 
-//
-// str1, str2 に囲まれた文字列を切り出す
-//
-std::string MISC::cut_str( const std::string& str, const std::string& str1, const std::string& str2 )
+/** @brief front_sep, back_sep に囲まれた文字列を切り出す
+ *
+ * @param[in] str 処理する文字列
+ * @param[in] front_sep 前の区切り
+ * @param[in] back_sep 後の区切り
+ * @return 切り出した結果。引数が空文字列または区切りが見つからないときは空文字列を返す。
+ */
+std::string MISC::cut_str( const std::string& str, std::string_view front_sep, std::string_view back_sep )
 {
-    size_t i = str.find( str1 );
+    if( str.empty() || front_sep.empty() || back_sep.empty() ) return std::string{};
+
+    std::size_t i = str.find( front_sep );
     if( i == std::string::npos ) return std::string();
-    i += str1.length();
-    size_t i2 = str.find( str2, i );
+    i += front_sep.size();
+    const std::size_t i2 = str.find( back_sep, i );
     if( i2 == std::string::npos ) return std::string();
     
     return str.substr( i, i2 - i );

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -96,8 +96,8 @@ namespace MISC
     // 正規表現を使ってstr1からqueryで示された文字列を除く
     std::string remove_str_regex( const std::string& str1, const std::string& query );
 
-    // str1, str2 に囲まれた文字列を切り出す
-    std::string cut_str( const std::string& str, const std::string& str1, const std::string& str2 );
+    /// front_sep, back_sep に囲まれた文字列を切り出す
+    std::string cut_str( const std::string& str, std::string_view front_sep, std::string_view back_sep );
 
     /// pattern を replacement に置き換える
     std::string replace_str( std::string_view str, std::string_view pattern, std::string_view replacement );

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -150,6 +150,47 @@ TEST_F(RemoveStrStartEndTest, much_end_marks)
 }
 
 
+class CutStrFrontBackTest : public ::testing::Test {};
+
+TEST_F(CutStrFrontBackTest, empty_data)
+{
+    EXPECT_EQ( "", MISC::cut_str( "", "", "" ) );
+    EXPECT_EQ( "", MISC::cut_str( "", "AA", "" ) );
+    EXPECT_EQ( "", MISC::cut_str( "", "AA", "BB" ) );
+    EXPECT_EQ( "", MISC::cut_str( "", "", "BB" ) );
+}
+
+TEST_F(CutStrFrontBackTest, empty_front_separator)
+{
+    EXPECT_EQ( "", MISC::cut_str( "Quick<<Brown>>Fox", "", ">>" ) );
+}
+
+TEST_F(CutStrFrontBackTest, empty_back_separator)
+{
+    EXPECT_EQ( "", MISC::cut_str( "Quick<<Brown>>Fox", "<<", "" ) );
+}
+
+TEST_F(CutStrFrontBackTest, different_separators)
+{
+    EXPECT_EQ( "Brown", MISC::cut_str( "Quick<<Brown>>Fox", "<<", ">>" ) );
+}
+
+TEST_F(CutStrFrontBackTest, same_separators)
+{
+    EXPECT_EQ( "Brown", MISC::cut_str( "Quick!!Brown!!Fox", "!!", "!!" ) );
+}
+
+TEST_F(CutStrFrontBackTest, much_front_separators)
+{
+    EXPECT_EQ( "Quick(Brown", MISC::cut_str( "The(Quick(Brown)Fox", "(", ")" ) );
+}
+
+TEST_F(CutStrFrontBackTest, much_back_separators)
+{
+    EXPECT_EQ( "Quick", MISC::cut_str( "The(Quick)Brown)Fox", "(", ")" ) );
+}
+
+
 class ReplaceStrTest : public ::testing::Test {};
 
 TEST_F(ReplaceStrTest, empty_data)


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡している関数の引数を`std::string_view`に交換して整理します。

- テストを追加して動作をチェックします
- 無限ループしないように引数のチェックを追加します

関連のpull request: #905 
