### PR TITLE
Board2chCompati: Modify default subbbs.cgi path to /test/bbs.cgi

### DIFF
--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -43,7 +43,7 @@ Board2chCompati::Board2chCompati( const std::string& root, const std::string& pa
     set_path_dat( "/dat" );
     set_path_readcgi( "/test/read.cgi" );
     set_path_bbscgi( "/test/bbs.cgi" );
-    set_path_subbbscgi( "/test/subbbs.cgi" );
+    set_path_subbbscgi( "/test/bbs.cgi" );
     set_subjecttxt( "subject.txt" );
     set_ext( ".dat" );
     set_id( path_board.substr( 1 ) ); // 先頭の '/' を除く


### PR DESCRIPTION
open2ch.netに書き込みを行うと404 Not Foundになる問題を修正します。

修正前は書き込みで確認ページが表示されたときページに埋め込まれたURL、またはデフォルトの"/test/subbbs.cgi"を使って再度投稿していました。
open2chは確認ページにURLが埋め込まれていないためデフォルト設定を使いますが"subbbs.cgi"が存在しないためエラーになっていました。
["subbbs.cgi"は廃止][1]されているためデフォルト設定を"/test/bbs.cgi"に変更することで修正します。

関連のissue: #991 

[1]: https://info.5ch.net/?curid=686