### PR TITLE
Root: Decode HTML char reference for bbsmenu

### DIFF
--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -462,7 +462,7 @@ void Root::bbsmenu2xml( const std::string& menu )
         // 要素b( カテゴリ名 )
         if( child->nodeName() == "b" )
         {
-            const std::string category = child->firstChild()->nodeValue();
+            const std::string category = MISC::chref_decode( child->firstChild()->nodeValue() );
 
             // 追加しないカテゴリ
             if( category == "チャット"
@@ -481,7 +481,7 @@ void Root::bbsmenu2xml( const std::string& menu )
         // 要素bに続く要素a( 板URL )
         else if( subdir && enabled && child->nodeName() == "a" )
         {
-            const std::string board_name = child->firstChild()->nodeValue();
+            const std::string board_name = MISC::chref_decode( child->firstChild()->nodeValue() );
             const std::string url = child->getAttribute( "href" );
 
             // 板として扱うURLかどうかで要素名を変える

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1155,11 +1155,12 @@ std::string MISC::to_markup( const std::string& html )
 }
 
 
-//
-// HTMLの文字参照をデコード
-//
-// completely = true の時は'"' '&' '<' '>'もデコードする
-//
+/** @brief 文字列をコピーしてHTML文字参照をデコードする
+ *
+ * @param[in] str        デコード処理する文字列
+ * @param[in] completely `true` の時は`"` `&` `<` `>` もデコードする
+ * @return デコード処理した結果
+ */
 std::string MISC::chref_decode( std::string_view str, const bool completely )
 {
     std::string str_out;

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -155,7 +155,7 @@ namespace MISC
     std::string to_markup( const std::string& html );
 
     // HTML文字参照をデコード( completely=trueの場合は '&' '<' '>' '"' を含める )
-    std::string chref_decode( std::string_view str, const bool completely );
+    std::string chref_decode( std::string_view str, const bool completely = true );
 
     // URL中のスキームを判別する
     // 戻り値 : スキームタイプ


### PR DESCRIPTION
bbsmenuを解析してDOM構築するときname属性の値に含まれるHTML文字参照をデコードするように変更します。

関連のissue: #76