### PR TITLE
Use std::string::resize() instead of substr()

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -730,7 +730,10 @@ std::string MISC::cut_str( const std::string& str, const unsigned int maxsize )
     }
 
     // カットしたら"..."をつける
-    if( pos != outstr_length ) outstr = outstr.substr( 0, pos ) + "...";
+    if( pos != outstr_length ) {
+        outstr.resize( pos );
+        outstr.append( "..." );
+    }
 
     return outstr;
 }

--- a/src/message/logitem.h
+++ b/src/message/logitem.h
@@ -42,7 +42,9 @@ namespace MESSAGE
             , msg( _msg )
             , time_write{ std::time( nullptr ) }
         {
-            if( newthread && url.find( ID_OF_NEWTHREAD ) != std::string::npos ) url = url.substr( 0, url.find( ID_OF_NEWTHREAD ) );
+            if( newthread && url.find( ID_OF_NEWTHREAD ) != std::string::npos ) {
+                url.resize( url.find( ID_OF_NEWTHREAD ) );
+            }
 
             // WAVE DASH 問題
             msg = MISC::utf8_fix_wavedash( msg, MISC::WaveDashFix::UnixToWin );


### PR DESCRIPTION
非効率な`std::string::substr()`の呼び出しがあるとcppcheck 2.9に指摘されたため`resize()`に置き換えます。

cppcheckのレポート
```
src/message/logitem.h:45:87: performance: Ineffective call of function 'substr' because a prefix of the string is assigned to itself. Use resize() or pop_back() instead. [uselessCallsSubstr]
            if( newthread && url.find( ID_OF_NEWTHREAD ) != std::string::npos ) url = url.substr( 0, url.find( ID_OF_NEWTHREAD ) );
                                                                                      ^
src/jdlib/miscutil.cpp:733:41: performance: Ineffective call of function 'substr' because a prefix of the string is assigned to itself. Use replace() instead. [uselessCallsSubstr]
    if( pos != outstr_length ) outstr = outstr.substr( 0, pos ) + "...";
                                        ^
```

関連のpull request: #1055 