### PR TITLE
Bump version to 0.8.0-beta

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,5 @@
 # オンラインマニュアルのメンテナンスについて
 
-**※この項目は草案の段階です。**
-
 - [概要](#概要)
 - [ポリシー](#ポリシー)
 - [内容の更新について](#内容の更新について)
@@ -53,8 +51,8 @@ HTMLのタグによるマークアップはなるべく使わないようにし�
 # マージされた最新100件のPRから変更履歴を作る
 generate_changelogs () {
   API='https://api.github.com/repos/JDimproved/JDim/pulls?state=closed&base=master&per_page=100'
-  QUERY='.[] | select(.merged_at != null) | .title, .html_url'
-  curl "$API" | jq -r "$QUERY" | sed -e '1~2s/^ */- /' -e '2~2s%^.\+/\(.\+\)$%  ([#\1](&))%'
+  QUERY='.[] | select(.merged_at != null) | .html_url, .title'
+  curl "$API" | jq -r "$QUERY" | sed -e '1~2s%^.\+/\(.\+\)$%- ([#\1](&))%' -e '2~2s/^ */  /'
 }
 generate_changelogs
 ```
@@ -62,7 +60,7 @@ generate_changelogs
 # 特定のPRから変更履歴を作る
 generate_changelog () {
   API="https://api.github.com/repos/JDimproved/JDim/pulls/$1"
-  curl "$API" | jq -r '.title, .html_url' | sed -e '1~2s/^ */- /' -e '2~2s%^.\+/\(.\+\)$%  ([#\1](&))%'
+  curl "$API" | jq -r '.html_url, .title' | sed -e '1~2s%^.\+/\(.\+\)$%- ([#\1](&))%' -e '2~2s/^ */  /'
 }
 generate_changelog 1
 ```

--- a/docs/manual/2022.md
+++ b/docs/manual/2022.md
@@ -10,6 +10,99 @@ layout: default
 
 <a name="0.8.0-unreleased"></a>
 ### [0.8.0-unreleased](https://github.com/JDimproved/JDim/compare/b06a6a6fe71...master) (unreleased)
+- ([#1006](https://github.com/JDimproved/JDim/pull/1006))
+  Bump version to 0.8.0-beta
+- ([#1005](https://github.com/JDimproved/JDim/pull/1005))
+  `ImageViewPopup`: Use CSS styling instead of depreacted function
+- ([#1004](https://github.com/JDimproved/JDim/pull/1004))
+  `ImageViewIcon`: Use CSS styling instead of depreacted function
+- ([#1003](https://github.com/JDimproved/JDim/pull/1003))
+  `BBSListViewBase`: Update context menu construction to use `Gio::Menu`
+- ([#1002](https://github.com/JDimproved/JDim/pull/1002))
+  Snap: Add packager information to operating environment
+- ([#1001](https://github.com/JDimproved/JDim/pull/1001))
+  meson: Add `-Dpackager=PACKAGER` build option
+- ([#999](https://github.com/JDimproved/JDim/pull/999))
+  `BoardViewBase`: Update context menu construction to use `Gio::Menu`
+- ([#998](https://github.com/JDimproved/JDim/pull/998))
+  `History_Manager`: Move static variable to outside of fucntion
+- ([#997](https://github.com/JDimproved/JDim/pull/997))
+  `DrawAreaBase`: Get rid of variable assignments which never used
+- ([#996](https://github.com/JDimproved/JDim/pull/996))
+  `Loader`: Fix C-style pointer cast part3
+- ([#995](https://github.com/JDimproved/JDim/pull/995))
+  `Iconv`: Fix C-style pointer cast part2
+- ([#994](https://github.com/JDimproved/JDim/pull/994))
+  Fix C-style pointer cast part1
+- ([#993](https://github.com/JDimproved/JDim/pull/993))
+  `Admin`: Update context menu construction to use `Gio::Menu`
+- ([#992](https://github.com/JDimproved/JDim/pull/992))
+  `Board2chCompati`: Modify default subbbs.cgi path to /test/bbs.cgi
+- ([#990](https://github.com/JDimproved/JDim/pull/990))
+  `JDWindow`: Fix known condition true/false
+- ([#989](https://github.com/JDimproved/JDim/pull/989))
+  Fix local variable names that shadow outer function part2
+- ([#988](https://github.com/JDimproved/JDim/pull/988))
+  `ArticleViewBase`: Fix local variable names that shadow outer function
+- ([#987](https://github.com/JDimproved/JDim/pull/987))
+  Revert `Gtk::Menu` API to fix menu scrolling on older GTK
+- ([#986](https://github.com/JDimproved/JDim/pull/986))
+  `ChunkedDecoder`: Fix condition for breaking loop
+- ([#984](https://github.com/JDimproved/JDim/pull/984))
+  `SelectItemPref`: Improve while loop
+- ([#983](https://github.com/JDimproved/JDim/pull/983))
+  `EditTreeView`: Improve while loop
+- ([#982](https://github.com/JDimproved/JDim/pull/982))
+  Update OpenSSL client codes to support version 3.0
+- ([#981](https://github.com/JDimproved/JDim/pull/981))
+  `Loader`: Improve proccesing for Chunked transfer encording
+- ([#979](https://github.com/JDimproved/JDim/pull/979))
+  `LinkFilterPref`: Improve while loop
+- ([#978](https://github.com/JDimproved/JDim/pull/978))
+  environment: Improve while loop
+- ([#976](https://github.com/JDimproved/JDim/pull/976))
+  `DrawAreaBase`: Modify loop to return the variable value just as it is
+- ([#974](https://github.com/JDimproved/JDim/pull/974))
+  Update function `MISC::is_utf8()`
+- ([#973](https://github.com/JDimproved/JDim/pull/973))
+  Update function `MISC::is_sjis()`
+- ([#972](https://github.com/JDimproved/JDim/pull/972))
+  Update function `MISC::is_jis()`
+- ([#971](https://github.com/JDimproved/JDim/pull/971))
+  Update function `MISC::is_euc()` to `MISC::is_eucjp()`
+- ([#970](https://github.com/JDimproved/JDim/pull/970))
+  `Css_Manager`: Improve while loop
+- ([#969](https://github.com/JDimproved/JDim/pull/969))
+  `Core`: Improve while loop
+- ([#968](https://github.com/JDimproved/JDim/pull/968))
+  bbslist: Improve while loop
+- ([#967](https://github.com/JDimproved/JDim/pull/967))
+  meson: Improve `buildinfo.h` generation
+- ([#966](https://github.com/JDimproved/JDim/pull/966))
+  Move `MISC::utf8_fix_wavedash()` from miscutil to misccharcode
+- ([#964](https://github.com/JDimproved/JDim/pull/964))
+  `UsrCmdPref`: Use `Gio::SimpleActionGroup` instead of `Gtk::ActionGroup`
+- ([#963](https://github.com/JDimproved/JDim/pull/963))
+  Rename function `MISC::remove_spaces()` to `MISC::ascii_trim()`
+- ([#962](https://github.com/JDimproved/JDim/pull/962))
+  Implement `MISC::utf32toutf8()`
+- ([#961](https://github.com/JDimproved/JDim/pull/961))
+  Implement App class to use `GtkApplication` features
+- ([#960](https://github.com/JDimproved/JDim/pull/960))
+  Use `std::string_view` for `MISC::replace_newlines_to_str()`
+- ([#959](https://github.com/JDimproved/JDim/pull/959))
+  Use `std::string_view` for `MISC::cut_str()`
+- ([#958](https://github.com/JDimproved/JDim/pull/958))
+  Use `std::string_view` for `MISC::remove_str(str, pattern)`
+- ([#957](https://github.com/JDimproved/JDim/pull/957))
+  Remove unused `MISC::count_str()`
+- ([#956](https://github.com/JDimproved/JDim/pull/956))
+  meson: Fix check for `crypt(3)` to improve OpenBSD support
+- ([#955](https://github.com/JDimproved/JDim/pull/955))
+  `ICON_Manager`: Fix icon loading to prevent crash on start
+- ([#953](https://github.com/JDimproved/JDim/pull/953))
+  Implement `MISC::get_unicodeblock()`
+
 
 <a name="0.7.0-20220402"></a>
 ### [0.7.0-20220402](https://github.com/JDimproved/JDim/compare/JDim-v0.7.0...b06a6a6fe71) (2022-04-02)

--- a/meson.build
+++ b/meson.build
@@ -44,7 +44,7 @@
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 
 project('jdim', 'cpp',
-        version : '0.7.0',
+        version : '0.8.0-beta',
         license : 'GPL2',
         meson_version : '>= 0.49.0',
         default_options : ['warning_level=3', 'cpp_std=c++17'])

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -15,10 +15,10 @@
 // SEE ALSO: ENVIRONMENT::get_jdversion()
 
 #define MAJORVERSION 0
-#define MINORVERSION 7
+#define MINORVERSION 8
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20220402"
-#define JDTAG     ""
+#define JDDATE_FALLBACK    "20220625"
+#define JDTAG     "beta"
 
 //---------------------------------
 


### PR DESCRIPTION
#### [manual: Change command examples for generating histories](https://github.com/JDimproved/JDim/commit/d749a24a7c0d7bf44d52c1f319dd4d5377539b20)

オンラインマニュアルの履歴は項目の末尾にissue番号がついていますが位置が揃わず番号が見にくいため項目の先頭に表示するように履歴を生成するスクリプトを変更します。

また、マニュアルの更新方法は大きな変更がなく安定しているためREADMEの草案段階の表示は消します。

#### [Update histories](https://github.com/JDimproved/JDim/commit/a3dfba95b1bda3ed3cca772e49c623fec6f695e9)

#### [Bump version to 0.8.0-beta](https://github.com/JDimproved/JDim/commit/d0d38eb24a20eef14d4f26fc6d9df6ec8ed45875)

機能フリーズ期間に入るためバージョン番号をベータ版に更新します。

関連のissue: #951 