### PR TITLE
History_Manager: Move static variable to outside of fucntion

### DIFF
--- a/src/history/historymanager.cpp
+++ b/src/history/historymanager.cpp
@@ -461,13 +461,14 @@ bool History_Manager::replace_current_title_viewhistory( const std::string& url,
 }
 
 
+static std::vector<ViewHistoryItem*> s_nullitems;
+
+
 // item の取得
 std::vector< ViewHistoryItem* >& History_Manager::get_items_back_viewhistory( const std::string& url, const int count )
 {
-    static std::vector< ViewHistoryItem* > nullitems;
-
     ViewHistory* history = get_viewhistory( url );
-    if( !history ) return nullitems;
+    if( !history ) return s_nullitems;
 
     return history->get_items_back( count );
 }
@@ -475,10 +476,8 @@ std::vector< ViewHistoryItem* >& History_Manager::get_items_back_viewhistory( co
 
 std::vector< ViewHistoryItem* >& History_Manager::get_items_forward_viewhistory( const std::string& url, const int count )
 {
-    static std::vector< ViewHistoryItem* > nullitems;
-
     ViewHistory* history = get_viewhistory( url );
-    if( !history ) return nullitems;
+    if( !history ) return s_nullitems;
 
     return history->get_items_forward( count );
 }


### PR DESCRIPTION
変数のスコープ範囲を減らすことができるとcppcheck 2.8に指摘されたため静的変数を関数の外に移動します。

> style: The scope of the variable 'nullitems' can be reduced. Warning: Be careful when fixing this message, especially when there are inner loops. Here is an example where cppcheck will write that the scope for 'i' can be reduced:
> ```cpp
> void f(int x)
> {
>     int i = 0;
>     if (x) {
>         // it's safe to move 'int i = 0;' here
>         for (int n = 0; n < 10; ++n) {
>             // it is possible but not safe to move 'int i = 0;' here
>             do_something(&i);
>         }
>     }
> }
> ```
> When you see this message it is always safe to reduce the variable scope 1 level. [variableScope]

```
src/history/historymanager.cpp:467:44: style: The scope of the variable 'nullitems' can be reduced. (snip) [variableScope]
    static std::vector< ViewHistoryItem* > nullitems;
                                           ^
src/history/historymanager.cpp:478:44: style: The scope of the variable 'nullitems' can be reduced. (snip) [variableScope]
    static std::vector< ViewHistoryItem* > nullitems;
                                           ^
```

関連のpull request: #988 