### PR TITLE
miscutil: Fix std::string construction from pointer

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1627,9 +1627,11 @@ std::string MISC::get_dir( const std::string& path )
 //
 std::string MISC::getenv_limited( const char *name, const size_t size )
 {
-    if( ! name || ! getenv( name ) ) return std::string();
+    if( ! name ) return {};
+    char* p = getenv( name );
+    if( ! p ) return {};
 
-    std::string env = getenv( name );
+    std::string env{ p };
     if( env.size() > size ) env.resize( size );
     return env;
 }


### PR DESCRIPTION
std::stringの構築でnullの可能性があるポインターを渡しているとscan-build(clang 14)に指摘されたためポインターのチェックを修正します。

scan-buildのレポート
```
[179/322] Compiling C++ object src/jdlib/libjdlib.a.p/miscutil.cpp.o
../../../src/jdlib/miscutil.cpp:1632:23: warning: The parameter must not be null [cplusplus.StringChecker]
    std::string env = getenv( name );
                      ^~~~~~~~~~~~~~
```