### PR TITLE
Update function MISC::is_utf8()

### DIFF
--- a/src/jdlib/misccharcode.h
+++ b/src/jdlib/misccharcode.h
@@ -41,7 +41,7 @@ namespace MISC
     bool is_eucjp( std::string_view input, std::size_t read_byte );
     bool is_jis( std::string_view input, std::size_t& read_byte );
     bool is_sjis( std::string_view input, std::size_t read_byte );
-    bool is_utf8( const char* input, size_t read_byte );
+    bool is_utf8( std::string_view input, std::size_t read_byte );
     int judge_char_code( const std::string& str );
 
     /// utf-8文字のbyte数を返す

--- a/test/gtest_jdlib_misccharcode.cpp
+++ b/test/gtest_jdlib_misccharcode.cpp
@@ -276,7 +276,6 @@ class IsUtf8Test : public ::testing::Test {};
 
 TEST_F(IsUtf8Test, null_data)
 {
-    EXPECT_FALSE( MISC::is_utf8( nullptr, 0 ) );
     EXPECT_TRUE( MISC::is_utf8( "", 0 ) );
 }
 


### PR DESCRIPTION
#### [Add test cases for MISC:is_utf8()](https://github.com/JDimproved/JDim/commit/096a96998dd2bde33b4359a8aeb1704213d1813f)

#### [Update function MISC::is_utf8()](https://github.com/JDimproved/JDim/commit/69fef13aec3953994c4de7b788da1c0daa13b4a4)

関数の引数を更新して処理を効率化します。
追加された長さチェックはヌル終端の保証がある`const std::string&`なら不要ですが他の`is_*`関数との一貫性のため`std::string_view`を使います。

関連のpull request: #971 