### PR TITLE
Convert thread subject to plain text

### DIFF
--- a/src/article/articleadmin.cpp
+++ b/src/article/articleadmin.cpp
@@ -772,7 +772,7 @@ void ArticleAdmin::slot_drag_data_get( Gtk::SelectionData& selection_data, const
     CORE::DATA_INFO info;
     info.type = TYPE_THREAD;
     info.url = DBTREE::url_readcgi( url, 0, 0 );
-    info.name = DBTREE::article_modified_subject( info.url );
+    info.name = MISC::to_plain( DBTREE::article_modified_subject( info.url ) );
     info.path = Gtk::TreePath( "0" ).to_string();
 
     if( info.url.empty() ) return;

--- a/src/article/articleview.cpp
+++ b/src/article/articleview.cpp
@@ -472,7 +472,7 @@ void ArticleViewMain::update_finish()
     else if( is_overflow() ) str_tablabel = "[ レス数が最大表示可能数以上です ]  ";
 
     const std::string& subject = DBTREE::article_modified_subject( url_article() );
-    set_label( str_tablabel + subject );
+    set_label( str_tablabel + MISC::to_plain( subject ) );
     ARTICLE::get_admin()->set_command( "redraw_toolbar" );
 
     // タブのラベルセット
@@ -499,7 +499,7 @@ void ArticleViewMain::update_finish()
     ARTICLE::get_admin()->set_command( "set_status_color", get_url(), get_color(), force );
 
     // タイトルセット
-    set_title( subject );
+    set_title( MISC::to_plain( subject ) );
     ARTICLE::get_admin()->set_command( "set_title", get_url(), get_title() );
 
     drawarea()->set_enable_draw( true );

--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -1617,7 +1617,7 @@ void ArticleViewBase::show_res( const std::string& num, const bool show_title )
     if( show_title ){
 
         std::string html;
-        std::string tmpstr = DBTREE::board_name( m_url_article );
+        const std::string& tmpstr = DBTREE::board_name( m_url_article );
         if( ! tmpstr.empty() ) html += "[ " + MISC::html_escape( tmpstr ) + " ] ";
 
         html += DBTREE::article_modified_subject( m_url_article );
@@ -3697,7 +3697,7 @@ void ArticleViewBase::slot_copy_res( bool ref )
     if( ref ) tmpstr += CONFIG::get_ref_prefix();
     std::string board_name = DBTREE::board_name( m_url_article );
     if( ! board_name.empty() ) tmpstr += "[ " + board_name + " ] ";
-    tmpstr += DBTREE::article_subject( m_url_article ) + "\n\n";
+    tmpstr += MISC::to_plain( DBTREE::article_subject( m_url_article ) ) + "\n\n";
     tmpstr += m_article->get_res_str( atoi( m_str_num.c_str() ), ref );
 
     MISC::CopyClipboard( tmpstr );
@@ -3709,7 +3709,7 @@ void ArticleViewBase::slot_copy_res( bool ref )
 //
 void ArticleViewBase::slot_copy_title_url()
 {
-    MISC::CopyClipboard( DBTREE::article_subject( m_url_article ) + '\n' + url_for_copy() );
+    MISC::CopyClipboard( MISC::to_plain( DBTREE::article_subject( m_url_article ) ) + '\n' + url_for_copy() );
 }
 
 
@@ -3724,7 +3724,7 @@ void ArticleViewBase::set_favorite()
     info.type = TYPE_THREAD;
     info.parent = ARTICLE::get_admin()->get_win();
     info.url = m_url_article;;
-    info.name = DBTREE::article_modified_subject( m_url_article );
+    info.name = MISC::to_plain( DBTREE::article_modified_subject( m_url_article ) );
     info.path = Gtk::TreePath( "0" ).to_string();
 
     CORE::DATA_INFO_LIST list_info;

--- a/src/article/articleviewetc.cpp
+++ b/src/article/articleviewetc.cpp
@@ -11,6 +11,7 @@
 #include "dbtree/articlebase.h"
 
 #include "control/controlid.h"
+#include "jdlib/miscutil.h"
 
 #include "global.h"
 
@@ -37,7 +38,7 @@ ArticleViewRes::ArticleViewRes( const std::string& url )
     setup_view();
 
     // ラベル更新
-    set_label( " [ RES:" + m_str_num + " ] - " + DBTREE::article_modified_subject( url_article() ) );
+    set_label( " [ RES:" + m_str_num + " ] - " + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );
@@ -120,7 +121,7 @@ ArticleViewName::ArticleViewName( const std::string& url )
     setup_view();
 
     // ラベル更新
-    set_label( " [ 名前：" + m_str_name + " ] - " + DBTREE::article_modified_subject( url_article() ) );
+    set_label( " [ 名前：" + m_str_name + " ] - " + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );
@@ -200,7 +201,7 @@ ArticleViewID::ArticleViewID( const std::string& url )
     setup_view();
 
     // ラベル更新
-    set_label( " [ " + m_str_id.substr( strlen( PROTO_ID ) ) + " ] - " + DBTREE::article_modified_subject( url_article() ) );
+    set_label( " [ " + m_str_id.substr( strlen( PROTO_ID ) ) + " ] - " + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );
@@ -278,7 +279,7 @@ ArticleViewBM::ArticleViewBM( const std::string& url )
     setup_view();
 
     // ラベル更新
-    set_label( " [ しおり ] - " + DBTREE::article_modified_subject( url_article() ) );
+    set_label( " [ しおり ] - " + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );
@@ -357,7 +358,7 @@ ArticleViewPost::ArticleViewPost( const std::string& url )
 
 
     // ラベル更新
-    set_label( " [ 書き込み ] - " + DBTREE::article_modified_subject( url_article() ) );
+    set_label( " [ 書き込み ] - " + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );
@@ -512,7 +513,7 @@ ArticleViewURL::ArticleViewURL( const std::string& url )
     setup_view();
 
     // ラベル更新
-    set_label( " [ URL ] - " + DBTREE::article_modified_subject( url_article() ) );
+    set_label( " [ URL ] - " + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );
@@ -593,7 +594,7 @@ ArticleViewRefer::ArticleViewRefer( const std::string& url )
     setup_view();
 
     // ラベル更新
-    set_label( " [ Re:" + m_str_num + " ] - " + DBTREE::article_modified_subject( url_article() ) );
+    set_label( " [ Re:" + m_str_num + " ] - " + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );
@@ -682,7 +683,7 @@ ArticleViewDrawout::ArticleViewDrawout( const std::string& url )
     std::string str_label;
     if( m_mode_or ) str_label = "[ OR 抽出 ] - ";
     else str_label = "[ AND 抽出 ] - ";
-    set_label( str_label + DBTREE::article_modified_subject( url_article() ) );
+    set_label( str_label + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );

--- a/src/article/preference.cpp
+++ b/src/article/preference.cpp
@@ -22,7 +22,7 @@ using namespace ARTICLE;
 
 Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std::string& command )
     : SKELETON::PrefDiag( parent, url )
-    ,m_label_name( false, "スレタイトル : ", DBTREE::article_subject( get_url() ) )
+    ,m_label_name( false, "スレタイトル : ", MISC::to_plain( DBTREE::article_subject( get_url() ) ) )
     ,m_label_url( false, "スレのURL : ", DBTREE:: url_readcgi( get_url(),0,0 ) )
     ,m_label_url_dat( false, "DATファイルのURL : ", DBTREE:: url_dat( get_url() ) )
     ,m_label_cache( false, "ローカルキャッシュパス : ", std::string() )
@@ -206,7 +206,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     m_notebook.append_page( m_notebook_abone, "あぼ〜ん設定" );
 
     get_content_area()->pack_start( m_notebook );
-    set_title( "「" + DBTREE::article_modified_subject( get_url() ) + "」のプロパティ" );
+    set_title( "「" + MISC::to_plain( DBTREE::article_modified_subject( get_url() ) ) + "」のプロパティ" );
     resize( 600, 400 );
     show_all_children();
 

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -1628,9 +1628,21 @@ void BBSListViewBase::slot_copy_title_url()
     if( m_path_selected.empty() ) return;
 
     const std::string url = path2url( m_path_selected );
-    const std::string name = path2name( m_path_selected );
+    std::string name;
 
-    MISC::CopyClipboard( name + '\n' + url );
+    const int type = path2type( m_path_selected );
+    switch( type ){
+        case TYPE_THREAD:
+        case TYPE_THREAD_UPDATE:
+        case TYPE_THREAD_OLD:
+            name = MISC::to_plain( DBTREE::article_subject( url ) );
+            break;
+
+        default:
+            name = path2name( m_path_selected );
+    }
+
+    MISC::CopyClipboard( name + '\n' + url + '\n' );
 }
 
 
@@ -2578,7 +2590,7 @@ void BBSListViewBase::replace_thread( const std::string& url, const std::string&
     const std::string urldat_new = DBTREE::url_dat( url_new );
     if( urldat_new.empty() ) return;
 
-    const std::string name_new = DBTREE::article_modified_subject( urldat_new );
+    const std::string name_new = MISC::to_plain( DBTREE::article_modified_subject( urldat_new ) );
     if( name_new.empty() ) return;
 
     bool show_diag = CONFIG::show_diag_replace_favorite();
@@ -2586,7 +2598,7 @@ void BBSListViewBase::replace_thread( const std::string& url, const std::string&
     if( ! show_diag && mode == REPLACE_NEXT_NO ) return;
 
     const std::string urldat = DBTREE::url_dat( url );
-    const std::string name_old = DBTREE::article_modified_subject( urldat );
+    const std::string name_old = MISC::to_plain( DBTREE::article_modified_subject( urldat ) );
 
     int type = TYPE_THREAD;
     const int status = DBTREE::article_status( urldat_new );

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -1902,7 +1902,7 @@ void BoardViewBase::update_row_common( const Gtk::TreeModel::Row& row )
     const int res = art->get_number();
 
     // タイトル、レス数、抽出
-    row[ m_columns.m_col_subject ] = art->get_modified_subject( true );
+    row[ m_columns.m_col_subject ] = MISC::to_plain( art->get_modified_subject( true ) );
     row[ m_columns.m_col_res ] = res;
 
     // 読み込み数
@@ -2273,7 +2273,7 @@ bool BoardViewBase::slot_query_tooltip( int x, int y, bool keyboard_tooltip,
         // セルの内容が空ならツールチップを表示しない
         if( cell_text.empty() ) return false;
 
-        const auto layout = m_treeview.create_pango_layout( cell_text );
+        const auto layout = m_treeview.create_pango_layout( MISC::to_plain( cell_text ) );
         int pixel_width, ph;
         layout->get_pixel_size( pixel_width, ph );
         constexpr int offset{ 8 };
@@ -2447,7 +2447,7 @@ void BoardViewBase::slot_copy_title_url()
     if( m_path_selected.empty() ) return;
 
     const std::string url = DBTREE::url_readcgi( path2daturl( m_path_selected ), 0, 0 );
-    const std::string name = DBTREE::article_subject( url );
+    const std::string name = MISC::to_plain( DBTREE::article_subject( url ) );
 
     MISC::CopyClipboard( name + '\n' + url );
 }
@@ -2646,7 +2646,7 @@ bool BoardViewBase::drawout( const bool force_reset )
         const Glib::ustring subject = row[ m_columns.m_col_subject ];
 
         if( reset ) row[ m_columns.m_col_drawbg ] = false;
-        else if( regex.match( regexptn, subject, 0 ) ){
+        else if( regex.match( regexptn, MISC::to_plain( subject ), 0 ) ){
             row[ m_columns.m_col_drawbg ] = true;
             ++hit;
 
@@ -2744,7 +2744,7 @@ void BoardViewBase::exec_search()
         if( path == path_start ) break;
 
         Glib::ustring subject = get_name_of_cell( path, m_columns.m_col_subject );
-        if( regex.exec( query, subject, offset, icase, newline, usemigemo, wchar ) ){
+        if( regex.exec( query, MISC::to_plain( subject ), offset, icase, newline, usemigemo, wchar ) ){
             m_treeview.scroll_to_row( path, 0 );
             m_treeview.set_cursor( path );
             return;
@@ -3051,7 +3051,7 @@ void BoardViewBase::set_article_to_buffer()
             info.type = TYPE_THREAD;
             info.parent = BOARD::get_admin()->get_win();
             info.url = art->get_url();
-            info.name = name.raw();
+            info.name = MISC::to_plain( name.raw() );
             info.path = path.to_string();
 
             list_info.push_back( info );

--- a/src/board/boardviewnext.cpp
+++ b/src/board/boardviewnext.cpp
@@ -12,6 +12,7 @@
 #include "skeleton/msgdiag.h"
 
 #include "jdlib/tfidf.h"
+#include "jdlib/miscutil.h"
 
 #include "config/globalconf.h"
 
@@ -181,7 +182,7 @@ void BoardViewNext::slot_abone_thread()
 //
 void BoardViewNext::update_boardname()
 {
-    const std::string title = "[ 次スレ検索 ] - " + DBTREE::article_modified_subject( m_url_pre_article );
+    const std::string title = "[ 次スレ検索 ] - " + MISC::to_plain( DBTREE::article_modified_subject( m_url_pre_article ) );
 
     // ウィンドウタイトル表示
     set_title( title );

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -1622,7 +1622,7 @@ void ArticleBase::delete_cache( const bool cache_only )
 
         if( m_bookmarked_thread ){
 
-            const std::string msg = "「" + get_modified_subject() +
+            const std::string msg = "「" + MISC::to_plain( get_modified_subject() ) +
             "」にはしおりが付けられています。\n\nスレを削除しますか？\n\nしおりを解除するにはスレの上で右クリックしてしおり解除を選択してください。";
 
             SKELETON::MsgDiag mdiag( nullptr, msg, false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
@@ -1632,7 +1632,7 @@ void ArticleBase::delete_cache( const bool cache_only )
 
         if( CONFIG::get_show_del_written_thread_diag() && m_write_time ){
 
-            const std::string msg = "「" + get_modified_subject() + "」には書き込み履歴が残っています。\n\nスレを削除しますか？";
+            const std::string msg = "「" + MISC::to_plain( get_modified_subject() ) + "」には書き込み履歴が残っています。\n\nスレを削除しますか？";
 
             SKELETON::MsgCheckDiag mdiag( nullptr, msg,
                                           "今後表示しない(常に削除)(_D)",
@@ -1654,7 +1654,7 @@ void ArticleBase::delete_cache( const bool cache_only )
 
                 if( CONFIG::get_delete_img_in_thread() == 0 ){
 
-                    const std::string msg = "「" + get_modified_subject() + "」には画像が貼られています。\n\n画像のキャッシュも削除しますか？";
+                    const std::string msg = "「" + MISC::to_plain( get_modified_subject() ) + "」には画像が貼られています。\n\n画像のキャッシュも削除しますか？";
 
                     SKELETON::MsgCheckDiag mdiag( nullptr, msg,
                                                   "今後表示しない(常に削除しない)(_D)",

--- a/src/history/historymanager.cpp
+++ b/src/history/historymanager.cpp
@@ -9,6 +9,7 @@
 #include "viewhistoryitem.h"
 
 #include "dbtree/interface.h"
+#include "jdlib/miscutil.h"
 
 #include "xml/document.h"
 #include "xml/tools.h"
@@ -137,7 +138,7 @@ void History_Manager::append_history( const std::string& url_history, const std:
     if( url_history == URL_HISTTHREADVIEW || url_history == URL_HISTCLOSEVIEW ){
 
         info.url = DBTREE::url_dat( url );
-        info.name = DBTREE::article_subject( info.url );
+        info.name = MISC::to_plain( name );
     }
     if( url_history == URL_HISTBOARDVIEW || url_history == URL_HISTCLOSEBOARDVIEW ){
 

--- a/src/image/preference.cpp
+++ b/src/image/preference.cpp
@@ -33,7 +33,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url )
     const std::string daturl = DBTREE::url_dat( refurl, num_from, num_to, num_str );
     const std::string readcgi = DBTREE::url_readcgi( daturl, num_from, 0 );
 
-    m_label_ref.set_text( DBTREE::article_modified_subject( daturl ) );
+    m_label_ref.set_text( MISC::to_plain( DBTREE::article_modified_subject( daturl ) ) );
     m_label_url_ref.set_text( readcgi );
 
     m_open_ref.signal_clicked().connect( sigc::mem_fun(*this, &Preferences::slot_open_ref ) );

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -983,6 +983,47 @@ static std::string chref_decode_one( const char* str, int& n_in, const char pre_
 }
 
 
+/** @brief HTMLをプレーンテキストに変換する
+ *
+ * @details HTMLタグを取り除き文字参照をデコードして返す。
+ * @param[in] html プレーンテキストに変換する入力
+ * @return 変換した結果
+ */
+std::string MISC::to_plain( const std::string& html )
+{
+    if( html.empty() ) return html;
+    if( html.find_first_of( "<&" ) == std::string::npos ) return html;
+
+    std::string str_out;
+    const char* pos = html.c_str();
+    const char* pos_end = pos + html.size();
+
+    while( pos < pos_end ){
+
+        // '<' か '&' までコピーする
+        while( *pos != '<' && *pos != '&' && *pos != '\0' ) str_out.push_back( *pos++ );
+        if( pos >= pos_end ) break;
+
+        // タグを取り除く
+        if( *pos == '<' ){
+            while( *pos != '>' && *pos != '\0' ) pos++;
+            if( *pos == '>' ) ++pos;
+            continue;
+        }
+
+        // 文字参照を処理する
+        if( *pos == '&' ){
+            int n_in;
+            const char pre = str_out.empty() ? '\0' : str_out.back();
+            str_out += chref_decode_one( pos, n_in, pre, true );
+            pos += n_in;
+        }
+    }
+
+    return str_out;
+}
+
+
 //
 // HTMLの文字参照をデコード
 //

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -943,7 +943,7 @@ std::string MISC::html_unescape( const std::string& str )
 // strは'&'で始まる文字列を指定すること
 // completely = true の時は'"' '&' '<' '>'も含めて変換する
 //
-static std::string chref_decode_one( const char* str, int& n_in, const bool completely )
+static std::string chref_decode_one( const char* str, int& n_in, const char pre_char, const bool completely )
 {
     std::string out_char( 15u, '\0' );
     int n_out;
@@ -951,7 +951,7 @@ static std::string chref_decode_one( const char* str, int& n_in, const bool comp
     out_char.resize( n_out );
 
     // 改行、タブ、スペースの処理
-    if( type != DBTREE::NODE_NONE && ( out_char[0] == ' ' || out_char[0] == '\n' ) ) {
+    if( type != DBTREE::NODE_NONE && ( out_char[0] == ' ' || out_char[0] == '\n' ) && pre_char != ' ' ) {
         out_char.assign( 1u, ' ' );
     }
     // 変換できない文字
@@ -1009,7 +1009,7 @@ std::string MISC::chref_decode( std::string_view str, const bool completely )
 
         // 文字参照のデコード
         int n_in;
-        str_out.append( chref_decode_one( pos, n_in, completely ) );
+        str_out.append( chref_decode_one( pos, n_in, '\0', completely ) );
         pos += n_in;
     }
 

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -145,6 +145,9 @@ namespace MISC
     // HTMLで特別な意味を持つ記号の文字実体参照(&quot; &amp; &lt; &gt;)をアンエスケープする
     std::string html_unescape( const std::string& str );
 
+    // HTMLをプレーンテキストに変換する
+    std::string to_plain( const std::string& html );
+
     // HTML文字参照をデコード( completely=trueの場合は '&' '<' '>' '"' を含める )
     std::string chref_decode( std::string_view str, const bool completely );
 

--- a/src/message/messageview.cpp
+++ b/src/message/messageview.cpp
@@ -36,10 +36,10 @@ MessageViewMain::MessageViewMain( const std::string& url, const std::string& msg
     const std::string& subject = DBTREE::article_modified_subject( get_url() );
 
     // メインウィンドウのタイトルに表示する文字
-    set_title( "[ 書き込み ] " + subject );
+    set_title( "[ 書き込み ] " + MISC::to_plain( subject ) );
 
     // ツールバーにスレ名を表示
-    set_label( subject );
+    set_label( MISC::to_plain( subject ) );
 }
 
 
@@ -158,7 +158,7 @@ void MessageViewMain::reload()
     MESSAGE::get_admin()->show_entry_new_subject( true );
 
     // メインウィンドウのタイトルに表示する文字
-    set_title( "[ 新スレ作成 ] " + DBTREE::article_modified_subject( get_url() ) );
+    set_title( "[ 新スレ作成 ] " + MISC::to_plain( DBTREE::article_modified_subject( get_url() ) ) );
 
     // 板のフロントページをダウンロードしてスレ立てに使うキーワードを更新する
     DBTREE::board_download_front( get_url() );

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -1829,11 +1829,12 @@ void Admin::set_tablabel( const std::string& url, const std::string& str_label )
     SKELETON::View* view = get_view( url );
     if( view ){
 
-        m_notebook->set_tab_fulltext( str_label, m_notebook->page_num( *view ) );
+        const std::string label = MISC::to_plain( str_label );
+        m_notebook->set_tab_fulltext( label, m_notebook->page_num( *view ) );
 
         // View履歴のタイトルも更新
         if( m_use_viewhistory ){
-            HISTORY::get_history_manager()->replace_current_title_viewhistory( view->get_url(), str_label );
+            HISTORY::get_history_manager()->replace_current_title_viewhistory( view->get_url(), label );
         }
     }
 }

--- a/src/usrcmdmanager.cpp
+++ b/src/usrcmdmanager.cpp
@@ -280,7 +280,7 @@ std::string Usrcmd_Manager::replace_cmd( const std::string& cmd,
     cmd_out = MISC::replace_str( cmd_out, "$DATNAMEL", DBTREE::article_key( link ) );
     cmd_out = MISC::replace_str( cmd_out, "$DATNAME", DBTREE::article_key( url ) );
 
-    cmd_out = MISC::replace_str( cmd_out, "$TITLE", DBTREE::article_subject( url ) );
+    cmd_out = MISC::replace_str( cmd_out, "$TITLE", MISC::to_plain( DBTREE::article_subject( url ) ) );
     cmd_out = MISC::replace_str( cmd_out, "$BOARDNAME", DBTREE::board_name( url ) );
 
     // 範囲選択した文字列

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -1122,6 +1122,58 @@ TEST_F(MISC_ParseHtmlFormActionTest, https_url)
 }
 
 
+class ToPlainTest : public ::testing::Test {};
+
+TEST_F(ToPlainTest, empty)
+{
+    const std::string result = MISC::to_plain( std::string{} );
+    EXPECT_EQ( result, std::string{} );
+}
+
+TEST_F(ToPlainTest, no_conversion)
+{
+    const std::string result = MISC::to_plain( "hello 世界" );
+    EXPECT_EQ( result, "hello 世界" );
+}
+
+TEST_F(ToPlainTest, decimal_hello)
+{
+    const std::string result = MISC::to_plain( "&#104;&#101;&#108;&#108;&#111;" );
+    EXPECT_EQ( result, "hello" );
+}
+
+TEST_F(ToPlainTest, hexadecimal_hello)
+{
+    const std::string result = MISC::to_plain( "&#x68;&#x65;&#X6c;&#x6C;&#x6f;" );
+    EXPECT_EQ( result, "hello" );
+}
+
+TEST_F(ToPlainTest, escape_html_char_completely)
+{
+    const std::string input = "&#60;&#62;&#38;&#34; &#x3c;&#x3e;&#x26;&#x22; &lt;&gt;&amp;&quot;";
+    const std::string result = MISC::to_plain( input );
+    EXPECT_EQ( result, R"(<>&" <>&" <>&")" );
+}
+
+TEST_F(ToPlainTest, flatten_tags)
+{
+    const std::string input = "Hello<foo>世界<bar>Quick</bar></foo>Brown Fox";
+    const std::string result = MISC::to_plain( input );
+    EXPECT_EQ( result, "Hello世界QuickBrown Fox" );
+}
+
+TEST_F(ToPlainTest, broken_tags)
+{
+    std::string input = "Hello<fo<o>世界</f>oo>Quick Brown Fox";
+    std::string result = MISC::to_plain( input );
+    EXPECT_EQ( result, "Hello世界oo>Quick Brown Fox" );
+
+    input = "Hello<foo>世界>Quick</foo<Brown Fox";
+    result = MISC::to_plain( input );
+    EXPECT_EQ( result, "Hello世界>Quick" );
+}
+
+
 class ChrefDecodeTest : public ::testing::Test {};
 
 TEST_F(ChrefDecodeTest, empty)


### PR DESCRIPTION
#### [Add parameter pre_char to MISC::chref_decode_one()](https://github.com/JDimproved/JDim/commit/291d034b587d1f33c6888cc7777a384996787473) 

文字参照をデコードする際に前の文字を見て空白の処理を決定するように関数の引数を追加します。
また、修正に合わせて関数を呼び出している箇所の実引数を追加します。

#### [Implement MISC::to_plain()](https://github.com/JDimproved/JDim/commit/9bdf902bdf2ec62e19c007391978273d4e7098f3)

入力された文字列をコピーしてプレーンテキスト化(HTMLタグを取り除き、文字参照をデコード)して返す関数を追加します。

#### [Add test cases for MISC::to_plain()](https://github.com/JDimproved/JDim/commit/3d7f3947fd13a1e13d42891684912a8de5a9a168)

#### [Convert thread subject to plain text](https://github.com/JDimproved/JDim/commit/41e14a2f257868446c1a0f40c966e3ca57235245)

スレタイトルをプレーンテキストに変換して表示するように修正します。