### PR TITLE
toolbar: Add setting that changes color for thread subject per state

### DIFF
--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -263,6 +263,7 @@ void AboutConfig::append_rows()
     append_row( "スレビューのスクロールバーを左に配置する", get_confitem()->left_scrbar, CONF_LEFT_SCRBAR );
     append_row( "メニューバーを非表示にした時にダイアログを表示", get_confitem()->show_hide_menubar_diag, CONF_SHOW_HIDE_MENUBAR_DIAG );
     append_row( "状態変更時にメインステータスバーの色を変える", get_confitem()->change_stastatus_color, CONF_CHANGE_STASTATUS_COLOR );
+    append_row( "状態変更時にスレビュータイトルの色を変える", get_confitem()->change_statitle_color, CONF_CHANGE_STATITLE_COLOR );
     append_row( "Client-Side Decorationを使うか( 0: 使わない 1: 使う 2: デスクトップに合わせる )",
                 get_confitem()->use_header_bar, CONF_USE_HEADER_BAR );
 

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -562,6 +562,9 @@ bool ConfigItems::load( const bool restore )
     // 状態変更時にメインステータスバーの色を変える
     change_stastatus_color = cf.get_option_bool( "change_stastatus_color", CONF_CHANGE_STASTATUS_COLOR );
 
+    // 状態変更時にスレビュータイトルの色を変える
+    change_statitle_color = cf.get_option_bool( "change_statitle_color", CONF_CHANGE_STATITLE_COLOR );
+
     // Client-Side Decorationを使うか( 0: 使わない 1: 使う 2: デスクトップに合わせる )
     use_header_bar = cf.get_option_int( "use_header_bar", CONF_USE_HEADER_BAR, 0, 2 );
 
@@ -917,6 +920,7 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "disable_close", disable_close );
     cf.update( "show_hide_menubar_diag", show_hide_menubar_diag );
     cf.update( "change_stastatus_color", change_stastatus_color );
+    cf.update( "change_statitle_color", change_statitle_color );
     cf.update( "use_header_bar", use_header_bar );
     cf.update( "use_machi_offlaw", use_machi_offlaw );
     cf.update( "show_del_written_thread_diag", show_del_written_thread_diag );

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -507,6 +507,9 @@ namespace CONFIG
         // 状態変更時にメインステータスバーの色を変える
         bool change_stastatus_color{};
 
+        // 状態変更時にスレビュータイトルの色を変える
+        bool change_statitle_color{};
+
         // Client-Side Decorationを使うか( 0: 使わない 1: 使う 2: デスクトップに合わせる )
         int use_header_bar{};
 

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -155,6 +155,7 @@ namespace CONFIG
         CONF_DISABLE_CLOSE = 0, // Ctrl+qでウィンドウを閉じない
         CONF_SHOW_HIDE_MENUBAR_DIAG = 1, // メニューバーを非表示にした時にダイアログを表示
         CONF_CHANGE_STASTATUS_COLOR = 1, // 状態変更時にメインステータスバーの色を変える
+        CONF_CHANGE_STATITLE_COLOR = 1, // 状態変更時にスレビュータイトルの色を変える
         CONF_USE_HEADER_BAR = 2, // Client-Side Decorationを使うか( 0: 使わない 1: 使う 2: デスクトップに合わせる )
         CONF_USE_MACHI_OFFLAW = 0, // まちBBSの取得に offlaw.cgi を使用する
         CONF_SHOW_DEL_WRITTEN_THREAD_DIAG = 1, // 書き込み履歴のあるスレを削除する時にダイアログを表示

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -586,6 +586,9 @@ void CONFIG::set_show_hide_menubar_diag( const bool set ){ get_confitem()->show_
 // 状態変更時にメインステータスバーの色を変える
 bool CONFIG::get_change_stastatus_color(){ return get_confitem()->change_stastatus_color; }
 
+// 状態変更時にスレビュータイトルの色を変える
+bool CONFIG::get_change_statitle_color(){ return get_confitem()->change_statitle_color; }
+
 // Client-Side Decorationを使うか( 0: 使わない 1: 使う 2: デスクトップに合わせる )
 int CONFIG::get_use_header_bar() { return get_confitem()->use_header_bar; }
 

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -583,6 +583,9 @@ namespace CONFIG
     // 状態変更時にメインステータスバーの色を変える
     bool get_change_stastatus_color();
 
+    // 状態変更時にスレビュータイトルの色を変える
+    bool get_change_statitle_color();
+
     // Client-Side Decorationを使うか( 0: 使わない 1: 使う 2: デスクトップに合わせる )
     int get_use_header_bar();
 

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -79,7 +79,9 @@ void ToolBar::set_view( SKELETON::View* view )
                      tooltip.empty() ? view->get_label() : tooltip,
                      view->get_label_use_markup() );
     }
-    if( view->is_broken() || view->is_old() || view->is_overflow() ) set_color( view->get_color() );
+    if( CONFIG::get_change_statitle_color() && ( view->is_broken() || view->is_old() || view->is_overflow() ) ) {
+        set_color( view->get_color() );
+    }
 
     // 閉じるボタンの表示更新
     if( m_button_close ){


### PR DESCRIPTION
スレッドの状態が変わったときにツールバーのスレタイトル色を変える設定を追加します。
修正前は色を変える状態で固定されていました。

関連のissue: #76 
