### PR TITLE
Get rid of unused headers

### DIFF
--- a/src/jdlib/confloader.h
+++ b/src/jdlib/confloader.h
@@ -10,8 +10,6 @@
 #include <string>
 #include <list>
 
-#include "config/defaultconf.h"
-
 namespace JDLIB
 {
     struct ConfData

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,6 @@
 #include "iomonitor.h"
 
 #include "jdlib/miscmsg.h"
-#include "jdlib/miscutil.h"
 #include "jdlib/ssl.h"
 #include "jdlib/jdregex.h"
 


### PR DESCRIPTION
使っていない #include ディレクティブを取り除きます。

関連のissue: #76
