### PR TITLE
Rename function `MISC::remove_space()` to `MISC::utf8_trim()`

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -4446,7 +4446,7 @@ std::string DrawAreaBase::get_selection_as_url( const CARET_POSITION& caret_pos 
     if( is_caret_on_selection( caret_pos ) ){
 
         size_t n,dig;
-        std::string select_str = MISC::remove_space( m_selection.str );
+        std::string select_str = MISC::utf8_trim( m_selection.str );
         select_str = MISC::remove_str( select_str, "\n" );
         int num = MISC::str_to_uint( select_str.c_str(), dig, n );
 

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -1475,11 +1475,11 @@ void BBSListViewBase::add_newetcboard( const bool move, // true なら編集モ�
 
         diag.hide();
 
-        std::string url_org = MISC::remove_space( diag.get_url() );
-        name = MISC::remove_space( diag.get_name() );
+        std::string url_org = MISC::utf8_trim( diag.get_url() );
+        name = MISC::utf8_trim( diag.get_name() );
         url = url_org;
-        id = MISC::remove_space( diag.get_id() );
-        passwd = MISC::remove_space( diag.get_passwd() );
+        id = MISC::utf8_trim( diag.get_id() );
+        passwd = MISC::utf8_trim( diag.get_passwd() );
         if( ! id.empty() && ! passwd.empty() ) basicauth = id + ":" + passwd;
 
         if( name.empty() || url.empty() ){
@@ -2587,7 +2587,7 @@ void BBSListViewBase::replace_thread( const std::string& url, const std::string&
 
     const std::string urldat = DBTREE::url_dat( url );
     const std::string urlcgi = DBTREE::url_readcgi( url, 0, 0 );
-    const std::string name_old = MISC::remove_space( DBTREE::article_subject( urldat ) );
+    const std::string name_old = MISC::utf8_trim( DBTREE::article_subject( urldat ) );
 
     int type = TYPE_THREAD;
     const int status = DBTREE::article_status( urldat_new );
@@ -2661,7 +2661,7 @@ void BBSListViewBase::replace_thread( const std::string& url, const std::string&
 #ifdef _DEBUG
                         std::cout << "name_row = " << ustr_name << std::endl;
 #endif
-                        if( MISC::remove_space( ustr_name ) == name_old ){
+                        if( MISC::utf8_trim( ustr_name ) == name_old ){
 #ifdef _DEBUG
                             std::cout << "replace name\n";
 #endif

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -499,7 +499,7 @@ void Preferences::slot_ok_clicked()
     if( m_proxy_frame.rd_disable.get_active() ) mode = DBTREE::PROXY_DISABLE;
     else if( m_proxy_frame.rd_local.get_active() ) mode = DBTREE::PROXY_LOCAL;
     DBTREE::board_set_mode_local_proxy( get_url(), mode );
-    DBTREE::board_set_local_proxy( get_url(), MISC::remove_space( m_proxy_frame.entry_host.get_text() ) );
+    DBTREE::board_set_local_proxy( get_url(), MISC::utf8_trim( m_proxy_frame.entry_host.get_text() ) );
     DBTREE::board_set_local_proxy_port( get_url(), atoi( m_proxy_frame.entry_port.get_text().c_str() ) );
 
     mode = DBTREE::PROXY_GLOBAL;
@@ -507,7 +507,7 @@ void Preferences::slot_ok_clicked()
     else if( m_proxy_frame_w.rd_local.get_active() ) mode = DBTREE::PROXY_LOCAL;
 
     DBTREE::board_set_mode_local_proxy_w( get_url(), mode );
-    DBTREE::board_set_local_proxy_w( get_url(), MISC::remove_space( m_proxy_frame_w.entry_host.get_text() ) );
+    DBTREE::board_set_local_proxy_w( get_url(), MISC::utf8_trim( m_proxy_frame_w.entry_host.get_text() ) );
     DBTREE::board_set_local_proxy_port_w( get_url(), atoi( m_proxy_frame_w.entry_port.get_text().c_str() ) );
 
     // 書き込み設定

--- a/src/browserpref.h
+++ b/src/browserpref.h
@@ -28,7 +28,7 @@ namespace CORE
         void slot_ok_clicked() override
         {
             CONFIG::set_browsercombo_id( m_combo.get_active_row_number() );
-            CONFIG::set_command_openurl( MISC::remove_space( m_entry_browser.get_text() ) );
+            CONFIG::set_command_openurl( MISC::utf8_trim( m_entry_browser.get_text() ) );
         }
 
         // コンボボックスが変わった

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -97,7 +97,7 @@ bool ConfigItems::load( const bool restore )
     ref_prefix = cf.get_option_str( "ref_prefix", CONF_REF_PREFIX, 16 );
 
     // 参照文字( ref_prefix ) の後のスペースの数
-    // JDLIB::ConfLoader の中で MISC::remove_space() が呼ばれて空白が消えるので別設定とした
+    // JDLIB::ConfLoader の中で MISC::utf8_trim() が呼ばれて空白が消えるので別設定とした
     ref_prefix_space = cf.get_option_int( "ref_prefix_space", CONF_REF_PREFIX_SPACE, 0, 16 );
     for( int i = 0; i < ref_prefix_space; ++i ) ref_prefix_space_str += " ";
 

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -309,7 +309,7 @@ MouseKeyDiag::MouseKeyDiag( Gtk::Window* parent, const std::string& url,
     // キー設定をスペース毎に区切って行を作成
     std::list< std::string > list_motions = MISC::StringTokenizer( str_motions, ' ' );
     if( list_motions.size() ){
-        for( const std::string& motion : list_motions ) append_row( MISC::remove_space( motion ) );
+        for( const std::string& motion : list_motions ) append_row( MISC::utf8_trim( motion ) );
 
         // 先頭にカーソルセット
         Gtk::TreeModel::Children children = m_liststore->children();
@@ -470,7 +470,7 @@ void MouseKeyDiag::slot_reset()
     std::list< std::string > list_defaults;
     for( const std::string& raw_motion : list_motions ) {
 
-        std::string motion = MISC::remove_space( raw_motion );
+        std::string motion = MISC::utf8_trim( raw_motion );
 
         bool conflict = false;
         const std::vector< int > vec_ids = check_conflict( m_controlmode, motion );

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -3212,7 +3212,7 @@ void Core::exec_command()
     else if( command.command  == "open_url" ){
 
         // プロトコルが指定されていない場合
-        command.url = MISC::remove_space( command.url );
+        command.url = MISC::utf8_trim( command.url );
         if( command.url.rfind( "http://", 0 ) != 0
             && command.url.rfind( "https://", 0 ) != 0
             && command.url.rfind( "file://", 0 ) != 0

--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -741,7 +741,7 @@ bool Css_Manager::read_html()
             block = block.substr( pos );
         }
 
-        block = MISC::remove_space( MISC::tolower_str( block.substr( 1 ) ) );
+        block = MISC::utf8_trim( MISC::tolower_str( block.substr( 1 ) ) );
 
 #ifdef _DEBUG
         std::cout << "tag = " << block << std::endl;

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -311,7 +311,7 @@ void BoardBase::set_list_cookies( const std::list< std::string >& list_cookies )
     const std::string hostname = MISC::get_hostname( get_root(), false );
 
     for( const std::string& input : list_cookies ) {
-        cookie_manager->feed( hostname, MISC::remove_space( input ) );
+        cookie_manager->feed( hostname, MISC::utf8_trim( input ) );
     }
 
     update_hap();
@@ -1541,7 +1541,7 @@ bool BoardBase::is_abone_thread( ArticleBase* article )
     // スレあぼーん
     if( check_thread ){
         for( const std::string& subject : m_list_abone_thread ) {
-            if( MISC::remove_space( article->get_subject() ) == MISC::remove_space( subject ) ){
+            if( MISC::utf8_trim( article->get_subject() ) == MISC::utf8_trim( subject ) ){
 
                 // 対象スレがDat落ちした場合はあぼーんしなかったスレ名をリストから消去する
                 // remove_old_abone_thread() も参照

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -302,10 +302,10 @@ void BoardJBBS::parse_subject( const char* str_subject_txt )
         ARTICLE_INFO artinfo;
 
         artinfo.id.assign( str_id_dat, lng_id_dat );
-        artinfo.id = MISC::remove_space( artinfo.id );
+        artinfo.id = MISC::utf8_trim( artinfo.id );
 
         artinfo.subject.assign( str_subject, lng_subject );
-        artinfo.subject = MISC::remove_space( artinfo.subject );
+        artinfo.subject = MISC::utf8_trim( artinfo.subject );
         artinfo.subject = MISC::replace_str( artinfo.subject, "&lt;", "<" );
         artinfo.subject = MISC::replace_str( artinfo.subject, "&gt;", ">" );
 

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -262,10 +262,10 @@ void BoardMachi::parse_subject( const char* str_subject_txt )
         ARTICLE_INFO artinfo;
 
         artinfo.id.assign( str_id_dat, lng_id_dat );
-        artinfo.id = MISC::remove_space( artinfo.id );
+        artinfo.id = MISC::utf8_trim( artinfo.id );
 
         artinfo.subject.assign( str_subject, lng_subject );
-        artinfo.subject = MISC::remove_space( artinfo.subject );
+        artinfo.subject = MISC::utf8_trim( artinfo.subject );
         artinfo.subject = MISC::replace_str( artinfo.subject, "&lt;", "<" );
         artinfo.subject = MISC::replace_str( artinfo.subject, "&gt;", ">" );
 

--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -166,7 +166,7 @@ char* NodeTreeMachi::process_raw_lines( char* rawlines )
     std::list< std::string > lines = MISC::get_lines( rawlines );
     for( std::string& line : lines ) {
 
-        line = MISC::remove_space( line );
+        line = MISC::utf8_trim( line );
 
         if( m_tmp_buffer.empty() ){
 
@@ -252,7 +252,7 @@ const char* NodeTreeMachi::raw2dat( char* rawlines, int& byte )
     std::list< std::string > lines = MISC::get_lines( str_lines );
     for( std::string& line : lines ) {
 
-        line = MISC::remove_space( line );
+        line = MISC::utf8_trim( line );
         if( line.empty() ) continue;
 
         int num = 0;

--- a/src/jdlib/confloader.cpp
+++ b/src/jdlib/confloader.cpp
@@ -40,8 +40,8 @@ ConfLoader::ConfLoader( const std::string& file, std::string str_conf )
             const size_t i = line.find( '=' );
             if( i != std::string::npos ){
 
-                m_data.push_back({ MISC::remove_space( line.substr( 0, i ) ),
-                                   MISC::remove_space( line.substr( i + 1 ) ) });
+                m_data.push_back({ MISC::utf8_trim( line.substr( 0, i ) ),
+                                   MISC::utf8_trim( line.substr( i + 1 ) ) });
 #ifdef _DEBUG
                 const ConfData& data = m_data.back();
                 std::cout << data.name << " = " << data.value << std::endl;

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -54,7 +54,7 @@ std::list< std::string > MISC::get_elisp_lists( const std::string& str )
 #endif 
    
     std::list< std::string > lists;
-    std::string str2 = remove_space( str );
+    std::string str2 = utf8_trim( str );
     const char* data = str2.c_str();
     if( data[ 0 ] != '(' ) return lists;
 
@@ -202,7 +202,7 @@ std::list< std::string > MISC::remove_nullline_from_list( const std::list< std::
 {
     std::list< std::string > list_ret;
     for( const std::string& s : list_in ) {
-        std::string tmp_str = MISC::remove_space( s );
+        std::string tmp_str = MISC::utf8_trim( s );
         if( ! tmp_str.empty() ) list_ret.push_back( s );
     }
 
@@ -217,7 +217,7 @@ std::list< std::string > MISC::remove_space_from_list( const std::list< std::str
 {
     std::list< std::string > list_ret;
     for( const std::string& s : list_in ) {
-        std::string tmp_str = MISC::remove_space( s );
+        std::string tmp_str = MISC::utf8_trim( s );
         list_ret.push_back( std::move( tmp_str ) );
     }
 
@@ -234,7 +234,7 @@ std::list< std::string > MISC::remove_commentline_from_list( const std::list< st
 
     std::list< std::string > list_ret;
     for( const std::string& s : list_in ) {
-        std::string tmp_str = MISC::remove_space( s );
+        std::string tmp_str = MISC::utf8_trim( s );
         if( tmp_str[0] != commentchr ) list_ret.push_back( s );
     }
 
@@ -302,10 +302,12 @@ std::string MISC::concat_with_suffix( const std::list<std::string>& list_in, cha
 
 
 
-//
-// strの前後の空白削除
-//
-std::string MISC::remove_space( const std::string& str )
+/** @brief str前後の半角スペース(U+0020)と全角スペース(U+3000)を削除
+ *
+ * @param[in] str トリミングする文字列
+ * @return トリミングした結果
+ */
+std::string MISC::utf8_trim( const std::string& str )
 {
     constexpr const char* str_space = u8"\u3000"; // "\xE3\x80\x80" 全角スペース
     constexpr size_t lng_space = 3;
@@ -1833,16 +1835,16 @@ std::vector<MISC::FormDatum> MISC::parse_html_form_data( const std::string& html
         if( regex.match( pat, html, offset ) ) {
             const std::string name_value = MISC::tolower_str( regex.str( 3 ) );
             if( name_value.rfind( "name=", 0 ) == 0 ) {
-                name = MISC::remove_space( regex.str( 4 ) );
-                value = MISC::remove_space( regex.str( 5 ) );
+                name = MISC::utf8_trim( regex.str( 4 ) );
+                value = MISC::utf8_trim( regex.str( 5 ) );
             }
             else if( name_value.rfind( "value=", 0 ) == 0 ) {
-                name = MISC::remove_space( regex.str( 7 ) );
-                value = MISC::remove_space( regex.str( 6 ) );
+                name = MISC::utf8_trim( regex.str( 7 ) );
+                value = MISC::utf8_trim( regex.str( 6 ) );
             }
             else {
-                name = MISC::remove_space( regex.str( 8 ) );
-                value = MISC::remove_space( regex.str( 9 ) );
+                name = MISC::utf8_trim( regex.str( 8 ) );
+                value = MISC::utf8_trim( regex.str( 9 ) );
             }
         }
 

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -304,6 +304,7 @@ std::string MISC::concat_with_suffix( const std::list<std::string>& list_in, cha
 
 /** @brief str前後の半角スペース(U+0020)と全角スペース(U+3000)を削除
  *
+ * 半角スペースが含まれてないときはトリミングせずstrをそのまま返す。
  * @param[in] str トリミングする文字列
  * @return トリミングした結果
  */
@@ -315,6 +316,7 @@ std::string MISC::utf8_trim( const std::string& str )
     size_t lng = str.length();
     
     if( lng == 0 ) return str;
+    // TODO: 半角スペースがなくてもトリミングしたほうがよいか検証する
     if( str.find( ' ' ) == std::string::npos ) return str;
 
     // 前

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -73,8 +73,8 @@ namespace MISC
     // (例) {"aa", "", "bb", "cc"}, '!' -> "aa!bb!cc!"
     std::string concat_with_suffix( const std::list<std::string>& list_in, char suffix );
 
-    // strの前後の空白削除
-    std::string remove_space( const std::string& str );
+    /// str前後の半角スペース(U+0020)と全角スペース(U+3000)を削除
+    std::string utf8_trim( const std::string& str );
 
     /// str前後の改行(\r, \\n)、タブ(\t)、スペース(U+0020)を削除
     std::string ascii_trim( const std::string& str );

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -280,13 +280,13 @@ void Post::receive_finish()
     icase = true;
     newline = false; // . に改行をマッチさせる
     regex.exec( ".*<title>([^<]*)</title>.*", m_return_html, offset, icase, newline, usemigemo, wchar );
-    title = MISC::remove_space( regex.str( 1 ) );
+    title = MISC::utf8_trim( regex.str( 1 ) );
 
     // 2chタグ
     icase = false;
     newline = false; // . に改行をマッチさせる
     regex.exec( ".*2ch_X:([^\\-]*)\\-\\->.*", m_return_html, offset, icase, newline, usemigemo, wchar );
-    tag_2ch = MISC::remove_space( regex.str( 1 ) );
+    tag_2ch = MISC::utf8_trim( regex.str( 1 ) );
 
     // エラー内容を取得
 
@@ -353,7 +353,7 @@ void Post::receive_finish()
     icase = false;
     newline = true;
     regex.exec( ".*<font size=\\+1 color=#FF0000>([^<]*)</font>.*", m_return_html, offset, icase, newline, usemigemo, wchar );
-    conf = MISC::remove_space( regex.str( 1 ) );
+    conf = MISC::utf8_trim( regex.str( 1 ) );
 
     // メッセージ本文
 
@@ -365,7 +365,7 @@ void Post::receive_finish()
         regex.exec( ".*</ul>.*<b>(.*)</b>.*<input.*", m_return_html, offset, icase, newline, usemigemo, wchar );
     }
 
-    msg = MISC::remove_space( regex.str( 1 ) );
+    msg = MISC::utf8_trim( regex.str( 1 ) );
     const::std::list< std::string > list_cookies = SKELETON::Loadable::cookies();
 
 #ifdef _DEBUG

--- a/src/passwdpref.h
+++ b/src/passwdpref.h
@@ -97,12 +97,12 @@ namespace CORE
         void slot_ok_clicked() override
         {
             // 2ch
-            CORE::get_login2ch()->set_username( MISC::remove_space( m_frame_2ch.entry_id.get_text() ) );
-            CORE::get_login2ch()->set_passwd( MISC::remove_space( m_frame_2ch.entry_passwd.get_text() ) );
+            CORE::get_login2ch()->set_username( MISC::utf8_trim( m_frame_2ch.entry_id.get_text() ) );
+            CORE::get_login2ch()->set_passwd( MISC::utf8_trim( m_frame_2ch.entry_passwd.get_text() ) );
 
             // BE
-            CORE::get_loginbe()->set_username( MISC::remove_space( m_frame_be.entry_id.get_text() ) );
-            CORE::get_loginbe()->set_passwd( MISC::remove_space( m_frame_be.entry_passwd.get_text() ) );
+            CORE::get_loginbe()->set_username( MISC::utf8_trim( m_frame_be.entry_id.get_text() ) );
+            CORE::get_loginbe()->set_passwd( MISC::utf8_trim( m_frame_be.entry_passwd.get_text() ) );
         }
 
       public:

--- a/src/proxypref.h
+++ b/src/proxypref.h
@@ -73,19 +73,19 @@ namespace CORE
             // 2ch
             CONFIG::set_use_proxy_for2ch( m_frame_2ch.ckbt.get_active() );
             CONFIG::set_send_cookie_to_proxy_for2ch( m_frame_2ch.send_cookie_check.get_active() );
-            CONFIG::set_proxy_for2ch( MISC::remove_space( m_frame_2ch.entry_host.get_text() ) );
+            CONFIG::set_proxy_for2ch( MISC::utf8_trim( m_frame_2ch.entry_host.get_text() ) );
             CONFIG::set_proxy_port_for2ch( atoi( m_frame_2ch.entry_port.get_text().c_str() ) );
 
             // 2ch書き込み用
             CONFIG::set_use_proxy_for2ch_w( m_frame_2ch_w.ckbt.get_active() );
             CONFIG::set_send_cookie_to_proxy_for2ch_w( m_frame_2ch_w.send_cookie_check.get_active() );
-            CONFIG::set_proxy_for2ch_w( MISC::remove_space( m_frame_2ch_w.entry_host.get_text() ) );
+            CONFIG::set_proxy_for2ch_w( MISC::utf8_trim( m_frame_2ch_w.entry_host.get_text() ) );
             CONFIG::set_proxy_port_for2ch_w( atoi( m_frame_2ch_w.entry_port.get_text().c_str() ) );
 
             // 一般
             CONFIG::set_use_proxy_for_data( m_frame_data.ckbt.get_active() );
             CONFIG::set_send_cookie_to_proxy_for_data( m_frame_data.send_cookie_check.get_active() );
-            CONFIG::set_proxy_for_data( MISC::remove_space( m_frame_data.entry_host.get_text() ) );
+            CONFIG::set_proxy_for_data( MISC::utf8_trim( m_frame_data.entry_host.get_text() ) );
             CONFIG::set_proxy_port_for_data( atoi( m_frame_data.entry_port.get_text().c_str() ) );
         }
 

--- a/src/usrcmdmanager.cpp
+++ b/src/usrcmdmanager.cpp
@@ -112,7 +112,7 @@ void Usrcmd_Manager::analyze_xml()
 
 void Usrcmd_Manager::set_cmd( const std::string& cmd )
 {
-    std::string cmd2 = MISC::remove_space( cmd );
+    std::string cmd2 = MISC::utf8_trim( cmd );
     m_list_cmd.push_back( cmd2 );
 
 #ifdef _DEBUG
@@ -192,14 +192,14 @@ void Usrcmd_Manager::exec( const std::string& command, // コマンド
     if( cmd.rfind( "$VIEW", 0 ) == 0 ){
         use_browser = true;
         cmd = cmd.substr( 5 );
-        cmd = MISC::remove_space( cmd );
+        cmd = MISC::utf8_trim( cmd );
     }
 
     bool show_dialog = false;
     if( cmd.rfind( "$DIALOG", 0 ) == 0 ){
         show_dialog = true;
         cmd = cmd.substr( 7 );
-        cmd = MISC::remove_space( cmd );
+        cmd = MISC::utf8_trim( cmd );
     }
 
     cmd = replace_cmd( cmd, url, link, selection, number );

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -76,36 +76,36 @@ TEST_F(ConcatWithSuffixTest, ignore_empty_string)
 }
 
 
-class RemoveSpaceTest : public ::testing::Test {};
+class Utf8TrimTest : public ::testing::Test {};
 
-TEST_F(RemoveSpaceTest, remove_empty)
+TEST_F(Utf8TrimTest, remove_empty)
 {
     std::string expect = {};
-    EXPECT_EQ( expect, MISC::remove_space( u8"" ) );
+    EXPECT_EQ( expect, MISC::utf8_trim( "" ) );
 }
 
-TEST_F(RemoveSpaceTest, remove_U_0020)
+TEST_F(Utf8TrimTest, remove_U_0020)
 {
     std::string expect = {};
-    EXPECT_EQ( expect, MISC::remove_space( u8"    " ) );
+    EXPECT_EQ( expect, MISC::utf8_trim( "    " ) );
 
-    expect.assign( u8"the quick  brown   fox" );
-    EXPECT_EQ( expect, MISC::remove_space( u8" the quick  brown   fox  " ) );
+    expect.assign( "the quick  brown   fox" );
+    EXPECT_EQ( expect, MISC::utf8_trim( " the quick  brown   fox  " ) );
 }
 
-TEST_F(RemoveSpaceTest, remove_U_3000)
+TEST_F(Utf8TrimTest, remove_U_3000)
 {
     std::string expect = {};
-    EXPECT_EQ( expect, MISC::remove_space( u8"\u3000 \u3000 " ) );
+    EXPECT_EQ( expect, MISC::utf8_trim( "\u3000 \u3000 " ) );
 
-    expect.assign( u8"the quick\u3000brown\u3000 fox" );
-    EXPECT_EQ( expect, MISC::remove_space( u8"\u3000the quick\u3000brown\u3000 fox\u3000 " ) );
+    expect.assign( "the quick\u3000brown\u3000 fox" );
+    EXPECT_EQ( expect, MISC::utf8_trim( "\u3000the quick\u3000brown\u3000 fox\u3000 " ) );
 }
 
-TEST_F(RemoveSpaceTest, remove_doublequote)
+TEST_F(Utf8TrimTest, remove_doublequote)
 {
-    std::string expect = u8"\"\"";
-    EXPECT_EQ( expect, MISC::remove_space( u8"\u3000 \"\"\u3000 " ) );
+    std::string expect = "\"\"";
+    EXPECT_EQ( expect, MISC::utf8_trim( "\u3000 \"\"\u3000 " ) );
 }
 
 

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -93,13 +93,23 @@ TEST_F(Utf8TrimTest, remove_U_0020)
     EXPECT_EQ( expect, MISC::utf8_trim( " the quick  brown   fox  " ) );
 }
 
-TEST_F(Utf8TrimTest, remove_U_3000)
+TEST_F(Utf8TrimTest, remove_mixed_U_2000_U_3000)
 {
     std::string expect = {};
     EXPECT_EQ( expect, MISC::utf8_trim( "\u3000 \u3000 " ) );
 
     expect.assign( "the quick\u3000brown\u3000 fox" );
     EXPECT_EQ( expect, MISC::utf8_trim( "\u3000the quick\u3000brown\u3000 fox\u3000 " ) );
+}
+
+TEST_F(Utf8TrimTest, not_remove_U_3000_only)
+{
+    // 半角スペースが含まれてないときはU+3000が先頭末尾にあってもトリミングしない
+    std::string expect = "\u3000\u3000";
+    EXPECT_EQ( expect, MISC::utf8_trim( "\u3000\u3000" ) );
+
+    expect.assign( "\u3000the\u3000quick\u3000brown\u3000fox\u3000" );
+    EXPECT_EQ( expect, MISC::utf8_trim( expect ) );
 }
 
 TEST_F(Utf8TrimTest, remove_doublequote)


### PR DESCRIPTION
#### [Rename function MISC::remove_space() to MISC::utf8_trim()](https://github.com/JDimproved/JDim/commit/95ca1df9e4498a908310d4d0190e28f789ead83b)

以前変更した`MISC::ascii_trim()`[1]と同じく関数名を変更して何を行うのか分かりやすくします。

[1]: commit https://github.com/JDimproved/JDim/commit/62abdbfc55c9e1df8d92d862cfb33c33b8a01b90

#### [Add a test case MISC::utf8_trim()](https://github.com/JDimproved/JDim/commit/0da0f71e9cdfb778dde395c2bf5604f5574c58ae)

`utf8_trim()`は入力に半角スペース(U+0020)が含まれてないときはトリミングが実行されない挙動になっています。
この挙動が合っているかどうか検証を考えていますが今のところはコメントとテストケースを追加して補足しておきます。
