### PR TITLE
docs: Get rid of the note for running on old MATE desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,16 +315,9 @@ WaylandやXWaylandではX11限定の機能を使うことができないため�
 * Wayland上で起動したときポップアップ内のアンカーからポップアップを出すとマウスポインターから離れた位置に表示される。
 * Weston(Waylandコンポジタ)環境でXWaylandをバックエンドに指定して起動した場合、右クリックしながらポップアップ内に
   マウスポインターを動かすとポップアップ内容ではなくポップアップに隠れたスレビューに反応する。
-* 32bit OSの古いMATE環境（バージョン[1.10][mate-1-10]から[1.16][mate-1-16]？）でJDim GTK3版を実行したとき
-  スレビューの上に別のウインドウを重ねて移動させると残像でスレビュー内のみ描画が乱れる。
-  スレビューをスクロール等させて再描画すると直る。([背景事情][mate-background])
 * Wayland環境では画像ビュー(ウインドウ表示)のフォーカスが外れたら折りたたむ機能が正常に動作しない。
 * gcc(バージョン10以降)を使いAddressSanitizer(ASan)を有効にしてビルドすると
   書き込みのプレビューでトリップを表示するときにクラッシュすることがある。([上記](#crash-with-asan)を参照)
-
-[mate-1-10]: https://mate-desktop.org/blog/2015-06-11-mate-1-10-released/ "GTK3の実験的なサポート追加"
-[mate-1-16]: https://mate-desktop.org/blog/2016-09-21-mate-1-16-released/ "GTK3に移行途中"
-[mate-background]: https://github.com/JDimproved/JDim/commit/ffbce60ede#commitcomment-40911816 "別の不具合が再発する"
 
 
 ## JDとの互換性

--- a/docs/manual/start.md
+++ b/docs/manual/start.md
@@ -136,16 +136,10 @@ WaylandやXWaylandではX11限定の機能を使うことができないため�
 * Wayland上で起動したときポップアップ内のアンカーからポップアップを出すとマウスポインターから離れた位置に表示される。
 * Weston(Waylandコンポジタ)環境でXWaylandをバックエンドに指定して起動した場合、右クリックしながらポップアップ内に
   マウスポインターを動かすとポップアップ内容ではなくポップアップに隠れたスレビューに反応する。
-* 32bit OSの古いMATE環境（バージョン[1.10][mate-1-10]から[1.16][mate-1-16]？）でJDim GTK3版を実行したとき
-  スレビューの上に別のウインドウを重ねて移動させると残像でスレビュー内のみ描画が乱れる。
-  スレビューをスクロール等させて再描画すると直る。([背景事情][mate-background])
 * Wayland環境では画像ビュー(ウインドウ表示)のフォーカスが外れたら折りたたむ機能が正常に動作しない。
 * gcc(バージョン10以降)を使いAddressSanitizer(ASan)を有効にしてビルドすると
   書き込みのプレビューでトリップを表示するときにクラッシュすることがある。([Issue #943][#943]を参照)
 
-[mate-1-10]: https://mate-desktop.org/blog/2015-06-11-mate-1-10-released/ "GTK3の実験的なサポート追加"
-[mate-1-16]: https://mate-desktop.org/blog/2016-09-21-mate-1-16-released/ "GTK3に移行途中"
-[mate-background]: https://github.com/JDimproved/JDim/commit/ffbce60ede#commitcomment-40911816 "別の不具合が再発する"
 [#943]: https://github.com/JDimproved/JDim/issues/943
 
 


### PR DESCRIPTION
情報が古くなったため古いMATE環境で実行するときの注意を取り除きます。