### PR TITLE
ArticleViewMain: Reserve relayout if the view is not mapped

### DIFF
--- a/src/article/articleview.h
+++ b/src/article/articleview.h
@@ -9,6 +9,9 @@
 
 #include "articleviewbase.h"
 
+#include <optional>
+
+
 namespace ARTICLE
 {
     class ArticleViewMain : public ArticleViewBase
@@ -31,6 +34,9 @@ namespace ARTICLE
 
         // 連続リロード防止用
         int m_cancel_reload_counter{};
+
+        /// true または false なら再レイアウトが予約されている
+        std::optional<bool> m_reserve_relayout;
 
       public:
         explicit ArticleViewMain( const std::string& url );
@@ -71,6 +77,9 @@ namespace ARTICLE
         void create_status_message();
 
         void show_instruct_diag();
+
+        void do_relayout( bool completely );
+        void slot_view_map();
     };
 }
 

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -253,6 +253,7 @@ namespace ARTICLE
         SIG_KEY_RELEASE sig_key_release(){ return m_sig_key_release; }
         SIG_ON_URL sig_on_url(){ return m_sig_on_url; }
         SIG_LEAVE_URL sig_leave_url(){ return m_sig_leave_url; }
+        auto sig_view_map() { return m_view.signal_map(); }
 
         explicit DrawAreaBase( const std::string& url );
         ~DrawAreaBase();


### PR DESCRIPTION
スレビューの再レイアウト処理をすべてのタブで実行する実装だとタブ数が増えたとき処理時間が増加し一時的にフリーズすることがありました。
そのため表示中(mapped)ではないタブは処理を予約してタブが表示されるときに再レイアウトを行うように変更します。