### PR TITLE
Use Pango Markup to display thread subject

### DIFF
--- a/src/article/articleview.cpp
+++ b/src/article/articleview.cpp
@@ -471,8 +471,9 @@ void ArticleViewMain::update_finish()
     else if( is_old() ) str_tablabel = "[ DAT落ち ]  ";
     else if( is_overflow() ) str_tablabel = "[ レス数が最大表示可能数以上です ]  ";
 
+    set_tooltip_label( str_tablabel + MISC::to_markup( DBTREE::article_subject( url_article() ) ) );
     const std::string& subject = DBTREE::article_modified_subject( url_article() );
-    set_label( str_tablabel + MISC::to_plain( subject ) );
+    set_label( str_tablabel + MISC::to_markup( subject ), true );
     ARTICLE::get_admin()->set_command( "redraw_toolbar" );
 
     // タブのラベルセット

--- a/src/article/articleviewetc.cpp
+++ b/src/article/articleviewetc.cpp
@@ -38,7 +38,7 @@ ArticleViewRes::ArticleViewRes( const std::string& url )
     setup_view();
 
     // ラベル更新
-    set_label( " [ RES:" + m_str_num + " ] - " + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
+    set_label( " [ RES:" + m_str_num + " ] - " + MISC::to_markup( DBTREE::article_modified_subject( url_article() ) ), true );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );
@@ -121,7 +121,7 @@ ArticleViewName::ArticleViewName( const std::string& url )
     setup_view();
 
     // ラベル更新
-    set_label( " [ 名前：" + m_str_name + " ] - " + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
+    set_label( " [ 名前：" + m_str_name + " ] - " + MISC::to_markup( DBTREE::article_modified_subject( url_article() ) ), true );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );
@@ -201,7 +201,7 @@ ArticleViewID::ArticleViewID( const std::string& url )
     setup_view();
 
     // ラベル更新
-    set_label( " [ " + m_str_id.substr( strlen( PROTO_ID ) ) + " ] - " + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
+    set_label( " [ " + m_str_id.substr( strlen( PROTO_ID ) ) + " ] - " + MISC::to_markup( DBTREE::article_modified_subject( url_article() ) ), true );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );
@@ -279,7 +279,7 @@ ArticleViewBM::ArticleViewBM( const std::string& url )
     setup_view();
 
     // ラベル更新
-    set_label( " [ しおり ] - " + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
+    set_label( " [ しおり ] - " + MISC::to_markup( DBTREE::article_modified_subject( url_article() ) ), true );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );
@@ -358,7 +358,7 @@ ArticleViewPost::ArticleViewPost( const std::string& url )
 
 
     // ラベル更新
-    set_label( " [ 書き込み ] - " + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
+    set_label( " [ 書き込み ] - " + MISC::to_markup( DBTREE::article_modified_subject( url_article() ) ), true );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );
@@ -513,7 +513,7 @@ ArticleViewURL::ArticleViewURL( const std::string& url )
     setup_view();
 
     // ラベル更新
-    set_label( " [ URL ] - " + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
+    set_label( " [ URL ] - " + MISC::to_markup( DBTREE::article_modified_subject( url_article() ) ), true );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );
@@ -594,7 +594,7 @@ ArticleViewRefer::ArticleViewRefer( const std::string& url )
     setup_view();
 
     // ラベル更新
-    set_label( " [ Re:" + m_str_num + " ] - " + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
+    set_label( " [ Re:" + m_str_num + " ] - " + MISC::to_markup( DBTREE::article_modified_subject( url_article() ) ), true );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );
@@ -683,7 +683,7 @@ ArticleViewDrawout::ArticleViewDrawout( const std::string& url )
     std::string str_label;
     if( m_mode_or ) str_label = "[ OR 抽出 ] - ";
     else str_label = "[ AND 抽出 ] - ";
-    set_label( str_label + MISC::to_plain( DBTREE::article_modified_subject( url_article() ) ) );
+    set_label( str_label + MISC::to_markup( DBTREE::article_modified_subject( url_article() ) ), true );
 
     // タブ更新
     ARTICLE::get_admin()->set_command( "set_tablabel", get_url(), get_label() );

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -711,7 +711,11 @@ void BoardViewBase::update_columns()
         Gtk::CellRenderer *cell = column->get_first_cell();
 
         // 実際の描画の際に cellrendere のプロパティをセットするスロット関数
-        if( cell ) column->set_cell_data_func( *cell, sigc::mem_fun( *this, &BoardViewBase::slot_cell_data ) );
+        if( cell ) {
+            auto slot_func{ id == COL_SUBJECT ? &BoardViewBase::slot_cell_data_markup
+                                              : &BoardViewBase::slot_cell_data };
+            column->set_cell_data_func( *cell, sigc::mem_fun( *this, slot_func ) );
+        }
 
         Gtk::CellRendererText* rentext = dynamic_cast< Gtk::CellRendererText* >( cell );
         if( rentext ){
@@ -859,6 +863,28 @@ void BoardViewBase::save_column_width()
             break;
         }
     }
+}
+
+
+
+//
+// Subjectの実際の描画の際に cellrenderer のプロパティをセットするスロット関数
+//
+void BoardViewBase::slot_cell_data_markup( Gtk::CellRenderer* cell, const Gtk::TreeModel::iterator& it )
+{
+    Gtk::TreeModel::Row row = *it;
+
+    // ハイライト色 ( 抽出状態 )
+    if( row[ m_columns.m_col_drawbg ] ){
+        cell->property_cell_background() = CONFIG::get_color( COLOR_BACK_HIGHLIGHT_TREE );
+        cell->property_cell_background_set() = true;
+    }
+
+    else m_treeview.slot_cell_data( cell, it );
+
+    Gtk::CellRendererText* rentext = dynamic_cast<Gtk::CellRendererText*>( cell );
+    rentext->property_text() = "";
+    rentext->property_markup() = row[ m_columns.m_col_subject ];
 }
 
 
@@ -1902,7 +1928,7 @@ void BoardViewBase::update_row_common( const Gtk::TreeModel::Row& row )
     const int res = art->get_number();
 
     // タイトル、レス数、抽出
-    row[ m_columns.m_col_subject ] = MISC::to_plain( art->get_modified_subject( true ) );
+    row[ m_columns.m_col_subject ] = MISC::to_markup( art->get_modified_subject( true ) );
     row[ m_columns.m_col_res ] = res;
 
     // 読み込み数
@@ -2281,7 +2307,12 @@ bool BoardViewBase::slot_query_tooltip( int x, int y, bool keyboard_tooltip,
         if( pixel_width + offset < column->get_width() ) return false;
 
         // ツールチップにセルの内容をセットする
-        tooltip->set_text( cell_text );
+        if( title == ITEM_NAME_NAME ) {
+            tooltip->set_markup( cell_text );
+        }
+        else {
+            tooltip->set_text( cell_text );
+        }
         return true;
     }
     return false;

--- a/src/board/boardviewbase.h
+++ b/src/board/boardviewbase.h
@@ -239,6 +239,7 @@ namespace BOARD
         // 列の幅の保存
         virtual void save_column_width();
 
+        void slot_cell_data_markup( Gtk::CellRenderer* cell, const Gtk::TreeModel::iterator& it );
         void slot_cell_data( Gtk::CellRenderer* cell, const Gtk::TreeModel::iterator& it );
 
         // 全ての行の表示内容更新

--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -201,6 +201,16 @@ void Css_Manager::set_default_css()
     css.border_bottom_width_px = 1;
 
     set_property( "imgpopup", css );
+
+
+    /////////////////
+    // mark
+    std::map< std::string, std::string > props{
+        { "color", "black" },
+        { "background-color", "yellow" },
+    };
+
+    set_property( "mark", create_property( props ) );
 }
 
 

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -13,6 +13,8 @@
 #include "dbtree/spchar_decoder.h"
 #include "dbtree/node.h"
 
+#include "cssmanager.h"
+
 #include <glib.h>
 
 #include <sstream>
@@ -1021,6 +1023,96 @@ std::string MISC::to_plain( const std::string& html )
     }
 
     return str_out;
+}
+
+
+/** @brief HTMLをPango markupテキストに変換する
+ *
+ * @details <mark>と<span>タグの色を設定して文字参照をデコードして返す。
+ * @param[in] html Pango markupテキストに変換する入力
+ * @return 変換した結果
+ */
+std::string MISC::to_markup( const std::string& html )
+{
+    if( html.empty() ) return html;
+    if( html.find_first_of( "<&" ) == std::string::npos ) return html;
+
+    std::string markuptxt;
+    const char* pos = html.c_str();
+    const char* pos_end = pos + html.size();
+
+    while( pos < pos_end ){
+
+        // '<' か '&' までコピーする
+        while( *pos != '<' && *pos != '&' && *pos != '\0' ) markuptxt.push_back( *pos++ );
+        if( pos >= pos_end ) break;
+
+        // タグを処理する
+        if( *pos == '<' ) {
+            ++pos;
+
+            // <mark>と<span>タグは色を変える
+            if( std::strncmp( pos, "mark", 4 ) == 0 || std::strncmp( pos, "span", 4 ) == 0 ) {
+                std::string classname = ( ( *pos ) == 'm' ) ? "mark" : "";
+                pos += 4;
+                if( std::strncmp( pos, " class=\"", 8 ) == 0 ) {
+                    pos += 8;
+                    const char* pos_name = pos;
+                    while( *pos != '"' && *pos != '\0' ) ++pos;
+                    classname.assign( pos_name, pos - pos_name );
+                    if( *pos != '\0' ) ++pos;
+                }
+
+                markuptxt += "<span";
+
+                if( classname.size() ) {
+                    CORE::Css_Manager* mgr = CORE::get_css_manager();
+                    const int classid = mgr->get_classid( classname );
+                    if( classid != -1 ) {
+                        CORE::CSS_PROPERTY css = mgr->get_property( classid );
+                        if( css.color != -1 ) markuptxt += " color=\"" + mgr->get_color( css.color ) + "\"";
+                        if( css.bg_color != -1 ) markuptxt += " background=\"" + mgr->get_color( css.bg_color ) + "\"";
+                    }
+                }
+
+                while( *pos != '>' && *pos != '\0' ) markuptxt.push_back( *pos++ );
+                markuptxt.push_back( '>' );
+                if( *pos != '\0' ) ++pos;
+                continue;
+            }
+
+            // </mark> は </span> に置換する
+            if( std::strncmp( pos, "/mark>", 6 ) == 0 || std::strncmp( pos, "/span>", 6 ) == 0 ) {
+                pos += 6;
+                markuptxt += "</span>";
+                continue;
+            }
+
+            // XXX: その他のタグは取り除く
+            while( *pos != '>' && *pos != '\0' ) ++pos;
+            if( *pos == '>' ) ++pos;
+            continue;
+        }
+
+        // 文字参照を処理する
+        if( *pos == '&' ) {
+            if( std::strncmp( pos + 1, "quot;", 5 ) == 0 ) {
+                markuptxt.push_back( '"' );
+                pos += 6;
+            }
+            else {
+                int n_in;
+                const char pre{ markuptxt.empty() ? '\0' : markuptxt.back() };
+                markuptxt += chref_decode_one( pos, n_in, pre, false );
+                if( n_in == 1 && markuptxt.back() == '&' ){
+                    markuptxt += "amp;";
+                }
+                pos += n_in;
+            }
+        }
+    }
+
+    return markuptxt;
 }
 
 

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -148,6 +148,9 @@ namespace MISC
     // HTMLをプレーンテキストに変換する
     std::string to_plain( const std::string& html );
 
+    // HTMLをPango Markupテキストに変換する
+    std::string to_markup( const std::string& html );
+
     // HTML文字参照をデコード( completely=trueの場合は '&' '<' '>' '"' を含める )
     std::string chref_decode( std::string_view str, const bool completely );
 

--- a/src/message/messageview.cpp
+++ b/src/message/messageview.cpp
@@ -39,7 +39,7 @@ MessageViewMain::MessageViewMain( const std::string& url, const std::string& msg
     set_title( "[ 書き込み ] " + MISC::to_plain( subject ) );
 
     // ツールバーにスレ名を表示
-    set_label( MISC::to_plain( subject ) );
+    set_label( MISC::to_markup( subject ), true );
 }
 
 

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -72,7 +72,13 @@ void ToolBar::set_view( SKELETON::View* view )
     set_url( view->get_url() );
 
     // ラベル表示更新
-    set_label( view->get_label() );
+    set_label( view->get_label(), view->get_label_use_markup() );
+    if( m_tool_label ) {
+        const std::string& tooltip{ view->get_tooltip_label() };
+        set_tooltip( *m_tool_label,
+                     tooltip.empty() ? view->get_label() : tooltip,
+                     view->get_label_use_markup() );
+    }
     if( view->is_broken() || view->is_old() || view->is_overflow() ) set_color( view->get_color() );
 
     // 閉じるボタンの表示更新
@@ -234,9 +240,10 @@ void ToolBar::pack_transparent_separator()
 //
 // ツールチップ
 //
-void ToolBar::set_tooltip( Gtk::ToolItem& toolitem, const std::string& tip )
+void ToolBar::set_tooltip( Gtk::ToolItem& toolitem, const std::string& tip, const bool use_markup )
 {
-    toolitem.set_tooltip_text( tip );
+    if( use_markup ) toolitem.set_tooltip_markup( tip );
+    else toolitem.set_tooltip_text( tip );
 }
 
 
@@ -283,12 +290,12 @@ Gtk::ToolItem* ToolBar::get_label()
 }
 
 
-void ToolBar::set_label( const std::string& label )
+void ToolBar::set_label( const std::string& label, const bool use_markup )
 {
     if( ! m_ebox_label ) return;
 
     m_label->set_text( label );
-    if( m_tool_label ) set_tooltip( *m_tool_label, label );
+    m_label->set_use_markup( use_markup );
     set_color( "" );
 }
 

--- a/src/skeleton/toolbar.h
+++ b/src/skeleton/toolbar.h
@@ -163,12 +163,12 @@ namespace SKELETON
 
         void pack_separator();
         void pack_transparent_separator();
-        void set_tooltip( Gtk::ToolItem& toolitem, const std::string& tip );
+        void set_tooltip( Gtk::ToolItem& toolitem, const std::string& tip, const bool use_markup = false );
 
       private:
 
         // ラベル関係
-        void set_label( const std::string& label );
+        void set_label( const std::string& label, const bool use_markup = false );
         void set_color( const std::string& color );
 
         // 検索関係

--- a/src/skeleton/view.h
+++ b/src/skeleton/view.h
@@ -44,6 +44,12 @@ namespace SKELETON
         // ツールバーに表示する文字列
         std::string m_label;
 
+        /// ツールバーのツールチップに表示する文字列
+        std::string m_tooltip_label;
+
+        /// ツールバーに表示する文字列にmarkupを使用するか
+        bool m_label_use_markup{};
+
         // メインウィンドウのタイトルに表示する文字
         std::string m_title;
 
@@ -99,8 +105,15 @@ namespace SKELETON
         // コントローラ
         CONTROL::Control& get_control(){ return m_control; }
 
-        // ツールバーに表示するラベル
-        void set_label( const std::string& label ){ m_label = label; }
+        /// ツールバーに表示するラベルをセット
+        void set_label( const std::string& label, const bool use_markup = false )
+        {
+            m_label = label;
+            m_label_use_markup = use_markup;
+        }
+
+        /// ツールバーに表示するラベルのツールチップをセット
+        void set_tooltip_label( const std::string& label ) { m_tooltip_label = label; }
 
         // メインウィンドウのタイトルに表示する文字列
         void set_title( const std::string& title ){ m_title = title; }
@@ -214,6 +227,12 @@ namespace SKELETON
 
         // ツールバーのラベルに表示する文字列
         const std::string& get_label() const { return m_label; }
+
+        /// ツールバーのラベルのツールチップに表示する文字列
+        const std::string& get_tooltip_label() const { return m_tooltip_label; }
+
+        /// ツールバーのラベルに表示する文字列にmarkupを使用するか
+        bool get_label_use_markup() const { return m_label_use_markup; }
 
         // メインウィンドウのタイトルバーに表示する文字列
         virtual const std::string& get_title() const { return m_title; }

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -1174,6 +1174,81 @@ TEST_F(ToPlainTest, broken_tags)
 }
 
 
+class ToMarkupTest : public ::testing::Test {};
+
+TEST_F(ToMarkupTest, empty)
+{
+    const std::string result = MISC::to_markup( std::string{} );
+    EXPECT_EQ( result, std::string{} );
+}
+
+TEST_F(ToMarkupTest, no_conversion)
+{
+    const std::string result = MISC::to_markup( "hello 世界" );
+    EXPECT_EQ( result, "hello 世界" );
+}
+
+TEST_F(ToMarkupTest, decimal_hello)
+{
+    const std::string result = MISC::to_markup( "&#104;&#101;&#108;&#108;&#111;" );
+    EXPECT_EQ( result, "hello" );
+}
+
+TEST_F(ToMarkupTest, hexadecimal_hello)
+{
+    const std::string result = MISC::to_markup( "&#x68;&#x65;&#X6c;&#x6C;&#x6f;" );
+    EXPECT_EQ( result, "hello" );
+}
+
+TEST_F(ToMarkupTest, escape_html_char_completely)
+{
+    // 動作の根拠がはっきりしていないが &quot; は " に変換される
+    const std::string input = "&#60;&#62;&#38;&#34; &#x3c;&#x3e;&#x26;&#x22; &lt;&gt;&amp;&quot;";
+    const std::string result = MISC::to_markup( input );
+    EXPECT_EQ( result, R"(&lt;&gt;&amp;&quot; &lt;&gt;&amp;&quot; &lt;&gt;&amp;")" );
+}
+
+TEST_F(ToMarkupTest, flatten_tags)
+{
+    const std::string input = "Hello<foo>世界<bar>Quick</bar></foo>Brown Fox";
+    const std::string result = MISC::to_markup( input );
+    EXPECT_EQ( result, "Hello世界QuickBrown Fox" );
+}
+
+TEST_F(ToMarkupTest, broken_tags)
+{
+    std::string input = "Hello<fo<o>世界</f>oo>Quick Brown Fox";
+    std::string result = MISC::to_markup( input );
+    EXPECT_EQ( result, "Hello世界oo>Quick Brown Fox" );
+
+    input = "Hello<foo>世界>Quick</foo<Brown Fox";
+    result = MISC::to_markup( input );
+    EXPECT_EQ( result, "Hello世界>Quick" );
+}
+
+TEST_F(ToMarkupTest, span_tags)
+{
+    std::string input = "Hello<span>世界</span>Quick Brown Fox";
+    std::string result = MISC::to_markup( input );
+    EXPECT_EQ( result, "Hello<span>世界</span>Quick Brown Fox" );
+
+    input = R"(Hello 世界<span class="mark">Quick</span>Brown Fox)";
+    result = MISC::to_markup( input );
+    EXPECT_EQ( result, R"(Hello 世界<span color="#000000000000" background="#ffffffff0000">Quick</span>Brown Fox)" );
+}
+
+TEST_F(ToMarkupTest, mark_tags)
+{
+    std::string input = "Hello<mark>世界</mark>Quick Brown Fox";
+    std::string result = MISC::to_markup( input );
+    EXPECT_EQ( result, R"(Hello<span color="#000000000000" background="#ffffffff0000">世界</span>Quick Brown Fox)" );
+
+    input = R"(Hello<mark class="jdim-unused-css-class">世界</mark>Quick Brown Fox)";
+    result = MISC::to_markup( input );
+    EXPECT_EQ( result, "Hello<span>世界</span>Quick Brown Fox" );
+}
+
+
 class ChrefDecodeTest : public ::testing::Test {};
 
 TEST_F(ChrefDecodeTest, empty)


### PR DESCRIPTION
### [Css_Manager: Add "mark" class selector to default settings](https://github.com/JDimproved/JDim/commit/fabb03fb84367340322afd6ed322d8621335daa2)

CSSのデフォルト設定に"mark"クラスセレクタを追加します。
"mark"クラスセレクタは主にスレタイトルの装飾で使われています。

### [Implement MISC::to_markup()](https://github.com/JDimproved/JDim/commit/b7503e6903a3c09cbb840227d8a3f09f6cd2dac7)

入力された文字列をコピーしてPango Markupテキスト化(`<mark>`と`<span>`タグの色を設定して文字参照をデコード)して返す関数を追加します。

#### 参考文献
https://docs.gtk.org/Pango/pango_markup.html

### [Add test cases for MISC::to_markup()](https://github.com/JDimproved/JDim/commit/d0849763eb1d1db94ea9b6c2542f470d29d81d65)

### [toolbar: Implement Pango Markup decoration for label and tooltip](https://github.com/JDimproved/JDim/commit/6ca231ec22fa40d0498f278a09939d69de7a9673)

ツールバーに表示するラベルやツールチップにPango Markupの装飾を適用する仕組みを実装します。

### [toolbar: Use Pango Markup decoration to display thread subject](https://github.com/JDimproved/JDim/commit/73293fc0766fc7aff45e12c46188a496ef5ab88a)

ツールバーのラベルとツールチップに表示するスレタイトルをPango Markupで装飾して表示するように変更します。

### [BoardViewBase: Use Pango Markup decoration to display thread subject](https://github.com/JDimproved/JDim/commit/6cdf3feb0e4bef566bdeb1a55a6a13890d3ebc82)

スレ一覧に表示するスレタイトルをPango Markupで装飾して表示するように変更します。

関連のissue: #76 
