### PR TITLE
ReplaceStrPref: Add ignore case option without regex

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -479,6 +479,44 @@ std::string MISC::replace_str( std::string_view str, std::string_view pattern, s
 }
 
 
+/** @brief 文字列をコピーし部分文字列 old を new_ に置換して返す (ASCIIだけignore case)
+ *
+ * @param[in] str コピーする文字列
+ * @param[in] old 置き換え対象 (ASCIIだけ大文字小文字を無視)
+ * @param[in] new_ 置き換える内容
+ * @return 置換処理した結果
+ * - old が空文字列のときは str を返す
+ * - old が見つからなかったときは str を返す
+ */
+std::string MISC::replace_casestr( const std::string& str, const std::string& old, const std::string& new_ )
+{
+    if( old.empty() ) return str;
+
+    std::string str_out;
+
+    const char head[3] = { g_ascii_toupper( old[0] ), g_ascii_tolower( old[0] ) };
+    std::size_t p0 = 0;
+    std::size_t p1 = 0;
+    while( true ) {
+        const std::size_t p2 = str.find_first_of( head, p1 );
+        if( p2 == std::string::npos ) break;
+        // ヌル終端文字列が要件なので注意
+        if( g_ascii_strncasecmp( str.c_str() + p2, old.data(), old.size() ) == 0 ) {
+            str_out.append( str, p0, p2 - p0 );
+            str_out.append( new_ );
+            p0 = p1 = p2 + old.size();
+            continue;
+        }
+        p1 = p2 + 1;
+    }
+    if( p0 == 0 ) return str;
+
+    str_out.append( str, p0 );
+
+    return str_out;
+}
+
+
 /** @brief list_inから pattern を replacement に置き換えてリストを返す
  *
  * @param[in] list_in 置き換えを実行する文字列のリスト

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -94,6 +94,9 @@ namespace MISC
     /// pattern を replacement に置き換える
     std::string replace_str( std::string_view str, std::string_view pattern, std::string_view replacement );
 
+    /// 文字列をコピーし部分文字列 old を new_ に置換して返す (ASCIIだけignore case)
+    std::string replace_casestr( const std::string& str, const std::string& old, const std::string& new_ );
+
     /// list_inから pattern を replacement に置き換えてリストを返す
     std::list<std::string> replace_str_list( const std::list<std::string>& list_in,
                                              std::string_view pattern, std::string_view replacement );

--- a/src/replacestrmanager.cpp
+++ b/src/replacestrmanager.cpp
@@ -290,6 +290,7 @@ std::string ReplaceStr_Manager::replace( std::string_view str, const int id ) co
         }
 
         // 正規表現を使わない置換処理
+        else if( condition.icase ) buffer = MISC::replace_casestr( buffer, item.pattern, item.replace );
         else buffer = MISC::replace_str( buffer, item.pattern, item.replace );
     }
 

--- a/src/replacestrpref.cpp
+++ b/src/replacestrpref.cpp
@@ -38,7 +38,6 @@ ReplaceStrDiag::ReplaceStrDiag( Gtk::Window* parent, ReplaceStrCondition conditi
 
     m_check_active.set_active( condition.active );
     m_check_icase.set_active( condition.icase );
-    m_check_icase.set_sensitive( condition.regex );
     m_check_regex.set_active( condition.regex );
 
     m_check_active.set_tooltip_text( "この条件の置換を有効にする" );
@@ -107,7 +106,6 @@ void ReplaceStrDiag::slot_copy()
 //
 void ReplaceStrDiag::slot_sens()
 {
-    m_check_icase.set_sensitive( get_regex() );
 }
 
 

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -281,6 +281,47 @@ TEST_F(ReplaceStrTest, multi_match)
 }
 
 
+class ReplaceCaseStrTest : public ::testing::Test {};
+
+TEST_F(ReplaceCaseStrTest, empty_data)
+{
+    EXPECT_EQ( "", MISC::replace_casestr( "", "", "" ) );
+    EXPECT_EQ( "", MISC::replace_casestr( "", "AA", "" ) );
+    EXPECT_EQ( "", MISC::replace_casestr( "", "AA", "BB" ) );
+    EXPECT_EQ( "", MISC::replace_casestr( "", "", "BB" ) );
+}
+
+TEST_F(ReplaceCaseStrTest, empty_match)
+{
+    EXPECT_EQ( "Quick Brown Fox", MISC::replace_casestr( "Quick Brown Fox", "", "Red" ) );
+}
+
+TEST_F(ReplaceCaseStrTest, replace_with_empty)
+{
+    EXPECT_EQ( "Quick//Fox", MISC::replace_casestr( "Quick/Brown/Fox", "Brown", "" ) );
+}
+
+TEST_F(ReplaceCaseStrTest, replace_with_empty_ignore_case)
+{
+    EXPECT_EQ( "Quick//Fox", MISC::replace_casestr( "Quick/BrOwN/Fox", "bRoWn", "" ) );
+}
+
+TEST_F(ReplaceCaseStrTest, not_match)
+{
+    EXPECT_EQ( "Quick Brown Fox", MISC::replace_casestr( "Quick Brown Fox", "Red", "Blue" ) );
+}
+
+TEST_F(ReplaceCaseStrTest, multi_match)
+{
+    EXPECT_EQ( "Quick Red Red Fox", MISC::replace_casestr( "Quick Brown Brown Fox", "Brown", "Red" ) );
+}
+
+TEST_F(ReplaceCaseStrTest, multi_match_ignore_case)
+{
+    EXPECT_EQ( "Quick Red Red Fox", MISC::replace_casestr( "Quick BrOwN bRoWn Fox", "BRowN", "Red" ) );
+}
+
+
 class ReplaceStrListTest : public ::testing::Test {};
 
 TEST_F(ReplaceStrListTest, empty_data)


### PR DESCRIPTION
### [Implement MISC::replace_casestr()](https://github.com/JDimproved/JDim/commit/807f8edd6811d8933681def3dfb6cbc01cabd4bd)

文字列をコピーし部分文字列に一致する箇所を置換して返す関数を実装します。
部分文字列はASCIIの大文字小文字を無視して一致します。

### [Add test cases for MISC::replace_casestr()](https://github.com/JDimproved/JDim/commit/7f58833db0427eb4a1f13ee075aba3008fb4279c)

### [ReplaceStrPref: Add ignore case option without regex](https://github.com/JDimproved/JDim/commit/db0ea91e4c33d89d10c8297ca735ae9496fd944f)

正規表現を使わずにASCIIの大文字小文字を無視して文字列置換するオプションを追加します。

関連のissue: #76 
