### PR TITLE
Dom: Distinguish letter cases for tag name on XML parse mode

### DIFF
--- a/src/xml/dom.cpp
+++ b/src/xml/dom.cpp
@@ -186,7 +186,8 @@ void Dom::parse( const std::string& str )
                     current_pos = close_tag_gt_pos + 1;
 
                     // タグの中身を取り出す
-                    const std::string close_tag = MISC::tolower_str( str.substr( close_tag_lt_pos + 1, close_tag_gt_pos - close_tag_lt_pos - 1 ) );
+                    std::string close_tag = str.substr( close_tag_lt_pos + 1, close_tag_gt_pos - close_tag_lt_pos - 1 );
+                    if( m_html ) close_tag = MISC::tolower_str( close_tag );
 
                     // タグ構造が壊れてる場合
                     if( close_tag.empty() ) continue;
@@ -196,11 +197,13 @@ void Dom::parse( const std::string& str )
                          continue;
                     }
 
+                    const std::string& tag_name{ m_html ? name : element_name };
                     // 空要素でない同名の開始タグを見つけたらカウントを増やす
-                    if( close_tag.rfind( name, 0 ) == 0
-                        && close_tag.compare( close_tag.size() - 1, 1, "/" ) != 0 ) ++count;
+                    if( close_tag.back() != '/'
+                        && close_tag.rfind( tag_name, 0 ) == 0 ) ++count;
                     // 終了タグを見つけたらカウントを減らす
-                    else if( close_tag.compare( 0, name.length() + 1, "/" + name ) == 0 ) --count;
+                    else if( close_tag.front() == '/'
+                             && close_tag.compare( 1, tag_name.size(), tag_name ) == 0 ) --count;
 
                     // 終了タグを見つける必要数が 0 になったらループを抜ける
                     if( count == 0 ) break;


### PR DESCRIPTION
XMLを解析するモードのときはタグ名の大文字と小文字を区別するように変更します。

関連のissue: #76 