### PR TITLE
article: Escape board name for extraction view

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -1618,7 +1618,7 @@ void ArticleViewBase::show_res( const std::string& num, const bool show_title )
 
         std::string html;
         std::string tmpstr = DBTREE::board_name( m_url_article );
-        if( ! tmpstr.empty() ) html += "[ " + tmpstr + " ] ";
+        if( ! tmpstr.empty() ) html += "[ " + MISC::html_escape( tmpstr ) + " ] ";
 
         tmpstr = DBTREE::article_subject( m_url_article );
         if( ! tmpstr.empty() ) html += tmpstr;

--- a/src/article/articleviewsearch.cpp
+++ b/src/article/articleviewsearch.cpp
@@ -257,7 +257,7 @@ void ArticleViewSearch::relayout()
     if( m_searchmode == CORE::SEARCHMODE_ALLLOG ) comment <<  "検索対象：キャッシュ内の全ログ<br>";
     else if( m_searchmode == CORE::SEARCHMODE_TITLE ) comment << "検索サイト : "
                                                 + MISC::get_hostname( CONFIG::get_url_search_title() ) + "<br>";
-    else comment <<  "検索対象：" << DBTREE::board_name( m_url_board ) << "<br>";
+    else comment <<  "検索対象：" << MISC::html_escape( DBTREE::board_name( m_url_board ) ) << "<br>";
 
     if( get_bm() ) comment << "検索条件：しおり<br>";
 
@@ -284,11 +284,11 @@ void ArticleViewSearch::relayout()
 
                 // 板名表示
                 if( m_searchmode == CORE::SEARCHMODE_ALLLOG || m_searchmode == CORE::SEARCHMODE_TITLE  ) {
-                    comment << "[ <a href=\"" << DBTREE::url_boardbase( data.url_readcgi ) << "\">" << data.boardname
-                            << "</a> ] ";
+                    comment << "[ <a href=\"" << DBTREE::url_boardbase( data.url_readcgi ) << "\">"
+                            << MISC::html_escape( data.boardname ) << "</a> ] ";
                 }
 
-                comment << "<a href=\"" << data.url_readcgi << "\">" << MISC::html_escape( data.subject ) << "</a>";
+                comment << "<a href=\"" << data.url_readcgi << "\">" << data.subject << "</a>";
 
                 if( data.num ) comment << " ( " << data.num << " )";
 


### PR DESCRIPTION
抽出ビューやログ検索ビューで表示する板名に対してHTMLの特殊文字をエスケープするように修正します。

関連のissue: #76 
