### PR TITLE
Use std::string_view for MISC::url_decode()

### DIFF
--- a/src/jdlib/misctrip.cpp
+++ b/src/jdlib/misctrip.cpp
@@ -117,7 +117,7 @@ std::string create_trip_newtype( const std::string& key )
             char key_binary[17] = { 0 };
 
             // 16進数文字列を全てバイナリに変換出来た [0-9A-Za-z]{16}
-            if( MISC::chrtobin( hex_part.c_str(), key_binary ) == 16 )
+            if( MISC::chrtobin( hex_part, key_binary ) == 16 )
             {
                 std::string salt;
 

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1296,48 +1296,52 @@ bool MISC::is_url_char( const char* str_in, const bool loose_url )
 
 
 
-//
-// URLデコード
-//
-std::string MISC::url_decode( const std::string& url )
+/** @brief URLに含まれるパーセントエンコーディングをバイト列にデコードする
+ *
+ * @param[in] url デコードするURL
+ * @return デコードした結果
+ */
+std::string MISC::url_decode( std::string_view url )
 {
-    if( url.empty() ) return std::string();
+    std::string decoded;
+    if( url.empty() ) return decoded;
 
-    const size_t url_length = url.length();
-
-    std::vector< char > decoded( url_length + 1, '\0' );
-
-    unsigned int a, b;
-    for( a = 0, b = a; a < url_length; ++a, ++b )
+    const std::size_t size = url.size();
+    for( std::size_t n = 0; n < size; ++n )
     {
-        if( url[a] == '%' && ( a + 2 < url_length ) )
+        if( url[n] == '%' && ( n + 2 ) < size )
         {
-            char src[3] = { url[ a + 1 ], url[ a + 2 ], '\0' };
+            char src[3] = { url[ n + 1 ], url[ n + 2 ], '\0' };
             char tmp[3] = { '\0', '\0', '\0' };
 
             if( chrtobin( src, tmp ) == 2 )
             {
+                // 改行はLFにする
+                if( *tmp == '\n' && ! decoded.empty() && decoded.back() == '\r' )
+                {
+                    decoded.pop_back();
+                }
                 // '%4A' など、2文字が変換できていること
-                decoded[b] = *tmp;
-                a += 2;
+                decoded.push_back( *tmp );
+                n += 2;
             }
             else
             {
                 // 変換失敗は、単なる '%' 文字として扱う
-                decoded[b] = url[a];
+                decoded.push_back( url[n] );
             }
         }
-        else if( url[a] == '+' )
+        else if( url[n] == '+' )
         {
-            decoded[b] = ' ';
+            decoded.push_back( ' ' );
         }
         else
         {
-            decoded[b] = url[a];
+            decoded.push_back( url[n] );
         }
     }
 
-    return decoded.data();
+    return decoded;
 }
 
 

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -676,38 +676,39 @@ std::string MISC::intlisttostr( const std::list< int >& list_num )
 
 
 
-//
-// 16進数表記文字をバイナリに変換する( 例 "E38182" -> 0xE38182 )
-//
-// 出力 : char_out 
-// 戻り値: 変換に成功した chr_in のバイト数
-//
-size_t MISC::chrtobin( const char* chr_in, char* chr_out )
+/** @brief 16進数表記文字列をバイト列に変換する( 例 "E38182" -> "\xE3\x81\x82" )
+ *
+ * @param[in]  chr_in 入力
+ * @param[out] chr_out 出力 (not null)
+ * @return 変換に成功した chr_in のバイト数
+ */
+std::size_t MISC::chrtobin( std::string_view chr_in, char* chr_out )
 {
-    if( ! chr_in ) return 0;
+    assert( chr_out );
+    if( chr_in.empty() ) return 0;
 
-    const size_t chr_in_length = strlen( chr_in );
+    const std::size_t chr_in_length = chr_in.length();
 
-    size_t a, b;
-    for( a = 0, b = a; a < chr_in_length; ++a )
+    std::size_t n = 0;
+    for( ; n < chr_in_length; ++n )
     {
-        unsigned char chr = chr_in[a];
+        const unsigned int chr = static_cast<unsigned char>( chr_in[n] );
 
-        chr_out[b] <<= 4;
+        *chr_out <<= 4;
 
         // 0(0x30)〜9(0x39)
-        if( (unsigned char)( chr - 0x30 ) < 10 ) chr_out[b] |= chr - 0x30;
+        if( ( chr - 0x30 ) < 10 ) *chr_out |= chr - 0x30;
         // A(0x41)〜F(0x46)
-        else if( (unsigned char)( chr - 0x41 ) < 6 ) chr_out[b] |= chr - 0x37;
+        else if( ( chr - 0x41 ) < 6 ) *chr_out |= chr - 0x37;
         // a(0x61)〜f(0x66)
-        else if( (unsigned char)( chr - 0x61 ) < 6 ) chr_out[b] |= chr - 0x57;
+        else if( ( chr - 0x61 ) < 6 ) *chr_out |= chr - 0x57;
         // その他
         else break;
 
-        if( a % 2 != 0 ) ++b;
+        if( n % 2 != 0 ) ++chr_out;
     }
 
-    return a;
+    return n;
 }
 
 

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -171,8 +171,8 @@ namespace MISC
     // "RFC 2396" : http://www.ietf.org/rfc/rfc2396.txt
     bool is_url_char( const char* str_in, const bool loose_url );
 
-    // URLデコード
-    std::string url_decode( const std::string& url );
+    /// URLに含まれるパーセントエンコーディングをバイト列にデコードする
+    std::string url_decode( std::string_view url );
 
     // urlエンコード
     std::string url_encode( const char* str, const size_t n );

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -125,7 +125,7 @@ namespace MISC
     // 16進数表記文字をバイナリに変換する( 例 "E38182" -> 0xE38182 )
     // 出力 : char_out 
     // 戻り値: 変換に成功した chr_in のバイト数
-    size_t chrtobin( const char* chr_in, char* chr_out );
+    std::size_t chrtobin( std::string_view chr_in, char* chr_out );
 
     // strが半角でmaxsize文字を超えたらカットして後ろに...を付ける
     std::string cut_str( const std::string& str, const unsigned int maxsize );

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -1401,6 +1401,37 @@ TEST_F(ChrefDecodeTest, escape_html_char_keeping)
 }
 
 
+class UrlDecodeTest : public ::testing::Test {};
+
+TEST_F(UrlDecodeTest, empty)
+{
+    EXPECT_EQ( "", MISC::url_decode( "" ) );
+}
+
+TEST_F(UrlDecodeTest, not_decode)
+{
+    EXPECT_EQ( "http://foobar.test?a=1&b=c", MISC::url_decode( "http://foobar.test?a=1&b=c" ) );
+}
+
+TEST_F(UrlDecodeTest, decode_hiragana)
+{
+    constexpr const char* url = "http://hira.test/%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A";
+    EXPECT_EQ( "http://hira.test/あいうえお", MISC::url_decode( url ) );
+}
+
+TEST_F(UrlDecodeTest, decode_plus_sign)
+{
+    constexpr const char* url = "http://plus.test/Quick+Brown+Fox";
+    EXPECT_EQ( "http://plus.test/Quick Brown Fox", MISC::url_decode( url ) );
+}
+
+TEST_F(UrlDecodeTest, out_of_range_segments)
+{
+    constexpr const char* url = "http://out.test/%41%4G%61%G1%%a";
+    EXPECT_EQ( "http://out.test/A%4Ga%G1%%a", MISC::url_decode( url ) );
+}
+
+
 class AsciiIgnoreCaseFindTest : public ::testing::Test {};
 
 TEST_F(AsciiIgnoreCaseFindTest, empty)

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -372,12 +372,6 @@ TEST_F(ReplaceNewlinesToStrTest, replace_crlf)
 
 class ChrToBinTest : public ::testing::Test {};
 
-TEST_F(ChrToBinTest, null_input)
-{
-    char output[4]{};
-    EXPECT_EQ( 0, MISC::chrtobin( nullptr, output ) );
-}
-
 TEST_F(ChrToBinTest, empty_input)
 {
     char output[4]{};

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -370,6 +370,82 @@ TEST_F(ReplaceNewlinesToStrTest, replace_crlf)
 }
 
 
+class ChrToBinTest : public ::testing::Test {};
+
+TEST_F(ChrToBinTest, null_input)
+{
+    char output[4]{};
+    EXPECT_EQ( 0, MISC::chrtobin( nullptr, output ) );
+}
+
+TEST_F(ChrToBinTest, empty_input)
+{
+    char output[4]{};
+    EXPECT_EQ( 0, MISC::chrtobin( "", output ) );
+}
+
+TEST_F(ChrToBinTest, fullwidth_input)
+{
+    char output[4]{};
+    EXPECT_EQ( 0, MISC::chrtobin( "ＡＢ", output ) );
+    EXPECT_EQ( 0, MISC::chrtobin( "１２", output ) );
+}
+
+TEST_F(ChrToBinTest, non_ascii_input)
+{
+    char output[4]{};
+    EXPECT_EQ( 0, MISC::chrtobin( "あい", output ) );
+    EXPECT_EQ( 0, MISC::chrtobin( "アイ", output ) );
+}
+
+TEST_F(ChrToBinTest, non_hexadecimal_input)
+{
+    char output[4]{};
+    EXPECT_EQ( 0, MISC::chrtobin( "GH", output ) );
+    EXPECT_EQ( 0, MISC::chrtobin( "gh", output ) );
+    EXPECT_EQ( 0, MISC::chrtobin( " !", output ) );
+}
+
+TEST_F(ChrToBinTest, hexadecimal_input)
+{
+    char output[16];
+
+    std::memset( output, '\0', 16 );
+    EXPECT_EQ( 10, MISC::chrtobin( "0123456789", output ) );
+    EXPECT_STREQ( "\x01\x23\x45\x67\x89", output );
+
+    std::memset( output, '\0', 16 );
+    EXPECT_EQ( 6, MISC::chrtobin( "ABCDEF", output ) );
+    EXPECT_STREQ( "\xAB\xCD\xEF", output );
+}
+
+TEST_F(ChrToBinTest, hexadecimal_incomplete_input)
+{
+    char output[16];
+
+    std::memset( output, '\0', 16 );
+    EXPECT_EQ( 3, MISC::chrtobin( "123", output ) );
+    EXPECT_STREQ( "\x12\x03", output );
+
+    std::memset( output, '\0', 16 );
+    EXPECT_EQ( 3, MISC::chrtobin( "ABC", output ) );
+    EXPECT_STREQ( "\xAB\x0C", output );
+}
+
+TEST_F(ChrToBinTest, break_at_non_hexadecimal)
+{
+    char output[16];
+
+    std::memset( output, '\0', 16 );
+    EXPECT_EQ( 4, MISC::chrtobin( "1234あFFFF", output ) );
+    EXPECT_STREQ( "\x12\x34", output );
+
+    std::memset( output, '\0', 16 );
+    EXPECT_EQ( 3, MISC::chrtobin( "ABC FFFF", output ) );
+    EXPECT_STREQ( "\xAB\xC0", output );
+}
+
+
 class HtmlEscapeTest : public ::testing::Test {};
 
 TEST_F(HtmlEscapeTest, empty_data)


### PR DESCRIPTION
### [Add test cases for MISC::chrtobin()](https://github.com/JDimproved/JDim/commit/f85117eb4c46b230af1e2cd8e75e2f1894b916b4)

### [Add test cases for MISC::url_decode()](https://github.com/JDimproved/JDim/commit/27d60d565f5c234ec4e8ca6d7fd1e2fee1988e60)

### [Use std::string_view for MISC::url_decode()](https://github.com/JDimproved/JDim/commit/221d4fe36fe3abd3a8cb1b2dc55207796470764e)

変更不可の文字列のポインターと長さを渡している関数の引数を`std::string_view`に交換して整理します。

- 改行 CRLF は LF に変換します。

### [Use std::string_view for MISC::chrtobin()](https://github.com/JDimproved/JDim/commit/7349941674f4acadee60fbe1de6cca08fde15f34)

変更不可の文字列のポインターと長さを渡している関数の引数を`std::string_view`に交換して整理します。

関連のissue: #76 