### PR TITLE
ChunkedDecoder: Fix condition for breaking loop

### DIFF
--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -354,10 +354,10 @@ bool ChunkedDecoder::decode( char* buf, std::size_t& read_size )
         }
 
         // バッファ終わり
-        if( pos_chunk == read_size ){
+        if( pos_chunk == read_size || m_state == State::completed ) {
             read_size = decoded_size;
             buf[read_size] = '\0';
-            // 処理の途中なので m_state は変更しない
+            // 処理の途中または完了したので m_state は変更しない
             return true;
         }
     }

--- a/test/gtest_jdlib_loader.cpp
+++ b/test/gtest_jdlib_loader.cpp
@@ -169,7 +169,7 @@ TEST_F(JDLIB_ChunkedDecoder_Decode, fail_pase_size)
     JDLIB::ChunkedDecoder decoder;
     char buf[64];
     std::size_t size;
-    for( auto [input, output, output_size, is_completed] : chunks ) {
+    for( auto [input, unused_1, unused_2, is_completed] : chunks ) {
         std::strcpy( buf, input );
         size = std::strlen( buf );
         EXPECT_FALSE( decoder.decode( buf, size ) );
@@ -187,12 +187,31 @@ TEST_F(JDLIB_ChunkedDecoder_Decode, fail_pase_body_cr_lf)
     JDLIB::ChunkedDecoder decoder;
     char buf[64];
     std::size_t size;
-    for( auto [input, output, output_size, is_completed] : chunks ) {
+    for( auto [input, unused_1, unused_2, is_completed] : chunks ) {
         std::strcpy( buf, input );
         size = std::strlen( buf );
         EXPECT_FALSE( decoder.decode( buf, size ) );
         EXPECT_FALSE( decoder.is_completed() );
         decoder.clear();
+    }
+}
+
+TEST_F(JDLIB_ChunkedDecoder_Decode, call_again_after_completed)
+{
+    constexpr const ChunkedDecoderDataSet chunks[] = {
+        { "F\r\nQuick Brown Fox\r\n0\r\n", "Quick Brown Fox", 15, true },
+        { "F\r\nQuick Brown Fox\r\n0\r\n", "", 0, true },
+    };
+    JDLIB::ChunkedDecoder decoder;
+    char buf[64];
+    std::size_t size;
+    for( auto [input, output, output_size, is_completed] : chunks ) {
+        std::strcpy( buf, input );
+        size = std::strlen( buf );
+        EXPECT_TRUE( decoder.decode( buf, size ) );
+        EXPECT_STREQ( buf, output );
+        EXPECT_EQ( size, output_size );
+        EXPECT_TRUE( decoder.is_completed() );
     }
 }
 


### PR DESCRIPTION
`ChunkedDecoder::decode()`の処理が完了した後にさらに入力を渡して呼び出すと終了条件を満たせず無限ループする問題を修正します。

関連のpull request: #981 