### PR TITLE
Board2ch: Change return value of get_unicode() to empty string

### DIFF
--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -274,6 +274,18 @@ std::string Board2ch::url_subbbscgi_new() const
 }
 
 
+/** @brief SETTING.TXT の項目 BBS_UNICODE の値を返す
+ *
+ * @remarks 2022-04-30 以降、5chでは BBS_UNICODE が無効になったため
+ * 設定値に関係なく空文字列を返すように変更する
+ */
+std::string Board2ch::get_unicode() const
+{
+    // XXX: "pass" のほうが適切な値か？
+    return {};
+}
+
+
 
 //
 // 新しくArticleBaseクラスを追加してそのポインタを返す

--- a/src/dbtree/board2ch.h
+++ b/src/dbtree/board2ch.h
@@ -69,6 +69,9 @@ namespace DBTREE
         // datの最大サイズ(Kバイト)
         int get_max_dat_lng() const override { return DEFAULT_MAX_DAT_LNG; }
 
+        // SETTING.TXT
+        std::string get_unicode() const override;
+
       protected:
 
         // クッキー


### PR DESCRIPTION
2022-04-30 以降、5chでは SETTING.TXT の項目[`BBS_UNICODE`が無効][1]になったため設定値に関係なく空文字列を返すように変更します。
5chに書き込むときUnicodeモードの表示や動作がoffになります。

#### 要検証
"pass" を返すほうが適切な値か？

[1]: https://agree.5ch.net/test/read.cgi/operate/1642399917/922