### PR TITLE
Revert "BoardViewBase: Use PANGO markup to display thread subject (#1033)"

### DIFF
--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -711,11 +711,7 @@ void BoardViewBase::update_columns()
         Gtk::CellRenderer *cell = column->get_first_cell();
 
         // 実際の描画の際に cellrendere のプロパティをセットするスロット関数
-        if( cell ) {
-            auto slot_func{ id == COL_SUBJECT ? &BoardViewBase::slot_cell_data_markup
-                                              : &BoardViewBase::slot_cell_data };
-            column->set_cell_data_func( *cell, sigc::mem_fun( *this, slot_func ) );
-        }
+        if( cell ) column->set_cell_data_func( *cell, sigc::mem_fun( *this, &BoardViewBase::slot_cell_data ) );
 
         Gtk::CellRendererText* rentext = dynamic_cast< Gtk::CellRendererText* >( cell );
         if( rentext ){
@@ -863,28 +859,6 @@ void BoardViewBase::save_column_width()
             break;
         }
     }
-}
-
-
-
-//
-// Subjectの実際の描画の際に cellrenderer のプロパティをセットするスロット関数
-//
-void BoardViewBase::slot_cell_data_markup( Gtk::CellRenderer* cell, const Gtk::TreeModel::iterator& it )
-{
-    Gtk::TreeModel::Row row = *it;
-
-    // ハイライト色 ( 抽出状態 )
-    if( row[ m_columns.m_col_drawbg ] ){
-        cell->property_cell_background() = CONFIG::get_color( COLOR_BACK_HIGHLIGHT_TREE );
-        cell->property_cell_background_set() = true;
-    }
-
-    else m_treeview.slot_cell_data( cell, it );
-
-    Gtk::CellRendererText* rentext = dynamic_cast<Gtk::CellRendererText*>( cell );
-    rentext->property_text() = "";
-    rentext->property_markup() = row[ m_columns.m_col_subject ];
 }
 
 

--- a/src/board/boardviewbase.h
+++ b/src/board/boardviewbase.h
@@ -239,7 +239,6 @@ namespace BOARD
         // 列の幅の保存
         virtual void save_column_width();
 
-        void slot_cell_data_markup( Gtk::CellRenderer* cell, const Gtk::TreeModel::iterator& it );
         void slot_cell_data( Gtk::CellRenderer* cell, const Gtk::TreeModel::iterator& it );
 
         // 全ての行の表示内容更新


### PR DESCRIPTION
This reverts commit 3ec7460fd17307adac2116a5846587d413e0cdea.

コンソールにGTK警告が表示されたため原因のコミットを一旦差し戻します。

error log
```
(jdim:556244): Gtk-WARNING **: 20:58:40.881:
Failed to set text from markup due to error parsing markup:
1 行目にエラーがあります: エンティティ名“copy”は不明です
```

修正にあたり不具合報告をしていただきありがとうございました。
https://next2ch.net/test/read.cgi/linux/1613035222/979-981