### PR TITLE
ReplaceStr: Rebuild nodetree to relayout completely if ok clicked

### DIFF
--- a/src/article/articleview.cpp
+++ b/src/article/articleview.cpp
@@ -661,7 +661,7 @@ void ArticleViewMain::show_instruct_diag()
 //
 // 画面を消してレイアウトやりなおし & 再描画
 //
-void ArticleViewMain::relayout()
+void ArticleViewMain::relayout( const bool completely )
 {
 #ifdef _DEBUG
     std::cout << "ArticleViewMain::relayout " << DBTREE::article_subject( url_article() ) << std::endl;;
@@ -672,6 +672,8 @@ void ArticleViewMain::relayout()
     int seen = drawarea()->get_seen_current();
     int num_reserve = drawarea()->get_goto_num_reserve();
     int separator_new = drawarea()->get_separator_new();
+
+    if( completely ) DBTREE::article_clear_nodetree( url_article() );
 
     drawarea()->clear_screen();
     drawarea()->set_separator_new( separator_new );

--- a/src/article/articleview.h
+++ b/src/article/articleview.h
@@ -55,7 +55,7 @@ namespace ARTICLE
         void show_view() override;
         void update_view() override;
         void update_finish() override;
-        void relayout() override;
+        void relayout( const bool completely = false ) override;
 
       protected:
 

--- a/src/article/articleviewetc.cpp
+++ b/src/article/articleviewetc.cpp
@@ -60,7 +60,7 @@ ArticleViewRes::~ArticleViewRes()
 //
 // 画面を消してレイアウトやりなおし & 再描画
 //
-void ArticleViewRes::relayout()
+void ArticleViewRes::relayout( const bool completely )
 {
 #ifdef _DEBUG
     std::cout << "ArticleViewRes::relayout\n";
@@ -143,7 +143,7 @@ ArticleViewName::~ArticleViewName()
 //
 // 画面を消してレイアウトやりなおし & 再描画
 //
-void ArticleViewName::relayout()
+void ArticleViewName::relayout( const bool completely )
 {
 #ifdef _DEBUG
     std::cout << "ArticleViewName::relayout\n";
@@ -223,7 +223,7 @@ ArticleViewID::~ArticleViewID()
 //
 // 画面を消してレイアウトやりなおし & 再描画
 //
-void ArticleViewID::relayout()
+void ArticleViewID::relayout( const bool completely )
 {
 #ifdef _DEBUG
     std::cout << "ArticleViewID::relayout\n";
@@ -301,7 +301,7 @@ ArticleViewBM::~ArticleViewBM()
 //
 // 画面を消してレイアウトやりなおし & 再描画
 //
-void ArticleViewBM::relayout()
+void ArticleViewBM::relayout( const bool completely )
 {
 #ifdef _DEBUG
     std::cout << "ArticleViewBM::relayout\n";
@@ -380,7 +380,7 @@ ArticleViewPost::~ArticleViewPost()
 //
 // 画面を消してレイアウトやりなおし & 再描画
 //
-void ArticleViewPost::relayout()
+void ArticleViewPost::relayout( const bool completely )
 {
 #ifdef _DEBUG
     std::cout << "ArticleViewPost::relayout\n";
@@ -458,7 +458,7 @@ ArticleViewHighRefRes::~ArticleViewHighRefRes()
 //
 // 画面を消してレイアウトやりなおし & 再描画
 //
-void ArticleViewHighRefRes::relayout()
+void ArticleViewHighRefRes::relayout( const bool completely )
 {
 #ifdef _DEBUG
     std::cout << "ArticleViewHighRefRes::relayout\n";
@@ -535,7 +535,7 @@ ArticleViewURL::~ArticleViewURL()
 //
 // 画面を消してレイアウトやりなおし & 再描画
 //
-void ArticleViewURL::relayout()
+void ArticleViewURL::relayout( const bool completely )
 {
 #ifdef _DEBUG
     std::cout << "ArticleViewURL::relayout\n";
@@ -616,7 +616,7 @@ ArticleViewRefer::~ArticleViewRefer()
 //
 // 画面を消してレイアウトやりなおし & 再描画
 //
-void ArticleViewRefer::relayout()
+void ArticleViewRefer::relayout( const bool completely )
 {
 #ifdef _DEBUG
     std::cout << "ArticleViewRefer::relayout\n";
@@ -706,7 +706,7 @@ ArticleViewDrawout::~ArticleViewDrawout()
 //
 // 画面を消してレイアウトやりなおし & 再描画
 //
-void ArticleViewDrawout::relayout()
+void ArticleViewDrawout::relayout( const bool completely )
 {
 #ifdef _DEBUG
     std::cout << "ArticleViewDrawout::relayout\n";
@@ -803,7 +803,7 @@ void ArticleViewPostlog::operate_search( const std::string& controlid )
 //
 // 画面を消してレイアウトやりなおし & 再描画
 //
-void ArticleViewPostlog::relayout()
+void ArticleViewPostlog::relayout( const bool completely )
 {
 #ifdef _DEBUG
     std::cout << "ArticleViewPostlog::relayout\n";

--- a/src/article/articleviewetc.h
+++ b/src/article/articleviewetc.h
@@ -22,7 +22,7 @@ namespace ARTICLE
         ~ArticleViewRes();
 
         // SKELETON::View の関数のオーバロード
-        void relayout() override;
+        void relayout( const bool completely = false ) override;
 
         void show_view() override;
         void reload() override;
@@ -46,7 +46,7 @@ namespace ARTICLE
         ~ArticleViewName();
 
         // SKELETON::View の関数のオーバロード
-        void relayout() override;
+        void relayout( const bool completely = false ) override;
 
         void show_view() override;
         void reload() override;
@@ -70,7 +70,7 @@ namespace ARTICLE
         ~ArticleViewID();
 
         // SKELETON::View の関数のオーバロード
-        void relayout() override;
+        void relayout( const bool completely = false ) override;
 
         void show_view() override;
         void reload() override;
@@ -94,7 +94,7 @@ namespace ARTICLE
         ~ArticleViewBM();
 
         // SKELETON::View の関数のオーバロード
-        void relayout() override;
+        void relayout( const bool completely = false ) override;
 
         void show_view() override;
         void reload() override;
@@ -119,7 +119,7 @@ namespace ARTICLE
         ~ArticleViewPost();
 
         // SKELETON::View の関数のオーバロード
-        void relayout() override;
+        void relayout( const bool completely = false ) override;
 
         void show_view() override;
         void reload() override;
@@ -144,7 +144,7 @@ namespace ARTICLE
         ~ArticleViewHighRefRes();
 
         // SKELETON::View の関数のオーバロード
-        void relayout() override;
+        void relayout( const bool completely = false ) override;
 
         void show_view() override;
         void reload() override;
@@ -167,7 +167,7 @@ namespace ARTICLE
         ~ArticleViewURL();
 
         // SKELETON::View の関数のオーバロード
-        void relayout() override;
+        void relayout( const bool completely = false ) override;
 
         void show_view() override;
         void reload() override;
@@ -191,7 +191,7 @@ namespace ARTICLE
         ~ArticleViewRefer();
 
         // SKELETON::View の関数のオーバロード
-        void relayout() override;
+        void relayout( const bool completely = false ) override;
 
         void show_view() override;
         void reload() override;
@@ -217,7 +217,7 @@ namespace ARTICLE
         ~ArticleViewDrawout();
 
         // SKELETON::View の関数のオーバロード
-        void relayout() override;
+        void relayout( const bool completely = false ) override;
 
         void show_view() override;
         void reload() override;
@@ -240,7 +240,7 @@ namespace ARTICLE
         ~ArticleViewPostlog();
 
         // SKELETON::View の関数のオーバロード
-        void relayout() override;
+        void relayout( const bool completely = false ) override;
         void stop() override {} // キャンセル
 
         // 検索

--- a/src/article/articleviewsearch.cpp
+++ b/src/article/articleviewsearch.cpp
@@ -242,7 +242,7 @@ void ArticleViewSearch::show_view()
 //
 // 画面を消してレイアウトやりなおし & 再描画
 //
-void ArticleViewSearch::relayout()
+void ArticleViewSearch::relayout( const bool completely )
 {
 #ifdef _DEBUG
     std::cout << "ArticleViewSearch::relayout\n";

--- a/src/article/articleviewsearch.h
+++ b/src/article/articleviewsearch.h
@@ -44,7 +44,7 @@ namespace ARTICLE
 
         void focus_view() override;
         void show_view() override;
-        void relayout() override;
+        void relayout( const bool completely = false ) override;
         void reload() override;
         void stop() override;
 

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -671,7 +671,7 @@ void BBSListViewBase::redraw_view()
 //
 // 色やフォントなどの変更
 //
-void BBSListViewBase::relayout()
+void BBSListViewBase::relayout( const bool completely )
 {
     m_treeview.init_color( COLOR_CHAR_BBS, COLOR_BACK_BBS, COLOR_BACK_BBS_EVEN );
     m_treeview.init_font( CONFIG::get_fontname( FONT_BBS ) );

--- a/src/bbslist/bbslistviewbase.h
+++ b/src/bbslist/bbslistviewbase.h
@@ -214,7 +214,7 @@ namespace BBSLIST
 
         void stop() override;
         void redraw_view() override;
-        void relayout() override;  // 色やフォントなどの変更
+        void relayout( const bool completely = false ) override;  // 色やフォントなどの変更
         void focus_view() override;
         void focus_out() override;
         void close_view() override;

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -1303,7 +1303,7 @@ void BoardViewBase::show_view()
 //
 // 色、フォント、表示内容の更新
 //
-void BoardViewBase::relayout()
+void BoardViewBase::relayout( const bool completely )
 {
     m_treeview.init_color( COLOR_CHAR_BOARD, COLOR_BACK_BOARD, COLOR_BACK_BOARD_EVEN );
     m_treeview.init_font( CONFIG::get_fontname( FONT_BOARD ) );

--- a/src/board/boardviewbase.h
+++ b/src/board/boardviewbase.h
@@ -137,7 +137,7 @@ namespace BOARD
         void write() override;
         void stop() override;
         void show_view() override;
-        void relayout() override;
+        void relayout( const bool completely = false ) override;
         void focus_view() override;
         void focus_out() override;
         void close_view() override;

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -2311,7 +2311,7 @@ void Core::set_command( const COMMAND_ARGS& command )
 
     // 全articleviewの再レイアウト
     else if( command.command == "relayout_all_article" ){
-        ARTICLE::get_admin()->set_command( "relayout_all" );
+        ARTICLE::get_admin()->set_command( "relayout_all", command.url, command.arg1 );
     }
 
     // 全articleviewのフォントの初期化

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -417,6 +417,9 @@ namespace DBTREE
         // スレッド924か
         bool is_924() const noexcept { return m_924; }
 
+        // NodeTree削除
+        void unlock_impl() override;
+
       private:
 
         // 更新チェック可能
@@ -432,7 +435,6 @@ namespace DBTREE
 
         void slot_node_updated();
         void slot_load_finished();
-        void unlock_impl() override;
 
         // お気に入りのアイコンとスレビューのタブのアイコンに更新マークを表示
         // update == true の時に表示。falseなら戻す

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -1023,6 +1023,13 @@ void DBTREE::article_clear_post_history( const std::string& url )
 }
 
 
+// NodeTree削除
+void DBTREE::article_clear_nodetree( const std::string& url )
+{
+    DBTREE::get_article( url )->unlock_impl();
+}
+
+
 // ユーザーエージェント
 // ダウンロード用
 const std::string& DBTREE::get_agent( const std::string& url )

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -261,6 +261,9 @@ namespace DBTREE
     void article_update_writetime( const std::string& url );
     size_t article_lng_dat( const std::string& url );
 
+    // NodeTree削除
+    void article_clear_nodetree( const std::string& url );
+
     // ユーザーエージェント
     const std::string& get_agent( const std::string& url );   // ダウンロード用
     const std::string& get_agent_w( const std::string& url ); // 書き込み用

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -730,7 +730,7 @@ bool MessageViewBase::slot_button_press( GdkEventButton* event )
 //
 // フォントの更新
 //
-void MessageViewBase::relayout()
+void MessageViewBase::relayout( const bool completely )
 {
     init_font( CONFIG::get_fontname( FONT_MESSAGE ) );
     init_color();

--- a/src/message/messageviewbase.h
+++ b/src/message/messageviewbase.h
@@ -108,7 +108,7 @@ namespace MESSAGE
         void clock_in() override;
         void write() override;
         void reload() override {}
-        void relayout() override;
+        void relayout( const bool completely = false ) override;
         void close_view() override;
         void redraw_view() override;
         void focus_view() override;

--- a/src/replacestrpref.cpp
+++ b/src/replacestrpref.cpp
@@ -354,7 +354,7 @@ void ReplaceStrPref::slot_ok_clicked()
 
     //DBTREE::update_abone_thread();
     CORE::core_set_command( "relayout_all_board" );
-    CORE::core_set_command( "relayout_all_article" );
+    CORE::core_set_command( "relayout_all_article", "", "completely" );
 }
 
 

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -650,7 +650,10 @@ void Admin::exec_command()
     }
 
     // 全てのビューを再描画
-    else if( command.command == "relayout_all" ) relayout_all();
+    else if( command.command == "relayout_all" ){
+        const bool completely = ( command.arg1 == "completely" );
+        relayout_all( completely );
+    }
 
     // タイトル表示
     // アクティブなviewから依頼が来たらコアに渡す
@@ -1844,11 +1847,11 @@ void Admin::set_tablabel( const std::string& url, const std::string& str_label )
 //
 // 再レイアウト実行
 //
-void Admin::relayout_all()
+void Admin::relayout_all( const bool completely )
 {
     std::list< SKELETON::View* > list_view = get_list_view();
     for( SKELETON::View* view : list_view ) {
-        if( view ) view->relayout();
+        if( view ) view->relayout( completely );
     }
 }
 

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -222,7 +222,7 @@ namespace SKELETON
         virtual void restore_focus();
         virtual void focus_out();
         virtual void set_tablabel( const std::string& url, const std::string& str_label );
-        virtual void relayout_all();
+        virtual void relayout_all( const bool completely = false );
         virtual void open_window(){}
         virtual void close_window(){}
         virtual void toggle_tab();

--- a/src/skeleton/view.h
+++ b/src/skeleton/view.h
@@ -297,7 +297,7 @@ namespace SKELETON
         virtual void stop(){}
         virtual void show_view(){}
         virtual void redraw_view(){}
-        virtual void relayout(){}
+        virtual void relayout( const bool completely = false ){}
         virtual void update_view(){}
         virtual void update_finish(){}        
         virtual void focus_view(){}


### PR DESCRIPTION
### [Implement DBTREE::article_clear_nodetree()](https://github.com/JDimproved/JDim/commit/d8c12d26c4e0981c3709ff7309adf86a5fa3b5ad)

スレッドをURLで指定してNodeTreeを削除する関数を実装します。

### [Add the "completely" parameter to View::relayout()](https://github.com/JDimproved/JDim/commit/6ab8ccaaadc6cd7d067e7386eb9a2a29eb177c26)

ビューの再レイアウトを行うときレイアウトの元になるデータから再構築するオプションをメンバー関数に追加します。

スレビューの再レイアウトで"completely"が指定されたときスレッドのデータ(NodeTree)を削除し再構築を行う処理を追加します。

### [ReplaceStr: Rebuild nodetree to relayout completely if ok clicked](https://github.com/JDimproved/JDim/commit/deadb9c1bd3e97434330fa97a950ac251c379147)

置換文字列設定のダイアログでOKを押して閉じたときスレッドのツリー情報を再構築して置換処理の変更を反映するように修正します。

関連のissue: #76 