### PR TITLE
ToolBar: Remove signal handler slot_focusout_write_button()

### DIFF
--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -645,7 +645,6 @@ Gtk::ToolButton* ToolBar::get_button_write()
         set_tooltip( *m_button_write, CONTROL::get_label_motions( CONTROL::WriteMessage ) );
 
         m_button_write->signal_clicked().connect( sigc::mem_fun(*this, &ToolBar::slot_clicked_write ) );
-        m_button_write->get_child()->signal_focus_out_event().connect( sigc::mem_fun(*this, &ToolBar::slot_focusout_write_button ) );
     }
 
     return m_button_write;
@@ -669,16 +668,6 @@ void ToolBar::slot_clicked_write()
 void ToolBar::focus_button_write()
 {
     get_button_write()->get_child()->grab_focus();
-}
-
-
-bool ToolBar::slot_focusout_write_button( GdkEventFocus* )
-{
-#ifdef _DEBUG
-    std::cout << "ToolBar::slot_focusout_write_button\n";
-#endif
-
-    return true;
 }
 
 

--- a/src/skeleton/toolbar.h
+++ b/src/skeleton/toolbar.h
@@ -171,9 +171,6 @@ namespace SKELETON
         void set_label( const std::string& label );
         void set_color( const std::string& color );
 
-        // 書き込みボタン関係
-        bool slot_focusout_write_button( GdkEventFocus* event );
-
         // 検索関係
         void slot_toggle_searchbar();
         void slot_changed_search();


### PR DESCRIPTION
書き込みボタンからフォーカスが外れたときに実行するシグナルハンドラを削除します。

commit bf79a502b539bb9a3304d1e84f85ab49508ea3d4 (2020-08)
で処理が削除され何もしない状態になっていました。