### PR TITLE
BBSListViewBase: Update context menu construction to use Gio::Menu

### DIFF
--- a/src/bbslist/bbslistview.cpp
+++ b/src/bbslist/bbslistview.cpp
@@ -215,12 +215,12 @@ Gtk::Menu* BBSListViewMain::get_popupmenu( const std::string& url )
 #endif
 
         if( type == TYPE_DIR ){
-            if( is_etcdir( path ) ) popupmenu = id2popupmenu(  "/popup_menu_etcdir" );
-            else popupmenu = id2popupmenu(  "/popup_menu_dir" );
+            if( is_etcdir( path ) ) popupmenu = id2popupmenu(  "popup_menu_etcdir" );
+            else popupmenu = id2popupmenu(  "popup_menu_dir" );
         }
         else if( type == TYPE_BOARD || type == TYPE_BOARD_UPDATE ){
-            if( is_etcboard( path ) ) popupmenu = id2popupmenu(  "/popup_menu_etc" );
-            else popupmenu = id2popupmenu(  "/popup_menu" );
+            if( is_etcboard( path ) ) popupmenu = id2popupmenu(  "popup_menu_etc" );
+            else popupmenu = id2popupmenu(  "popup_menu" );
         }
     }
     else{
@@ -228,8 +228,8 @@ Gtk::Menu* BBSListViewMain::get_popupmenu( const std::string& url )
         const bool have_etc = std::all_of( list_it.cbegin(), list_it.cend(),
                                            [this]( const Gtk::TreeIter& iter ) { return is_etcboard( iter ); } );
 
-        if( have_etc ) popupmenu = id2popupmenu(  "/popup_menu_mul_etc" );
-        else popupmenu = id2popupmenu(  "/popup_menu_mul" );
+        if( have_etc ) popupmenu = id2popupmenu(  "popup_menu_mul_etc" );
+        else popupmenu = id2popupmenu(  "popup_menu_mul" );
     }
 
     return popupmenu;

--- a/src/bbslist/bbslistviewbase.h
+++ b/src/bbslist/bbslistviewbase.h
@@ -16,6 +16,7 @@
 
 #include <gtkmm.h>
 
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -86,6 +87,10 @@ namespace BBSLIST
 
         // スレを追加したときにそのスレにしおりを付ける
         bool m_set_bookmark{};
+
+        Glib::RefPtr<Gio::SimpleActionGroup> m_action_group;
+        Glib::RefPtr<Gtk::Builder> m_builder;
+        std::map<std::string, Gtk::Menu> m_map_popupmenu;
 
       protected:
 

--- a/src/bbslist/favoriteview.cpp
+++ b/src/bbslist/favoriteview.cpp
@@ -74,19 +74,19 @@ void FavoriteListView::show_view()
 Gtk::Menu* FavoriteListView::get_popupmenu( const std::string& url )
 {
     Gtk::Menu* popupmenu = nullptr;
-    if( url.empty() ) popupmenu = id2popupmenu(  "/popup_menu_favorite_space" );
+    if( url.empty() ) popupmenu = id2popupmenu(  "popup_menu_favorite_space" );
     else{
         std::list< Gtk::TreeModel::iterator > list_it = get_treeview().get_selected_iterators();
         if( list_it.size() == 1 ){
 
             const int type = path2type( *( get_treeview().get_selection()->get_selected_rows().begin() ) );
 
-            if( type == TYPE_DIR ) popupmenu = id2popupmenu(  "/popup_menu_favorite_dir" );
-            else if( type == TYPE_COMMENT ) popupmenu = id2popupmenu(  "/popup_menu_favorite_com" );
-            else if( type == TYPE_VBOARD ) popupmenu = id2popupmenu(  "/popup_menu_favorite_vboard" );
-            else popupmenu = id2popupmenu(  "/popup_menu_favorite" );
+            if( type == TYPE_DIR ) popupmenu = id2popupmenu(  "popup_menu_favorite_dir" );
+            else if( type == TYPE_COMMENT ) popupmenu = id2popupmenu(  "popup_menu_favorite_com" );
+            else if( type == TYPE_VBOARD ) popupmenu = id2popupmenu(  "popup_menu_favorite_vboard" );
+            else popupmenu = id2popupmenu(  "popup_menu_favorite" );
         }
-        else popupmenu = id2popupmenu(  "/popup_menu_favorite_mul" );
+        else popupmenu = id2popupmenu(  "popup_menu_favorite_mul" );
     }
 
     return popupmenu;

--- a/src/bbslist/historyview.cpp
+++ b/src/bbslist/historyview.cpp
@@ -66,10 +66,10 @@ Gtk::Menu* HistoryViewBase::get_popupmenu( const std::string& url )
 
             const int type = path2type( *( get_treeview().get_selection()->get_selected_rows().begin() ) );
 
-            if( type == TYPE_VBOARD ) popupmenu = id2popupmenu( "/popup_menu_history_vboard" );
-            else popupmenu = id2popupmenu( "/popup_menu_history" );
+            if( type == TYPE_VBOARD ) popupmenu = id2popupmenu( "popup_menu_history_vboard" );
+            else popupmenu = id2popupmenu( "popup_menu_history" );
         }
-        else popupmenu = id2popupmenu(  "/popup_menu_history_mul" );
+        else popupmenu = id2popupmenu(  "popup_menu_history_mul" );
     }
 
     return popupmenu;

--- a/src/bbslist/selectlistview.cpp
+++ b/src/bbslist/selectlistview.cpp
@@ -64,18 +64,18 @@ bool SelectListView::operate_view( const int control )
 Gtk::Menu* SelectListView::get_popupmenu( const std::string& url )
 {
     Gtk::Menu* popupmenu;
-    if( url.empty() ) popupmenu = id2popupmenu(  "/popup_menu_favorite_space" );
+    if( url.empty() ) popupmenu = id2popupmenu(  "popup_menu_favorite_space" );
     else{
         std::list< Gtk::TreeModel::iterator > list_it = get_treeview().get_selected_iterators();
         if( list_it.size() == 1 ){
 
             int type = path2type( *( get_treeview().get_selection()->get_selected_rows().begin() ) );
 
-            if( type == TYPE_DIR ) popupmenu = id2popupmenu(  "/popup_menu_favorite_dir" );
-            else if( type == TYPE_COMMENT ) popupmenu = id2popupmenu(  "/popup_menu_favorite_com" );
-            else popupmenu = id2popupmenu(  "/popup_menu_select" );
+            if( type == TYPE_DIR ) popupmenu = id2popupmenu(  "popup_menu_favorite_dir" );
+            else if( type == TYPE_COMMENT ) popupmenu = id2popupmenu(  "popup_menu_favorite_com" );
+            else popupmenu = id2popupmenu(  "popup_menu_select" );
         }
-        else popupmenu = id2popupmenu(  "/popup_menu_favorite_mul" );
+        else popupmenu = id2popupmenu(  "popup_menu_favorite_mul" );
     }
 
     return popupmenu;


### PR DESCRIPTION
サイドバーの右クリックメニューの構築を更新して廃止予定の`GtkAction`や`GtkUIManager`のかわりに`GAction`、`GtkBuilder`、`GMenu`を使った方法にします。
サイドバーの種類によっては使わないメニューがあるため構築を分けることでメモリ使用量を削減します。
合わせて、GTK4で廃止される`GtkMenu`への依存を減らすためメニューラベルにアクセラレーターキーやマウスジェスチャーの表示を追加する処理を削除します。

関連のissue: #977