### PR TITLE
Implement MISC::utf32toutf8()

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -7,9 +7,10 @@
 #include "spchar_decoder.h"
 #include "interface.h"
 
-#include "jdlib/miscutil.h"
-#include "jdlib/miscmsg.h"
 #include "jdlib/loaderdata.h"
+#include "jdlib/misccharcode.h"
+#include "jdlib/miscmsg.h"
+#include "jdlib/miscutil.h"
 
 #include "dbimg/imginterface.h"
 
@@ -56,7 +57,7 @@ constexpr size_t SIZE_OF_HEAP = MAXSISE_OF_LINES + 64;
 
 constexpr size_t INITIAL_RES_BUFSIZE = 128;  // レスの文字列を返すときの初期バッファサイズ
 
-constexpr std::size_t kMaxBytesOfUTF8Char = 4 + 1; // UTF-8文字の最大バイト数 + ヌル文字
+constexpr std::size_t kMaxBytesOfUTF8Char = 8; // UTF-8文字の最大バイト数4 + ヌル文字
 
 
 // レジュームのモード
@@ -2562,7 +2563,7 @@ void NodeTreeBase::parse_write( std::string_view str, const std::size_t max_lng_
 
             const int num = MISC::decode_spchar_number( pos, offset_num, lng_num );
             char utf8[kMaxBytesOfUTF8Char]{};
-            const int n_out = MISC::ucs2toutf8( num, utf8 );
+            const int n_out = MISC::utf32toutf8( num, utf8 );
             m_buffer_write.append( utf8, n_out );
             pos += offset_num + lng_num;
 

--- a/src/dbtree/spchar_decoder.cpp
+++ b/src/dbtree/spchar_decoder.cpp
@@ -7,6 +7,7 @@
 #include "spchar_tbl.h"
 #include "node.h"
 
+#include "jdlib/misccharcode.h"
 #include "jdlib/miscutil.h"
 
 #include <string.h>
@@ -68,7 +69,7 @@ int decode_char_number( const char* in_char, int& n_in,  char* out_char, int& n_
             break;
 
         default:
-            n_out = MISC::ucs2toutf8( num, out_char );
+            n_out = MISC::utf32toutf8( num, out_char );
             if( ! n_out ) return DBTREE::NODE_NONE;
     }
 
@@ -123,7 +124,7 @@ int DBTREE::decode_char( const char* in_char, int& n_in,  char* out_char, int& n
 
             // zwnj, zwj, lrm, rlm は今のところ無視する(zwspにする)
             if( ucs >= UCS_ZWSP && ucs <= UCS_RLM ) ret = DBTREE::NODE_ZWSP;
-            else n_out = MISC::ucs2toutf8( ucs, out_char );
+            else n_out = MISC::utf32toutf8( ucs, out_char );
 
             break;
         }

--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -355,6 +355,51 @@ char32_t MISC::utf8toutf32( const char* utf8str, int& byte )
 }
 
 
+/**
+ * @brief UTF-32 から UTF-8 に変換する
+ *
+ * @param[in]  uch     変換するコードポイント。有効範囲は [0, 0x10FFFF]
+ * @param[out] utf8str 変換後の文字。渡された文字列は末尾にヌル文字を追加する
+ * @return 変換したUTF-8のバイト数。入力が有効範囲外のときは 0 が返る
+ */
+int MISC::utf32toutf8( const char32_t uch,  char* utf8str )
+{
+    int byte = 0;
+    if( ! utf8str ) return byte;
+
+    if( uch <= 0x7F ){ // ascii
+        byte = 1;
+        utf8str[0] = uch;
+    }
+    else if( uch <= 0x07FF ){
+        byte = 2;
+        utf8str[0] = ( 0xC0 ) + ( uch >> 6 );
+        utf8str[1] = ( 0x80 ) + ( uch & 0x3F );
+    }
+    else if( uch <= 0xFFFF ){
+        byte = 3;
+        utf8str[0] = ( 0xE0 ) + ( uch >> 12 );
+        utf8str[1] = ( 0x80 ) + ( ( uch >> 6 ) & 0x3F );
+        utf8str[2] = ( 0x80 ) + ( uch & 0x3F );
+    }
+    else if( uch <= 0x10FFFF ){
+        byte = 4;
+        utf8str[0] = ( 0xF0 ) + ( uch >> 18 );
+        utf8str[1] = ( 0x80 ) + ( ( uch >> 12 ) & 0x3F );
+        utf8str[2] = ( 0x80 ) + ( ( uch >> 6 ) & 0x3F );
+        utf8str[3] = ( 0x80 ) + ( uch & 0x3F );
+    }
+#ifdef _DEBUG
+    else{
+        std::cout << "MISC::utf32toutf8 : invalid uch = " << uch << std::endl;
+    }
+#endif
+
+    utf8str[byte] = 0;
+    return byte;
+}
+
+
 /** @brief 特定のUnicodeブロックかコードポイントを調べる
  *
  * @param[in] unich Unicodeコードポイント

--- a/src/jdlib/misccharcode.h
+++ b/src/jdlib/misccharcode.h
@@ -44,6 +44,11 @@ namespace MISC
     // 戻り値 : unicode code point
     char32_t utf8toutf32( const char* utf8str, int& byte );
 
+    // UTF-32 から UTF-8 に変換する
+    // 出力 : utf8str 変換後の文字
+    // 戻り値 : バイト数
+    int utf32toutf8( const char32_t uch, char* utf8str );
+
     /// 特定のUnicodeブロックかコードポイントを調べる
     UnicodeBlock get_unicodeblock( const char32_t unich );
 }

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1343,7 +1343,7 @@ int MISC::spchar_number_ln( const char* in_char, int& offset )
     // offset == 2 なら 10 進数、3 なら16進数
     if( in_char[ offset ] == 'x' || in_char[ offset ] == 'X' ) ++offset;
 
-    // UCS2の2バイトの範囲でデコードするので最大65535
+    // UTF-32の範囲でデコードするので最大1114111
     // デコードするとき「;」で終端されていなくてもよい
 
     // デコード可能かチェック
@@ -1514,62 +1514,20 @@ std::string MISC::decode_spchar_number( const std::string& str )
 
             const int num = MISC::decode_spchar_number( str.c_str()+i, offset, lng );
 
-            char out_char[ 64 ];
-            const int n_out = MISC::ucs2toutf8( num, out_char );
+            char out_char[8];
+            const int n_out = MISC::utf32toutf8( num, out_char );
             if( ! n_out ){
                 str_out += str[ i ];
                 continue;
             }
 
-            for( int j = 0; j < n_out; ++j ) str_out += out_char[ j ];
+            str_out.append( out_char, n_out );
             i += offset + lng;
         }
         else str_out += str[ i ];
     }
 
     return str_out;
-}
-
-
-//
-// ucs2 -> utf8 変換
-//
-// 出力 : utfstr 変換後の文字
-//
-// 戻り値 : バイト数
-//
-int MISC::ucs2toutf8( const int ucs2,  char* utfstr )
-{
-    int byte = 0;
-
-    if( ucs2 <= 0x7f ){ // ascii
-        byte = 1;
-        utfstr[ 0 ] = ucs2;
-    }
-
-    else if( ucs2 <= 0x07ff ){
-        byte = 2;
-        utfstr[ 0 ] = ( 0xc0 ) + ( ucs2 >> 6 );
-        utfstr[ 1 ] = ( 0x80 ) + ( ucs2 & 0x3f );
-    }
-
-    else if( ucs2 <= 0xffff){
-        byte = 3;
-        utfstr[ 0 ] = ( 0xe0 ) + ( ucs2 >> 12 );
-        utfstr[ 1 ] = ( 0x80 ) + ( ( ucs2 >>6 ) & 0x3f );
-        utfstr[ 2 ] = ( 0x80 ) + ( ucs2 & 0x3f );
-    }
-
-    else{
-        byte = 4;
-        utfstr[ 0 ] = ( 0xf0 ) + ( ucs2 >> 18 );
-        utfstr[ 1 ] = ( 0x80 ) + ( ( ucs2 >>12 ) & 0x3f );
-        utfstr[ 2 ] = ( 0x80 ) + ( ( ucs2 >>6 ) & 0x3f );
-        utfstr[ 3 ] = ( 0x80 ) + ( ucs2 & 0x3f );
-    }
-
-    utfstr[ byte ] = 0;
-    return byte;
 }
 
 

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -218,11 +218,6 @@ namespace MISC
     // str に含まれる「&#数字;」形式の数字参照文字列を全てユニーコード文字に変換する
     std::string decode_spchar_number( const std::string& str );
 
-    // ucs2 -> utf8 変換
-    // 出力 : utfstr 変換後の文字
-    // 戻り値 : バイト数
-    int ucs2toutf8( const int ucs2, char* utfstr );
-
     // WAVEDASHなどのWindows系UTF-8文字をUnix系文字と相互変換
     std::string utf8_fix_wavedash( const std::string& str, const int mode );
 

--- a/test/gtest_jdlib_misccharcode.cpp
+++ b/test/gtest_jdlib_misccharcode.cpp
@@ -164,6 +164,58 @@ TEST_F(Utf8ToUtf32Test, invalid_bytes)
     EXPECT_EQ( 0, byte );
 }
 
+
+class Utf32ToUtf8Test : public ::testing::Test {};
+
+TEST_F(Utf32ToUtf8Test, null_data)
+{
+    EXPECT_EQ( 0, MISC::utf32toutf8( 0x1000, nullptr ) );
+}
+
+TEST_F(Utf32ToUtf8Test, ascii)
+{
+    char out_char[8];
+    EXPECT_EQ( 1, MISC::utf32toutf8( 0x0000, out_char ) );
+    EXPECT_STREQ( "\u0000", out_char );
+    EXPECT_EQ( 1, MISC::utf32toutf8( 0x007F, out_char ) );
+    EXPECT_STREQ( "\u007F", out_char );
+}
+
+TEST_F(Utf32ToUtf8Test, two_bytes)
+{
+    char out_char[8];
+    EXPECT_EQ( 2, MISC::utf32toutf8( 0x0080, out_char ) );
+    EXPECT_STREQ( "\u0080", out_char );
+    EXPECT_EQ( 2, MISC::utf32toutf8( 0x07FF, out_char ) );
+    EXPECT_STREQ( "\u07FF", out_char );
+}
+
+TEST_F(Utf32ToUtf8Test, three_bytes)
+{
+    char out_char[8];
+    EXPECT_EQ( 3, MISC::utf32toutf8( 0x0800, out_char ) );
+    EXPECT_STREQ( "\u0800", out_char );
+    EXPECT_EQ( 3, MISC::utf32toutf8( 0xFFFF, out_char ) );
+    EXPECT_STREQ( "\uFFFF", out_char );
+}
+
+TEST_F(Utf32ToUtf8Test, four_bytes)
+{
+    char out_char[8];
+    EXPECT_EQ( 4, MISC::utf32toutf8( 0x00010000, out_char ) );
+    EXPECT_STREQ( "\U00010000", out_char );
+    EXPECT_EQ( 4, MISC::utf32toutf8( 0x0010FFFF, out_char ) );
+    EXPECT_STREQ( "\U0010FFFF", out_char );
+}
+
+TEST_F(Utf32ToUtf8Test, out_of_range)
+{
+    char out_char[8];
+    EXPECT_EQ( 0, MISC::utf32toutf8( 0x00110000, out_char ) );
+    EXPECT_STREQ( "", out_char );
+}
+
+
 class GetUnicodeBlockTest : public ::testing::Test {};
 
 TEST_F(GetUnicodeBlockTest, basic_latin)


### PR DESCRIPTION
#### [Implement MISC::utf32toutf8()](https://github.com/JDimproved/JDim/commit/e24116a0413199fa76cac599c20ba107178f76a1)

jdlib/miscutil.h の`MISC::ucs2toutf8()`の代替としてjdlib/misccharcode.h にUnicodeのコードポイントからUTF-8のバイト列へ
変換する関数を追加する。さらに`MISC::ucs2toutf8()`はもう必要ないので削除する。


#### [Add test cases for MISC::utf32toutf8()](https://github.com/JDimproved/JDim/commit/8e88ff5559bd6b3c536d4659f67969af11197774)
