### PR TITLE
NodeTreeBase: Refactor convert_amp()

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -3665,21 +3665,9 @@ bool NodeTreeBase::remove_imenu( char* str_link )
 int NodeTreeBase::convert_amp( char* text, const int n )
 {
     int m = n;
-
-    int i;
-    for( i = 0; i < m; i++ ){
-
-        if( text[ i ] == '&' &&
-            m > (i + 4) &&
-            text[i + 1] == 'a' &&
-            text[i + 2] == 'm' &&
-            text[i + 3] == 'p' &&
-            text[i + 4] == ';' ){
-
-            // &の次, &amp;の次, &amp;の次からの長さ
-            memmove( text + i + 1, text + i + 5, n - i - 5 );
-
-            // "amp;"の分減らす
+    for( int i = 0; i < m; ++i ) {
+        if( std::strncmp( text + i, "&amp;", 5 ) == 0 ) {
+            std::memmove( text + i + 1, text + i + 5, n - i - 5 );
             m -= 4;
         }
     }

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -398,6 +398,7 @@ namespace DBTREE
         // http://ime.nu/ などをリンクから削除
         static bool remove_imenu( char* str_link );
 
+      public:
         // 文字列中の"&amp;"を"&"に変換する
         static int convert_amp( char* text, const int n );
     };

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -108,6 +108,7 @@ gtest_jdim_LDADD = \
 # テストコードのファイルを追加したらここにリストします
 # 行末のバックスラッシュに注意
 gtest_jdim_SOURCES = \
+	gtest_dbtree_nodetreebase.cpp \
 	gtest_jdlib_cookiemanager.cpp \
 	gtest_jdlib_jdiconv.cpp \
 	gtest_jdlib_jdregex.cpp \

--- a/test/gtest_dbtree_nodetreebase.cpp
+++ b/test/gtest_dbtree_nodetreebase.cpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "dbtree/nodetreebase.h"
+
+#include "gtest/gtest.h"
+
+#include <cstring>
+
+
+namespace {
+
+class NodeTreeBase_ConvertAmpTest : public ::testing::Test {};
+
+TEST_F(NodeTreeBase_ConvertAmpTest, empty_string)
+{
+    char buffer[] = "";
+    EXPECT_EQ( 0, DBTREE::NodeTreeBase::convert_amp( buffer, std::strlen( buffer ) ) );
+    EXPECT_STREQ( "", buffer );
+}
+
+TEST_F(NodeTreeBase_ConvertAmpTest, no_amp)
+{
+    char buffer[] = "hello world!";
+    EXPECT_EQ( 12, DBTREE::NodeTreeBase::convert_amp( buffer, std::strlen( buffer ) ) );
+    EXPECT_STREQ( "hello world!", buffer );
+}
+
+TEST_F(NodeTreeBase_ConvertAmpTest, missing_ampersand)
+{
+    char buffer[] = "helloamp;world!";
+    EXPECT_EQ( 15, DBTREE::NodeTreeBase::convert_amp( buffer, std::strlen( buffer ) ) );
+    EXPECT_STREQ( "helloamp;world!", buffer );
+}
+
+TEST_F(NodeTreeBase_ConvertAmpTest, missing_semicolon)
+{
+    char buffer[] = "hello&ampworld!";
+    EXPECT_EQ( 15, DBTREE::NodeTreeBase::convert_amp( buffer, std::strlen( buffer ) ) );
+    EXPECT_STREQ( "hello&ampworld!", buffer );
+}
+
+TEST_F(NodeTreeBase_ConvertAmpTest, one_amp)
+{
+    char buffer[] = "hello&amp;world!";
+    EXPECT_EQ( 12, DBTREE::NodeTreeBase::convert_amp( buffer, std::strlen( buffer ) ) );
+    EXPECT_STREQ( "hello&world!", buffer );
+}
+
+TEST_F(NodeTreeBase_ConvertAmpTest, multi_amp)
+{
+    char buffer[] = "&amp;hello&amp;world&amp;";
+    EXPECT_EQ( 13, DBTREE::NodeTreeBase::convert_amp( buffer, std::strlen( buffer ) ) );
+    EXPECT_STREQ( "&hello&world&", buffer );
+}
+
+TEST_F(NodeTreeBase_ConvertAmpTest, amp_amp)
+{
+    char buffer[] = "&amp;amp; &amp;&amp;";
+    EXPECT_EQ( 8, DBTREE::NodeTreeBase::convert_amp( buffer, std::strlen( buffer ) ) );
+    EXPECT_STREQ( "&amp; &&", buffer );
+}
+
+TEST_F(NodeTreeBase_ConvertAmpTest, include_nul)
+{
+    char buffer[] = "hello&amp;\0&amp;world!";
+    EXPECT_EQ( 14, DBTREE::NodeTreeBase::convert_amp( buffer, 22 ) );
+    EXPECT_STREQ( "hello&\0&world!", buffer );
+}
+
+} // namespace

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,5 +1,6 @@
 # Add test code source files to following list.
 sources = [
+  'gtest_dbtree_nodetreebase.cpp',
   'gtest_jdlib_cookiemanager.cpp',
   'gtest_jdlib_jdiconv.cpp',
   'gtest_jdlib_jdregex.cpp',


### PR DESCRIPTION
#### [Add test cases for NodeTreeBase::convert_amp()](https://github.com/JDimproved/JDim/commit/fcecbd55002e7364f8d3e76dea252bc7cf23a5f7)

テストコードで呼び出すため関数をpublicにします。

#### [NodeTreeBase: Refactor convert_amp()](https://github.com/JDimproved/JDim/commit/5df142162bfe78d86e5842d6cc202ed725f83c53)

比較演算の左辺値がgarbage valueであるとscan-build(llvm-14)に指摘されたためチェックを変更します。(偽陽性?)

scan-buildのレポート
```
[189/323] Compiling C++ object src/dbtree/libdbtree.a.p/nodetreebase.cpp.o
(snip)
../../../src/dbtree/nodetreebase.cpp:3672:23: warning: The left operand of '==' is a garbage value [core.UndefinedBinaryOperatorResult]
        if( text[ i ] == '&' &&
            ~~~~~~~~~ ^
```
