### PR TITLE
NodeTreeBase: Fix parsing <li> tag

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -2176,9 +2176,9 @@ void NodeTreeBase::parse_html( std::string_view str, const int color_text,
 
                 ) br = true;
 
-            // <li>は・にする
-            else if( ( *( pos + 1 ) == 'l' || *( pos + 2 ) == 'L' )
-                     && ( *( pos + 2 ) == 'i' || *( pos + 3 ) == 'I' )
+            // <li>はBULLET (•)にする
+            else if( ( *( pos + 1 ) == 'l' || *( pos + 1 ) == 'L' )
+                     && ( *( pos + 2 ) == 'i' || *( pos + 2 ) == 'I' )
                 ){
 
                 pos += 4;


### PR DESCRIPTION
HTMLの`<li>`タグを判定する処理でインデックスがずれている箇所を修正します。

関連のissue: #76 