### PR TITLE
Change return type int with char32_t for MISC::decode_spchar_number()

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -2570,9 +2570,9 @@ void NodeTreeBase::parse_write( std::string_view str, const std::size_t max_lng_
         // 数字参照
         else if( *pos == '&' && *( pos + 1 ) == '#' && ( lng_num = MISC::spchar_number_ln( pos, offset_num ) ) != -1 ){
 
-            const int num = MISC::decode_spchar_number( pos, offset_num, lng_num );
+            const char32_t uch = MISC::decode_spchar_number( pos, offset_num, lng_num );
             char utf8[kMaxBytesOfUTF8Char]{};
-            const int n_out = MISC::utf32toutf8( num, utf8 );
+            const int n_out = MISC::utf32toutf8( uch, utf8 );
             m_buffer_write.append( utf8, n_out );
             pos += offset_num + lng_num;
 

--- a/src/dbtree/spchar_decoder.cpp
+++ b/src/dbtree/spchar_decoder.cpp
@@ -45,9 +45,9 @@ int decode_char_number( const char* in_char, int& n_in, JDLIB::span<char> out_ch
     const int lng = MISC::spchar_number_ln( in_char, offset );
     if( lng == -1 ) return DBTREE::NODE_NONE;
 
-    const int num = MISC::decode_spchar_number( in_char, offset, lng );
+    const char32_t uch = MISC::decode_spchar_number( in_char, offset, lng );
 
-    switch( num ){
+    switch( uch ){
 
         //zwnj,zwj,lrm,rlm は今のところ無視(zwspにする)
         case UCS_ZWSP:
@@ -65,7 +65,7 @@ int decode_char_number( const char* in_char, int& n_in, JDLIB::span<char> out_ch
             break;
 
         default:
-            n_out = MISC::utf32toutf8( num, out_char.data() );
+            n_out = MISC::utf32toutf8( uch, out_char.data() );
             if( ! n_out ) return DBTREE::NODE_NONE;
     }
 

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1554,7 +1554,7 @@ int MISC::spchar_number_ln( const char* in_char, int& offset )
 
 
 // 特定の変換が必要なコードポイントをチェックする
-static int transform_7f_9f( int raw_point )
+static char32_t transform_7f_9f( char32_t raw_point )
 {
     switch( raw_point ) {
         case 0x80: return 0x20AC; // EURO SIGN (€)
@@ -1596,7 +1596,7 @@ static int transform_7f_9f( int raw_point )
 // 参考文献 : Numeric character reference end state (HTML 5.3)
 //            https://www.w3.org/TR/html53/syntax.html#numeric-character-reference-end-state
 //
-static int sanitize_numeric_character_reference( int raw_point )
+static char32_t sanitize_numeric_character_reference( char32_t raw_point )
 {
     // NOTE: 記号や絵文字を速やかに処理できるよう順番が組まれている
 
@@ -1646,7 +1646,7 @@ static int sanitize_numeric_character_reference( int raw_point )
 //
 // 戻り値 : 「&#数字;」の中の数字(int型)
 //
-int MISC::decode_spchar_number( const char* in_char, const int offset, const int lng )
+char32_t MISC::decode_spchar_number( const char* in_char, const int offset, const int lng )
 {
     char str_num[ 16 ];
 
@@ -1657,11 +1657,9 @@ int MISC::decode_spchar_number( const char* in_char, const int offset, const int
     std::cout << "MISC::decode_spchar_number offset = " << offset << " lng = " << lng << " str = " << str_num << std::endl;
 #endif
 
-    int num = 0;
-    if( offset == 2 ) num = atoi( str_num );
-    else num = strtol( str_num, nullptr, 16 );
-
-    return sanitize_numeric_character_reference( num );
+    const int base{ offset == 2 ? 10 : 16 };
+    const char32_t uch = static_cast<char32_t>( std::strtoul( str_num, nullptr, base ) );
+    return sanitize_numeric_character_reference( uch );
 }
 
 
@@ -1684,10 +1682,10 @@ std::string MISC::decode_spchar_number( const std::string& str )
                 continue;
             }
 
-            const int num = MISC::decode_spchar_number( str.c_str()+i, offset, lng );
+            const char32_t uch = MISC::decode_spchar_number( str.c_str()+i, offset, lng );
 
             char out_char[8];
-            const int n_out = MISC::utf32toutf8( num, out_char );
+            const int n_out = MISC::utf32toutf8( uch, out_char );
             if( ! n_out ){
                 str_out += str[ i ];
                 continue;

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -214,7 +214,7 @@ namespace MISC
     //
     // 戻り値 : 「&#数字;」の中の数字(int型)
     //
-    int decode_spchar_number( const char* in_char, const int offset, const int lng );
+    char32_t decode_spchar_number( const char* in_char, const int offset, const int lng );
 
     // str に含まれる「&#数字;」形式の数字参照文字列を全てユニーコード文字に変換する
     std::string decode_spchar_number( const std::string& str );


### PR DESCRIPTION
戻り値の型を char32_t へ変更してソースコードの可読性を向上させます。