### PR TITLE
Revert Gtk::Menu API to fix menu scrolling on older GTK

### DIFF
--- a/src/history/historysubmenu.cpp
+++ b/src/history/historysubmenu.cpp
@@ -210,7 +210,12 @@ bool HistorySubMenu::slot_button_press( GdkEventButton* event, int i )
     // ポップアップメニュー表示
     if( event->button == 3 )
     {
+#if GTK_CHECK_VERSION(3,24,6)
         m_popupmenu.popup_at_pointer( reinterpret_cast<GdkEvent*>( event ) );
+#else
+        // GTK 3.24.5 以下のバージョンではメニューのスクロールが出来なくなることがあるため廃止予定APIを使う
+        m_popupmenu.popup( 0, gtk_get_current_event_time() );
+#endif
     }
 
     return true;

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -2220,7 +2220,12 @@ void Admin::slot_tab_menu( int page, int x, int y )
         if( label ) label->set_text_with_mnemonic( ITEM_NAME_GO + std::string( " [ タブ数 " )
                                                    + std::to_string( m_notebook->get_n_pages() ) +" ](_M)" );
 
+#if GTK_CHECK_VERSION(3,24,6)
         popupmenu->popup_at_pointer( nullptr ); // current event
+#else
+        // GTK 3.24.5 以下のバージョンではメニューのスクロールが出来なくなることがあるため廃止予定APIを使う
+        popupmenu->popup( 0, gtk_get_current_event_time() );
+#endif
     }
 }
 
@@ -2239,10 +2244,40 @@ void Admin::slot_show_tabswitchmenu()
     m_tabswitchmenu->update_labels();
     m_tabswitchmenu->update_icons();
 
+#if GTK_CHECK_VERSION(3,24,6)
     // Specify the current event by nullptr.
     m_tabswitchmenu->popup_at_widget( &( m_notebook->get_tabswitch_button() ),
                                       Gdk::GRAVITY_SOUTH_EAST, Gdk::GRAVITY_NORTH_EAST, nullptr );
+#else
+    // GTK 3.24.5 以下のバージョンではメニューのスクロールが出来なくなることがあるため廃止予定APIを使う
+    m_tabswitchmenu->popup( Gtk::Menu::SlotPositionCalc( sigc::mem_fun( *this, &Admin::slot_popup_pos ) ),
+                            0, gtk_get_current_event_time() );
+#endif
 }
+
+
+#if ! GTK_CHECK_VERSION(3,24,6)
+/**
+ * @brief タブ切り替えメニューの位置決め
+ */
+void Admin::slot_popup_pos( int& x, int& y, bool& push_in )
+{
+    if( ! m_tabswitchmenu ) return;
+
+    const int mrg = 16;
+
+    m_notebook->get_tabswitch_button().get_pointer( x, y );
+
+    int ox, oy;
+    m_notebook->get_tabswitch_button().get_window()->get_origin( ox, oy );
+    const Gdk::Rectangle rect = m_notebook->get_tabswitch_button().get_allocation();
+
+    x += ox + rect.get_x() - mrg;
+    y = oy + rect.get_y() + rect.get_height();
+
+    push_in = false;
+}
+#endif
 
 
 //

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -284,6 +284,11 @@ namespace SKELETON
         // タブ切り替えメニュー表示
         void slot_show_tabswitchmenu();
 
+#if ! GTK_CHECK_VERSION(3,24,6)
+        /// タブ切り替えメニューの位置決め
+        void slot_popup_pos( int& x, int& y, bool& push_in );
+#endif
+
         // 右クリックメニュー
         virtual void slot_close_tab();
         virtual void slot_lock();

--- a/src/skeleton/menubutton.h
+++ b/src/skeleton/menubutton.h
@@ -70,6 +70,11 @@ namespace SKELETON
 
       void slot_menu_selected( int i );
 
+#if ! GTK_CHECK_VERSION(3,24,6)
+        /// ポップアップメニューの位置決め
+        void slot_popup_pos( int& x, int& y, bool& push_in );
+#endif
+
       bool slot_enter( GdkEventCrossing* event );
       bool slot_leave( GdkEventCrossing* event );
       bool slot_motion( GdkEventMotion* event );

--- a/src/usrcmdpref.cpp
+++ b/src/usrcmdpref.cpp
@@ -242,8 +242,12 @@ void UsrCmdPref::show_popupmenu()
         act_delete->set_enabled( true );
     }
 
+#if GTK_CHECK_VERSION(3,24,6)
     // Specify the current event by nullptr.
     m_treeview_menu.popup_at_pointer( nullptr );
+#else
+    m_treeview_menu.popup( 0, gtk_get_current_event_time() );
+#endif
 }
 
 


### PR DESCRIPTION
GTK 3.24.6 未満のバージョンではメニューのスクロールが出来なくなることがあるため条件コンパイルで以前の実装へ差し戻します。
Debian busterのGTK3のバージョンが3.24.5で影響を受けていました。

原因となった修正
* 8d8b246df9d8a517bba039896b65697c01a6fe99
* 81bfe64cacc292dc5f181a8e2623cb412d865112

関連のissue(GNOME)
https://gitlab.gnome.org/GNOME/gtk/-/issues/1651

関連のissue(JDim)
#985 