### PR TITLE
Rename function MISC::remove_spaces() to MISC::ascii_trim()

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -3398,7 +3398,7 @@ void ArticleViewBase::slot_select_all()
 void ArticleViewBase::slot_drawout_selection_str()
 {
     std::string query = m_drawarea->str_selection();
-    query = MISC::remove_spaces( query );
+    query = MISC::ascii_trim( query );
     query = MISC::replace_str( query, "\n", "" );
     if( query.find( ' ' ) != std::string::npos ) query = "\"" + query + "\"";
 

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -543,7 +543,7 @@ void Preferences::slot_ok_clicked()
         // 不適切な文字が含まれてないかチェックと先頭末尾の空白文字を削除する
         const std::string& raw = agent_text.raw();
         if( std::all_of( raw.begin(), raw.end(), []( char c ) { return g_ascii_isprint( c ); } ) ) {
-            board_agent = MISC::remove_spaces( raw );
+            board_agent = MISC::ascii_trim( raw );
         }
     }
     if( board_agent != DBTREE::board_get_board_agent( get_url() ) ) {

--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -233,7 +233,7 @@ bool Css_Manager::read_css()
             ( r_pos = css_data.find( '}', l_pos + 1 ) ) != std::string::npos )
     {
         // セレクタ部分を取り出す
-        std::string selector = MISC::remove_spaces( css_data.substr( start_pos, l_pos - start_pos ) );
+        std::string selector = MISC::ascii_trim( css_data.substr( start_pos, l_pos - start_pos ) );
         start_pos = r_pos + 1;
         if( selector.rfind( '.', 0 ) == 0 ) selector.erase( 0, 1 );
         if( selector.empty() ) break;
@@ -254,8 +254,8 @@ bool Css_Manager::read_css()
         while( it != properties.end() )
         {
             size_t colon = (*it).find( ':' );
-            std::string key = MISC::remove_spaces( (*it).substr( 0, colon ) );
-            std::string value = MISC::remove_spaces( (*it).substr( colon + 1 ) );
+            std::string key = MISC::ascii_trim( it->substr( 0, colon ) );
+            std::string value = MISC::ascii_trim( it->substr( colon + 1 ) );
 
 #ifdef _DEBUG
             std::cout << "  key = " << key << " value = " << value << std::endl;

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -198,8 +198,8 @@ std::string ENVIRONMENT::get_distname()
             size_t e;
             if( ( e = (*it).find( '=' ) ) != std::string::npos )
             {
-                name = MISC::remove_spaces( (*it).substr( 0, e ) );
-                value = MISC::remove_spaces( (*it).substr( e + 1 ) );
+                name = MISC::ascii_trim( it->substr( 0, e ) );
+                value = MISC::ascii_trim( it->substr( e + 1 ) );
             }
 
             if( name == "PRETTY_NAME" && ! value.empty() )
@@ -223,8 +223,8 @@ std::string ENVIRONMENT::get_distname()
             size_t e;
             if( ( e = (*it).find( '=' ) ) != std::string::npos )
             {
-                lsb_name = MISC::remove_spaces( (*it).substr( 0, e ) );
-                lsb_data = MISC::remove_spaces( (*it).substr( e + 1 ) );
+                lsb_name = MISC::ascii_trim( it->substr( 0, e ) );
+                lsb_data = MISC::ascii_trim( it->substr( e + 1 ) );
             }
 
             // 「DISTRIB_DESCRIPTION="Ubuntu 7.10"」などから「Ubuntu 7.10」を取得
@@ -308,7 +308,7 @@ std::string ENVIRONMENT::get_distname()
     }
 
     // 文字列両端のスペースなどを削除する
-    std::string dist_name = MISC::remove_spaces( tmp );
+    std::string dist_name = MISC::ascii_trim( tmp );
 
     // 取得した文字が異常に長い場合は空にする
     if( dist_name.length() > 50 ) dist_name.clear();

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -349,30 +349,21 @@ std::string MISC::remove_space( const std::string& str )
 }
 
 
-//
-// str前後の改行、タブ、スペースを削除
-//
-std::string MISC::remove_spaces( const std::string& str )
+/** @brief str前後の改行(\r, \\n)、タブ(\t)、スペース(U+0020)を削除
+ *
+ * @param[in] str トリミングする文字列
+ * @return トリミングした結果
+ */
+std::string MISC::ascii_trim( const std::string& str )
 {
     if( str.empty() ) return std::string();
 
-    size_t l = 0, r = str.length();
+    constexpr std::string_view space_chars = " \n\t\r";
+    const auto start = str.find_first_not_of( space_chars );
+    if( start == std::string::npos ) return str;
 
-    while( l < r
-         && ( str[l] == '\n'
-           || str[l] == '\r'
-           || str[l] == '\t'
-           || str[l] == ' ' ) ) ++l;
-
-    // 最後の文字の位置は文字数より1少ない
-    size_t p = r - 1;
-    while( p > 0
-         && ( str[p] == '\n'
-           || str[p] == '\r'
-           || str[p] == '\t'
-           || str[p] == ' ' ) ){ --p; --r; }
-
-    return str.substr( l, r - l );
+    const auto end = str.find_last_not_of( space_chars ) + 1;
+    return str.substr( start, end - start );
 }
 
 

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -84,8 +84,8 @@ namespace MISC
     // strの前後の空白削除
     std::string remove_space( const std::string& str );
 
-    // str前後の改行、タブ、スペースを削除
-    std::string remove_spaces( const std::string& str );
+    /// str前後の改行(\r, \\n)、タブ(\t)、スペース(U+0020)を削除
+    std::string ascii_trim( const std::string& str );
 
     /// strからpatternで示された文字列を除く
     std::string remove_str( std::string_view str, std::string_view pattern );

--- a/src/message/logitem.h
+++ b/src/message/logitem.h
@@ -54,7 +54,7 @@ namespace MESSAGE
 
             // MISC::replace_str( ..., "\n", " \n" ) しているのは MISC::get_lines 実行時に
             // 改行のみの行を削除しないようにするため
-            msg_lines = MISC::get_lines( MISC::replace_str( MISC::remove_spaces( msg ), "\n", " \n" ) );
+            msg_lines = MISC::get_lines( MISC::replace_str( MISC::ascii_trim( msg ), "\n", " \n" ) );
 
             // 簡易チェック用に先頭の文字列をコピー(空白は除く)
             for( size_t i = 0, i2 = 0; i < LOGITEM_SIZE_HEAD -1 && i2 < msg.length(); ++i2 ){

--- a/src/message/logmanager.cpp
+++ b/src/message/logmanager.cpp
@@ -219,7 +219,7 @@ bool Log_Manager::check_write( const std::string& url, const bool newthread, con
         
         // MISC::replace_str( ..., "\n", " \n" ) しているのは MISC::get_lines 実行時に
         // 改行のみの行を削除しないようにするため
-        std::list< std::string > msg_lines = MISC::get_lines( MISC::replace_str( MISC::remove_spaces( msg ), "\n", " \n" ) );
+        std::list< std::string > msg_lines = MISC::get_lines( MISC::replace_str( MISC::ascii_trim( msg ), "\n", " \n" ) );
 
 #ifdef _DEBUG
         std::cout << "lines = " << msg_lines.size() << " : " << item.msg_lines.size() << std::endl;
@@ -234,7 +234,7 @@ bool Log_Manager::check_write( const std::string& url, const bool newthread, con
 #ifdef _DEBUG
             std::cout << (*it_msg) << " | " << (*it_item) << std::endl;
 #endif
-            if( MISC::remove_spaces( (*it_msg) ) != MISC::remove_spaces( (*it_item ) ) ) break;
+            if( MISC::ascii_trim( *it_msg ) != MISC::ascii_trim( *it_item ) ) break;
         }
         if( it_msg != msg_lines.end() ) continue;
 

--- a/src/xml/dom.cpp
+++ b/src/xml/dom.cpp
@@ -386,7 +386,7 @@ std::string Dom::get_xml( const int n ) const
         // テキストノード
         case NODE_TYPE_TEXT:
 
-            text = MISC::remove_spaces( m_nodeValue );
+            text = MISC::ascii_trim( m_nodeValue );
             if( ! text.empty() )
             {
                 // インデントを追加

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -109,6 +109,55 @@ TEST_F(RemoveSpaceTest, remove_doublequote)
 }
 
 
+class AsciiTrimTest : public ::testing::Test {};
+
+TEST_F(AsciiTrimTest, empty_data)
+{
+    EXPECT_EQ( "", MISC::ascii_trim( "" ) );
+}
+
+TEST_F(AsciiTrimTest, no_space_chars_at_start_and_end)
+{
+    EXPECT_EQ( "Hello \n \r \t World", MISC::ascii_trim( "Hello \n \r \t World" ) );
+    EXPECT_EQ( "あいうえお", MISC::ascii_trim( "あいうえお" ) );
+}
+
+TEST_F(AsciiTrimTest, trim_front)
+{
+    EXPECT_EQ( "Hello", MISC::ascii_trim( " Hello" ) );
+    EXPECT_EQ( "Hello", MISC::ascii_trim( "\nHello" ) );
+    EXPECT_EQ( "Hello", MISC::ascii_trim( "\rHello" ) );
+    EXPECT_EQ( "Hello", MISC::ascii_trim( "\tHello" ) );
+    EXPECT_EQ( "Hello", MISC::ascii_trim( "\n \r \t Hello" ) );
+}
+
+TEST_F(AsciiTrimTest, trim_back)
+{
+    EXPECT_EQ( "World", MISC::ascii_trim( "World " ) );
+    EXPECT_EQ( "World", MISC::ascii_trim( "World\n" ) );
+    EXPECT_EQ( "World", MISC::ascii_trim( "World\r" ) );
+    EXPECT_EQ( "World", MISC::ascii_trim( "World\t" ) );
+    EXPECT_EQ( "World", MISC::ascii_trim( "World\n \r \t" ) );
+}
+
+TEST_F(AsciiTrimTest, trim_both_side)
+{
+    EXPECT_EQ( "Hello\t \n \rWorld", MISC::ascii_trim( "\n \r \t Hello\t \n \rWorld \n \r \t" ) );
+}
+
+TEST_F(AsciiTrimTest, not_trim_ascii)
+{
+    EXPECT_EQ( "\vHello\v", MISC::ascii_trim( "\vHello\v" ) ); // VERTICAL TAB
+    EXPECT_EQ( "\fHello\f", MISC::ascii_trim( "\fHello\f" ) ); // FORM FEED
+}
+
+TEST_F(AsciiTrimTest, not_trim_unicode)
+{
+    EXPECT_EQ( "\u00A0Hello\u00A0", MISC::ascii_trim( "\u00A0Hello\u00A0" ) ); // NO-BREAK SPACE
+    EXPECT_EQ( "\u3000Hello\u3000", MISC::ascii_trim( "\u3000Hello\u3000" ) ); // IDEOGRAPHIC SPACE
+}
+
+
 class RemoveStrStartEndTest : public ::testing::Test {};
 
 TEST_F(RemoveStrStartEndTest, empty_data)


### PR DESCRIPTION
#### [Rename function MISC::remove_spaces() to MISC::ascii_trim()](https://github.com/JDimproved/JDim/commit/62abdbfc55c9e1df8d92d862cfb33c33b8a01b90)

関数の名称が紛らわしいため名前を変更します。さらに実装を自作のループから`std::string`のメンバー関数に置き換えてコードを整理します。

#### [Add test cases for MISC::ascii_trim()](https://github.com/JDimproved/JDim/commit/51dca09f7cd529a99ace256abdea6bf5d0fd1fe0)
