### PR TITLE
Implement MISC::decode_spchar_number_raw()

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1590,30 +1590,45 @@ static char32_t transform_7f_9f( char32_t raw_point )
 }
 
 
-//
-// 「&#数字;」形式の数字参照文字列を数字(int)に変換する
-//
-// 最初に MISC::spchar_number_ln() を呼び出して offset と lng を取得すること
-//
-// in_char: 入力文字列、in_char[0] == "&" && in_char[1] == "#" であること
-// offset : spchar_number_ln() の戻り値
-// lng : spchar_number_ln() の戻り値
-//
-// 戻り値 : 「&#数字;」の中の数字(int型)
-//
-char32_t MISC::decode_spchar_number( const char* in_char, const int offset, const int lng )
+/** @brief 「&#数字;」形式の数値文字参照をコードポイント(char32_t)に変換する
+ *
+ * @details 数値文字参照の解析エラーとなる値もそのまま返す
+ * (Unicodeの範囲外、サロゲート、非文字など)
+ * @param[in] in_char 入力文字列、 `in_char[0] == "&" && in_char[1] == "#"` であること (not null)
+ * @param[in] offset  spchar_number_ln() の戻り値
+ * @param[in] lng     spchar_number_ln() の戻り値
+ * @return 「&#数字;」の中の数字(char32_t型)
+ * @remarks 最初に MISC::spchar_number_ln() を呼び出して `offset` と `lng` を取得すること
+ */
+char32_t MISC::decode_spchar_number_raw( const char* in_char, const int offset, const int lng )
 {
     char str_num[ 16 ];
 
-    memcpy( str_num, in_char + offset, lng );
+    std::memcpy( str_num, in_char + offset, lng );
     str_num[ lng ] = '\0';
 
 #ifdef _DEBUG
-    std::cout << "MISC::decode_spchar_number offset = " << offset << " lng = " << lng << " str = " << str_num << std::endl;
+    std::cout << "MISC::decode_spchar_number_raw offset = " << offset << " lng = " << lng
+              << " str = " << str_num << std::endl;
 #endif
 
     const int base{ offset == 2 ? 10 : 16 };
-    const char32_t uch = static_cast<char32_t>( std::strtoul( str_num, nullptr, base ) );
+    return static_cast<char32_t>( std::strtoul( str_num, nullptr, base ) );
+}
+
+
+/** @brief 「&#数字;」形式の数値文字参照をコードポイント(char32_t)に変換する
+ *
+ * @details 数値文字参照の解析エラーとなる値は規定の値に変換して返す
+ * @param[in] in_char 入力文字列、 `in_char[0] == "&" && in_char[1] == "#"` であること (not null)
+ * @param[in] offset  spchar_number_ln() の戻り値
+ * @param[in] lng     spchar_number_ln() の戻り値
+ * @return 「&#数字;」の中の数字(char32_t型)
+ * @remarks 最初に MISC::spchar_number_ln() を呼び出して `offset` と `lng` を取得すること
+ */
+char32_t MISC::decode_spchar_number( const char* in_char, const int offset, const int lng )
+{
+    const char32_t uch = MISC::decode_spchar_number_raw( in_char, offset, lng );
     return MISC::sanitize_numeric_charref( uch );
 }
 

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -204,15 +204,17 @@ namespace MISC
     //
     int spchar_number_ln( const char* in_char, int& offset );
 
-    // 「&#数字;」形式の数字参照文字列を数字(int)に変換する
+    // 「&#数字;」形式の数値文字参照をコードポイント(char32_t)に変換する
+    char32_t decode_spchar_number_raw( const char* in_char, const int offset, const int lng );
+
+    // @brief 「&#数字;」形式の数値文字参照をコードポイント(char32_t)に変換する
     //
-    // 最初に MISC::spchar_number_ln() を呼び出して offset と lng を取得すること
-    //
-    // in_char: 入力文字列、in_char[0] == "&" && in_char[1] == "#" であること
-    // offset : spchar_number_ln() の戻り値
-    // lng : spchar_number_ln() の戻り値
-    //
-    // 戻り値 : 「&#数字;」の中の数字(int型)
+    // @details 数値文字参照の解析エラーとなる値は規定の値に変換して返す
+    // @param[in] in_char 入力文字列、 `in_char[0] == "&" && in_char[1] == "#"` であること (not null)
+    // @param[in] offset  spchar_number_ln() の戻り値
+    // @param[in] lng     spchar_number_ln() の戻り値
+    // @return 「&#数字;」の中の数字(char32_t型)
+    // @remarks 最初に MISC::spchar_number_ln() を呼び出して `offset` と `lng` を取得すること
     //
     char32_t decode_spchar_number( const char* in_char, const int offset, const int lng );
 

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -1996,6 +1996,83 @@ TEST_F(MISC_DecodeSpcharNumberRawTest, between_u007F_and_u009F_hexdecimal)
 }
 
 
+class MISC_DecodeSpcharNumberTest : public ::testing::Test {};
+
+TEST_F(MISC_DecodeSpcharNumberTest, result_ok)
+{
+    EXPECT_EQ( 0xC, MISC::decode_spchar_number( "&#xC;", 3, 4 ) );
+    EXPECT_EQ( 32, MISC::decode_spchar_number( "&#32;", 2, 4 ) );
+    EXPECT_EQ( 0x20, MISC::decode_spchar_number( "&#x20;", 3, 5 ) );
+    EXPECT_EQ( 0xA0, MISC::decode_spchar_number( "&#xA0;", 3, 5 ) );
+    EXPECT_EQ( 1234, MISC::decode_spchar_number( "&#1234;", 2, 6 ) );
+    EXPECT_EQ( 0x1234, MISC::decode_spchar_number( "&#x1234;", 3, 7 ) );
+
+    EXPECT_EQ( 0xD7FF, MISC::decode_spchar_number( "&#xD7FF;", 3, 7 ) );
+    EXPECT_EQ( 0xE000, MISC::decode_spchar_number( "&#xE000;", 3, 7 ) );
+    EXPECT_EQ( 0xFDCF, MISC::decode_spchar_number( "&#xFDCF;", 3, 7 ) );
+    EXPECT_EQ( 0xFDF0, MISC::decode_spchar_number( "&#xFDF0;", 3, 7 ) );
+
+    EXPECT_EQ( 1114109, MISC::decode_spchar_number( "&#1114109;", 2, 9 ) );
+    EXPECT_EQ( 0x10FFFD, MISC::decode_spchar_number( "&#x10FFFD;", 3, 9 ) );
+    EXPECT_EQ( 0x0abcde, MISC::decode_spchar_number( "&#xabcde;", 3, 8 ) );
+}
+
+TEST_F(MISC_DecodeSpcharNumberTest, result_error)
+{
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#0;", 2, 3 ) );
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#8;", 2, 3 ) );
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#xB;", 3, 4 ) );
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#xD;", 3, 4 ) );
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#31;", 2, 4 ) );
+
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#xD800;", 3, 7 ) );
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#xDFFF;", 3, 7 ) );
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#xFDD0;", 3, 7 ) );
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#xFDEF;", 3, 7 ) );
+
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#x110000;", 3, 9 ) );
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#1114112;", 2, 9 ) );
+}
+
+TEST_F(MISC_DecodeSpcharNumberTest, result_transform)
+{
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#x7F;", 3, 5 ) );
+    EXPECT_EQ( 0x20AC, MISC::decode_spchar_number( "&#x80;", 3, 5 ) );
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#x81;", 3, 5 ) );
+    EXPECT_EQ( 0x201A, MISC::decode_spchar_number( "&#x82;", 3, 5 ) );
+    EXPECT_EQ( 0x0192, MISC::decode_spchar_number( "&#x83;", 3, 5 ) );
+    EXPECT_EQ( 0x201E, MISC::decode_spchar_number( "&#x84;", 3, 5 ) );
+    EXPECT_EQ( 0x2026, MISC::decode_spchar_number( "&#x85;", 3, 5 ) );
+    EXPECT_EQ( 0x2020, MISC::decode_spchar_number( "&#x86;", 3, 5 ) );
+    EXPECT_EQ( 0x2021, MISC::decode_spchar_number( "&#x87;", 3, 5 ) );
+    EXPECT_EQ( 0x02C6, MISC::decode_spchar_number( "&#x88;", 3, 5 ) );
+    EXPECT_EQ( 0x2030, MISC::decode_spchar_number( "&#x89;", 3, 5 ) );
+    EXPECT_EQ( 0x0160, MISC::decode_spchar_number( "&#x8A;", 3, 5 ) );
+    EXPECT_EQ( 0x2039, MISC::decode_spchar_number( "&#x8B;", 3, 5 ) );
+    EXPECT_EQ( 0x0152, MISC::decode_spchar_number( "&#x8C;", 3, 5 ) );
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#x8D;", 3, 5 ) );
+    EXPECT_EQ( 0x017D, MISC::decode_spchar_number( "&#x8E;", 3, 5 ) );
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#x8F;", 3, 5 ) );
+
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#x90;", 3, 5 ) );
+    EXPECT_EQ( 0x2018, MISC::decode_spchar_number( "&#x91;", 3, 5 ) );
+    EXPECT_EQ( 0x2019, MISC::decode_spchar_number( "&#x92;", 3, 5 ) );
+    EXPECT_EQ( 0x201C, MISC::decode_spchar_number( "&#x93;", 3, 5 ) );
+    EXPECT_EQ( 0x201D, MISC::decode_spchar_number( "&#x94;", 3, 5 ) );
+    EXPECT_EQ( 0x2022, MISC::decode_spchar_number( "&#x95;", 3, 5 ) );
+    EXPECT_EQ( 0x2013, MISC::decode_spchar_number( "&#x96;", 3, 5 ) );
+    EXPECT_EQ( 0x2014, MISC::decode_spchar_number( "&#x97;", 3, 5 ) );
+    EXPECT_EQ( 0x02DC, MISC::decode_spchar_number( "&#x98;", 3, 5 ) );
+    EXPECT_EQ( 0x2122, MISC::decode_spchar_number( "&#x99;", 3, 5 ) );
+    EXPECT_EQ( 0x0161, MISC::decode_spchar_number( "&#x9A;", 3, 5 ) );
+    EXPECT_EQ( 0x203A, MISC::decode_spchar_number( "&#x9B;", 3, 5 ) );
+    EXPECT_EQ( 0x0153, MISC::decode_spchar_number( "&#x9C;", 3, 5 ) );
+    EXPECT_EQ( 0xFFFD, MISC::decode_spchar_number( "&#x9D;", 3, 5 ) );
+    EXPECT_EQ( 0x017E, MISC::decode_spchar_number( "&#x9E;", 3, 5 ) );
+    EXPECT_EQ( 0x0178, MISC::decode_spchar_number( "&#x9F;", 3, 5 ) );
+}
+
+
 class MISC_SanitizeNumericCharrefTest : public ::testing::Test {};
 
 TEST_F(MISC_SanitizeNumericCharrefTest, null_character)

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -1821,6 +1821,181 @@ TEST_F(UrlDecodeTest, out_of_range_segments)
 }
 
 
+class MISC_DecodeSpcharNumberRawTest : public ::testing::Test {};
+
+TEST_F(MISC_DecodeSpcharNumberRawTest, empty_string)
+{
+    EXPECT_EQ( 0, MISC::decode_spchar_number_raw( "", 0, 0 ) );
+}
+
+TEST_F(MISC_DecodeSpcharNumberRawTest, padding_zeros)
+{
+    EXPECT_EQ( 0, MISC::decode_spchar_number_raw( "&#0000;", 2, 4 ) );
+    EXPECT_EQ( 0, MISC::decode_spchar_number_raw( "&#x0000;", 3, 4 ) );
+    EXPECT_EQ( 0, MISC::decode_spchar_number_raw( "&#X0000;", 3, 4 ) );
+    EXPECT_EQ( 0x000D, MISC::decode_spchar_number_raw( "&#0013;", 2, 4 ) );
+    EXPECT_EQ( 0x000D, MISC::decode_spchar_number_raw( "&#x000D;", 3, 4 ) );
+    EXPECT_EQ( 0x000D, MISC::decode_spchar_number_raw( "&#X000d;", 3, 4 ) );
+}
+
+TEST_F(MISC_DecodeSpcharNumberRawTest, null_character)
+{
+    EXPECT_EQ( 0, MISC::decode_spchar_number_raw( "&#0;", 2, 1 ) );
+    EXPECT_EQ( 0, MISC::decode_spchar_number_raw( "&#x0;", 3, 1 ) );
+    EXPECT_EQ( 0, MISC::decode_spchar_number_raw( "&#X0;", 3, 1 ) );
+}
+
+TEST_F(MISC_DecodeSpcharNumberRawTest, carriage_return)
+{
+    EXPECT_EQ( 0x000D, MISC::decode_spchar_number_raw( "&#13;", 2, 2 ) );
+    EXPECT_EQ( 0x000D, MISC::decode_spchar_number_raw( "&#xD;", 3, 1 ) );
+    EXPECT_EQ( 0x000D, MISC::decode_spchar_number_raw( "&#Xd;", 3, 1 ) );
+}
+
+TEST_F(MISC_DecodeSpcharNumberRawTest, ascii_whitespace)
+{
+    EXPECT_EQ( 0x0009, MISC::decode_spchar_number_raw( "&#9;", 2, 1 ) );
+    EXPECT_EQ( 0x0009, MISC::decode_spchar_number_raw( "&#x9;", 3, 1 ) );
+
+    EXPECT_EQ( 0x000A, MISC::decode_spchar_number_raw( "&#10;", 2, 2 ) );
+    EXPECT_EQ( 0x000A, MISC::decode_spchar_number_raw( "&#xA;", 3, 1 ) );
+
+    EXPECT_EQ( 0x000C, MISC::decode_spchar_number_raw( "&#12;", 2, 2 ) );
+    EXPECT_EQ( 0x000C, MISC::decode_spchar_number_raw( "&#xC;", 3, 1 ) );
+
+    EXPECT_EQ( 0x0020, MISC::decode_spchar_number_raw( "&#32;", 2, 2 ) );
+    EXPECT_EQ( 0x0020, MISC::decode_spchar_number_raw( "&#x20;", 3, 2 ) );
+}
+
+TEST_F(MISC_DecodeSpcharNumberRawTest, out_of_range)
+{
+    EXPECT_EQ( 0x110000, MISC::decode_spchar_number_raw( "&#1114112;", 2, 7 ) );
+    EXPECT_EQ( 0x110000, MISC::decode_spchar_number_raw( "&#x110000;", 3, 6 ) );
+
+    EXPECT_EQ( 0x1000000, MISC::decode_spchar_number_raw( "&#16777216;", 2, 8 ) );
+    EXPECT_EQ( 0x1000000, MISC::decode_spchar_number_raw( "&#x1000000;", 3, 7 ) );
+}
+
+TEST_F(MISC_DecodeSpcharNumberRawTest, high_surrogate)
+{
+    EXPECT_EQ( 0xD800, MISC::decode_spchar_number_raw( "&#55296;", 2, 5 ) );
+    EXPECT_EQ( 0xD800, MISC::decode_spchar_number_raw( "&#xD800;", 3, 4 ) );
+
+    EXPECT_EQ( 0xDBFF, MISC::decode_spchar_number_raw( "&#56319;", 2, 5 ) );
+    EXPECT_EQ( 0xDBFF, MISC::decode_spchar_number_raw( "&#xDBFF;", 3, 4 ) );
+}
+
+TEST_F(MISC_DecodeSpcharNumberRawTest, low_surrogate)
+{
+    EXPECT_EQ( 0xDC00, MISC::decode_spchar_number_raw( "&#56320;", 2, 5 ) );
+    EXPECT_EQ( 0xDC00, MISC::decode_spchar_number_raw( "&#xDC00;", 3, 4 ) );
+
+    EXPECT_EQ( 0xDFFF, MISC::decode_spchar_number_raw( "&#57343;", 2, 5 ) );
+    EXPECT_EQ( 0xDFFF, MISC::decode_spchar_number_raw( "&#xDFFF;", 3, 4 ) );
+}
+
+TEST_F(MISC_DecodeSpcharNumberRawTest, noncharacter)
+{
+    EXPECT_EQ( 0xFDD0, MISC::decode_spchar_number_raw( "&#64976;", 2, 5 ) );
+    EXPECT_EQ( 0xFDD0, MISC::decode_spchar_number_raw( "&#xFDD0;", 3, 4 ) );
+
+    EXPECT_EQ( 0xFDEF, MISC::decode_spchar_number_raw( "&#65007;", 2, 5 ) );
+    EXPECT_EQ( 0xFDEF, MISC::decode_spchar_number_raw( "&#xFDEF;", 3, 4 ) );
+
+    EXPECT_EQ( 0xFFFE, MISC::decode_spchar_number_raw( "&#65534;", 2, 5 ) );
+    EXPECT_EQ( 0xFFFE, MISC::decode_spchar_number_raw( "&#xFFFE;", 3, 4 ) );
+
+    EXPECT_EQ( 0xFFFF, MISC::decode_spchar_number_raw( "&#65535;", 2, 5 ) );
+    EXPECT_EQ( 0xFFFF, MISC::decode_spchar_number_raw( "&#xFFFF;", 3, 4 ) );
+
+    EXPECT_EQ( 0x1FFFE, MISC::decode_spchar_number_raw( "&#131070;", 2, 6 ) );
+    EXPECT_EQ( 0x1FFFE, MISC::decode_spchar_number_raw( "&#x1FFFE;", 3, 5 ) );
+
+    EXPECT_EQ( 0x1FFFF, MISC::decode_spchar_number_raw( "&#131071;", 2, 6 ) );
+    EXPECT_EQ( 0x1FFFF, MISC::decode_spchar_number_raw( "&#x1FFFF;", 3, 5 ) );
+
+    EXPECT_EQ( 0x10FFFE, MISC::decode_spchar_number_raw( "&#1114110;", 2, 7 ) );
+    EXPECT_EQ( 0x10FFFE, MISC::decode_spchar_number_raw( "&#x10FFFE;", 3, 6 ) );
+
+    EXPECT_EQ( 0x10FFFF, MISC::decode_spchar_number_raw( "&#1114111;", 2, 7 ) );
+    EXPECT_EQ( 0x10FFFF, MISC::decode_spchar_number_raw( "&#x10FFFF;", 3, 6 ) );
+}
+
+TEST_F(MISC_DecodeSpcharNumberRawTest, between_u007F_and_u009F_decimal)
+{
+    EXPECT_EQ( 0x007F, MISC::decode_spchar_number_raw( "&#127;", 2, 3 ) );
+    EXPECT_EQ( 0x0080, MISC::decode_spchar_number_raw( "&#128;", 2, 3 ) );
+    EXPECT_EQ( 0x0081, MISC::decode_spchar_number_raw( "&#129;", 2, 3 ) );
+    EXPECT_EQ( 0x0082, MISC::decode_spchar_number_raw( "&#130;", 2, 3 ) );
+    EXPECT_EQ( 0x0083, MISC::decode_spchar_number_raw( "&#131;", 2, 3 ) );
+    EXPECT_EQ( 0x0084, MISC::decode_spchar_number_raw( "&#132;", 2, 3 ) );
+    EXPECT_EQ( 0x0085, MISC::decode_spchar_number_raw( "&#133;", 2, 3 ) );
+    EXPECT_EQ( 0x0086, MISC::decode_spchar_number_raw( "&#134;", 2, 3 ) );
+    EXPECT_EQ( 0x0087, MISC::decode_spchar_number_raw( "&#135;", 2, 3 ) );
+    EXPECT_EQ( 0x0088, MISC::decode_spchar_number_raw( "&#136;", 2, 3 ) );
+    EXPECT_EQ( 0x0089, MISC::decode_spchar_number_raw( "&#137;", 2, 3 ) );
+    EXPECT_EQ( 0x008A, MISC::decode_spchar_number_raw( "&#138;", 2, 3 ) );
+    EXPECT_EQ( 0x008B, MISC::decode_spchar_number_raw( "&#139;", 2, 3 ) );
+    EXPECT_EQ( 0x008C, MISC::decode_spchar_number_raw( "&#140;", 2, 3 ) );
+    EXPECT_EQ( 0x008D, MISC::decode_spchar_number_raw( "&#141;", 2, 3 ) );
+    EXPECT_EQ( 0x008E, MISC::decode_spchar_number_raw( "&#142;", 2, 3 ) );
+    EXPECT_EQ( 0x008F, MISC::decode_spchar_number_raw( "&#143;", 2, 3 ) );
+    EXPECT_EQ( 0x0090, MISC::decode_spchar_number_raw( "&#144;", 2, 3 ) );
+    EXPECT_EQ( 0x0091, MISC::decode_spchar_number_raw( "&#145;", 2, 3 ) );
+    EXPECT_EQ( 0x0092, MISC::decode_spchar_number_raw( "&#146;", 2, 3 ) );
+    EXPECT_EQ( 0x0093, MISC::decode_spchar_number_raw( "&#147;", 2, 3 ) );
+    EXPECT_EQ( 0x0094, MISC::decode_spchar_number_raw( "&#148;", 2, 3 ) );
+    EXPECT_EQ( 0x0095, MISC::decode_spchar_number_raw( "&#149;", 2, 3 ) );
+    EXPECT_EQ( 0x0096, MISC::decode_spchar_number_raw( "&#150;", 2, 3 ) );
+    EXPECT_EQ( 0x0097, MISC::decode_spchar_number_raw( "&#151;", 2, 3 ) );
+    EXPECT_EQ( 0x0098, MISC::decode_spchar_number_raw( "&#152;", 2, 3 ) );
+    EXPECT_EQ( 0x0099, MISC::decode_spchar_number_raw( "&#153;", 2, 3 ) );
+    EXPECT_EQ( 0x009A, MISC::decode_spchar_number_raw( "&#154;", 2, 3 ) );
+    EXPECT_EQ( 0x009B, MISC::decode_spchar_number_raw( "&#155;", 2, 3 ) );
+    EXPECT_EQ( 0x009C, MISC::decode_spchar_number_raw( "&#156;", 2, 3 ) );
+    EXPECT_EQ( 0x009D, MISC::decode_spchar_number_raw( "&#157;", 2, 3 ) );
+    EXPECT_EQ( 0x009E, MISC::decode_spchar_number_raw( "&#158;", 2, 3 ) );
+    EXPECT_EQ( 0x009F, MISC::decode_spchar_number_raw( "&#159;", 2, 3 ) );
+}
+
+TEST_F(MISC_DecodeSpcharNumberRawTest, between_u007F_and_u009F_hexdecimal)
+{
+    EXPECT_EQ( 0x007F, MISC::decode_spchar_number_raw( "&#x7F;", 3, 2 ) );
+    EXPECT_EQ( 0x0080, MISC::decode_spchar_number_raw( "&#x80;", 3, 2 ) );
+    EXPECT_EQ( 0x0081, MISC::decode_spchar_number_raw( "&#x81;", 3, 2 ) );
+    EXPECT_EQ( 0x0082, MISC::decode_spchar_number_raw( "&#x82;", 3, 2 ) );
+    EXPECT_EQ( 0x0083, MISC::decode_spchar_number_raw( "&#x83;", 3, 2 ) );
+    EXPECT_EQ( 0x0084, MISC::decode_spchar_number_raw( "&#x84;", 3, 2 ) );
+    EXPECT_EQ( 0x0085, MISC::decode_spchar_number_raw( "&#x85;", 3, 2 ) );
+    EXPECT_EQ( 0x0086, MISC::decode_spchar_number_raw( "&#x86;", 3, 2 ) );
+    EXPECT_EQ( 0x0087, MISC::decode_spchar_number_raw( "&#x87;", 3, 2 ) );
+    EXPECT_EQ( 0x0088, MISC::decode_spchar_number_raw( "&#x88;", 3, 2 ) );
+    EXPECT_EQ( 0x0089, MISC::decode_spchar_number_raw( "&#x89;", 3, 2 ) );
+    EXPECT_EQ( 0x008A, MISC::decode_spchar_number_raw( "&#x8A;", 3, 2 ) );
+    EXPECT_EQ( 0x008B, MISC::decode_spchar_number_raw( "&#x8B;", 3, 2 ) );
+    EXPECT_EQ( 0x008C, MISC::decode_spchar_number_raw( "&#x8C;", 3, 2 ) );
+    EXPECT_EQ( 0x008D, MISC::decode_spchar_number_raw( "&#x8D;", 3, 2 ) );
+    EXPECT_EQ( 0x008E, MISC::decode_spchar_number_raw( "&#x8E;", 3, 2 ) );
+    EXPECT_EQ( 0x008F, MISC::decode_spchar_number_raw( "&#x8F;", 3, 2 ) );
+    EXPECT_EQ( 0x0090, MISC::decode_spchar_number_raw( "&#x90;", 3, 2 ) );
+    EXPECT_EQ( 0x0091, MISC::decode_spchar_number_raw( "&#x91;", 3, 2 ) );
+    EXPECT_EQ( 0x0092, MISC::decode_spchar_number_raw( "&#x92;", 3, 2 ) );
+    EXPECT_EQ( 0x0093, MISC::decode_spchar_number_raw( "&#x93;", 3, 2 ) );
+    EXPECT_EQ( 0x0094, MISC::decode_spchar_number_raw( "&#x94;", 3, 2 ) );
+    EXPECT_EQ( 0x0095, MISC::decode_spchar_number_raw( "&#x95;", 3, 2 ) );
+    EXPECT_EQ( 0x0096, MISC::decode_spchar_number_raw( "&#x96;", 3, 2 ) );
+    EXPECT_EQ( 0x0097, MISC::decode_spchar_number_raw( "&#x97;", 3, 2 ) );
+    EXPECT_EQ( 0x0098, MISC::decode_spchar_number_raw( "&#x98;", 3, 2 ) );
+    EXPECT_EQ( 0x0099, MISC::decode_spchar_number_raw( "&#x99;", 3, 2 ) );
+    EXPECT_EQ( 0x009A, MISC::decode_spchar_number_raw( "&#x9A;", 3, 2 ) );
+    EXPECT_EQ( 0x009B, MISC::decode_spchar_number_raw( "&#x9B;", 3, 2 ) );
+    EXPECT_EQ( 0x009C, MISC::decode_spchar_number_raw( "&#x9C;", 3, 2 ) );
+    EXPECT_EQ( 0x009D, MISC::decode_spchar_number_raw( "&#x9D;", 3, 2 ) );
+    EXPECT_EQ( 0x009E, MISC::decode_spchar_number_raw( "&#x9E;", 3, 2 ) );
+    EXPECT_EQ( 0x009F, MISC::decode_spchar_number_raw( "&#x9F;", 3, 2 ) );
+}
+
+
 class MISC_SanitizeNumericCharrefTest : public ::testing::Test {};
 
 TEST_F(MISC_SanitizeNumericCharrefTest, null_character)


### PR DESCRIPTION
### [Implement MISC::decode_spchar_number_raw()](https://github.com/JDimproved/JDim/commit/5d12dbc8a456366d8b5e9cdb5116731ff3c6ec85)

「&#数字;」形式の数値文字参照をコードポイント(char32_t)に変換する処理を分割して数値文字参照の解析エラーとなる値もそのまま返す関数を実装します。
オリジナル`MISC::decode_spchar_number()`は`MISC::decode_spchar_number_raw()`を呼び出すように変更します。

### [Add test cases for MISC::decode_spchar_number_raw()](https://github.com/JDimproved/JDim/commit/ea6f13f8990475768118f32948c4a09b521fca64)

### [Add test cases for MISC::decode_spchar_number()](https://github.com/JDimproved/JDim/commit/1ad091a090fccfbf258cac8299a8b11b8260c7b7)
