### PR TITLE
DrawAreaBase: Modify loop to return the variable value just as it is

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -510,13 +510,15 @@ int DrawAreaBase::get_current_res_num() const
 
     // 先頭のヘッダブロックから順に調べる
     const LAYOUT* header = m_layout_tree->top_header();
-    while( header ){
+    const LAYOUT* next_header = header ? header->next_header : nullptr;
+    while( next_header ){
 
         // y が含まれているブロックを探す
-        if( header->rect->y >= y ) return header->res_number -1;
+        if( next_header->rect->y >= y ) return header->res_number;
 
         // 次のブロックへ
-        header = header->next_header;
+        header = next_header;
+        next_header = header->next_header;
     }
 
     return max_number();


### PR DESCRIPTION
構造体のリストを走査して条件を満たしたとき返す値を固定値で補正していましたがリストの前後要素を一時変数に保持しておくことで変数値をそのまま返すように修正します。

関連のpull request: #76 