### PR TITLE
GnuTLS: Set GNUTLS_NO_SIGNAL to ignore SIGPIPE for preventing crash

### DIFF
--- a/src/jdlib/ssl.cpp
+++ b/src/jdlib/ssl.cpp
@@ -63,7 +63,7 @@ bool JDSSL::connect( const int soc, const char *host )
 
     int ret;
 
-    ret = gnutls_init( &m_session, GNUTLS_CLIENT );
+    ret = gnutls_init( &m_session, GNUTLS_CLIENT | GNUTLS_NO_SIGNAL );
     if( ret != 0 ){
         m_errmsg = "gnutls_init failed";
         return false;


### PR DESCRIPTION
接続が閉じられたソケットに書き込むと強制終了するため原因となるシグナル(SIGPIPE)を無効にするよう設定します。

#### 参考文献
https://gnutls.org/manual/html_node/Session-initialization.html