### PR TITLE
Modify HEAP::clear() to not free allocated blocks

### DIFF
--- a/src/jdlib/heap.h
+++ b/src/jdlib/heap.h
@@ -13,21 +13,24 @@ namespace JDLIB
 {
     class HEAP
     {
-        std::list< std::unique_ptr<unsigned char[]> > m_heap_list;
+        using BlockList = std::list< std::unique_ptr<unsigned char[]> >;
+
+        BlockList m_heap_list;
         std::size_t m_blocksize; // ブロックサイズ
         std::size_t m_space_avail{}; // ブロックの未使用サイズ
         void* m_ptr_head{}; // 検索開始位置
+        BlockList::iterator m_block_iter; // ブロックを再利用するためのイテレーター
 
       public:
         explicit HEAP( std::size_t blocksize ) noexcept;
-        ~HEAP();
+        ~HEAP() noexcept;
 
         HEAP( const HEAP& ) = delete;
         HEAP& operator=( const HEAP& ) = delete;
         HEAP( HEAP&& ) noexcept = default;
         HEAP& operator=( HEAP&& ) = default;
 
-        void clear();
+        void clear(); // ブロックを確保したまま利用状況を初期化する
 
         // 戻り値はunsigned char*のエイリアス
         void* heap_alloc( std::size_t size_bytes, std::size_t alignment );


### PR DESCRIPTION
HEAPの使用状況を初期状態に戻すメンバー関数`clear()`を修正して確保したメモリブロックを解放せずに使用状況だけリセットするようにします。