### PR TITLE
UsrCmdPref: Use Gio::SimpleActionGroup instead of Gtk::ActionGroup

### DIFF
--- a/src/usrcmdpref.h
+++ b/src/usrcmdpref.h
@@ -50,8 +50,8 @@ namespace CORE
         Gtk::TreeModel::Path m_path_selected;
 
         // ポップアップメニュー
-        Glib::RefPtr< Gtk::ActionGroup > m_action_group;
-        Glib::RefPtr< Gtk::UIManager > m_ui_manager;
+        Glib::RefPtr<Gio::SimpleActionGroup> m_action_group;
+        Gtk::Menu m_treeview_menu;
 
         CONTROL::Control m_control;
 


### PR DESCRIPTION
GTK4で廃止される`Gtk::ActionGroup`をGTK3から導入された`Gio::SimpleActionGroup`に置き換えます。
ショットカットキーの表示はユーザーコマンドのダイアログボックスには効果がないため削除します。

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

<details>
<summary>コンパイラのレポート</summary>

```
../src/usrcmdpref.h:54:28: error: 'UIManager' is not a member of 'Gtk'
   54 |         Glib::RefPtr< Gtk::UIManager > m_ui_manager;
      |                            ^~~~~~~~~
../src/usrcmdpref.h:54:28: error: 'UIManager' is not a member of 'Gtk'
../src/usrcmdpref.h:54:38: error: template argument 1 is invalid
   54 |         Glib::RefPtr< Gtk::UIManager > m_ui_manager;
      |                                      ^
../src/usrcmdpref.cpp:98:40: error: incomplete type 'Gtk::ActionGroup' used in nested name specifier
   98 |     m_action_group = Gtk::ActionGroup::create();
      |                                        ^~~~~~
../src/usrcmdpref.cpp:99:19: error: invalid use of incomplete type 'class Gtk::ActionGroup'
   99 |     m_action_group->add( Gtk::Action::create( "NewCmd", "新規コマンド(_C)"), sigc::mem_fun( *this, &UsrCmdPref::slot_newcmd ) );
      |                   ^~
../src/usrcmdpref.cpp:100:19: error: invalid use of incomplete type 'class Gtk::ActionGroup'
  100 |     m_action_group->add( Gtk::Action::create( "NewDir", "新規ディレクトリ(_N)"), sigc::mem_fun( *this, &UsrCmdPref::slot_newdir ) );
      |                   ^~
  101 |     m_action_group->add( Gtk::Action::create( "NewSepa", "区切り(_S)"), sigc::mem_fun( *this, &UsrCmdPref::slot_newsepa ) );
      |                   ^~
../src/usrcmdpref.cpp:102:75: error: no matching function for call to 'Gtk::Action::create(const char [7], const char [17])'
  102 |     m_action_group->add( Gtk::Action::create( "Rename", "名前変更(_R)"), sigc::mem_fun( *this, &UsrCmdPref::slot_rename ) );
      |                                                                           ^
../src/usrcmdpref.cpp:103:19: error: invalid use of incomplete type 'class Gtk::ActionGroup'
  103 |     m_action_group->add( Gtk::Action::create( "Delete_Menu", "Delete" ) );
      |                   ^~
../src/usrcmdpref.cpp:104:19: error: invalid use of incomplete type 'class Gtk::ActionGroup'
  104 |     m_action_group->add( Gtk::Action::create( "Delete", "削除する(_D)"), sigc::mem_fun( *this, &UsrCmdPref::slot_delete ) );
      |                   ^~
../src/usrcmdpref.cpp:130:25: error: 'Gtk::UIManager' has not been declared
  130 |     m_ui_manager = Gtk::UIManager::create();
      |                         ^~~~~~~~~
../src/usrcmdpref.cpp:131:17: error: base operand of '->' is not a pointer
  131 |     m_ui_manager->insert_action_group( m_action_group );
      |                 ^~
../src/usrcmdpref.cpp:132:17: error: base operand of '->' is not a pointer
  132 |     m_ui_manager->add_ui_from_string( str_ui );
      |                 ^~
../src/usrcmdpref.cpp:135:63: error: base operand of '->' is not a pointer
  135 |     Gtk::Menu* menu = dynamic_cast< Gtk::Menu* >( m_ui_manager->get_widget( "/popup_menu" ) );
      |                                                               ^~
../src/usrcmdpref.cpp:137:52: error: base operand of '->' is not a pointer
  137 |     menu = dynamic_cast< Gtk::Menu* >( m_ui_manager->get_widget( "/popup_menu_mul" ) );
      |                                                    ^~
../src/usrcmdpref.cpp:246:78: error: base operand of '->' is not a pointer
  246 |     if( list_it.size() <= 1 ) menu = dynamic_cast< Gtk::Menu* >( m_ui_manager->get_widget( "/popup_menu" ) );
      |                                                                              ^~
../src/usrcmdpref.cpp:247:57: error: base operand of '->' is not a pointer
  247 |     else menu = dynamic_cast< Gtk::Menu* >( m_ui_manager->get_widget( "/popup_menu_mul" ) );
      |                                                         ^~
../src/usrcmdpref.cpp:252:32: error: invalid use of incomplete type 'class Gtk::ActionGroup'
  252 |     act_rename = m_action_group->get_action( "Rename" );
      |                                ^~
../src/usrcmdpref.cpp:253:29: error: invalid use of incomplete type 'class Gtk::ActionGroup'
  253 |     act_del = m_action_group->get_action( "Delete_Menu" );
      |                             ^~
../src/usrcmdpref.cpp:256:38: error: 'class Gtk::Action' has no member named 'set_sensitive'
  256 |         if( act_rename ) act_rename->set_sensitive( false );
      |                                      ^~~~~~~~~~~~~
../src/usrcmdpref.cpp:257:32: error: 'class Gtk::Action' has no member named 'set_sensitive'
  257 |         if( act_del ) act_del->set_sensitive( false );
      |                                ^~~~~~~~~~~~~
../src/usrcmdpref.cpp:265:54: error: 'class Gtk::Action' has no member named 'set_sensitive'
  265 |             if( type != TYPE_SEPARATOR ) act_rename->set_sensitive( true );
      |                                                      ^~~~~~~~~~~~~
../src/usrcmdpref.cpp:266:30: error: 'class Gtk::Action' has no member named 'set_sensitive'
  266 |             else act_rename->set_sensitive( false );
      |                              ^~~~~~~~~~~~~
../src/usrcmdpref.cpp:268:32: error: 'class Gtk::Action' has no member named 'set_sensitive'
  268 |         if( act_del ) act_del->set_sensitive( true );
      |                                ^~~~~~~~~~~~~
```

</details>