### PR TITLE
Prenotice end of support for Autotools

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -49,12 +49,14 @@
   OSやディストリビューション別の解説は https://github.com/JDimproved/JDim/discussions/592 を参照。
 
   configure のかわりに meson を使ってビルドする方法は https://github.com/JDimproved/JDim/discussions/556 を参照。
-  (v0.4.0+から暫定サポート)
+  (v0.4.0+からサポート)
 
   GTKがデフォルトでサポートしていないWebPやAVIF形式の画像を表示する方法は
   https://github.com/JDimproved/JDim/discussions/737 を参照。(v0.5.0+からサポート)
 
 * ビルド方法( configure + make の場合 )
+    Autotoolsのサポートは2023年7月のリリースをもって廃止されます。かわりにMesonを利用してください。
+    詳しくは https://github.com/JDimproved/rfcs/blob/master/docs/0012-end-of-autotools-support.md を参照。
 
     1. autoreconf -i ( 又は ./autogen.sh )
     2. ./configure

--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ i386版ディストロを利用されている場合は更新をお願いいた�
 ソースコードからJDimをビルドします。**GTK3版がビルド**されますのでご注意ください。
 詳細は [INSTALL](./INSTALL) にも書いてあります。
 
-ビルドツール [meson][mesonbuild] を暫定的にサポートしています。
+**Autotoolsのサポートは2023年7月のリリースをもって廃止されます。
+かわりに[meson][mesonbuild]を利用してください。([RFC 0012][rfc0012])**
 configure のかわりに meson を使ってビルドする方法は [Discussions][dis556] を参照してください。
 
 [mesonbuild]: https://mesonbuild.com
 [dis556]: https://github.com/JDimproved/JDim/discussions/556 "Mesonを使ってJDimをビルドする方法 - Discussions #556"
+[rfc0012]: https://github.com/JDimproved/rfcs/blob/master/docs/0012-end-of-autotools-support.md
 
 
 ### 事前準備

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,8 @@
 dnl
 dnl JDim用 configure.ac
 dnl
+dnl Autotoolsのサポートは2023年7月のリリースをもって廃止されます。かわりにMesonを利用してください。
+dnl
 AC_PREREQ([2.69])
 AC_INIT([jdim],[1.0])
 AM_INIT_AUTOMAKE

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -61,7 +61,7 @@ layout: default
 OSやディストリビューション別の解説は [#592][dis592] を参照。
 
 configure のかわりに [meson] を使ってビルドする方法は [#556][dis556] を参照。
-<small>(v0.4.0+から暫定サポート)</small>
+<small>(v0.4.0+からサポート)</small>
 
 WebPやAVIF形式の画像を表示する方法は [#737][dis737] を参照。
 <small>(v0.5.0+からサポート)</small>
@@ -69,6 +69,8 @@ WebPやAVIF形式の画像を表示する方法は [#737][dis737] を参照。
 
 <a name="make-configure"></a>
 ### ビルド方法( configure + make の場合 )
+**Autotoolsのサポートは2023年7月のリリースをもって廃止されます。
+かわりに[meson]を利用してください。([RFC 0012][rfc0012])**
 
 1. `autoreconf -i` ( 又は `./autogen.sh` )
 2. `./configure`
@@ -153,3 +155,4 @@ WebPやAVIF形式の画像を表示する方法は [#737][dis737] を参照。
 [dis556]: https://github.com/JDimproved/JDim/discussions/556 "Mesonを使ってJDimをビルドする方法 - Discussions #556"
 [dis592]: https://github.com/JDimproved/JDim/discussions/592 "OS/ディストリビューション別インストール方法 - Discussions #592"
 [dis737]: https://github.com/JDimproved/JDim/discussions/737 "[v0.5.0+] WebPやAVIF形式の画像を表示する方法 - Discussions #737"
+[rfc0012]: https://github.com/JDimproved/rfcs/blob/master/docs/0012-end-of-autotools-support.md

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,4 @@
 # JDim用 meson.build
-# NOTE: 暫定的なサポートのため変更の可能性がある
 
 # Autotoolsからの移行はGNOMEのガイドラインを参考にする
 # https://wiki.gnome.org/Initiatives/GnomeGoals/MesonPorting


### PR DESCRIPTION
[RFC 0012][*]に基づきビルドツールAutotoolsのサポートは2023年7月のリリースをもって終了することをドキュメントに記載します。

[*]: https://github.com/JDimproved/rfcs/blob/master/docs/0012-end-of-autotools-support.md