### PR TITLE
Loader: Improve proccesing for Chunked transfer encording

### DIFF
--- a/src/jdlib/loader.h
+++ b/src/jdlib/loader.h
@@ -28,6 +28,38 @@ namespace SKELETON
 
 namespace JDLIB
 {
+    /**
+     * @brief Chunked transfer encodingで送られてきたデータをデコードする
+     */
+    class ChunkedDecoder
+    {
+        /// @brief デコーダーの状態
+        enum class State
+        {
+            parse_size, ///< 初期状態、サイズ部の解析
+            format_body, ///< データ部の整形
+            check_body_cr, ///< データ部の後ろにあるCRのチェック
+            check_body_lf, ///< データ部の後ろにあるLFのチェック
+            completed, ///< 最後のチャンク(長さ0)を読み込んで処理が完了した
+        };
+
+        State m_state = State::parse_size; ///< デコーダーの状態
+        std::size_t m_lng_leftdata{}; ///< データ部の残りサイズ
+        std::string m_buf_sizepart; ///< 解析途中のサイズ部を保存しておくバッファ
+
+    public:
+        ChunkedDecoder() = default;
+        ~ChunkedDecoder() noexcept = default;
+
+        /// 最後のチャンク(長さ0)まで読み込んで処理が完了したか
+        bool is_completed() const noexcept { return m_state == State::completed; }
+
+        /// デコーダーの状態を初期化する
+        void clear();
+        /// chunked なデータを切りつめる
+        bool decode( char* buf, std::size_t& read_size );
+    };
+
     class Loader
     {
         LOADERDATA m_data;

--- a/src/jdlib/loader.h
+++ b/src/jdlib/loader.h
@@ -85,11 +85,8 @@ namespace JDLIB
 
         // chunk 用変数
         bool m_use_chunk;
-        long m_status_chunk;
-        char m_str_sizepart[ 64 ]; // サイズ部のバッファ。64byte以下と仮定(超えるとエラー)
-        char* m_pos_sizepart;
-        size_t m_lng_leftdata;
-    
+        ChunkedDecoder m_chunk_decoder;
+
         // zlib 用変数
         bool m_use_zlib;
         z_stream m_zstream;
@@ -130,9 +127,6 @@ namespace JDLIB
         bool analyze_header();
         std::string analyze_header_option( std::string_view option ) const;
         std::list< std::string > analyze_header_option_list( std::string_view option ) const;
-
-        // chunk用
-        bool skip_chunk( char* buf, size_t& read_size );
 
         // unzip 用
         bool init_unzip();

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -111,6 +111,7 @@ gtest_jdim_SOURCES = \
 	gtest_jdlib_cookiemanager.cpp \
 	gtest_jdlib_jdiconv.cpp \
 	gtest_jdlib_jdregex.cpp \
+	gtest_jdlib_loader.cpp \
 	gtest_jdlib_misccharcode.cpp \
 	gtest_jdlib_misctime.cpp \
 	gtest_jdlib_misctrip.cpp \

--- a/test/gtest_jdlib_loader.cpp
+++ b/test/gtest_jdlib_loader.cpp
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "jdlib/loader.h"
+
+#include "gtest/gtest.h"
+
+#include <cstring>
+
+
+namespace {
+
+struct ChunkedDecoderDataSet
+{
+    const char* input{};
+    const char* output{};
+    std::size_t output_size{};
+    bool is_completed{};
+};
+
+class JDLIB_ChunkedDecoder_Decode : public ::testing::Test {};
+
+TEST_F(JDLIB_ChunkedDecoder_Decode, empty)
+{
+    JDLIB::ChunkedDecoder decoder;
+    char buf[] = "";
+    std::size_t size = 0;
+    EXPECT_TRUE( decoder.decode( buf, size ) );
+    EXPECT_STREQ( buf, "" );
+    EXPECT_EQ( size, 0 );
+    EXPECT_FALSE( decoder.is_completed() );
+}
+
+TEST_F(JDLIB_ChunkedDecoder_Decode, last_chunk_only)
+{
+    JDLIB::ChunkedDecoder decoder;
+    char buf[] = "0\r\n";
+    std::size_t size = 3;
+    EXPECT_TRUE( decoder.decode( buf, size ) );
+    EXPECT_STREQ( buf, "" );
+    EXPECT_EQ( size, 0 );
+    EXPECT_TRUE( decoder.is_completed() );
+}
+
+TEST_F(JDLIB_ChunkedDecoder_Decode, one_chunk)
+{
+    JDLIB::ChunkedDecoder decoder;
+    char buf[] = "a\r\nhelloworld\r\n0\r\n\r\n";
+    std::size_t size = std::strlen( buf );
+    EXPECT_TRUE( decoder.decode( buf, size ) );
+    EXPECT_STREQ( buf, "helloworld" );
+    EXPECT_EQ( size, 10 );
+    EXPECT_TRUE( decoder.is_completed() );
+}
+
+TEST_F(JDLIB_ChunkedDecoder_Decode, one_chunk_including_crlf)
+{
+    JDLIB::ChunkedDecoder decoder;
+    char buf[] = "C\r\nhello\r\nworld\r\n0\r\n\r\n";
+    std::size_t size = std::strlen( buf );
+    EXPECT_TRUE( decoder.decode( buf, size ) );
+    EXPECT_STREQ( buf, "hello\r\nworld" );
+    EXPECT_EQ( size, 12 );
+    EXPECT_TRUE( decoder.is_completed() );
+}
+
+TEST_F(JDLIB_ChunkedDecoder_Decode, multiple_chunks)
+{
+    JDLIB::ChunkedDecoder decoder;
+    char buf[] = "5\r\nhello\r\n5\r\nworld\r\n0\r\n\r\n";
+    std::size_t size = std::strlen( buf );
+    EXPECT_TRUE( decoder.decode( buf, size ) );
+    EXPECT_STREQ( buf, "helloworld" );
+    EXPECT_EQ( size, 10 );
+    EXPECT_TRUE( decoder.is_completed() );
+}
+
+TEST_F(JDLIB_ChunkedDecoder_Decode, chunk_ext)
+{
+    JDLIB::ChunkedDecoder decoder;
+    char buf[] = "5;foo=bar\r\nhello\r\n5;baz\r\nworld\r\n0\r\n\r\n";
+    std::size_t size = std::strlen( buf );
+    EXPECT_TRUE( decoder.decode( buf, size ) );
+    EXPECT_STREQ( buf, "helloworld" );
+    EXPECT_EQ( size, 10 );
+    EXPECT_TRUE( decoder.is_completed() );
+}
+
+TEST_F(JDLIB_ChunkedDecoder_Decode, traier_part)
+{
+    JDLIB::ChunkedDecoder decoder;
+    char buf[] = "5\r\nhello\r\n5\r\nworld\r\n0\r\nAdditional: Data\r\n\r\n";
+    std::size_t size = std::strlen( buf );
+    EXPECT_TRUE( decoder.decode( buf, size ) );
+    EXPECT_STREQ( buf, "helloworld" );
+    EXPECT_EQ( size, 10 );
+    EXPECT_TRUE( decoder.is_completed() );
+}
+
+TEST_F(JDLIB_ChunkedDecoder_Decode, multiple_time_feed_chunks)
+{
+    constexpr const ChunkedDecoderDataSet chunks[] = {
+        { "5\r\nhello\r\n", "hello", 5, false },
+        { "5\r\nworld\r\n", "world", 5, false },
+        { "0\r\n\r\n", "", 0, true },
+    };
+    JDLIB::ChunkedDecoder decoder;
+    char buf[64];
+    std::size_t size;
+    for( auto [input, output, output_size, is_completed] : chunks ) {
+        std::strcpy( buf, input );
+        size = std::strlen( buf );
+        EXPECT_TRUE( decoder.decode( buf, size ) );
+        EXPECT_STREQ( buf, output );
+        EXPECT_EQ( size, output_size );
+        EXPECT_EQ( decoder.is_completed(), is_completed );
+    }
+}
+
+TEST_F(JDLIB_ChunkedDecoder_Decode, multiple_time_feed_crlf_fragmentation)
+{
+    constexpr const ChunkedDecoderDataSet chunks[] = {
+        { "5\r\nQuick", "Quick", 5, false },
+        { "\r\n5\r\nBrown\r", "Brown", 5, false },
+        { "\n3\r\nFox\r\n", "Fox", 3, false },
+        { "0\r\n\r\n", "", 0, true },
+    };
+    JDLIB::ChunkedDecoder decoder;
+    char buf[64];
+    std::size_t size;
+    for( auto [input, output, output_size, is_completed] : chunks ) {
+        std::strcpy( buf, input );
+        size = std::strlen( buf );
+        EXPECT_TRUE( decoder.decode( buf, size ) );
+        EXPECT_STREQ( buf, output );
+        EXPECT_EQ( size, output_size );
+        EXPECT_EQ( decoder.is_completed(), is_completed );
+    }
+}
+
+TEST_F(JDLIB_ChunkedDecoder_Decode, multiple_time_feed_body_fragmentation)
+{
+    constexpr const ChunkedDecoderDataSet chunks[] = {
+        { "5\r", "", 0, false },
+        { "\nQuick\r\n5\r\nB", "QuickB", 6, false },
+        { "rown\r\n3\r\nFox\r\n5", "rownFox", 7, false },
+        { "\r\nJumps\r\n4\r\nOve", "JumpsOve", 8, false },
+        { "r\r\n0\r", "r", 1, false },
+        { "\n\r\n", "", 0, true },
+    };
+    JDLIB::ChunkedDecoder decoder;
+    char buf[64];
+    std::size_t size;
+    for( auto [input, output, output_size, is_completed] : chunks ) {
+        std::strcpy( buf, input );
+        size = std::strlen( buf );
+        EXPECT_TRUE( decoder.decode( buf, size ) );
+        EXPECT_STREQ( buf, output );
+        EXPECT_EQ( size, output_size );
+        EXPECT_EQ( decoder.is_completed(), is_completed );
+    }
+}
+
+TEST_F(JDLIB_ChunkedDecoder_Decode, fail_pase_size)
+{
+    constexpr const ChunkedDecoderDataSet chunks[] = {
+        { "5\r\nQuick\r\n\r\n" },
+        { "5\r\nQuick\r\nZ\r\nBrown\r\n0\r\n\r\n" },
+    };
+    JDLIB::ChunkedDecoder decoder;
+    char buf[64];
+    std::size_t size;
+    for( auto [input, output, output_size, is_completed] : chunks ) {
+        std::strcpy( buf, input );
+        size = std::strlen( buf );
+        EXPECT_FALSE( decoder.decode( buf, size ) );
+        EXPECT_FALSE( decoder.is_completed() );
+        decoder.clear();
+    }
+}
+
+TEST_F(JDLIB_ChunkedDecoder_Decode, fail_pase_body_cr_lf)
+{
+    constexpr const ChunkedDecoderDataSet chunks[] = {
+        { "5\r\nQuick\n0\r\n" },
+        { "5\r\nQuick\r\n5\r\nBrown\r0\r\n\r\n" },
+    };
+    JDLIB::ChunkedDecoder decoder;
+    char buf[64];
+    std::size_t size;
+    for( auto [input, output, output_size, is_completed] : chunks ) {
+        std::strcpy( buf, input );
+        size = std::strlen( buf );
+        EXPECT_FALSE( decoder.decode( buf, size ) );
+        EXPECT_FALSE( decoder.is_completed() );
+        decoder.clear();
+    }
+}
+
+} // namespace

--- a/test/meson.build
+++ b/test/meson.build
@@ -3,6 +3,7 @@ sources = [
   'gtest_jdlib_cookiemanager.cpp',
   'gtest_jdlib_jdiconv.cpp',
   'gtest_jdlib_jdregex.cpp',
+  'gtest_jdlib_loader.cpp',
   'gtest_jdlib_misccharcode.cpp',
   'gtest_jdlib_misctime.cpp',
   'gtest_jdlib_misctrip.cpp',


### PR DESCRIPTION
### [Loader: Improve proccesing for Chunked transfer encording](https://github.com/JDimproved/JDim/commit/80a6ab30f387883d78b0b28f196986e4fd8f3b52) 

Chunked transfer encodingのデコード処理を見直してHTTPの仕様により近くなるよう改善したものを追加します。

* サイズ部の終端はCRLFを探すようにしてLFのみの入力は無効にする
* サイズ部の解析は入力の長さ制限を撤廃して解析結果のチェックを追加する
* 最後のチャンク(長さ0)を読み込んだらトレーラー部は解析せず処理を完了する

### [Add test cases for JDLIB::Loader](https://github.com/JDimproved/JDim/commit/db970a33f8253eefbc75cbf137c09a8154d7864b)

### [Replace Loader::skip_chunk() with ChunkedDecoder class](https://github.com/JDimproved/JDim/commit/d69e675f85612beab7cdf6bf8bdbe8da4a548f66)

新たに実装したChunked transfer encodingのデコード処理を導入して前の実装を削除します。

関連のissue: #975 