### PR TITLE
Abandon Ubuntu 18.04 support

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -12,6 +12,10 @@ jobs:
 
   compiler-18:
     runs-on: ubuntu-18.04
+    # Ubuntu 18.04 runner image will be unsupported by 2022-12-01.
+    # Set continue on error to avoid job failed by planned brownout.
+    # https://github.com/actions/runner-images/issues/6002
+    continue-on-error: true
     env:
       CC: ${{ matrix.sets.cc }}
       CXX: ${{ matrix.sets.cxx }}
@@ -21,20 +25,6 @@ jobs:
           - cc: gcc-7
             cxx: g++-7
             package: g++-7
-          - cc: gcc-8
-            cxx: g++-8
-            package: g++-8
-          - cc: clang-6.0
-            cxx: clang++-6.0
-            package: clang-6.0
-          - cc: clang-7
-            cxx: clang++-7
-            package: clang-7
-          # failed by SIGABRT on Ubuntu 20.04
-          # https://github.com/JDimproved/JDim/runs/2589523269?check_suite_focus=true
-          - cc: clang-9
-            cxx: clang++-9
-            package: clang-9
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -43,7 +33,7 @@ jobs:
       - name: dependencies installation
         run: |
           sudo apt update
-          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev libltdl-dev libtool ninja-build zlib1g-dev ${{ matrix.sets.package }}
+          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev ninja-build zlib1g-dev ${{ matrix.sets.package }}
       - name: install meson==0.49.0
         run: |
           python -m pip install --upgrade pip setuptools wheel
@@ -67,30 +57,69 @@ jobs:
     strategy:
       matrix:
         sets:
+          - cc: gcc-8
+            cxx: g++-8
+            package: g++-8
           - cc: gcc-9
             cxx: g++-9
             package: g++-9
           - cc: gcc-10
             cxx: g++-10
             package: g++-10
+          - cc: clang-7
+            cxx: clang++-7
+            package: clang-7
           - cc: clang-8
             cxx: clang++-8
             package: clang-8
+          - cc: clang-9
+            cxx: clang++-9
+            package: clang-9
           - cc: clang-10
             cxx: clang++-10
             package: clang-10
-          - cc: clang-11
-            cxx: clang++-11
-            package: clang-11
-          - cc: clang-12
-            cxx: clang++-12
-            package: clang-12
     steps:
       - uses: actions/checkout@v3
       - name: dependencies installation
         run: |
           sudo apt update
-          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev libltdl-dev libtool meson zlib1g-dev ${{ matrix.sets.package }}
+          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev ${{ matrix.sets.package }}
+      - name: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
+        run: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
+      - name: ninja -C builddir
+        run: ninja -C builddir
+      - name: meson test -v -C builddir
+        run: meson test -v -C builddir
+      - name: ./builddir/src/jdim -V
+        run: ./builddir/src/jdim -V
+
+  compiler-22:
+    runs-on: ubuntu-22.04
+    env:
+      CC: ${{ matrix.sets.cc }}
+      CXX: ${{ matrix.sets.cxx }}
+    strategy:
+      matrix:
+        sets:
+          - cc: gcc-11
+            cxx: g++-11
+            package: g++-11
+          - cc: clang-11
+            cxx: clang++-11
+            package: clang-11
+            # Omit clang-12 due to jobs are too many.
+          - cc: clang-13
+            cxx: clang++-13
+            package: clang-13
+          - cc: clang-14
+            cxx: clang++-14
+            package: clang-14
+    steps:
+      - uses: actions/checkout@v3
+      - name: dependencies installation
+        run: |
+          sudo apt update
+          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev ${{ matrix.sets.package }}
       - name: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
         run: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
       - name: ninja -C builddir
@@ -110,14 +139,10 @@ jobs:
     strategy:
       matrix:
         sets:
-          - os: ubuntu-18.04
-            cc: gcc-7
-            cxx: g++-7
-            package: g++-7
-          - os: ubuntu-20.04
-            cc: gcc-9
-            cxx: g++-9
-            package: g++-9
+          - os: ubuntu-22.04
+            cc: gcc-11
+            cxx: g++-11
+            package: g++-11
     steps:
       - uses: actions/checkout@v3
       - name: dependencies installation
@@ -135,14 +160,13 @@ jobs:
       - name: ./src/jdim -V
         run: ./src/jdim -V
 
-  library-18:
+  library-20:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
-      CC: gcc-7
-      CXX: g++-7
+      CC: gcc-9
+      CXX: g++-9
       CXXFLAGS: -Og -pipe -D_DEBUG
-      GTEST_SRCDIR: /usr/src/googletest
     strategy:
       matrix:
         deps:
@@ -157,7 +181,7 @@ jobs:
       - name: dependencies installation (${{ matrix.deps.packages }})
         run: |
           sudo apt update
-          sudo apt install autoconf-archive libgtest-dev libtool libltdl-dev libgtkmm-3.0-dev ${{ matrix.deps.packages }} g++-7
+          sudo apt install autoconf-archive libgtest-dev libtool libltdl-dev libgtkmm-3.0-dev ${{ matrix.deps.packages }} g++-9
       - name: autoreconf -i
         run: autoreconf -i
       - name: ./configure ${{ matrix.deps.config_args }}
@@ -169,12 +193,12 @@ jobs:
       - name: ./src/jdim -V
         run: ./src/jdim -V
 
-  library-20:
+  library-22:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
-      CC: gcc-9
-      CXX: g++-9
+      CC: gcc-11
+      CXX: g++-11
     strategy:
       matrix:
         deps:
@@ -189,7 +213,7 @@ jobs:
       - name: dependencies installation (${{ matrix.deps.packages }})
         run: |
           sudo apt update
-          sudo apt install meson libgtest-dev libtool libltdl-dev libgtkmm-3.0-dev ${{ matrix.deps.packages }} g++-9
+          sudo apt install meson libgtest-dev libgtkmm-3.0-dev ${{ matrix.deps.packages }} g++-11
       - name: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG" ${{ matrix.deps.config_args }}
         run: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG" ${{ matrix.deps.config_args }}
       - name: ninja -C builddir
@@ -201,7 +225,7 @@ jobs:
 
   manual:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
     steps:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -54,8 +54,8 @@ jobs:
       - name: ninja -C builddir
         run: ninja -C builddir
         # Since Meson 0.57, `test` subcommand will only rebuild test program.
-      - name: meson test -C builddir
-        run: meson test -C builddir
+      - name: meson test -v -C builddir
+        run: meson test -v -C builddir
       - name: ./builddir/src/jdim -V
         run: ./builddir/src/jdim -V
 
@@ -95,8 +95,8 @@ jobs:
         run: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
       - name: ninja -C builddir
         run: ninja -C builddir
-      - name: meson test -C builddir
-        run: meson test -C builddir
+      - name: meson test -v -C builddir
+        run: meson test -v -C builddir
       - name: ./builddir/src/jdim -V
         run: ./builddir/src/jdim -V
 
@@ -194,8 +194,8 @@ jobs:
         run: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG" ${{ matrix.deps.config_args }}
       - name: ninja -C builddir
         run: ninja -C builddir
-      - name: meson test -C builddir
-        run: meson test -C builddir
+      - name: meson test -v -C builddir
+        run: meson test -v -C builddir
       - name: ./builddir/src/jdim -V
         run: ./builddir/src/jdim -V
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -36,8 +36,8 @@ jobs:
             cxx: clang++-9
             package: clang-9
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.6'
       - name: dependencies installation
@@ -86,7 +86,7 @@ jobs:
             cxx: clang++-12
             package: clang-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: dependencies installation
         run: |
           sudo apt update
@@ -119,7 +119,7 @@ jobs:
             cxx: g++-9
             package: g++-9
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: dependencies installation
         run: |
           sudo apt update
@@ -153,7 +153,7 @@ jobs:
           - config_args: --with-tls=openssl --with-sessionlib=xsmp --with-alsa --with-pangolayout
             packages: libssl-dev libasound2-dev
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: dependencies installation (${{ matrix.deps.packages }})
         run: |
           sudo apt update
@@ -185,7 +185,7 @@ jobs:
           - config_args: -Dtls=openssl -Dsessionlib=xsmp -Dalsa=enabled -Dpangolayout=enabled
             packages: libssl-dev libasound2-dev
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: dependencies installation (${{ matrix.deps.packages }})
         run: |
           sudo apt update
@@ -205,7 +205,7 @@ jobs:
     env:
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: dependencies installation
         run: |
           sudo apt update

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -223,16 +223,12 @@ jobs:
       - name: ./builddir/src/jdim -V
         run: ./builddir/src/jdim -V
 
-  manual:
+  manual-build:
 
-    runs-on: ubuntu-20.04
-    env:
-      NOKOGIRI_USE_SYSTEM_LIBRARIES: true
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: dependencies installation
-        run: |
-          sudo apt update
-          sudo apt install ruby-dev ruby-bundler libcurl4-openssl-dev libxslt1-dev
-      - name: make -j$(nproc) -C docs build
-        run: make -j$(nproc) -C docs build
+      - uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./docs/_site

--- a/README.md
+++ b/README.md
@@ -44,14 +44,16 @@ JDim は GPLv2 の下で公開されている [JD][jd-project] からforkした�
 LinuxなどのUnixライクなOS(FreeBSD,OpenBSD,Nexenta,MacOSXでも動作報告例があります)。
 
 ##### サポートの最新情報
-gccのバージョンが7未満のプラットフォームはサポートを終了しました。
-Ubuntu 18.04(2018年)より前にリリースされたディストリビューションを利用されている場合は更新をお願いいたします。
+Ubuntu 18.04のテスト環境が[使えなくなる][#1035]ため前倒しで18.04のサポートを放棄しました。
+次のリリースまで動作環境の変更は行いませんが18.04では問題が起こるかもしれません。
+Debian buster(2019年)より前にリリースされたディストリビューションを利用されている場合は更新をお願いいたします。
 
 メンテナンスの都合によりWindows(MinGW)版のサポートは[終了][#445]しました。
 
 Snap i386(32bit)版は2023年1月のリリースをもって[更新を終了][#890]する予定です。
 i386版ディストロを利用されている場合は更新をお願いいたします。
 
+[#1035]: https://github.com/JDimproved/JDim/issues/1035
 [#445]: https://github.com/JDimproved/JDim/issues/445
 [#890]: https://github.com/JDimproved/JDim/issues/890
 


### PR DESCRIPTION
### [Update README to abandon Ubuntu 18.04 support](https://github.com/JDimproved/JDim/commit/a3edff6bcfb718c6407ee90e2c2632bd909dd83b)

Ubuntu 18.04のテスト環境が[使えなくなる][a]ため前倒しで18.04のサポートを放棄します。
次のリリースまで動作環境の変更は行いませんが18.04では問題が起こるかもしれません。
2019年より前にリリースされたディストリビューションを利用されている場合は更新をお願いいたします。

[a]: https://github.com/JDimproved/JDim/issues/1035

### [GitHub Actions: Update versions for reusable actions](https://github.com/JDimproved/JDim/commit/79ad28b54c115de945c39425316fe3640800a838)

CIで利用しているアクションのバージョンを最新版に更新します。

### [GitHub Actions: Set verbose output for meson test](https://github.com/JDimproved/JDim/commit/cd51edcd6c414479adebac88f3a4fd38ffff15ef)

Mesonのテスト実行するときに詳細な結果を出力するように設定します。

### [Update CI settings to abandon Ubuntu 18.04 support](https://github.com/JDimproved/JDim/commit/a3d86411fcb8eae89ca35a542f73753ffa06719d)

GitHub ActionsのCI設定を更新してUbuntu18.04のジョブ削減とUbuntu22.04のジョブを追加します。
[20 jobs][b]を超えると実行待機が発生するため廃止予定オプションとコンパイラオプションはテストから除外しています。
ディストロとツールチェーンの組み合わせも網羅していません。

Ubuntu18.04 は 2022-12-01 の[サポート終了][c]に向けてジョブの強制キャンセルが計画されているため失敗やキャンセルになってもCIが継続するように設定します。

コンパイラ: gcc-8 ~ gcc-11, clang-7.0 ~ clang-14 (clang-12は除く)
ディストロ: Ubuntu18.04, Ubuntu20.04, Ubuntu22.04
ビルドツール: Autotools, Meson

<details>
<summary>ビルドの構成 (20 jobs)</summary>

Mesonを利用したビルド (12 jobs)
Ubuntu18.04
- gcc-7

Ubuntu20.04
- gcc-8
- gcc-9
- gcc-10
- clang-7
- clang-8
- clang-9
- clang-10

Ubuntu22.04
- gcc-11
- clang-11
- clang-13
- clang-14

Autotoolsを使用したビルド (1 job)
Ubuntu22.04
- gcc-11

オプションのビルド (6 jobs)
Ubuntu20.04 (Autotools)
- gnutls, xsmp, migemo, alsa, pangolayout
- openssl, migemo, sessionlib=no, compat_cache_dir=disabled
- openssl, xsmp, alsa, pangolayout

Ubuntu22.04 (Meson)
- gnutls, xsmp, migemo, alsa, pangolayout
- openssl, migemo, sessionlib=no, compat_cache_dir=disabled
- openssl, xsmp, alsa, pangolayout

マニュアルのビルド (1 job)
</details>

[b]: https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits
[c]: https://github.com/actions/runner-images/issues/6002

### [GitHub Actions: Use actions/jekyll-build-pages@v1](https://github.com/JDimproved/JDim/commit/22463a1164dab65f18407ecabfa80c32eb8cbf23)

自前で設定したjekyllではなくGitHubが保守している[アクション][d]を使ってマニュアルのビルドをテストするように変更します。

[d]: https://github.com/actions/jekyll-build-pages