### PR TITLE
DrawAreaBase: Add null check to read LAYOUT::rect

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -3095,7 +3095,7 @@ void DrawAreaBase::exec_scroll()
             std::cout << "DrawAreaBase::exec_scroll : goto " << m_scrollinfo.res << std::endl;
 #endif
             const LAYOUT* layout = m_layout_tree->get_header_of_res_const( m_scrollinfo.res );
-            if( layout ) y = layout->rect->y;
+            if( layout && layout->rect ) y = layout->rect->y;
             m_scrollinfo.reset();
         }
         break;


### PR DESCRIPTION
スレビュー閲覧中にJDimがクラッシュしたためnullチェックを追加します。
状況の再現が難しかったためコードを逆上って原因の特定はできていません。

GDBのレポート
```
Thread 1 "jdim" received signal SIGSEGV, Segmentation fault.
0x00005555559940d3 in ARTICLE::DrawAreaBase::exec_scroll (this=0x55555855b000) at ../src/article/drawareabase.cpp:3098
3098                if( layout ) y = layout->rect->y;
```