### PR TITLE
Iconv: Fix C-style pointer cast part2

### DIFF
--- a/src/jdlib/jdiconv.h
+++ b/src/jdlib/jdiconv.h
@@ -4,6 +4,7 @@
 #define _JDICONV_H
 
 #include <string>
+#include <vector>
 
 #include <gmodule.h> // GIConv
 
@@ -23,10 +24,10 @@ namespace JDLIB
         GIConv m_cd; // iconv実装は環境で違いがあるためGlibのラッパーAPIを利用する
 
         size_t m_byte_left_in{};
-        char* m_buf_in{};
+        std::vector<char> m_buf_in;
         char* m_buf_in_tmp{};
 
-        char* m_buf_out{};
+        std::vector<char> m_buf_out;
 
         std::string m_coding_from;
 


### PR DESCRIPTION
C言語スタイルのポインターキャストではなくC++のキャストを使うべきとcppcheck 2.8に指摘されたため修正します。

> C-style pointer casting detected. C++ offers four different kinds of casts as replacements: static_cast, const_cast, dynamic_cast and reinterpret_cast. A C-style cast could evaluate to any of those automatically, thus it is considered safer if the programmer explicitly states which kind of cast is expected. See also: https://www.securecoding.cert.org/confluence/display/cplusplus/EXP05-CPP.+Do+not+use+C-style+casts. [cstyleCast]

cppcheckのレポート
```
src/jdlib/jdiconv.cpp:26:16: style: C-style pointer casting detected. (snip) [cstyleCast]
    m_buf_in = ( char* )malloc( BUF_SIZE_ICONV_IN );
               ^
src/jdlib/jdiconv.cpp:27:17: style: C-style pointer casting detected. (snip) [cstyleCast]
    m_buf_out = ( char* )malloc( BUF_SIZE_ICONV_OUT );
                ^
```

関連のpull request: #988 