### PR TITLE
NodeTreeBase: Improve remove_imenu()

### DIFF
--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -394,11 +394,10 @@ namespace DBTREE
         // number番のレスのフォント判定を更新
         void check_fontid( const int number );
 
-
+      public:
         // http://ime.nu/ などをリンクから削除
         static bool remove_imenu( char* str_link );
 
-      public:
         // 文字列中の"&amp;"を"&"に変換する
         static int convert_amp( char* text, const int n );
     };

--- a/test/gtest_dbtree_nodetreebase.cpp
+++ b/test/gtest_dbtree_nodetreebase.cpp
@@ -45,6 +45,7 @@ TEST_F(NodeTreeBase_RemoveImenuTest, single_ime_nu)
     constexpr const char* test_data[][2] = {
         { "http://ime.nu/foobar.baz", "http://foobar.baz" },
         { "https://ime.nu/foobar.baz", "https://foobar.baz" },
+        { "https://ime.nu/http://foobar.baz", "http://foobar.baz" },
     };
 
     char buffer[128];
@@ -60,6 +61,7 @@ TEST_F(NodeTreeBase_RemoveImenuTest, single_ime_st)
     constexpr const char* test_data[][2] = {
         { "http://ime.st/foobar.baz", "http://foobar.baz" },
         { "https://ime.st/foobar.baz", "https://foobar.baz" },
+        { "http://ime.nu/https://foobar.baz", "https://foobar.baz" },
     };
 
     char buffer[128];
@@ -75,6 +77,7 @@ TEST_F(NodeTreeBase_RemoveImenuTest, single_nun_nu)
     constexpr const char* test_data[][2] = {
         { "http://nun.nu/foobar.baz", "http://foobar.baz" },
         { "https://nun.nu/foobar.baz", "https://foobar.baz" },
+        { "https://nun.nu/http://foobar.baz", "http://foobar.baz" },
     };
 
     char buffer[128];
@@ -90,6 +93,39 @@ TEST_F(NodeTreeBase_RemoveImenuTest, single_pinktower_com)
     constexpr const char* test_data[][2] = {
         { "http://pinktower.com/foobar.baz", "http://foobar.baz" },
         { "https://pinktower.com/foobar.baz", "https://foobar.baz" },
+        { "http://pinktower.com/https://foobar.baz", "https://foobar.baz" },
+    };
+
+    char buffer[128];
+    for( auto [input, expect] : test_data ) {
+        std::strcpy( buffer, input );
+        EXPECT_TRUE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
+        EXPECT_STREQ( expect, buffer );
+    }
+}
+
+TEST_F(NodeTreeBase_RemoveImenuTest, single_jump_5ch_net)
+{
+    constexpr const char* test_data[][2] = {
+        { "http://jump.5ch.net/?http://foobar.baz", "http://foobar.baz" },
+        { "https://jump.5ch.net/?https://foobar.baz", "https://foobar.baz" },
+        { "http://jump.5ch.net/?https://foobar.baz", "https://foobar.baz" },
+    };
+
+    char buffer[128];
+    for( auto [input, expect] : test_data ) {
+        std::strcpy( buffer, input );
+        EXPECT_TRUE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
+        EXPECT_STREQ( expect, buffer );
+    }
+}
+
+TEST_F(NodeTreeBase_RemoveImenuTest, single_jump_2ch_net)
+{
+    constexpr const char* test_data[][2] = {
+        { "http://jump.2ch.net/?http://foobar.baz", "http://foobar.baz" },
+        { "https://jump.2ch.net/?https://foobar.baz", "https://foobar.baz" },
+        { "http://jump.2ch.net/?https://foobar.baz", "https://foobar.baz" },
     };
 
     char buffer[128];

--- a/test/gtest_dbtree_nodetreebase.cpp
+++ b/test/gtest_dbtree_nodetreebase.cpp
@@ -9,6 +9,98 @@
 
 namespace {
 
+class NodeTreeBase_RemoveImenuTest : public ::testing::Test {};
+
+TEST_F(NodeTreeBase_RemoveImenuTest, empty_string)
+{
+    char inout[] = "";
+    EXPECT_FALSE( DBTREE::NodeTreeBase::remove_imenu( inout ) );
+    EXPECT_STREQ( "", inout );
+}
+
+TEST_F(NodeTreeBase_RemoveImenuTest, not_remove)
+{
+    constexpr const char* test_data[][2] = {
+        { "ftp://ime.nu/foobar.baz", "ftp://ime.nu/foobar.baz" },
+        { "http://example.test/foobar.baz", "http://example.test/foobar.baz" },
+
+        { "https://ime.nu/", "https://ime.nu/" },
+        { "https://ime.st/", "https://ime.st/" },
+        { "https://nun.nu/", "https://nun.nu/" },
+        { "https://jump.5ch.net/?", "https://jump.5ch.net/?" },
+        { "https://jump.2ch.net/?", "https://jump.2ch.net/?" },
+        { "https://pinktower.com/", "https://pinktower.com/" },
+    };
+
+    char buffer[128];
+    for( auto [input, expect] : test_data ) {
+        std::strcpy( buffer, input );
+        EXPECT_FALSE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
+        EXPECT_STREQ( expect, buffer );
+    }
+}
+
+TEST_F(NodeTreeBase_RemoveImenuTest, single_ime_nu)
+{
+    constexpr const char* test_data[][2] = {
+        { "http://ime.nu/foobar.baz", "http://foobar.baz" },
+        { "https://ime.nu/foobar.baz", "https://foobar.baz" },
+    };
+
+    char buffer[128];
+    for( auto [input, expect] : test_data ) {
+        std::strcpy( buffer, input );
+        EXPECT_TRUE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
+        EXPECT_STREQ( expect, buffer );
+    }
+}
+
+TEST_F(NodeTreeBase_RemoveImenuTest, single_ime_st)
+{
+    constexpr const char* test_data[][2] = {
+        { "http://ime.st/foobar.baz", "http://foobar.baz" },
+        { "https://ime.st/foobar.baz", "https://foobar.baz" },
+    };
+
+    char buffer[128];
+    for( auto [input, expect] : test_data ) {
+        std::strcpy( buffer, input );
+        EXPECT_TRUE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
+        EXPECT_STREQ( expect, buffer );
+    }
+}
+
+TEST_F(NodeTreeBase_RemoveImenuTest, single_nun_nu)
+{
+    constexpr const char* test_data[][2] = {
+        { "http://nun.nu/foobar.baz", "http://foobar.baz" },
+        { "https://nun.nu/foobar.baz", "https://foobar.baz" },
+    };
+
+    char buffer[128];
+    for( auto [input, expect] : test_data ) {
+        std::strcpy( buffer, input );
+        EXPECT_TRUE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
+        EXPECT_STREQ( expect, buffer );
+    }
+}
+
+TEST_F(NodeTreeBase_RemoveImenuTest, single_pinktower_com)
+{
+    constexpr const char* test_data[][2] = {
+        { "http://pinktower.com/foobar.baz", "http://foobar.baz" },
+        { "https://pinktower.com/foobar.baz", "https://foobar.baz" },
+    };
+
+    char buffer[128];
+    for( auto [input, expect] : test_data ) {
+        std::strcpy( buffer, input );
+        EXPECT_TRUE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
+        EXPECT_STREQ( expect, buffer );
+    }
+}
+
+
 class NodeTreeBase_ConvertAmpTest : public ::testing::Test {};
 
 TEST_F(NodeTreeBase_ConvertAmpTest, empty_string)


### PR DESCRIPTION
#### [NodeTreeBase: Add test cases for remove_imenu()](https://github.com/JDimproved/JDim/commit/0c76569cef154789a413356b75fa7e1c4f29b969)

テストコードで呼び出すため関数をpublicにします。

#### [NodeTreeBase: Improve remove_imenu()](https://github.com/JDimproved/JDim/commit/e69887878f22f2139b325d701bf3fa8253ed367b)

機能の改善
* URLが http[s]://jump.[25]ch.net/? で始まるときも削除するように変更します。
* 削除した残りにURLスキームが含まれているときは使います。

比較演算の左辺値がgarbage valueであるとscan-build(llvm-14)に指摘されたためチェックを変更します。

scan-buildのレポート
```
[187/322] Compiling C++ object src/dbtree/libdbtree.a.p/nodetreebase.cpp.o
../../../src/dbtree/nodetreebase.cpp:3643:13: warning: The left operand of '==' is a garbage value [core.UndefinedBinaryOperatorResult]
    if ( *p == 's' ) p++;
         ~~ ^
../../../src/dbtree/nodetreebase.cpp:3653:28: warning: The left operand of '==' is a garbage value [core.UndefinedBinaryOperatorResult]
            if ( p[cs_len] == '\0' ) return false;
                 ~~~~~~~~~ ^
```

#### [Add test cases for NodeTreeBase::remove_imenu() part2](https://github.com/JDimproved/JDim/commit/304970009503cde4f7923ebabaa7322425834e5e)

新規機能のテストケースを追加します。