### PR TITLE
Use std::string_view for MISC::replace_newlines_to_str()

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -499,28 +499,31 @@ std::list<std::string> MISC::replace_str_list( const std::list<std::string>& lis
 }
 
 
-//
-// str_in に含まれる改行文字を replace に置き換え
-//
-std::string MISC::replace_newlines_to_str( const std::string& str_in, const std::string& replace )
+/** @brief str に含まれる改行文字(`\r\n`)を replace に置き換え
+ *
+ * @param[in] str_in 処理する文字列
+ * @param[in] replace マッチした改行文字と置き換える内容
+ * @return 置き換えを実行した結果。str や replace が空文字列のときは str をそのまま返す。
+ */
+std::string MISC::replace_newlines_to_str( const std::string& str, std::string_view replace )
 {
-    if( str_in.empty() || replace.empty() ) return str_in;
+    if( str.empty() || replace.empty() ) return str;
 
     std::string str_out;
-    str_out.reserve( str_in.length() );
+    str_out.reserve( str.size() );
 
     size_t pos = 0, found = 0;
-    while( ( found = str_in.find_first_of( "\r\n", pos ) ) != std::string::npos )
+    while( ( found = str.find_first_of( "\r\n", pos ) ) != std::string::npos )
     {
-        str_out.append( str_in, pos, ( found - pos ) );
+        str_out.append( str, pos, ( found - pos ) );
         str_out.append( replace );
 
         pos = found + 1;
 
-        if( str_in[ found ] == '\r' && str_in[ found + 1 ] == '\n' ) ++pos;
+        if( str[ found ] == '\r' && str[ found + 1 ] == '\n' ) ++pos;
     }
 
-    str_out.append( str_in, pos, str_in.length() );
+    str_out.append( str, pos );
 
     return str_out;
 }

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -106,8 +106,8 @@ namespace MISC
     std::list<std::string> replace_str_list( const std::list<std::string>& list_in,
                                              std::string_view pattern, std::string_view replacement );
 
-    // str_in に含まれる改行文字を replace に置き換え
-    std::string replace_newlines_to_str( const std::string& str_in, const std::string& replace );
+    /// str に含まれる改行文字(`\r\n`)を replace に置き換え
+    std::string replace_newlines_to_str( const std::string& str, std::string_view replace );
 
     // " を \" に置き換え
     std::string replace_quot( const std::string& str );

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -239,6 +239,37 @@ TEST_F(ReplaceStrListTest, sample_match)
 }
 
 
+class ReplaceNewlinesToStrTest : public ::testing::Test {};
+
+TEST_F(ReplaceNewlinesToStrTest, empty_data)
+{
+    EXPECT_EQ( "", MISC::replace_newlines_to_str( "", "" ) );
+    EXPECT_EQ( "", MISC::replace_newlines_to_str( "", "A\nA" ) );
+}
+
+TEST_F(ReplaceNewlinesToStrTest, empty_replacement)
+{
+    EXPECT_EQ( "\nBrown\nFox\n", MISC::replace_newlines_to_str( "\nBrown\nFox\n", "" ) );
+    EXPECT_EQ( "\rBrown\rFox\r", MISC::replace_newlines_to_str( "\rBrown\rFox\r", "" ) );
+    EXPECT_EQ( "\r\nBrown\r\nFox\r\n", MISC::replace_newlines_to_str( "\r\nBrown\r\nFox\r\n", "" ) );
+}
+
+TEST_F(ReplaceNewlinesToStrTest, replace_cr)
+{
+    EXPECT_EQ( "!!Brown!!Fox!!", MISC::replace_newlines_to_str( "\rBrown\rFox\r", "!!" ) );
+}
+
+TEST_F(ReplaceNewlinesToStrTest, replace_lf)
+{
+    EXPECT_EQ( "!!Brown!!Fox!!", MISC::replace_newlines_to_str( "\nBrown\nFox\n", "!!" ) );
+}
+
+TEST_F(ReplaceNewlinesToStrTest, replace_crlf)
+{
+    EXPECT_EQ( "!!Brown!!Fox!!", MISC::replace_newlines_to_str( "\r\nBrown\r\nFox\r\n", "!!" ) );
+}
+
+
 class IsUrlSchemeTest : public ::testing::Test {};
 
 TEST_F(IsUrlSchemeTest, url_none)


### PR DESCRIPTION
変更不可の文字列のポインターと長さを渡している関数の引数を`std::string_view`に交換して整理します。

- テストを追加して動作をチェックします

関連のpull request: #905 