### PR TITLE
BBSListViewBase: Fix duplicate if-coindition

### DIFF
--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -400,7 +400,6 @@ const char* get_menu_ui( const std::string& id )
 {
     const char* menu_ui;
     if( id == "popup_menu" ) menu_ui = popup_menu;
-    else if( id == "popup_menu" ) menu_ui = popup_menu;
     else if( id == "popup_menu_etc" ) menu_ui = popup_menu_etc;
     else if( id == "popup_menu_mul" ) menu_ui = popup_menu_mul;
     else if( id == "popup_menu_mul_etc" ) menu_ui = popup_menu_mul_etc;


### PR DESCRIPTION
if文の条件が繰り返し現れているとcppcheck 2.8に指摘されたため修正します。

cppcheckのレポート
```
src/bbslist/bbslistviewbase.cpp:403:17: style: Expression is always false because 'else if' condition matches previous condition at line 402. [multiCondition]
    else if( id == "popup_menu" ) menu_ui = popup_menu;
                ^
```