### PR TITLE
Fix C-style pointer cast part1

### DIFF
--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -513,7 +513,7 @@ namespace ARTICLE
     //
     inline bool DrawAreaBase::is_wrapped( const int x, const int border, const char* str ) const
     {
-        const unsigned char* tmpchar = ( const unsigned char* ) str;
+        const unsigned char* tmpchar = reinterpret_cast<const unsigned char*>( str );
 
         if( x < border ) return false;
         if( ! tmpchar ) return true;

--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -1499,7 +1499,7 @@ bool Loader::unzip( char* buf, std::size_t read_size )
 #endif
             
             // コールバック呼び出し
-            if( byte_out && m_loadable ) m_loadable->receive( ( char* )m_buf_zlib_out, byte_out );
+            if( byte_out && m_loadable ) m_loadable->receive( reinterpret_cast<char*>( m_buf_zlib_out ), byte_out );
         }
         else return true;
                 

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1264,7 +1264,7 @@ std::string MISC::base64( const std::string& str )
 
     for( int i = 0; i < lng; i += 3 ){
 
-        unsigned char* cstr = (unsigned char*)( data.c_str() + i );
+        const auto cstr = reinterpret_cast<const unsigned char*>( data.c_str() + i );
         unsigned char key[ 4 ];
 
         key[ 0 ] = (*cstr) >> 2;

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -967,7 +967,7 @@ void MessageViewBase::show_status()
         else m_over_lines = false;
     }
 
-    const std::string message = m_text_message->get_text();
+    std::string message = m_text_message->get_text();
 
     ss << "   /  文字数 ";
 
@@ -978,8 +978,7 @@ void MessageViewBase::show_status()
     else if( m_text_changed )
     {
         int byte_out;
-        const char* msgc = message.c_str();
-        std::string str_enc = m_iconv->convert( (char*)msgc, strlen( msgc ), byte_out );
+        std::string str_enc = m_iconv->convert( message.data(), message.size(), byte_out );
         m_lng_str_enc = str_enc.length();
 
         // 特殊文字の文字数を計算


### PR DESCRIPTION
C言語スタイルのポインターキャストではなくC++のキャストを使うべきとcppcheck 2.8に指摘されたため修正します。

> C-style pointer casting detected. C++ offers four different kinds of casts as replacements: static_cast, const_cast, dynamic_cast and reinterpret_cast. A C-style cast could evaluate to any of those automatically, thus it is considered safer if the programmer explicitly states which kind of cast is expected. See also: https://www.securecoding.cert.org/confluence/display/cplusplus/EXP05-CPP.+Do+not+use+C-style+casts. [cstyleCast]

cppcheckのレポート
```
src/article/drawareabase.h:516:42: style: C-style pointer casting detected. (snip) [cstyleCast]
        const unsigned char* tmpchar = ( const unsigned char* ) str;
                                         ^
src/jdlib/loader.cpp:1502:63: style: C-style pointer casting detected. (snip) [cstyleCast]
            if( byte_out && m_loadable ) m_loadable->receive( ( char* )m_buf_zlib_out, byte_out );
                                                              ^
src/message/messageviewbase.cpp:982:49: style: C-style pointer casting detected. (snip) [cstyleCast]
        std::string str_enc = m_iconv->convert( (char*)msgc, strlen( msgc ), byte_out );
                                                ^
src/jdlib/miscutil.cpp:1267:31: style: C-style pointer casting detected. (snip) [cstyleCast]
        unsigned char* cstr = (unsigned char*)( data.c_str() + i );
                              ^
```

関連のpull request: #988 