### PR TITLE
Update histories

### DIFF
--- a/docs/manual/2022.md
+++ b/docs/manual/2022.md
@@ -9,7 +9,69 @@ layout: default
 
 
 <a name="0.9.0-unreleased"></a>
-### [0.9.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.8.0...master) (unreleased)
+### [0.9.0-unreleased](https://github.com/JDimproved/JDim/compare/660f4f6755...master) (unreleased)
+
+
+<a name="0.8.0-20221001"></a>
+### [0.8.0-20221001](https://github.com/JDimproved/JDim/compare/JDim-v0.8.0...660f4f6755) (2022-10-01)
+- ([#1048](https://github.com/JDimproved/JDim/pull/1048))
+  snap: Fix build error
+- ([#1047](https://github.com/JDimproved/JDim/pull/1047))
+  snap: Migrate base to core20
+- ([#1046](https://github.com/JDimproved/JDim/pull/1046))
+  docs: Get rid of the note for running on old MATE desktop
+- ([#1045](https://github.com/JDimproved/JDim/pull/1045))
+  `ReplaceStr`: Add ignore full/half width option
+- ([#1044](https://github.com/JDimproved/JDim/pull/1044))
+  `Dom`: Distinguish letter cases for tag name on XML parse mode
+- ([#1043](https://github.com/JDimproved/JDim/pull/1043))
+  Use `std::string_view` for `MISC::url_decode()`
+- ([#1042](https://github.com/JDimproved/JDim/pull/1042))
+  statusbar: Reset default color if setting turned off
+- ([#1041](https://github.com/JDimproved/JDim/pull/1041))
+  toolbar: Add setting that changes color for thread subject per state
+- ([#1040](https://github.com/JDimproved/JDim/pull/1040))
+  `ReplaceStrPref`: Add ignore case option without regex
+- ([#1039](https://github.com/JDimproved/JDim/pull/1039))
+  Use Pango Markup to display thread subject
+- ([#1038](https://github.com/JDimproved/JDim/pull/1038))
+  `ArticleBase`: Skip loading article if already read
+- ([#1037](https://github.com/JDimproved/JDim/pull/1037))
+  Convert thread subject to plain text
+- ([#1036](https://github.com/JDimproved/JDim/pull/1036))
+  Abandon Ubuntu 18.04 support
+- ([#1034](https://github.com/JDimproved/JDim/pull/1034))
+  Revert "`BoardViewBase`: Use PANGO markup to display thread subject (#1033)"
+- ([#1033](https://github.com/JDimproved/JDim/pull/1033))
+  `BoardViewBase`: Use PANGO markup to display thread subject
+- ([#1032](https://github.com/JDimproved/JDim/pull/1032))
+  GnuTLS: Set `GNUTLS_NO_SIGNAL` to ignore `SIGPIPE` for preventing crash
+- ([#1031](https://github.com/JDimproved/JDim/pull/1031))
+  Implement ReplaceStr for thread subject
+- ([#1030](https://github.com/JDimproved/JDim/pull/1030))
+  `Post`: Update error message extraction to support samba24
+- ([#1029](https://github.com/JDimproved/JDim/pull/1029))
+  `LayoutTree`: Show HTAB as single space if not multispace mode
+- ([#1028](https://github.com/JDimproved/JDim/pull/1028))
+  `ArticleBiewBase`: Update BE user link
+- ([#1027](https://github.com/JDimproved/JDim/pull/1027))
+  Update `MISC::html_unescape()`
+- ([#1026](https://github.com/JDimproved/JDim/pull/1026))
+  message: Change showing preview in the case of `BBS_UNICODE=change`
+- ([#1025](https://github.com/JDimproved/JDim/pull/1025))
+  article: Escape board name for extraction view
+- ([#1024](https://github.com/JDimproved/JDim/pull/1024))
+  Update misc html escape
+- ([#1023](https://github.com/JDimproved/JDim/pull/1023))
+  `Board2ch`: Change return value of `get_unicode()` to empty string
+- ([#1022](https://github.com/JDimproved/JDim/pull/1022))
+  `NodeTreeBase`: Improve `remove_imenu()`
+- ([#1021](https://github.com/JDimproved/JDim/pull/1021))
+  `NodeTreeBase`: Refactor `convert_amp()`
+- ([#1019](https://github.com/JDimproved/JDim/pull/1019))
+  miscutil: Fix `std::string` construction from pointer
+- ([#1018](https://github.com/JDimproved/JDim/pull/1018))
+  Snap: Fix typo for packager information
 
 
 <a name="JDim-v0.8.0"></a>

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -17,7 +17,7 @@
 #define MAJORVERSION 0
 #define MINORVERSION 8
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20220716"
+#define JDDATE_FALLBACK    "20221001"
 #define JDTAG     ""
 
 //---------------------------------


### PR DESCRIPTION
### [Update histories](https://github.com/JDimproved/JDim/commit/a3f21e91e02a7be047661b140b63f81752aae507) 

更新履歴の項目が長くなったため分割します。

### [Update JDDATE_FALLBACK macro to 20221001](https://github.com/JDimproved/JDim/commit/9e208823faf1405ffa6e9674c56c3056e2b1a2a3)

関連のissue: https://github.com/JDimproved/JDim/issues/1017