### PR TITLE
ArticleViewBase: Fix local variable names that shadow outer function

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -670,11 +670,11 @@ const char* ArticleViewBase::get_menu_item( const int item ) const
 int ArticleViewBase::width_client() const
 {
     if( m_drawarea ) {
-        const int width_client = m_drawarea->width_client();
+        const int width = m_drawarea->width_client();
 #ifdef _DEBUG
-        std::cout << "ArticleViewBase::width_client : " << width_client << std::endl;
+        std::cout << "ArticleViewBase::width_client : " << width << std::endl;
 #endif
-        return width_client;
+        return width;
     }
 
     return SKELETON::View::width_client();
@@ -687,11 +687,11 @@ int ArticleViewBase::width_client() const
 int ArticleViewBase::height_client() const
 {
     if( m_drawarea ) {
-        const int height_client = m_drawarea->height_client();
+        const int height = m_drawarea->height_client();
 #ifdef _DEBUG
-        std::cout << "ArticleViewBase::height_client : " << height_client << std::endl;
+        std::cout << "ArticleViewBase::height_client : " << height << std::endl;
 #endif
-        return height_client;
+        return height;
     }
 
 


### PR DESCRIPTION
外側の関数をシャドーイングするローカル変数があるとcppcheck 2.8に指摘されたため修正します。

cppcheckのレポート
```
src/article/articleviewbase.cpp:673:19: style: Local variable 'width_client' shadows outer function [shadowFunction]
        const int width_client = m_drawarea->width_client();
                  ^
src/article/articleviewbase.cpp:690:19: style: Local variable 'height_client' shadows outer function [shadowFunction]
        const int height_client = m_drawarea->height_client();
                  ^
```