### PR TITLE
Update MISC::html_unescape()

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -896,29 +896,33 @@ std::string MISC::html_escape( const std::string& str, const bool completely )
 }
 
 
-//
-// HTMLアンエスケープ
-//
+/** @brief HTMLで特別な意味を持つ記号の文字実体参照(\&quot; \&amp; \&lt; \&gt;)をアンエスケープする
+ *
+ * @param[in] str アンエスケープする入力
+ * @return アンエスケープした結果
+ */
 std::string MISC::html_unescape( const std::string& str )
 {
     if( str.empty() ) return str;
     if( str.find( '&' ) == std::string::npos ) return str;
 
     std::string str_out;
-    const size_t str_length = str.length();
+    str_out.reserve( str.size() );
+    const char* pos = str.c_str();
+    const char* pos_end = pos + str.size();
 
-    for( size_t pos = 0; pos < str_length; ++pos ){
+    while( pos < pos_end ){
 
-        const int bufsize = 64;
-        char out_char[ bufsize ];
-        int n_in, n_out;
-        DBTREE::decode_char( str.c_str() + pos, n_in, out_char, n_out, false );
+        // '&' までコピーする
+        while( *pos != '&' && *pos != '\0' ) str_out.push_back( *pos++ );
+        if( pos >= pos_end ) break;
 
-        if( n_out ){
-            str_out += out_char;
-            pos += n_in -1;
-        }
-        else str_out += str.c_str()[ pos ];
+        // エスケープ用の文字参照をデコード
+        if( std::strncmp( pos, "&quot;", 6 ) == 0 ){ str_out.push_back( '"' ); pos += 6; }
+        else if( std::strncmp( pos, "&amp;", 5 ) == 0 ){ str_out.push_back( '&' ); pos += 5; }
+        else if( std::strncmp( pos, "&lt;", 4 ) == 0 ){ str_out.push_back( '<' ); pos += 4; }
+        else if( std::strncmp( pos, "&gt;", 4 ) == 0 ){ str_out.push_back( '>' ); pos += 4; }
+        else str_out.push_back( *pos++ );
     }
 
 #ifdef _DEBUG

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -142,7 +142,7 @@ namespace MISC
     // completely : URL中でもエスケープする( デフォルト = true )
     std::string html_escape( const std::string& str, const bool completely = true );
 
-    // HTMLアンエスケープ
+    // HTMLで特別な意味を持つ記号の文字実体参照(&quot; &amp; &lt; &gt;)をアンエスケープする
     std::string html_unescape( const std::string& str );
 
     // HTML文字参照をデコード( completely=trueの場合は '&' '<' '>' '"' を含める )

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -376,6 +376,53 @@ TEST_F(HtmlEscapeTest, completely)
 }
 
 
+class HtmlUnescapeTest : public ::testing::Test {};
+
+TEST_F(HtmlUnescapeTest, empty_data)
+{
+    EXPECT_EQ( "", MISC::html_unescape( "" ) );
+    EXPECT_EQ( "", MISC::html_unescape( "" ) );
+}
+
+TEST_F(HtmlUnescapeTest, not_escape)
+{
+    EXPECT_EQ( "quick brown fox", MISC::html_unescape( "quick brown fox" ) );
+    EXPECT_EQ( "quick brown fox", MISC::html_unescape( "quick brown fox" ) );
+}
+
+TEST_F(HtmlUnescapeTest, escape_amp)
+{
+    EXPECT_EQ( "quick&brown&fox", MISC::html_unescape( "quick&amp;brown&amp;fox" ) );
+}
+
+TEST_F(HtmlUnescapeTest, escape_quot)
+{
+    EXPECT_EQ( "quick\"brown\"fox", MISC::html_unescape( "quick&quot;brown&quot;fox" ) );
+}
+
+TEST_F(HtmlUnescapeTest, escape_lt)
+{
+    EXPECT_EQ( "quick<brown<fox", MISC::html_unescape( "quick&lt;brown&lt;fox" ) );
+}
+
+TEST_F(HtmlUnescapeTest, escape_gt)
+{
+    EXPECT_EQ( "quick>brown>fox", MISC::html_unescape( "quick&gt;brown&gt;fox" ) );
+}
+
+TEST_F(HtmlUnescapeTest, DISABLED_numeric_char_reference)
+{
+    EXPECT_EQ( "quick&#123;brown&#234;fox", MISC::html_unescape( "quick&#123;brown&#234;fox" ) );
+    EXPECT_EQ( "quick&#xabcd;brown&#xEF01;fox", MISC::html_unescape( "quick&#xabcd;brown&#xEF01;fox" ) );
+}
+
+TEST_F(HtmlUnescapeTest, DISABLED_named_char_reference)
+{
+    EXPECT_EQ( "quick&auml;brown&Uuml;fox", MISC::html_unescape( "quick&auml;brown&Uuml;fox" ) );
+    EXPECT_EQ( "quick&Rarr;brown&dArr;fox", MISC::html_unescape( "quick&Rarr;brown&dArr;fox" ) );
+}
+
+
 class IsUrlSchemeTest : public ::testing::Test {};
 
 TEST_F(IsUrlSchemeTest, url_none)

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -410,13 +410,13 @@ TEST_F(HtmlUnescapeTest, escape_gt)
     EXPECT_EQ( "quick>brown>fox", MISC::html_unescape( "quick&gt;brown&gt;fox" ) );
 }
 
-TEST_F(HtmlUnescapeTest, DISABLED_numeric_char_reference)
+TEST_F(HtmlUnescapeTest, numeric_char_reference)
 {
     EXPECT_EQ( "quick&#123;brown&#234;fox", MISC::html_unescape( "quick&#123;brown&#234;fox" ) );
     EXPECT_EQ( "quick&#xabcd;brown&#xEF01;fox", MISC::html_unescape( "quick&#xabcd;brown&#xEF01;fox" ) );
 }
 
-TEST_F(HtmlUnescapeTest, DISABLED_named_char_reference)
+TEST_F(HtmlUnescapeTest, named_char_reference)
 {
     EXPECT_EQ( "quick&auml;brown&Uuml;fox", MISC::html_unescape( "quick&auml;brown&Uuml;fox" ) );
     EXPECT_EQ( "quick&Rarr;brown&dArr;fox", MISC::html_unescape( "quick&Rarr;brown&dArr;fox" ) );


### PR DESCRIPTION
#### [Add test cases for MISC::html_unescape()](https://github.com/JDimproved/JDim/commit/8882feadf991db60f3ac7e67215a263f95f4461c)

#### [Update MISC::html_unescape()](https://github.com/JDimproved/JDim/commit/9ed53a90450d37bd4bf4d641776a256439cb71f1)

`MISC::html_unescape()`の挙動を変更してHTMLで特別な意味を持つ記号の文字実体参照(\&quot; \&amp; \&lt; \&gt;) *のみ* をアンエスケープします。

関連のissue: #76 