### PR TITLE
NodeTree2ch: Add parse_extattr() to parse the result of "!extend:"

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -2780,8 +2780,15 @@ void Core::set_command( const COMMAND_ARGS& command )
             mdiag.run();
         }
         else{
+            std::size_t max_lng = DBTREE::article_get_dat_volume_max( command.url );
+#ifdef _DEBUG
+            std::cout << "Core::set_command : open_message subject = "
+                      << DBTREE::article_modified_subject( command.url )
+                      << ", max lng = " << max_lng << std::endl;;
+#endif
 
-            const size_t max_lng = DBTREE::board_get_max_dat_lng( command.url );
+            if( max_lng == 0 ) max_lng = DBTREE::board_get_max_dat_lng( command.url );
+
             if( max_lng > 0 && DBTREE::article_lng_dat( command.url ) > max_lng * 1000 ){
 
                 SKELETON::MsgDiag mdiag( nullptr, "スレのサイズが" + std::to_string( max_lng )

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -141,6 +141,16 @@ size_t ArticleBase::get_lng_dat()
 }
 
 
+/**
+ * @brief スレの最大DATサイズ(KB)
+ */
+std::size_t ArticleBase::get_dat_volume_max() const
+{
+    if( ! m_nodetree ) return 0;
+    return m_nodetree->get_dat_volume_max();
+}
+
+
 
 //
 // nodetree の number 番のレスのヘッダノードのポインタを返す

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -158,6 +158,9 @@ namespace DBTREE
         // キャッシュにあるdatファイルのサイズ
         size_t get_lng_dat();
 
+        // スレの最大DATサイズ(KB)
+        std::size_t get_dat_volume_max() const;
+
         // nodetree の number 番のレスのヘッダノードのポインタを返す
         NODE* res_header( int number );
 

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -1010,6 +1010,12 @@ int DBTREE::article_get_speed( const std::string& url )
 }
 
 
+std::size_t DBTREE::article_get_dat_volume_max( const std::string& url )
+{
+    return DBTREE::get_article( url )->get_dat_volume_max();
+}
+
+
 // 書き込み履歴のリセット
 void DBTREE::article_clear_post_history( const std::string& url )
 {

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -243,6 +243,7 @@ namespace DBTREE
     void article_copy_article_info( const std::string& url, const std::string& url_src );
     void article_stop_load( const std::string& url );
     int article_get_speed( const std::string& url );
+    std::size_t article_get_dat_volume_max( const std::string& url );
 
     // 書き込み履歴のリセット
     void article_clear_post_history( const std::string& url );

--- a/src/dbtree/nodetree2ch.cpp
+++ b/src/dbtree/nodetree2ch.cpp
@@ -109,14 +109,19 @@ void NodeTree2ch::parse_extattr( std::string_view str )
 
     str.remove_prefix( pos );
     const std::string extattr{ str };
-    if( regex.exec( "[^:]+:[^:]+:([^:]+):[^ ]+ EXT was configured",
+    if( regex.exec( "[^:]+:[^:]+:([^:]+):(?:([^:]+):)?[^ ]+ EXT was configured",
                     extattr, offset, icase, newline, usemigemo, wchar ) ) {
 
         // 最大レス数を取得
-        const std::string num_str = regex.str( 1 );
+        std::string num_str = regex.str( 1 );
         if( num_str == "V" ) m_res_number_max = 0;
         else if( num_str[0] >= '0' && num_str[0] <= '9' ) {
             m_res_number_max = std::atoi( num_str.c_str() );
+        }
+        // 最大DATサイズ(KB)を取得
+        num_str = regex.str( 2 );
+        if( num_str[0] >= '0' && num_str[0] <= '9' ) {
+            m_dat_volume_max = std::atoi( num_str.c_str() );
         }
     }
 }

--- a/src/dbtree/nodetree2ch.cpp
+++ b/src/dbtree/nodetree2ch.cpp
@@ -89,6 +89,39 @@ char* NodeTree2ch::process_raw_lines( char* rawlines )
 }
 
 
+/** @brief 5chスレッドの拡張属性を取り出す
+ *
+ * @param[in] str スレのレス番号1(`>>1`)の本文テキストデータ
+ */
+void NodeTree2ch::parse_extattr( std::string_view str )
+{
+    std::size_t pos = str.rfind( "<hr>VIPQ2_EXTDAT: " );
+    if( pos == std::string_view::npos ) return;
+    pos += 18;
+    if( pos >= str.size() ) return;
+
+    JDLIB::Regex regex;
+    constexpr std::size_t offset = 0;
+    constexpr bool icase = false; // 大文字小文字区別しない
+    constexpr bool newline = true; // . に改行をマッチさせない
+    constexpr bool usemigemo = false; // migemo使用
+    constexpr bool wchar = false; // 全角半角の区別をしない
+
+    str.remove_prefix( pos );
+    const std::string extattr{ str };
+    if( regex.exec( "[^:]+:[^:]+:([^:]+):[^ ]+ EXT was configured",
+                    extattr, offset, icase, newline, usemigemo, wchar ) ) {
+
+        // 最大レス数を取得
+        const std::string num_str = regex.str( 1 );
+        if( num_str == "V" ) m_res_number_max = 0;
+        else if( num_str[0] >= '0' && num_str[0] <= '9' ) {
+            m_res_number_max = std::atoi( num_str.c_str() );
+        }
+    }
+}
+
+
 //
 // ロード用データ作成
 //

--- a/src/dbtree/nodetree2ch.h
+++ b/src/dbtree/nodetree2ch.h
@@ -33,6 +33,8 @@ namespace DBTREE
 
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;
 
+        void parse_extattr( std::string_view str ) override;
+
       private:
 
         void receive_finish() override;

--- a/src/dbtree/nodetree2ch.h
+++ b/src/dbtree/nodetree2ch.h
@@ -18,7 +18,8 @@ namespace DBTREE
         time_t m_since_time; // スレが立った時刻
         int m_mode; // 読み込みモード
         int m_res_number_max; // 最大レス数
-        
+        std::size_t m_dat_volume_max{}; // 最大DATサイズ(KB)
+
       public:
 
         NodeTree2ch( const std::string& url, const std::string& org_url,
@@ -26,6 +27,7 @@ namespace DBTREE
         ~NodeTree2ch();
 
         int get_res_number_max() const noexcept override { return m_res_number_max; }
+        std::size_t get_dat_volume_max() const noexcept override { return m_dat_volume_max; }
 
       protected:
 

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1591,6 +1591,8 @@ const char* NodeTreeBase::add_one_dat_line( const char* datline )
 
     // 本文
     if( i > 3 ) {
+        // EXTDAT情報を取得
+        if( header->id_header == 1 ) parse_extattr( section[3] );
 
         header->headinfo->block[ BLOCK_MES ] = create_node_block();
 

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -293,6 +293,9 @@ namespace DBTREE
         void receive_data( const char* data, size_t size ) override;
         void receive_finish() override;
 
+        // 拡張属性を取り出す
+        virtual void parse_extattr( std::string_view str ) {};
+
       private:
 
         NODE* create_node();

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -164,6 +164,8 @@ namespace DBTREE
         bool is_checking_update() const { return m_check_update; }
 
         virtual int get_res_number_max() const noexcept { return -1; }
+        // スレの最大DATサイズ(KB)
+        virtual std::size_t get_dat_volume_max() const noexcept { return 0; }
 
         // number番のレスのヘッダノードのポインタを返す
         const NODE* res_header( int number ) const;


### PR DESCRIPTION
### [Add NodeTree2ch::parse_extattr() to parse "!extend: MAX LINE"](https://github.com/JDimproved/JDim/commit/b709f2133f8e49d70985eef66d6cdc3a8ffa4a88) 

5chのスレ立てで指定された`!extend:`コマンドの結果から`MAX LINE`(最大レス数)を解析して設定する処理を追加します。

### [Improve NodeTree2ch::parse_extattr() to parse the column "MAX VOLUME"](https://github.com/JDimproved/JDim/commit/93cf673cb6391a4f672afbcc2b79d388acdca0b3)

5chのスレ立てで指定された`!extend:`コマンドの結果から`MAX VOLUME`(最大DATサイズ,単位はキロバイト)を解析して設定する処理を追加します。

#### 参考文献
https://info.5ch.net/?curid=2759

関連のissue: #76 