### PR TITLE
Add const qualifier to local variables part2

### DIFF
--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -2004,7 +2004,7 @@ void BBSListViewBase::open_selected_rows()
     std::string list_url_board;
     std::string list_url_article;
 
-    for( Gtk::TreeIter& iter : m_treeview.get_selected_iterators() ) {
+    for( const Gtk::TreeIter& iter : m_treeview.get_selected_iterators() ) {
 
         Gtk::TreeModel::Row row = *iter;
         const int type = row2type( row );
@@ -2044,7 +2044,7 @@ void BBSListViewBase::open_selected_rows()
 //
 void BBSListViewBase::checkupdate_selected_rows( const bool open )
 {
-    for( Gtk::TreeIter& iter : m_treeview.get_selected_iterators() ) {
+    for( const Gtk::TreeIter& iter : m_treeview.get_selected_iterators() ) {
 
         Gtk::TreeModel::Row row = *iter;
         const int type = row2type( row );

--- a/src/history/viewhistory.cpp
+++ b/src/history/viewhistory.cpp
@@ -109,7 +109,7 @@ void ViewHistory::replace_url( const std::string& url_old, const std::string& ur
               << "end = " << m_history_end << std::endl;
 #endif
 
-    for( auto& item : m_items ) {
+    for( const auto& item : m_items ) {
         if( item->url == url_old ) {
             item->url = url_new;
 #ifdef _DEBUG

--- a/src/image/imageviewbase.cpp
+++ b/src/image/imageviewbase.cpp
@@ -1222,7 +1222,7 @@ void ImageViewBase::activate_act_before_popupmenu( const std::string& url )
     }
 
     // サイズ系メニュー、お気に入り、保存
-    std::string sizemenus[] =
+    constexpr const char* sizemenus[] =
     {
         "Size_Menu",
         "OrgSizeImage",
@@ -1232,7 +1232,7 @@ void ImageViewBase::activate_act_before_popupmenu( const std::string& url )
         "AppendFavorite",
         "Save"
     };
-    for( const std::string& menu : sizemenus ) {
+    for( const char* menu : sizemenus ) {
         act = action_group()->get_action( menu );
         if( act ){
             if( m_img->is_cached() ) act->set_sensitive( true );


### PR DESCRIPTION
ローカル変数にconstを付けれるとcppcheck 2.9に指摘されたため修正します。

cppcheckのレポート
```
src/bbslist/bbslistviewbase.cpp:2007:25: style: Variable 'iter' can be declared as reference to const [constVariable]
    for( Gtk::TreeIter& iter : m_treeview.get_selected_iterators() ) {
                        ^
src/bbslist/bbslistviewbase.cpp:2047:25: style: Variable 'iter' can be declared as reference to const [constVariable]
    for( Gtk::TreeIter& iter : m_treeview.get_selected_iterators() ) {
                        ^
src/history/viewhistory.cpp:112:16: style: Variable 'item' can be declared as reference to const [constVariable]
    for( auto& item : m_items ) {
               ^
src/image/imageviewbase.cpp:1225:17: style: Variable 'sizemenus' can be declared as const array [constVariable]
    std::string sizemenus[] =
                ^
```

関連のpull request: #1055 