### PR TITLE
Move MISC::utf8_fix_wavedash() from miscutil to misccharcode

### DIFF
--- a/src/jdlib/misccharcode.h
+++ b/src/jdlib/misccharcode.h
@@ -29,6 +29,13 @@ namespace MISC
         Other, ///< 上記以外
     };
 
+    /// utf8_fix_wavedash() の変換モード
+    enum class WaveDashFix
+    {
+        UnixToWin, ///< Unix から Windows へ
+        WinToUnix, ///< Windows から Unix へ
+    };
+
     bool is_euc( const char* input, size_t read_byte );
     bool is_jis( const char* input, size_t& read_byte );
     bool is_sjis( const char* input, size_t read_byte );
@@ -51,6 +58,9 @@ namespace MISC
 
     /// 特定のUnicodeブロックかコードポイントを調べる
     UnicodeBlock get_unicodeblock( const char32_t unich );
+
+    /// WAVE DASH(U+301C)などのWindows系UTF-8文字をUnix系文字と相互変換
+    std::string utf8_fix_wavedash( const std::string& str, const WaveDashFix mode );
 }
 
 #endif

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1523,59 +1523,6 @@ std::string MISC::decode_spchar_number( const std::string& str )
 
 
 //
-// WAVEDASHなどのWindows系UTF-8文字をUnix系文字と相互変換
-//
-std::string MISC::utf8_fix_wavedash( const std::string& str, const int mode )
-{
-    // WAVE DASH 問題
-    const size_t size = 4;
-    const unsigned char Win[size][4] = {
-        { 0xef, 0xbd, 0x9e, '\0' }, // FULLWIDTH TILDE (U+FF5E)
-        { 0xe2, 0x80, 0x95, '\0' }, // HORIZONTAL BAR (U+2015)
-        { 0xe2, 0x88, 0xa5, '\0' }, // PARALLEL TO (U+2225)
-        { 0xef, 0xbc, 0x8d, '\0' }  // FULLWIDTH HYPHEN-MINUS (U+FF0D)
-    };
-    const unsigned char Unix[size][4] = {
-        { 0xe3, 0x80, 0x9c, '\0' }, // WAVE DASH (U+301C)
-        { 0xe2, 0x80, 0x94, '\0' }, // EM DASH(U+2014)
-        { 0xe2, 0x80, 0x96, '\0' }, // DOUBLE VERTICAL LINE (U+2016)
-        { 0xe2, 0x88, 0x92, '\0' }  // MINUS SIGN (U+2212)
-    };
-    
-    std::string ret(str);
-
-    if( mode == WINtoUNIX ){
-
-        for( size_t i = 0; i < ret.length(); i++ ) {
-            for( size_t s = 0; s < size; s++ ) {
-                if( ret[ i ] != (char)Win[ s ][ 0 ] || ret[ i+1 ] != (char)Win[ s ][ 1 ] || ret[ i+2 ] != (char)Win[ s ][ 2 ] )
-                    continue;
-                for( size_t t = 0; t < 3; t++ )
-                    ret[ i+t ] = (char)Unix[ s ][ t ];
-                i += 2;
-                break;
-            }
-        }
-
-    }else{
-   
-        for( size_t i = 0; i < ret.length(); i++ ) {
-            for( size_t s = 0; s < size; s++ ) {
-                if( ret[ i ] != (char)Unix[ s ][ 0 ] || ret[ i+1 ] != (char)Unix[ s ][ 1 ] || ret[ i+2 ] != (char)Unix[ s ][ 2 ] )
-                    continue;
-                for( size_t t = 0; t < 3; t++ )
-                    ret[ i+t ] = (char)Win[ s ][ t ];
-                i += 2;
-                break;
-            }
-        }
-    }
-
-    return ret;
-}
-
-
-//
 // str を大文字化
 //
 std::string MISC::toupper_str( const std::string& str )

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -28,14 +28,6 @@ namespace MISC
                 SCHEME_SSSP
 	};
 
-
-     // utf8_fix_wavedash のモード
-     enum
-     {
-         UNIXtoWIN = 0,
-         WINtoUNIX
-     };
-
      // parse_html_form_data() の戻り値
      struct FormDatum
      {
@@ -217,9 +209,6 @@ namespace MISC
 
     // str に含まれる「&#数字;」形式の数字参照文字列を全てユニーコード文字に変換する
     std::string decode_spchar_number( const std::string& str );
-
-    // WAVEDASHなどのWindows系UTF-8文字をUnix系文字と相互変換
-    std::string utf8_fix_wavedash( const std::string& str, const int mode );
 
     // str を大文字化
     std::string toupper_str( const std::string& str );

--- a/src/message/logitem.h
+++ b/src/message/logitem.h
@@ -9,6 +9,7 @@
 
 #include "messageadmin.h"
 
+#include "jdlib/misccharcode.h"
 #include "jdlib/miscutil.h"
 
 #include <ctime>
@@ -44,7 +45,7 @@ namespace MESSAGE
             if( newthread && url.find( ID_OF_NEWTHREAD ) != std::string::npos ) url = url.substr( 0, url.find( ID_OF_NEWTHREAD ) );
 
             // WAVE DASH 問題
-            msg = MISC::utf8_fix_wavedash( msg, MISC::UNIXtoWIN );
+            msg = MISC::utf8_fix_wavedash( msg, MISC::WaveDashFix::UnixToWin );
 
             // 水平タブを空白に置き換える
             msg = MISC::replace_str( msg, "\t", " " );

--- a/test/gtest_jdlib_misccharcode.cpp
+++ b/test/gtest_jdlib_misccharcode.cpp
@@ -247,4 +247,51 @@ TEST_F(GetUnicodeBlockTest, other)
     EXPECT_EQ( MISC::UnicodeBlock::Other, MISC::get_unicodeblock( 0x110000 ) );
 }
 
+
+class Utf8FixWaveDashTest : public ::testing::Test {};
+
+TEST_F(Utf8FixWaveDashTest, empty_data)
+{
+    EXPECT_EQ( "", MISC::utf8_fix_wavedash( "", MISC::WaveDashFix::UnixToWin ) );
+    EXPECT_EQ( "", MISC::utf8_fix_wavedash( "", MISC::WaveDashFix::WinToUnix ) );
+}
+
+TEST_F(Utf8FixWaveDashTest, not_fix)
+{
+    EXPECT_EQ( "Hello World", MISC::utf8_fix_wavedash( "Hello World", MISC::WaveDashFix::UnixToWin ) );
+    EXPECT_EQ( "いろはにほへ", MISC::utf8_fix_wavedash( "いろはにほへ", MISC::WaveDashFix::WinToUnix ) );
+}
+
+TEST_F(Utf8FixWaveDashTest, fix_unix_to_win)
+{
+    EXPECT_EQ( "\uFF5E+a", MISC::utf8_fix_wavedash( "\u301C+a", MISC::WaveDashFix::UnixToWin ) );
+    EXPECT_EQ( "\u2015-b", MISC::utf8_fix_wavedash( "\u2014-b", MISC::WaveDashFix::UnixToWin ) );
+    EXPECT_EQ( "\u2225*c", MISC::utf8_fix_wavedash( "\u2016*c", MISC::WaveDashFix::UnixToWin ) );
+    EXPECT_EQ( "\uFF0D/d", MISC::utf8_fix_wavedash( "\u2212/d", MISC::WaveDashFix::UnixToWin ) );
+}
+
+TEST_F(Utf8FixWaveDashTest, fix_win_to_unix)
+{
+    EXPECT_EQ( "a+\u301C", MISC::utf8_fix_wavedash( "a+\uFF5E", MISC::WaveDashFix::WinToUnix ) );
+    EXPECT_EQ( "b-\u2014", MISC::utf8_fix_wavedash( "b-\u2015", MISC::WaveDashFix::WinToUnix ) );
+    EXPECT_EQ( "c*\u2016", MISC::utf8_fix_wavedash( "c*\u2225", MISC::WaveDashFix::WinToUnix ) );
+    EXPECT_EQ( "d/\u2212", MISC::utf8_fix_wavedash( "d/\uFF0D", MISC::WaveDashFix::WinToUnix ) );
+}
+
+TEST_F(Utf8FixWaveDashTest, not_fix_unix_to_win)
+{
+    EXPECT_EQ( "a+\uFF5E", MISC::utf8_fix_wavedash( "a+\uFF5E", MISC::WaveDashFix::UnixToWin ) );
+    EXPECT_EQ( "b-\u2015", MISC::utf8_fix_wavedash( "b-\u2015", MISC::WaveDashFix::UnixToWin ) );
+    EXPECT_EQ( "c*\u2225", MISC::utf8_fix_wavedash( "c*\u2225", MISC::WaveDashFix::UnixToWin ) );
+    EXPECT_EQ( "d/\uFF0D", MISC::utf8_fix_wavedash( "d/\uFF0D", MISC::WaveDashFix::UnixToWin ) );
+}
+
+TEST_F(Utf8FixWaveDashTest, not_fix_win_to_unix)
+{
+    EXPECT_EQ( "\u301C+a", MISC::utf8_fix_wavedash( "\u301C+a", MISC::WaveDashFix::WinToUnix ) );
+    EXPECT_EQ( "\u2014-b", MISC::utf8_fix_wavedash( "\u2014-b", MISC::WaveDashFix::WinToUnix ) );
+    EXPECT_EQ( "\u2016*c", MISC::utf8_fix_wavedash( "\u2016*c", MISC::WaveDashFix::WinToUnix ) );
+    EXPECT_EQ( "\u2212/d", MISC::utf8_fix_wavedash( "\u2212/d", MISC::WaveDashFix::WinToUnix ) );
+}
+
 } // namespace


### PR DESCRIPTION
#### [Move MISC::utf8_fix_wavedash() from miscutil to misccharcode](https://github.com/JDimproved/JDim/commit/ca3897fc9b66547828fd827c5dd32c77178b296f)

WAVE DASH(U+301C)などのWindows系UTF-8文字をUnix系文字と相互変換する関数`MISC::utf8_fix_wavedash()` を jdlib/miscutil.h からjdlib/misccharcode.h へ移動し、実装をリファクタリングする。

#### [Add test cases for MISC::utf8_fix_wavedash()](https://github.com/JDimproved/JDim/commit/833dc6c11d2ab2c579cc714eeb1e5ad01043ce1d)

関連のissue: #76 