### PR TITLE
Loader: Fix C-style pointer cast part3

### DIFF
--- a/src/jdlib/loader.h
+++ b/src/jdlib/loader.h
@@ -18,6 +18,7 @@
 #include <list>
 #include <string>
 #include <string_view>
+#include <vector>
 
 
 namespace SKELETON
@@ -75,13 +76,13 @@ namespace JDLIB
         
         // 読み込みバッファ
         unsigned long m_lng_buf; 
-        char* m_buf;
+        std::vector<char> m_buf;
 
         // zlib 用のバッファ
         unsigned long m_lng_buf_zlib_in;
         unsigned long m_lng_buf_zlib_out;
-        Bytef* m_buf_zlib_in;
-        Bytef* m_buf_zlib_out;
+        std::vector<Bytef> m_buf_zlib_in;
+        std::vector<Bytef> m_buf_zlib_out;
 
         // chunk 用変数
         bool m_use_chunk;


### PR DESCRIPTION
C言語スタイルのポインターキャストではなくC++のキャストを使うべきとcppcheck 2.8に指摘されたため修正します。

> C-style pointer casting detected. C++ offers four different kinds of casts as replacements: static_cast, const_cast, dynamic_cast and reinterpret_cast. A C-style cast could evaluate to any of those automatically, thus it is considered safer if the programmer explicitly states which kind of cast is expected. See also: https://www.securecoding.cert.org/confluence/display/cplusplus/EXP05-CPP.+Do+not+use+C-style+casts. [cstyleCast]

cppcheckのレポート
```
src/jdlib/loader.cpp:923:13: style: C-style pointer casting detected. (snip) [cstyleCast]
    m_buf = ( char* )malloc( m_lng_buf + mrg );
            ^
src/jdlib/loader.cpp:1459:21: style: C-style pointer casting detected. (snip) [cstyleCast]
    m_buf_zlib_in = ( Bytef* )malloc( sizeof( Bytef ) * m_lng_buf_zlib_in + 64 );
                    ^
src/jdlib/loader.cpp:1460:22: style: C-style pointer casting detected. (snip) [cstyleCast]
    m_buf_zlib_out = ( Bytef* )malloc( sizeof( Bytef ) * m_lng_buf_zlib_out + 64 );
                     ^
src/jdlib/loader.cpp:1502:63: style: C-style pointer casting detected. (snip) [cstyleCast]
            if( byte_out && m_loadable ) m_loadable->receive( ( char* )m_buf_zlib_out, byte_out );
                                                              ^
```

関連のpull request: #988 