### PR TITLE
Fix local variable names that shadow outer function part2

### DIFF
--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -119,19 +119,19 @@ void ImageAdmin::restore( const bool only_locked )
     for( int page = 0; it_url != list_url.end(); ++it_url, ++page ){
 
         // タブのロック状態
-        bool lock = false;
+        bool lock_img = false;
         if( it_locked != list_locked.end() ){
-            if( (*it_locked ) ) lock = true;
+            if( *it_locked ) lock_img = true;
             ++it_locked;
         }
 
         // ロックされているものだけ表示
-        if( only_locked && ! lock ) continue;
+        if( only_locked && ! lock_img ) continue;
 
         if( page == SESSION::image_page() ) set_page_num = get_tab_nums();
 
-        COMMAND_ARGS command_arg = url_to_openarg( *it_url, true, lock );
-        if( ! command_arg.url.empty() ) open_view( command_arg );        
+        COMMAND_ARGS command_arg = url_to_openarg( *it_url, true, lock_img );
+        if( ! command_arg.url.empty() ) open_view( command_arg );
     }
 
     SKELETON::View* view = get_nth_icon( set_page_num );

--- a/src/skeleton/msgdiag.cpp
+++ b/src/skeleton/msgdiag.cpp
@@ -80,8 +80,8 @@ int MsgDiag::run()
     CORE::core_set_command( "dialog_shown" );
 
     // タイマーセット
-    sigc::slot< bool > slot_timeout = sigc::bind( sigc::mem_fun(*this, &MsgDiag::slot_timeout), 0 );
-    m_conn_timer = JDLIB::Timeout::connect( slot_timeout, TIMER_TIMEOUT );
+    sigc::slot< bool > slot_tmout = sigc::bind( sigc::mem_fun(*this, &MsgDiag::slot_timeout), 0 );
+    m_conn_timer = JDLIB::Timeout::connect( slot_tmout, TIMER_TIMEOUT );
 
     int ret = Gtk::MessageDialog::run();
 

--- a/src/skeleton/prefdiag.cpp
+++ b/src/skeleton/prefdiag.cpp
@@ -97,8 +97,8 @@ int PrefDiag::run(){
     CORE::core_set_command( "dialog_shown" );
 
     // タイマーセット
-    sigc::slot< bool > slot_timeout = sigc::bind( sigc::mem_fun(*this, &PrefDiag::slot_timeout), 0 );
-    m_conn_timer = JDLIB::Timeout::connect( slot_timeout, TIMER_TIMEOUT );
+    sigc::slot< bool > slot_tmout = sigc::bind( sigc::mem_fun(*this, &PrefDiag::slot_timeout), 0 );
+    m_conn_timer = JDLIB::Timeout::connect( slot_tmout, TIMER_TIMEOUT );
 
     int ret = Gtk::Dialog::run();
 


### PR DESCRIPTION
外側の関数をシャドーイングするローカル変数があるとcppcheck 2.8に指摘されたため修正します。

cppcheckのレポート
```
src/image/imageadmin.cpp:122:14: style: Local variable 'lock' shadows outer function [shadowFunction]
        bool lock = false;
             ^
src/skeleton/msgdiag.cpp:83:24: style: Local variable 'slot_timeout' shadows outer function [shadowFunction]
    sigc::slot< bool > slot_timeout = sigc::bind( sigc::mem_fun(*this, &MsgDiag::slot_timeout), 0 );
                       ^
src/skeleton/prefdiag.cpp:100:24: style: Local variable 'slot_timeout' shadows outer function [shadowFunction]
    sigc::slot< bool > slot_timeout = sigc::bind( sigc::mem_fun(*this, &PrefDiag::slot_timeout), 0 );
                       ^
```

関連のpull request: #988 