### PR TITLE
snap: Migrate base to core20

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,12 +3,12 @@ adopt-info: jdim
 license: "GPL-2.0"
 
 confinement: strict
-base: core18
+base: core20
 grade: stable
 icon: jdim.png
 
-# https://snapcraft.io/gnome-3-34-1804
-# Snap Store does not provide gnome-3-34-1804 package for i386, ppc64el and s390x
+# https://snapcraft.io/gnome-3-38-2004
+# Snap Store does not provide gnome-3-38-2004 package for i386, ppc64el and s390x
 architectures:
   - build-on: amd64
     run-on: amd64
@@ -17,7 +17,8 @@ architectures:
   - build-on: armhf
     run-on: armhf
 
-# https://snapcraft.io/blog/gnome-3-34-snapcraft-extension
+# https://forum.snapcraft.io/t/supported-extensions/20521
+# https://forum.snapcraft.io/t/the-gnome-3-38-extension/22923
 parts:
   jdim:
     plugin: meson
@@ -29,24 +30,22 @@ parts:
       # Use dpkg-buildflags to set compiler flags instead of meson options
       - --buildtype=plain
       - --prefix=/
+      - --strip
       - -Dbuild_tests=disabled
       - -Dcompat_cache_dir=disabled
       - -Dpangolayout=enabled
-      - -Dpackager=Snap (JDimproved project)
+      - -Dpackager="Snap (JDimproved project)"
     build-environment:
       # https://wiki.debian.org/Hardening
+      - DEB_BUILD_MAINT_OPTIONS: "hardening=+all"
       # Use -isystem to suppress compiler warning:
-      # /snap/gnome-3-34-1804-sdk/current/usr/include/limits.h:124:3: warning: #include_next is a GCC extension
-      - CPPFLAGS: "$(dpkg-buildflags --get CPPFLAGS) -isystem /snap/gnome-3-34-1804-sdk/current/usr/include"
+      # /snap/gnome-3-38-2004-sdk/current/usr/include/limits.h:124:3: warning: #include_next is a GCC extension
+      - CPPFLAGS: "$(dpkg-buildflags --get CPPFLAGS) -isystem /snap/gnome-3-38-2004-sdk/current/usr/include"
       - CXXFLAGS: "$(dpkg-buildflags --get CXXFLAGS)"
       - LDFLAGS: "$(dpkg-buildflags --get LDFLAGS)"
-    build-packages:
-      - libgnutls28-dev
-      - libsigc++-2.0-dev
     override-build: |
       set -eu
       snapcraftctl build
-      strip -s ${SNAPCRAFT_PART_INSTALL}/bin/jdim
       VER="$(${SNAPCRAFT_PART_INSTALL}/bin/jdim -V | sed -n -e '1s%^[^0-9]*\([^-]\+\)-\([^(]\+\)(git:\([0-9a-f]\+\).*$%\1-\2-\3%p')"
       echo "version ${VER}"
       snapcraftctl set-version "${VER}"
@@ -55,14 +54,14 @@ parts:
       snapcraftctl prime
       sed --in-place -e 's|^Icon=.*|Icon=\${SNAP}/share/icons/hicolor/48x48/apps/jdim.png|' \
       ${SNAPCRAFT_PRIME}/share/applications/jdim.desktop
-    parse-info: [jdim.metainfo.xml]
+    parse-info: [share/metainfo/jdim.metainfo.xml]
 
 apps:
   jdim:
     command: bin/jdim
     common-id: com.github.jdimproved.jdim
     desktop: share/applications/jdim.desktop
-    extensions: [gnome-3-34]
+    extensions: [gnome-3-38]
     plugs:
       - home
       - network


### PR DESCRIPTION
snapのベースをcore20([gnome-3-38-2004][1])に移行します。

対応CPUアーキテクチャ: amd64, arm64, armhf

関連のissue: https://github.com/JDimproved/JDim/issues/890

[1]: https://forum.snapcraft.io/t/the-gnome-3-38-extension/22923