### PR TITLE
ImageViewPopup: Use CSS styling instead of depreacted function

### DIFF
--- a/src/image/imageviewpopup.h
+++ b/src/image/imageviewpopup.h
@@ -16,8 +16,7 @@ namespace IMAGE
 {
     class ImageViewPopup : public ImageViewBase
     {
-        Gtk::EventBox m_event_frame;
-        Gtk::EventBox m_event_margin;
+        Glib::RefPtr<Gtk::CssProvider> m_provider;
         std::unique_ptr<Gtk::Label> m_label;
         size_t m_length_prev{};
 


### PR DESCRIPTION
画像ポップアップの文字色、背景色の設定を更新して廃止予定の`Gtk::Widget::override_background_color()`や`override_color()`をCSSによる設定に置き換えます。

スタイルは`$XDG_CONFIG_HOME/gtk-3.0/gtk.css`にCSSセレクタ`#jdim-imageview-popup`の設定を追加することで変更できます。(テスト用のため変更の可能性がある)

キャッシュに[`jd.css`][1]を置くことで画像ポップアップのスタイルを設定できますがmarginの値がpaddingとして反映されます。
これはCSSとして正しくない動作ですがとりあえず修正前の動作を維持します。

[1]: https://jdimproved.github.io/JDim/skin/#stylesheet

関連のpull request: #1004 