### PR TITLE
Admin: Update context menu construction to use Gio::Menu

### DIFF
--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -2307,7 +2307,7 @@ void Admin::slot_show_tabswitchmenu()
  */
 void Admin::slot_popup_pos( int& x, int& y, bool& push_in )
 {
-    if( ! m_tabswitchmenu ) return;
+    if( ! m_model_tabswitch ) return;
 
     const int mrg = 16;
 

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -40,16 +40,18 @@ namespace SKELETON
         std::list< COMMAND_ARGS > m_list_command;
 
         // 右クリックメニュー用
-        Glib::RefPtr< Gtk::ActionGroup > m_action_group;
-        Glib::RefPtr< Gtk::UIManager > m_ui_manager;
+        Glib::RefPtr<Gio::SimpleActionGroup> m_action_group;
+        Glib::RefPtr<Gio::Menu> m_model_popup;
+        Gtk::Menu m_tablabel_menu;
+        int m_prev_n_pages; ///< 前回表示したときのタブ数
         int m_clicked_page;
 
         // 移動サブメニュー
-        Gtk::MenuItem* m_move_menuitem;
-        std::unique_ptr<TabSwitchMenu> m_move_menu;
+        Glib::RefPtr<Gio::MenuItem> m_item_sub;
+        Glib::RefPtr<SKELETON::TabSwitchMenu> m_model_tabswitch;
 
         // タブ切り替えメニュー
-        std::unique_ptr<TabSwitchMenu> m_tabswitchmenu;
+        Gtk::Menu m_tabswitchmenu;
 
         // view履歴使用
         bool m_use_viewhistory{};
@@ -138,7 +140,7 @@ namespace SKELETON
         void set_current_page( const int page );
 
         // フォーカスしてから指定したページに表示切替え
-        void set_current_page_focus( const int page );
+        void set_current_page_focus( const Glib::VariantBase& page );
 
         virtual View* get_current_view();
 

--- a/src/skeleton/tabswitchmenu.h
+++ b/src/skeleton/tabswitchmenu.h
@@ -4,41 +4,42 @@
 //
 
 #include <gtkmm.h>
+
 #include <vector>
 
 namespace SKELETON
 {
     class DragableNoteBook;
-    class Admin;
 
-    class TabSwitchMenu : public Gtk::Menu
+    /**
+     * @brief タブを切り替えるメニューのモデル
+     *
+     * SKELETON::Admin でメニュー項目の部品として使われる
+     */
+    class TabSwitchMenu : public Gio::Menu
     {
-        Admin* m_parentadmin;
+        /// Admin メンバー変数への参照で所有しない
         DragableNoteBook* m_parentnote;
+        std::vector<Glib::RefPtr<Gio::MenuItem>> m_items;
         bool m_deactivated;
-        int m_size{};
-
-        std::vector< Gtk::MenuItem* > m_vec_items;
-        std::vector< Gtk::Label* > m_vec_labels;
-        std::vector< Gtk::Image* > m_vec_images;
-
 
       public:
 
-        TabSwitchMenu( DragableNoteBook* notebook, Admin* admin );
-        ~TabSwitchMenu();
+        static Glib::RefPtr<TabSwitchMenu> create( DragableNoteBook* notebook );
 
-        void remove_items();
-        void append_items();
+        explicit TabSwitchMenu( DragableNoteBook* notebook );
+        ~TabSwitchMenu() noexcept = default;
 
-        void update_labels();
+        /// メニュー項目を作り直してラベルとアイコンを更新する
+        void update_labels_and_icons();
+        /// メニュー項目を作り直してアイコンを更新する
         void update_icons();
-
+        /// メニューがスクリーンから消されるときに呼び出す
         void deactivate();
 
-      protected:
+      private:
 
-        void on_deactivate() override;
-
+        /// メニュー項目を必要な分だけ確保しておき使い回す
+        void alloc_items();
     };
 }


### PR DESCRIPTION
タブの右クリックメニューの構築を更新して廃止予定の`GtkAction`や`GtkUIManager`のかわりに`GAction`、`GtkBuilder`、`GMenu`を使った方法にします。
合わせて、GTK4で廃止される`GtkMenu`への依存を減らすためメニューラベルにアクセラレーターキーやマウスジェスチャーの表示を追加する処理を削除します。

参考文献
* https://wiki.gnome.org/HowDoI/GAction
* https://wiki.gnome.org/HowDoI/GMenu

関連のissue: #977 