### PR TITLE
Update misc html escape

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -837,12 +837,13 @@ std::string MISC::regex_unescape( const std::string& str )
 }
 
 
-//
-// HTMLエスケープ
-//
-// include_url : URL中でもエスケープする( デフォルト = true )
-//
-std::string MISC::html_escape( const std::string& str, const bool include_url )
+/** @brief HTMLで特別な意味を持つ記号(& " < >)を文字実体参照へエスケープする
+ *
+ * @param[in] str        エスケープする入力
+ * @param[in] completely URL中でもエスケープする( デフォルト = true )
+ * @return エスケープした結果
+ */
+std::string MISC::html_escape( const std::string& str, const bool completely )
 {
     if( str.empty() ) return str;
 
@@ -856,7 +857,7 @@ std::string MISC::html_escape( const std::string& str, const bool include_url )
         char tmpchar = str.c_str()[ pos ];
 
         // URL中はエスケープしない場合
-        if( ! include_url )
+        if( ! completely )
         {
             // URLとして扱うかどうか
             // エスケープには影響がないので loose_url としておく
@@ -875,17 +876,9 @@ std::string MISC::html_escape( const std::string& str, const bool include_url )
             }
         }
 
-        // include_url = false でURL中ならエスケープしない
+        // completely = false でURL中ならエスケープしない
         if( is_url ) str_out += tmpchar;
-        else if( tmpchar == '&' )
-        {
-            const int bufsize = 64;
-            char out_char[ bufsize ];
-            int n_in, n_out;
-            const int type = DBTREE::decode_char( str.c_str() + pos, n_in, out_char, n_out, false );
-            if( type == DBTREE::NODE_NONE ) str_out += "&amp;";
-            else str_out += tmpchar;
-        }
+        else if( tmpchar == '&' ) str_out += "&amp;";
         else if( tmpchar == '\"' ) str_out += "&quot;";
         else if( tmpchar == '<' ) str_out += "&lt;";
         else if( tmpchar == '>' ) str_out += "&gt;";

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -138,9 +138,9 @@ namespace MISC
     // 正規表現のメタ文字をアンエスケープ
     std::string regex_unescape( const std::string& str );
 
-    // HTMLエスケープ
-    // include_url : URL中でもエスケープする( デフォルト = true )
-    std::string html_escape( const std::string& str, const bool include_url = true );
+    // HTMLで特別な意味を持つ記号(& " < >)を文字実体参照へエスケープする
+    // completely : URL中でもエスケープする( デフォルト = true )
+    std::string html_escape( const std::string& str, const bool completely = true );
 
     // HTMLアンエスケープ
     std::string html_unescape( const std::string& str );

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -880,8 +880,14 @@ void MessageViewBase::slot_switch_page( Gtk::Widget*, guint page )
         // URLを除外してエスケープ
         const bool include_url = false;
         std::string msg;
-        if( m_text_message ) msg = MISC::html_escape( m_text_message->get_text(), include_url );
-        msg = MISC::replace_str( msg, "\n", " <br> " );
+        if( m_text_message ) {
+            msg = m_text_message->get_text();
+
+            constexpr bool completely = true;
+            msg = MISC::chref_decode( msg, completely );
+            msg = MISC::html_escape( msg, include_url );
+            msg = MISC::replace_str( msg, "\n", " <br> " );
+        }
 
         std::stringstream ss;
 

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -329,6 +329,53 @@ TEST_F(ReplaceNewlinesToStrTest, replace_crlf)
 }
 
 
+class HtmlEscapeTest : public ::testing::Test {};
+
+TEST_F(HtmlEscapeTest, empty_data)
+{
+    EXPECT_EQ( "", MISC::html_escape( "", false ) );
+    EXPECT_EQ( "", MISC::html_escape( "", true ) );
+}
+
+TEST_F(HtmlEscapeTest, not_escape)
+{
+    EXPECT_EQ( "hello world", MISC::html_escape( "hello world", false ) );
+    EXPECT_EQ( "hello world", MISC::html_escape( "hello world", true ) );
+}
+
+TEST_F(HtmlEscapeTest, escape_amp)
+{
+    EXPECT_EQ( "hello&amp;world", MISC::html_escape( "hello&world", false ) );
+    EXPECT_EQ( "hello&amp;world", MISC::html_escape( "hello&world", true ) );
+}
+
+TEST_F(HtmlEscapeTest, escape_quot)
+{
+    EXPECT_EQ( "hello&quot;world", MISC::html_escape( "hello\"world", false ) );
+    EXPECT_EQ( "hello&quot;world", MISC::html_escape( "hello\"world", true ) );
+}
+
+TEST_F(HtmlEscapeTest, escape_lt)
+{
+    EXPECT_EQ( "hello&lt;world", MISC::html_escape( "hello<world", false ) );
+    EXPECT_EQ( "hello&lt;world", MISC::html_escape( "hello<world", true ) );
+}
+
+TEST_F(HtmlEscapeTest, escape_gt)
+{
+    EXPECT_EQ( "hello&gt;world", MISC::html_escape( "hello>world", false ) );
+    EXPECT_EQ( "hello&gt;world", MISC::html_escape( "hello>world", true ) );
+}
+
+TEST_F(HtmlEscapeTest, completely)
+{
+    // URLを含むテキスト
+    const std::string input = "& https://foobar.test/?a=b&c=d& &";
+    EXPECT_EQ( "&amp; https://foobar.test/?a=b&amp;c=d&amp; &amp;", MISC::html_escape( input, true ) );
+    EXPECT_EQ( "&amp; https://foobar.test/?a=b&c=d& &amp;", MISC::html_escape( input, false ) );
+}
+
+
 class IsUrlSchemeTest : public ::testing::Test {};
 
 TEST_F(IsUrlSchemeTest, url_none)


### PR DESCRIPTION
#### [Add test cases for MISC::html_escape()](https://github.com/JDimproved/JDim/commit/512a86c68333e5668b2b121d0d1cb32a8ef0593e)

#### [Update MISC::html_escape()](https://github.com/JDimproved/JDim/commit/82261744811678cc64e3b3a6a60adee6b8098ee4)

`MISC::html_escape()`の挙動を変更してHTMLで特別な意味を持つ記号(& " < >) *のみ* を文字実体参照へエスケープします。

また、これまでの挙動に依存しているコードは動作が変わらないように修正します。

関連のissue: #76 
