### PR TITLE
JDWindow: Fix known condition true/false

### DIFF
--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -618,7 +618,7 @@ bool JDWindow::on_delete_event( GdkEventAny* event )
         else{
 
             // hideする前に座標保存
-            if( ! is_maximized_win() && ! is_iconified_win() && get_window() ) set_win_pos();
+            if( ! is_iconified_win() && get_window() ) set_win_pos();
 
             hide();
             m_mode = JDWIN_HIDE;


### PR DESCRIPTION
値が既知の条件があるとcppcheck 2.8に指摘されたため修正します。

```
src/skeleton/window.cpp:621:17: style: Condition '!is_maximized_win()' is always true [knownConditionTrueFalse]
            if( ! is_maximized_win() && ! is_iconified_win() && get_window() ) set_win_pos();
                ^
```

関連のpull request: #988 