### PR TITLE
Update function MISC::is_jis()

### DIFF
--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -98,13 +98,22 @@ bool MISC::is_eucjp( std::string_view input, std::size_t read_byte )
 // エスケープシーケンスの開始文字 ESC(0x1B)
 #define JIS_ESC_SEQ_START( target ) ( target == 0x1B )
 //
-bool MISC::is_jis( const char* input, size_t& byte )
+/** @brief 文字列のエンコーディングがISO-2022-JPか簡易判定する
+ *
+ * エスケープシーケンス(ESC = \x1B)の有無と該当しないバイトが含まれるかチェックする。
+ * 呼び出し元の処理のため空文字列に対する返り値は他の`is_*`関数と逆(false)になっている。
+ * @param[in] input 入力
+ * @param[in,out] byte チェックを開始する位置、チェックを打ち切った位置を返す
+ * @return
+ *   - ESCを見つけたらtrue
+ *   - 0x80以上を見つけたらfalse
+ *   - 空文字列またはASCIIのみならfalse
+ */
+bool MISC::is_jis( std::string_view input, std::size_t& byte )
 {
-    if( ! input ) return false;
+    if( input.empty() ) return false;
 
-    const size_t input_length = strlen( input );
-
-    while( byte < input_length && byte < CHECK_LIMIT )
+    while( byte < input.size() && byte < CHECK_LIMIT )
     {
         // ESCが出現したか否かだけで判断
         if( JIS_ESC_SEQ_START( input[ byte ] ) ) return true;
@@ -265,7 +274,7 @@ int MISC::judge_char_code( const std::string& str )
     size_t read_byte = 0;
 
     // JISの判定
-    if( is_jis( str.c_str(), read_byte ) ) code = CHARCODE_JIS;
+    if( is_jis( str, read_byte ) ) code = CHARCODE_JIS;
     // JISの判定で最後まで進んでいたら制御文字かアスキー
     else if( read_byte == str.length() ) code = CHARCODE_ASCII;
     // is_jis()でASCII範囲外のバイトが現れた箇所から判定する

--- a/src/jdlib/misccharcode.h
+++ b/src/jdlib/misccharcode.h
@@ -39,7 +39,7 @@ namespace MISC
     };
 
     bool is_eucjp( std::string_view input, std::size_t read_byte );
-    bool is_jis( const char* input, size_t& read_byte );
+    bool is_jis( std::string_view input, std::size_t& read_byte );
     bool is_sjis( const char* input, size_t read_byte );
     bool is_utf8( const char* input, size_t read_byte );
     int judge_char_code( const std::string& str );

--- a/test/gtest_jdlib_misccharcode.cpp
+++ b/test/gtest_jdlib_misccharcode.cpp
@@ -108,6 +108,76 @@ TEST_F(IsEucjpTest, lack_following_bytes)
 }
 
 
+class IsJisTest : public ::testing::Test {};
+
+TEST_F(IsJisTest, null_data)
+{
+    std::size_t byte = 0;
+    EXPECT_FALSE( MISC::is_jis( nullptr, byte ) );
+    EXPECT_FALSE( MISC::is_jis( "", byte ) );
+}
+
+TEST_F(IsJisTest, ascii_only)
+{
+    std::size_t byte = 0;
+    EXPECT_FALSE( MISC::is_jis( "!\"#$%&'()*+,-./ :;<=>?@ [\\]^_` {|}~", byte ) );
+    EXPECT_EQ( 35, byte );
+    byte = 0;
+    EXPECT_FALSE( MISC::is_jis( "0123456789 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ", byte ) );
+    EXPECT_EQ( 64, byte );
+}
+
+TEST_F(IsJisTest, hiragana_katakana)
+{
+    std::size_t byte = 0;
+    EXPECT_TRUE( MISC::is_jis( "\x1B$B$\"$$$&$($*\x1B(B", byte ) ); // あいうえお
+    EXPECT_EQ( 0, byte );
+    EXPECT_TRUE( MISC::is_jis( "\x1B$B%\"%$%&%(%*\x1B(B", byte ) ); // アイウエオ
+    EXPECT_EQ( 0, byte );
+}
+
+TEST_F(IsJisTest, fullwidth_alnum)
+{
+    std::size_t byte = 0;
+    EXPECT_TRUE( MISC::is_jis( "\x1B$B!*!I!t!p!s\x1B(B", byte ) ); // ！”＃＄％
+    EXPECT_EQ( 0, byte );
+    EXPECT_TRUE( MISC::is_jis( "\x1B$B#1#2#3#4#5\x1B(B", byte ) ); // １２３４５
+    EXPECT_EQ( 0, byte );
+    EXPECT_TRUE( MISC::is_jis( "\x1B$B#A#B#C#D#E\x1B(B", byte ) ); // ＡＢＣＤＥ
+    EXPECT_EQ( 0, byte );
+    EXPECT_TRUE( MISC::is_jis( "\x1B$B#a#b#c#d#e\x1B(B", byte ) ); // ａｂｃｄｅ
+    EXPECT_EQ( 0, byte );
+}
+
+TEST_F(IsJisTest, eucjp)
+{
+    std::size_t byte = 0;
+    EXPECT_FALSE( MISC::is_jis( "\xA4\xA2\xA4\xA4\xA4\xA6\xA4\xA8\xA4\xAA", byte ) );
+    EXPECT_EQ( 0, byte );
+}
+
+TEST_F(IsJisTest, sjis)
+{
+    std::size_t byte = 0;
+    EXPECT_FALSE( MISC::is_jis( "\x82\xA0\x82\xA2\x82\xA4\x82\xA6\x82\xA8", byte ) );
+    EXPECT_EQ( 0, byte );
+}
+
+TEST_F(IsJisTest, utf8)
+{
+    std::size_t byte = 0;
+    EXPECT_FALSE( MISC::is_jis( "\u3042", byte ) ); // U+3042
+    EXPECT_EQ( 0, byte );
+}
+
+TEST_F(IsJisTest, skip_data)
+{
+    std::size_t byte = 3;
+    EXPECT_TRUE( MISC::is_jis( "\u3042\x1B$B#A#B#C#D#E\x1B(B", byte ) ); // U+3042ＡＢＣＤＥ
+    EXPECT_EQ( 3, byte );
+}
+
+
 class Utf8BytesTest : public ::testing::Test {};
 
 TEST_F(Utf8BytesTest, null_data)

--- a/test/gtest_jdlib_misccharcode.cpp
+++ b/test/gtest_jdlib_misccharcode.cpp
@@ -113,7 +113,6 @@ class IsJisTest : public ::testing::Test {};
 TEST_F(IsJisTest, null_data)
 {
     std::size_t byte = 0;
-    EXPECT_FALSE( MISC::is_jis( nullptr, byte ) );
     EXPECT_FALSE( MISC::is_jis( "", byte ) );
 }
 


### PR DESCRIPTION
#### [Add test cases for MISC::is_jis()](https://github.com/JDimproved/JDim/commit/1c3e71b9e8c0c57d0e6d477f511a11c67dba40b3)

#### [Update function MISC::is_jis()](https://github.com/JDimproved/JDim/commit/8846a7bc3f233e899b31de4bd7ac102eb5a65926)

関数の引数を更新して処理を効率化します。呼び出し元の処理のため空文字列に対する返り値は他の`is_*`関数と逆(false)になっています。

関連のpull request: #971 