### PR TITLE
statusbar: Reset default color if setting turned off

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -2979,6 +2979,7 @@ void Core::set_command( const COMMAND_ARGS& command )
 
     else if( command.command  == "set_status_color" ){
         if( CONFIG::get_change_stastatus_color() ) m_win_main.set_status_color( command.arg1 );
+        else m_win_main.set_status_color( "" );
     }
 
     // 一時的にステータスバーの表示を変える( マウスオーバーでのURL表示用 )


### PR DESCRIPTION
スレッドの状態が変わったときにステータスバーの色を変える設定がオフになっているときはステータスバーをデフォルト色に戻します。
