### PR TITLE
LayoutTree: Show HTAB as single space if not multispace mode

### DIFF
--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -438,7 +438,8 @@ void LayoutTree::append_block( DBTREE::NODE* block, const int res_number, IMGDAT
                 break;
 
             case DBTREE::NODE_HTAB: // 水平タブ
-                tmplayout = create_layout_hspace( tmpnode->type );
+                if( m_show_multispace ) tmplayout = create_layout_hspace( tmpnode->type );
+                else tmplayout = create_layout_text( " ", &tmpnode->color_text, tmpnode->bold );
                 break;
         }
 


### PR DESCRIPTION
連続半角スペースを表示しない設定のときは水平タブ(U+0009)を空白(U+0020)として表示します。

関連のissue: #76 
