### PR TITLE
Post: Update error message extraction to support samba24

### DIFF
--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -336,10 +336,9 @@ void Post::receive_finish()
         newline = false; // . に改行をマッチさせる
         // Smaba24規制の場合
         //   ＥＲＲＯＲ - 593 60 sec たたないと書けません。(1回目、8 sec しかたってない)
-        // 忍法帖規制の場合 ( samba秒だけ取得する。 )
-        //   ＥＲＲＯＲ：修行が足りません(Lv=2)。しばらくたってから投稿してください。(48 sec)
-        //   この板のsambaは samba=30 sec
-        if( regex.exec( "ＥＲＲＯＲ( +- +593 +|：.+samba=)([0-9]+) +sec", m_errmsg, offset, icase, newline, usemigemo, wchar ) ){
+        //   ERROR: Samba24:Caution 25 秒たたないと書けません。(1 回目、24 秒しかたってない)
+        if( regex.exec( "(ＥＲＲＯＲ +- +593|ERROR: +Samba24:Caution|) +([0-9]+) +",
+                        m_errmsg, offset, icase, newline, usemigemo, wchar ) ) {
             time_t sec = atoi( regex.str( 2 ).c_str() );
 #ifdef _DEBUG
             std::cout << "samba = " << sec << std::endl;


### PR DESCRIPTION
投稿失敗のエラーメッセージ抽出を更新してSamba24の秒数を取得するパターンを変更します。
5chではSamba24は[既に廃止][1]されていますがぜろちゃんねるプラスを利用する掲示板などで導入されています。

https://info.5ch.net/?curid=1247#.E9.80.A3.E7.B6.9A.E6.8A.95.E7.A8.BF

[1]: https://info.5ch.net/index.php/Samba24