### PR TITLE
ImageViewIcon: Use CSS styling instead of depreacted function

### DIFF
--- a/src/image/imageviewicon.h
+++ b/src/image/imageviewicon.h
@@ -13,7 +13,8 @@ namespace IMAGE
 {
     class ImageViewIcon : public ImageViewBase
     {
-        Gtk::EventBox* m_event_frame;
+        /// 選択されてる画像アイコンの背景色を赤に設定するプロバイダ
+        Glib::RefPtr<Gtk::CssProvider> m_provider;
 
       public:
         explicit ImageViewIcon( const std::string& url );


### PR DESCRIPTION
画像ビューのアイコン背景色切り替えを更新して廃止予定の`Gtk::Widget::override_background_color()`をCSSによる設定に置き換えます。

選択されたアイコンの背景色は`$XDG_CONFIG_HOME/gtk-3.0/gtk.css`にCSSセレクタ`#jdim-imageview-icon.selected`の設定を追加することで変更できます。(テスト用のため変更の可能性がある)