### PR TITLE
dbtree: Modify function parameters for DBTREE::decode_char()

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -2102,7 +2102,7 @@ void NodeTreeBase::parse_html( std::string_view str, const int color_text,
                             int n_in = 0;
                             int n_out = 0;
                             char out_char[kMaxBytesOfUTF8Char]{}; // FIXME: std::stringを受け付けるdecode_char()を作る
-                            const int ret_decode = DBTREE::decode_char( pos_str_start + pos_tmp, n_in, out_char, n_out, false );
+                            const int ret_decode = DBTREE::decode_char( pos_str_start + pos_tmp, n_in, out_char, n_out );
                             if( ret_decode != NODE_NONE ){
                                 m_parsed_text.append( out_char, n_out );
                                 pos_tmp += n_in;
@@ -2395,7 +2395,7 @@ void NodeTreeBase::parse_html( std::string_view str, const int color_text,
 
             int n_out = 0;
             char out_char[kMaxBytesOfUTF8Char]{};
-            const int ret_decode = DBTREE::decode_char( pos, n_in, out_char, n_out, false );
+            const int ret_decode = DBTREE::decode_char( pos, n_in, out_char, n_out );
 
             if( ret_decode != NODE_NONE ){
 
@@ -2788,7 +2788,7 @@ int NodeTreeBase::check_link( const char* str_in, const int lng_in, int& n_in, c
 
         // HTML特殊文字( &〜; )
         if ( *( str_in + n_in ) == '&' &&
-             DBTREE::decode_char( str_in + n_in, n_in_tmp, buf, n_out_tmp, false ) != DBTREE::NODE_NONE ){
+             DBTREE::decode_char( str_in + n_in, n_in_tmp, buf, n_out_tmp ) != DBTREE::NODE_NONE ){
 
              // デコード結果が"&(&amp;)"でないもの
              if( n_out_tmp != 1 || buf[0] != '&' ) break;

--- a/src/dbtree/spchar_decoder.cpp
+++ b/src/dbtree/spchar_decoder.cpp
@@ -37,7 +37,7 @@ bool check_spchar( const char* n_in, const char* spchar )
 //
 // 戻り値 : node.h で定義したノード番号
 //
-int decode_char_number( const char* in_char, int& n_in,  char* out_char, int& n_out )
+int decode_char_number( const char* in_char, int& n_in, JDLIB::span<char> out_char, int& n_out )
 {
     int ret = DBTREE::NODE_TEXT;
     n_in = n_out = 0;
@@ -66,17 +66,17 @@ int decode_char_number( const char* in_char, int& n_in,  char* out_char, int& n_
             break;
 
         default:
-            n_out = MISC::utf32toutf8( num, out_char );
+            n_out = MISC::utf32toutf8( num, out_char.data() );
             if( ! n_out ) return DBTREE::NODE_NONE;
     }
 
     n_in = offset + lng;
     if( in_char[n_in] == ';' ) n_in++; // 数値文字参照の終端「;」の場合は1文字削除
-    
-    if( out_char ) out_char[ n_out ] = '\0';
+
+    out_char[ n_out ] = '\0';
 
     return ret;
-}    
+}
 
 
 //
@@ -89,12 +89,14 @@ int decode_char_number( const char* in_char, int& n_in,  char* out_char, int& n_
 //
 // 戻り値 : node.h で定義したノード番号
 //
-int DBTREE::decode_char( const char* in_char, int& n_in,  char* out_char, int& n_out )
+int DBTREE::decode_char( const char* in_char, int& n_in, JDLIB::span<char> out_char, int& n_out )
 {
+    assert( out_char.size() >= 5 );
+
     // 1文字目が&以外の場合は出力しない
     if( in_char[ 0 ] != '&' ){
         n_in = n_out = 0;
-        if( out_char ) out_char[ n_out ] = '\0';
+        out_char[ n_out ] = '\0';
 
         return DBTREE::NODE_NONE;
     }
@@ -118,14 +120,14 @@ int DBTREE::decode_char( const char* in_char, int& n_in,  char* out_char, int& n
 
             // zwnj, zwj, lrm, rlm は今のところ無視する(zwspにする)
             if( ucs >= UCS_ZWSP && ucs <= UCS_RLM ) ret = DBTREE::NODE_ZWSP;
-            else n_out = MISC::utf32toutf8( ucs, out_char );
+            else n_out = MISC::utf32toutf8( ucs, out_char.data() );
 
             break;
         }
     }
 
     if( !n_in ) ret = DBTREE::NODE_NONE;
-    if( out_char ) out_char[ n_out ] = '\0';
+    out_char[ n_out ] = '\0';
 
     return ret;
 }

--- a/src/dbtree/spchar_decoder.cpp
+++ b/src/dbtree/spchar_decoder.cpp
@@ -34,11 +34,10 @@ bool check_spchar( const char* n_in, const char* spchar )
 // n_in : 入力で使用した文字数が返る
 // out_char : 出力文字列
 // n_out : 出力した文字数が返る
-// only_check : チェックのみ実施 ( out_char は nullptr でも可 )
 //
 // 戻り値 : node.h で定義したノード番号
 //
-int decode_char_number( const char* in_char, int& n_in,  char* out_char, int& n_out, const bool only_check )
+int decode_char_number( const char* in_char, int& n_in,  char* out_char, int& n_out )
 {
     int ret = DBTREE::NODE_TEXT;
     n_in = n_out = 0;
@@ -46,8 +45,6 @@ int decode_char_number( const char* in_char, int& n_in,  char* out_char, int& n_
     int offset;
     const int lng = MISC::spchar_number_ln( in_char, offset );
     if( lng == -1 ) return DBTREE::NODE_NONE;
-
-    if( only_check ) return ret;
 
     const int num = MISC::decode_spchar_number( in_char, offset, lng );
 
@@ -89,11 +86,10 @@ int decode_char_number( const char* in_char, int& n_in,  char* out_char, int& n_
 // n_in : 入力で使用した文字数が返る
 // out_char : 出力文字列
 // n_out : 出力した文字数が返る
-// only_check : チェックのみ実施 ( out_char は nullptr でも可 )
 //
 // 戻り値 : node.h で定義したノード番号
 //
-int DBTREE::decode_char( const char* in_char, int& n_in,  char* out_char, int& n_out, const bool only_check )
+int DBTREE::decode_char( const char* in_char, int& n_in,  char* out_char, int& n_out )
 {
     // 1文字目が&以外の場合は出力しない
     if( in_char[ 0 ] != '&' ){
@@ -104,7 +100,7 @@ int DBTREE::decode_char( const char* in_char, int& n_in,  char* out_char, int& n
     }
 
     // 数字参照 &#数字;
-    if( in_char[ 1 ] == '#' ) return decode_char_number( in_char, n_in, out_char, n_out, only_check );
+    if( in_char[ 1 ] == '#' ) return decode_char_number( in_char, n_in, out_char, n_out );
 
     // 文字参照 -> ユニコード変換
     int ret = DBTREE::NODE_TEXT;
@@ -117,8 +113,6 @@ int DBTREE::decode_char( const char* in_char, int& n_in,  char* out_char, int& n
 
         if( in_char[1] == t.str[0]
                 && check_spchar( in_char + 1, t.str ) ) {
-
-            if( only_check ) return ret;
 
             n_in = std::strlen( t.str ) + 1;
 

--- a/src/dbtree/spchar_decoder.cpp
+++ b/src/dbtree/spchar_decoder.cpp
@@ -27,16 +27,15 @@ bool check_spchar( const char* n_in, const char* spchar )
 }
 
 
-//
-// ユニコード文字参照  &#数字;
-//
-// in_char: 入力文字列、in_char[1] == "#" であること
-// n_in : 入力で使用した文字数が返る
-// out_char : 出力文字列
-// n_out : 出力した文字数が返る
-//
-// 戻り値 : node.h で定義したノード番号
-//
+/**
+ * @brief HTMLの数値文字参照 `&#数字;` をUTF-8文字列にデコードする
+ *
+ * @param[in]  in_char  入力文字列、in_char[1] == '#' であること (not null)
+ * @param[out] n_in     入力で使用した文字数が返る
+ * @param[out] out_char 出力文字列 (長さ5以上)
+ * @param[out] n_out    出力した文字数が返る
+ * @return デコードした文字の種類( node.h で定義したノード番号 )
+ */
 int decode_char_number( const char* in_char, int& n_in, JDLIB::span<char> out_char, int& n_out )
 {
     int ret = DBTREE::NODE_TEXT;
@@ -79,16 +78,15 @@ int decode_char_number( const char* in_char, int& n_in, JDLIB::span<char> out_ch
 }
 
 
-//
-// 文字参照のデコード
-//
-// in_char : 入力文字列, in_char[ 0 ] = '&' となっていること
-// n_in : 入力で使用した文字数が返る
-// out_char : 出力文字列
-// n_out : 出力した文字数が返る
-//
-// 戻り値 : node.h で定義したノード番号
-//
+/**
+ * @brief HTML 文字参照をUTF-8文字列にデコードする
+ *
+ * @param[in]  in_char  入力文字列, in_char[0] = '&' となっていること (not null)
+ * @param[out] n_in     入力で使用した文字数が返る
+ * @param[out] out_char 出力文字列 (長さ5以上)
+ * @param[out] n_out    出力した文字数が返る
+ * @return デコードした文字の種類( node.h で定義したノード番号 )
+ */
 int DBTREE::decode_char( const char* in_char, int& n_in, JDLIB::span<char> out_char, int& n_out )
 {
     assert( out_char.size() >= 5 );

--- a/src/dbtree/spchar_decoder.h
+++ b/src/dbtree/spchar_decoder.h
@@ -12,15 +12,15 @@
 
 namespace DBTREE
 {
-    // 文字参照のデコード
-    // in_char : 入力文字列, in_char[ 0 ] = '&' となっていること
-    // n_in : 入力で使用した文字数が返る
-    // out_char : 出力文字列
-    // n_out : 出力した文字数が返る
-    // only_check : チェックのみ実施 ( out_char は nullptr でも可 )
-    //
-    // 戻り値 : node.h で定義したノード番号
-    //
+    /**
+     * @brief HTML 文字参照をUTF-8文字列にデコードする
+     *
+     * @param[in]  in_char  入力文字列, in_char[0] = '&' となっていること (not null)
+     * @param[out] n_in     入力で使用した文字数が返る
+     * @param[out] out_char 出力文字列 (長さ5以上)
+     * @param[out] n_out    出力した文字数が返る
+     * @return デコードした文字の種類( node.h で定義したノード番号 )
+     */
     int decode_char( const char* in_char, int& n_in, JDLIB::span<char> out_char, int& n_out );
 }
 

--- a/src/dbtree/spchar_decoder.h
+++ b/src/dbtree/spchar_decoder.h
@@ -18,7 +18,7 @@ namespace DBTREE
     //
     // 戻り値 : node.h で定義したノード番号
     //
-    int decode_char( const char* in_char, int& n_in,  char* out_char, int& n_out, const bool only_check );
+    int decode_char( const char* in_char, int& n_in,  char* out_char, int& n_out );
 }
 
 #endif

--- a/src/dbtree/spchar_decoder.h
+++ b/src/dbtree/spchar_decoder.h
@@ -7,6 +7,9 @@
 #ifndef _SPCHAR_DECODER_H
 #define _SPCHAR_DECODER_H
 
+#include "jdlib/span.h"
+
+
 namespace DBTREE
 {
     // 文字参照のデコード
@@ -18,7 +21,7 @@ namespace DBTREE
     //
     // 戻り値 : node.h で定義したノード番号
     //
-    int decode_char( const char* in_char, int& n_in,  char* out_char, int& n_out );
+    int decode_char( const char* in_char, int& n_in, JDLIB::span<char> out_char, int& n_out );
 }
 
 #endif

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -991,7 +991,7 @@ static std::string chref_decode_one( const char* str, int& n_in, const char pre_
 {
     std::string out_char( 15u, '\0' );
     int n_out;
-    const int type = DBTREE::decode_char( str, n_in, out_char.data(), n_out );
+    const int type = DBTREE::decode_char( str, n_in, out_char, n_out );
     out_char.resize( n_out );
 
     // 改行、タブ、スペースの処理

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -991,7 +991,7 @@ static std::string chref_decode_one( const char* str, int& n_in, const char pre_
 {
     std::string out_char( 15u, '\0' );
     int n_out;
-    const int type = DBTREE::decode_char( str, n_in, &*out_char.begin(), n_out, false );
+    const int type = DBTREE::decode_char( str, n_in, out_char.data(), n_out );
     out_char.resize( n_out );
 
     // 改行、タブ、スペースの処理


### PR DESCRIPTION
### [dbtree: Get rid of DBTREE::decode_char() param only_check](https://github.com/JDimproved/JDim/commit/6b9c44f08e0e35c5fbf74f991c38a58b23fe875c)

commit https://github.com/JDimproved/JDim/commit/14b72ea6f28dfa25a16b8efe6c7ca4a0e7ffc223 (2012-11)
の修正以来使われていない`only_check`引数を取り除いてコードを整理します。

### [dbtree: Modify type of the out_char for DBTREE::decode_char() param](https://github.com/JDimproved/JDim/commit/3144fbdc0c13eee6a39606a884fc4b35bdf47148)

出力文字列を格納するパラメータ`out_char`の型を`JDLIB::span<char>`に変更してバッファの長さが足りているか`assert()`を使って確認します。

### [dbtree: Add source code documentation to the functions](https://github.com/JDimproved/JDim/commit/8e6d902f4b9fae06623fa2c4b7605187c8f8e7aa)
