### PR TITLE
article: Add config for number of max res to thread property

### DIFF
--- a/src/article/preference.cpp
+++ b/src/article/preference.cpp
@@ -22,25 +22,27 @@ using namespace ARTICLE;
 
 Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std::string& command )
     : SKELETON::PrefDiag( parent, url )
-    ,m_label_name( false, "スレタイトル : ", MISC::to_plain( DBTREE::article_subject( get_url() ) ) )
-    ,m_label_url( false, "スレのURL : ", DBTREE:: url_readcgi( get_url(),0,0 ) )
-    ,m_label_url_dat( false, "DATファイルのURL : ", DBTREE:: url_dat( get_url() ) )
-    ,m_label_cache( false, "ローカルキャッシュパス : ", std::string() )
-    ,m_label_size( false, "サイズ( byte / Kbyte ) : ", std::string() )
-    ,m_check_transpabone( "透明あぼ〜ん" )
-    ,m_check_chainabone( "連鎖あぼ〜ん" )
-    ,m_check_ageabone( "sage以外をあぼ〜ん" )
-    ,m_check_defnameabone( "デフォルト名無しをあぼ〜ん" )
-    ,m_check_noidabone( "ID無しをあぼ〜ん" )
-    ,m_check_boardabone( "板レベルでのあぼ〜んを有効にする" )
-    ,m_check_globalabone( "全体レベルでのあぼ〜んを有効にする" )
-    ,m_label_since( false, "スレ立て日時 : ", std::string() )
-    ,m_label_modified( false, "最終更新日時 : ", std::string() )
-    ,m_button_clearmodified( "日時クリア" )
-    ,m_label_write( false, "最終書き込み日時 : ", std::string() )
-    ,m_bt_clear_post_history( "書き込み履歴クリア" )
-    ,m_label_write_name( false, "名前 : ", std::string() )
-    ,m_label_write_mail( false, "メール : ", std::string() )
+    , m_label_name( false, "スレタイトル : ", MISC::to_plain( DBTREE::article_subject( get_url() ) ) )
+    , m_label_url( false, "スレのURL : ", DBTREE::url_readcgi( get_url(), 0, 0 ) )
+    , m_label_url_dat( false, "DATファイルのURL : ", DBTREE::url_dat( get_url() ) )
+    , m_label_cache( false, "ローカルキャッシュパス : ", std::string() )
+    , m_label_size( false, "サイズ( byte / Kbyte ) : ", std::string() )
+    , m_hbox_size{ Gtk::ORIENTATION_HORIZONTAL, 0 }
+    , m_label_maxres{ "最大レス数 (0 : 未設定)：" }
+    , m_check_transpabone( "透明あぼ〜ん" )
+    , m_check_chainabone( "連鎖あぼ〜ん" )
+    , m_check_ageabone( "sage以外をあぼ〜ん" )
+    , m_check_defnameabone( "デフォルト名無しをあぼ〜ん" )
+    , m_check_noidabone( "ID無しをあぼ〜ん" )
+    , m_check_boardabone( "板レベルでのあぼ〜んを有効にする" )
+    , m_check_globalabone( "全体レベルでのあぼ〜んを有効にする" )
+    , m_label_since( false, "スレ立て日時 : ", std::string() )
+    , m_label_modified( false, "最終更新日時 : ", std::string() )
+    , m_button_clearmodified( "日時クリア" )
+    , m_label_write( false, "最終書き込み日時 : ", std::string() )
+    , m_bt_clear_post_history( "書き込み履歴クリア" )
+    , m_label_write_name( false, "名前 : ", std::string() )
+    , m_label_write_mail( false, "メール : ", std::string() )
 {
     // 一般
     if( DBTREE::article_is_cached( get_url() ) ){
@@ -75,13 +77,23 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     m_hbox_write.pack_start( m_label_write );
     m_hbox_write.pack_start( m_bt_clear_post_history, Gtk::PACK_SHRINK );    
 
+    // 最大レス数
+    const int max_res = DBTREE::article_number_max( get_url() );
+    m_spin_maxres.set_range( 0, CONFIG::get_max_resnumber() );
+    m_spin_maxres.set_increments( 1, 1 );
+    m_spin_maxres.set_value( max_res );
+
+    m_hbox_size.pack_start( m_label_size );
+    m_hbox_size.pack_start( m_label_maxres, Gtk::PACK_SHRINK );
+    m_hbox_size.pack_start( m_spin_maxres, Gtk::PACK_SHRINK );
+
     m_vbox_info.set_border_width( 16 );
     m_vbox_info.set_spacing( 8 );
     m_vbox_info.pack_start( m_label_name, Gtk::PACK_SHRINK );
     m_vbox_info.pack_start( m_label_url, Gtk::PACK_SHRINK );
     m_vbox_info.pack_start( m_label_url_dat, Gtk::PACK_SHRINK );
     m_vbox_info.pack_start( m_label_cache, Gtk::PACK_SHRINK );
-    m_vbox_info.pack_start( m_label_size, Gtk::PACK_SHRINK );
+    m_vbox_info.pack_start( m_hbox_size, Gtk::PACK_SHRINK );
 
     m_vbox_info.pack_start( m_label_since, Gtk::PACK_SHRINK );
     m_vbox_info.pack_start( m_hbox_modified, Gtk::PACK_SHRINK );
@@ -246,6 +258,9 @@ void Preferences::slot_ok_clicked()
                          , m_check_transpabone.get_active(), m_check_chainabone.get_active(), m_check_ageabone.get_active(),
                          m_check_defnameabone.get_active(), m_check_noidabone.get_active(),
                          m_check_boardabone.get_active(), m_check_globalabone.get_active() );
+
+    // 最大レス数
+    DBTREE::article_set_number_max( get_url(), m_spin_maxres.get_value_as_int() );
 
     // viewの再レイアウト
     CORE::core_set_command( "relayout_article", get_url() );

--- a/src/article/preference.h
+++ b/src/article/preference.h
@@ -21,6 +21,12 @@ namespace ARTICLE
         SKELETON::LabelEntry m_label_cache;
         SKELETON::LabelEntry m_label_size;
 
+        Gtk::Box m_hbox_size;
+
+        // 最大レス数
+        Gtk::Label m_label_maxres;
+        Gtk::SpinButton m_spin_maxres;
+
         // あぼーん
         Gtk::VBox m_vbox_abone;
         Gtk::Notebook m_notebook_abone;

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -1986,7 +1986,7 @@ void BoardViewBase::update_row_common( const Gtk::TreeModel::Row& row )
         icon = ICON::OLD;
     }
 
-    // キャッシュはあるが規定のレス数を越えていて全てのレスが既読
+    // キャッシュが新着がない状態で存在し、さらに規定の最大レス数を越えている
     else if( art->is_finished() ){
         mark_val = COL_MARKVAL_FINISHED;
 

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -150,8 +150,7 @@ namespace DBTREE
         int get_number_new() const noexcept { return m_number_new; }
         int get_number_load() const noexcept { return m_number_load; }
         int get_number_seen() const noexcept {  return m_number_seen; }
-
-        void set_number_max( const int number ){ m_number_max = number; }
+        int get_number_max() const noexcept { return m_number_max; }
 
         // スレ速度
         int get_speed() const;
@@ -294,6 +293,7 @@ namespace DBTREE
         void set_number( const int number, const bool is_online );
         void set_number_load( const int number_load );
         void set_number_seen( const int number_seen );
+        void set_number_max( const int number_max );
         void update_writetime();
 
         // キャッシュ削除
@@ -313,7 +313,7 @@ namespace DBTREE
         // キャッシュがあって、かつ新着の読み込みが可能
         bool enable_load() const;
 
-        // キャッシュはあるが規定のレス数を越えていて、かつ全てのレスが既読
+        // キャッシュが新着がない状態で存在し、さらに規定の最大レス数を越えているか
         bool is_finished() const;
 
         // あぼーん情報

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -297,12 +297,8 @@ ArticleBase* Board2ch::append_article( const std::string& datbase, const std::st
     if( empty() ) return get_article_null();
 
     ArticleBase* article = insert( std::make_unique<DBTREE::Article2ch>( datbase, id, cached ) );
-    if( article ){
-        // 最大レス数セット
-        article->set_number_max( get_number_max_res() );
-    }
-    else return get_article_null();
 
+    if( ! article ) return get_article_null();
     return article;
 }
 

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -237,12 +237,8 @@ ArticleBase* Board2chCompati::append_article( const std::string& datbase, const 
     if( empty() ) return get_article_null();
 
     ArticleBase* article = insert( std::make_unique<DBTREE::Article2chCompati>( datbase, id, cached ) );
-    if( article ){
-        // 最大レス数セット
-        article->set_number_max( get_number_max_res() );
-    }
-    else return get_article_null();
-    
+
+    if( ! article ) return get_article_null();
     return article;
 }
 

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -472,8 +472,6 @@ void BoardBase::set_number_max_res( const int number )
 #endif
 
     m_number_max_res = MAX( 0, MIN( CONFIG::get_max_resnumber(), number ) );
-
-    for( ArticleBase* a : m_hash_article ) a->set_number_max( m_number_max_res );
 }
 
 

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -76,12 +76,8 @@ ArticleBase* BoardJBBS::append_article( const std::string& datbase, const std::s
     if( empty() ) return get_article_null();
 
     ArticleBase* article = insert( std::make_unique<DBTREE::ArticleJBBS>( datbase, id, cached ) );
-    if( article ){
-        // 最大レス数セット
-        article->set_number_max( get_number_max_res() );
-    }
-    else return get_article_null();
 
+    if( ! article ) return get_article_null();
     return article;
 }
 

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -79,12 +79,8 @@ ArticleBase* BoardMachi::append_article( const std::string& datbase, const std::
     if( empty() ) return get_article_null();
 
     ArticleBase* article = insert( std::make_unique<DBTREE::ArticleMachi>( datbase, id, cached ) );
-    if( article ){
-        // 最大レス数セット
-        article->set_number_max( get_number_max_res() );
-    }
-    else return get_article_null();
 
+    if( ! article ) return get_article_null();
     return article;
 }
 

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -963,6 +963,16 @@ int DBTREE::article_number_new( const std::string& url )
     return DBTREE::get_article( url )->get_number_new();
 }
 
+int DBTREE::article_number_max( const std::string& url )
+{
+    return DBTREE::get_article( url )->get_number_max();
+}
+
+void DBTREE::article_set_number_max( const std::string& url, int max )
+{
+    DBTREE::get_article( url )->set_number_max( max );
+}
+
 bool DBTREE::article_is_loading( const std::string& url )
 {
     return DBTREE::get_article( url )->is_loading();

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -234,6 +234,8 @@ namespace DBTREE
     int article_number_seen( const std::string& url );
     void article_set_number_seen( const std::string& url, int seen );
     int article_number_new( const std::string& url );
+    int article_number_max( const std::string& url );
+    void article_set_number_max( const std::string& url, int max );
     bool article_is_loading( const std::string& url );
     bool article_is_checking_update( const std::string& url );
     void article_download_dat( const std::string& url, const bool check_update );

--- a/src/dbtree/nodetree2ch.cpp
+++ b/src/dbtree/nodetree2ch.cpp
@@ -37,6 +37,7 @@ NodeTree2ch::NodeTree2ch( const std::string& url, const std::string& org_url,
     , m_org_url( org_url )
     , m_since_time( since_time )
     , m_mode( MODE_NORMAL )
+    , m_res_number_max( -1 )
 {
 #ifdef _DEBUG
     std::cout << "NodeTree2ch::NodeTree2ch url = " << url << std::endl

--- a/src/dbtree/nodetree2ch.h
+++ b/src/dbtree/nodetree2ch.h
@@ -17,12 +17,15 @@ namespace DBTREE
         std::string m_org_url;  // 移転前のオリジナルURL
         time_t m_since_time; // スレが立った時刻
         int m_mode; // 読み込みモード
+        int m_res_number_max; // 最大レス数
         
       public:
 
         NodeTree2ch( const std::string& url, const std::string& org_url,
                      const std::string& date_modified, time_t since_time );
         ~NodeTree2ch();
+
+        int get_res_number_max() const noexcept override { return m_res_number_max; }
 
       protected:
 

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -163,6 +163,8 @@ namespace DBTREE
         const std::string& get_ext_err() const { return m_ext_err; }
         bool is_checking_update() const { return m_check_update; }
 
+        virtual int get_res_number_max() const noexcept { return -1; }
+
         // number番のレスのヘッダノードのポインタを返す
         const NODE* res_header( int number ) const;
         NODE* res_header( int number )


### PR DESCRIPTION
スレッドのプロパティに最大レス数を設定する項目を追加します。
未設定のときは板のプロパティにある最大レス数の値を参照します。
(デフォルトは`0`:未設定)

`ArticleBase::is_finished()`の動作を "キャッシュはあるが規定のレス数を 越えていて、かつ全てのレスが既読ならtrueを返す" から "キャッシュが新着がない状態で存在し、さらに規定の最大レス数を越えているならtrueを返す" に変更します。

関連のissue: #76