### PR TITLE
Meson: Create dependency to organize macro

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -49,7 +49,6 @@ project('jdim', 'cpp',
         default_options : ['warning_level=3', 'cpp_std=c++17'])
 
 # 追加コンパイルオプション
-add_project_arguments('-DHAVE_CONFIG_H=1', language : 'cpp')
 add_project_arguments('-DGTK_DOMAIN="gtk30"', language : 'cpp')
 # -Wextraで有効になる-Wunused-parameterは修正方法の検討が必要なので暫定的に無効
 add_project_arguments('-Wno-unused-parameter', language : 'cpp')

--- a/meson.build
+++ b/meson.build
@@ -49,7 +49,6 @@ project('jdim', 'cpp',
         default_options : ['warning_level=3', 'cpp_std=c++17'])
 
 # 追加コンパイルオプション
-add_project_arguments('-DGTK_DOMAIN="gtk30"', language : 'cpp')
 # -Wextraで有効になる-Wunused-parameterは修正方法の検討が必要なので暫定的に無効
 add_project_arguments('-Wno-unused-parameter', language : 'cpp')
 
@@ -73,6 +72,8 @@ endif
 # 必須パッケージのチェック
 #
 gtkmm_dep = dependency('gtkmm-3.0', version : '>= 3.22.0')
+gtkmm_dep = declare_dependency(compile_args : '-DGTK_DOMAIN="gtk30"',
+                               dependencies : gtkmm_dep)
 threads_dep = dependency('threads')
 x11_dep = dependency('x11')
 zlib_dep = dependency('zlib', version : '>= 1.2.0')

--- a/src/article/meson.build
+++ b/src/article/meson.build
@@ -22,7 +22,7 @@ sources = [
 
 
 article_lib = static_library(
-  'article', [sources, config_h],
-  dependencies : gtkmm_dep,
+  'article', sources,
+  dependencies : [config_h_dep, gtkmm_dep],
   include_directories : include_directories('..'),
 )

--- a/src/config/meson.build
+++ b/src/config/meson.build
@@ -7,7 +7,7 @@ sources = [
 
 
 config_lib = static_library(
-  'config', [sources, config_h],
-  dependencies : gtkmm_dep,
+  'config', sources,
+  dependencies : [config_h_dep, gtkmm_dep],
   include_directories : include_directories('..'),
 )

--- a/src/control/meson.build
+++ b/src/control/meson.build
@@ -13,7 +13,7 @@ sources = [
 
 
 control_lib = static_library(
-  'control', [sources, config_h],
-  dependencies : gtkmm_dep,
+  'control', sources,
+  dependencies : [config_h_dep, gtkmm_dep],
   include_directories : include_directories('..'),
 )

--- a/src/jdlib/meson.build
+++ b/src/jdlib/meson.build
@@ -22,6 +22,7 @@ sources = [
 ]
 
 deps = [
+  config_h_dep,
   gtkmm_dep,
   socket_dep,
   tls_dep,
@@ -30,7 +31,7 @@ deps = [
 
 
 jdlib_lib = static_library(
-  'jdlib', [sources, config_h],
+  'jdlib', sources,
   dependencies : deps,
   include_directories : include_directories('..'),
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,8 @@
 config_h = configure_file(output : 'config.h',
                           configuration : conf)
+config_h_dep = declare_dependency(compile_args : '-DHAVE_CONFIG_H=1',
+                                  include_directories : include_directories('.'),
+                                  sources: config_h)
 
 # 作業ディレクトリの状態を反映するためにビルド毎に更新する
 buildinfo_h = custom_target('buildinfo.h',
@@ -112,8 +115,8 @@ jdim_libs = [
 
 
 jdim_exe = executable(
-  'jdim', [core_sources, sources, buildinfo_h, config_h],
-  dependencies : jdim_deps,
+  'jdim', [core_sources, sources, buildinfo_h],
+  dependencies : [config_h_dep, jdim_deps],
   include_directories : jdim_incs,
   link_with : jdim_libs,
   install : true,

--- a/src/sound/meson.build
+++ b/src/sound/meson.build
@@ -5,12 +5,13 @@ sources = [
 
 deps = [
   alsa_dep,
+  config_h_dep,
   gtkmm_dep,
 ]
 
 
 sound_lib = static_library(
-  'sound', [sources, config_h],
+  'sound', sources,
   dependencies : deps,
   include_directories : include_directories('..'),
 )

--- a/test/meson.build
+++ b/test/meson.build
@@ -15,6 +15,7 @@ sources = [
 ]
 
 deps = [
+  config_h_dep,
   gtest_main_dep,
   jdim_deps,
 ]


### PR DESCRIPTION
### [meson: Create config.h dependency to organize HAVE_CONFIG_H macro](https://github.com/JDimproved/JDim/commit/914180855adeb121d2a1b53bbfda8f693936cb38)

`HAVE_CONFIG_H`マクロをプロジェクト全体に設定する方法からconfig.h 依存関係にまとめる方法に変更します。

### [meson: Create gtkmm dependency to organize GTK_DOMAIN macro](https://github.com/JDimproved/JDim/commit/83d9c70e95e8360bdb0cdae4dff53a7ba3f8a062)

`GTK_DOMAIN`マクロをプロジェクト全体に設定する方法からgtkmm 依存関係にまとめる方法に変更します。
