### PR TITLE
snap: Fix build error

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,6 +43,9 @@ parts:
       - CPPFLAGS: "$(dpkg-buildflags --get CPPFLAGS) -isystem /snap/gnome-3-38-2004-sdk/current/usr/include"
       - CXXFLAGS: "$(dpkg-buildflags --get CXXFLAGS)"
       - LDFLAGS: "$(dpkg-buildflags --get LDFLAGS)"
+    build-packages:
+      - libgnutls28-dev
+      - libsigc++-2.0-dev
     override-build: |
       set -eu
       snapcraftctl build


### PR DESCRIPTION
snapcraft.ioのJDimビルドが失敗したためビルドに必要なパッケージを再度追加します。

エラーログ
```
Run-time dependency gtkmm-3.0 found: NO

../src/meson.build:77:0: ERROR: Could not generate cargs for gtkmm-3.0:
Package sigc++-2.0 was not found in the pkg-config search path.
Perhaps you should add the directory containing `sigc++-2.0.pc'
to the PKG_CONFIG_PATH environment variable
Package 'sigc++-2.0', required by 'glibmm-2.4', not found
```

関連のpull request: #1047 