### PR TITLE
Prenotice end of update for snap i386 after 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Ubuntu 18.04(2018年)より前にリリースされたディストリビュー�
 
 メンテナンスの都合によりWindows(MinGW)版のサポートは[終了][#445]しました。
 
+Snap i386(32bit)版は2023年1月のリリースをもって[更新を終了][#890]する予定です。
+i386版ディストロを利用されている場合は更新をお願いいたします。
+
 [#445]: https://github.com/JDimproved/JDim/issues/445
+[#890]: https://github.com/JDimproved/JDim/issues/890
 
 
 ## 導入方法

--- a/docs/manual/start.md
+++ b/docs/manual/start.md
@@ -187,8 +187,12 @@ Snapパッケージ版はアクセス制限が導入されているため通常�
   環境変数 (`GTK_THEME`) やGTKの設定ファイル (`$XDG_CONFIG_HOME/gtk-3.0/settings.ini`)
   を調整することで改善できるかもしれない
 
+#### サポートの最新情報
+Snap i386(32bit)版は2023年1月のリリースをもって[更新を終了][#890]する。
+更新終了後も最後のバージョンは利用可能だがStoreからパッケージが削除される可能性がある。
 
 [pr-merged]: https://github.com/JDimproved/JDim/pulls?q=is%3Apr+is%3Amerged
 [snapcraft]: https://snapcraft.io/jdim
+[#890]: https://github.com/JDimproved/JDim/issues/890
 
 [操作方法について]: {{ site.baseurl }}/operation/#threadview_touch "操作方法について \| JDim"


### PR DESCRIPTION
2023年1月のリリースでSnap i386(32bit)版の更新を終了することをドキュメントに記載します。

#### 背景
Snap i386版パッケージの基盤となっているUbuntu Core 18(Ubuntu 18.04 LTS)は2023年4月にサポートが終了します。新しいバージョンのUbuntu Core 20はi386をサポートしていないためSnap i386版の更新を行うことができません。

そのため2023年初頭のリリースをもってSnap i386版パッケージの更新を終了しSnapパッケージのベースをCore 20へ移行します。

関連のissue: #890