### PR TITLE
Add surrogate pair handling to DBTREE::decode_char_number()

### DIFF
--- a/src/dbtree/spchar_decoder.h
+++ b/src/dbtree/spchar_decoder.h
@@ -23,6 +23,9 @@ namespace DBTREE
      */
     int decode_char( const char* in_char, int& n_in, JDLIB::span<char> out_char, int& n_out );
 
+    // HTMLの数値文字参照 `&#数字;` をUTF-8文字列にデコードする
+    int decode_char_number( const char* in_char, int& n_in, JDLIB::span<char> out_char, int& n_out,
+                            bool correct_surrogate );
     // HTML 文字実体参照をUTF-8文字列にデコードする
     int decode_char_name( const char* in_char, int& n_in, JDLIB::span<char> out_char, int& n_out );
 }

--- a/src/dbtree/spchar_tbl.h
+++ b/src/dbtree/spchar_tbl.h
@@ -2338,12 +2338,13 @@ static constexpr std::array<JDLIB::span<const UCSTBL>, 26> const ucstbl_upper = 
 
 enum
 {
-    UCS_ZWSP    = 8203,
-    UCS_ZWNJ    = 8204,
-    UCS_ZWJ     = 8205,
-    UCS_LRM     = 8206,
-    UCS_RLM     = 8207,
+    UCS_ZWSP    = 0x200B,
+    UCS_ZWNJ    = 0x200C,
+    UCS_ZWJ     = 0x200D,
+    UCS_LRM     = 0x200E,
+    UCS_RLM     = 0x200F,
     CP_LINE_SEPARATOR = 8232,
+    UCS_REPLACE = 0xFFFD,
 };
 
 


### PR DESCRIPTION
### Add surrogate pair handling to `DBTREE::decode_char_number()`
HTMLの仕様ではサロゲート(U+D800 - U+DFFF)の数値文字参照は不正な値として U+FFFD REPLACEMENT CHARACTER に変換されます。
仕様と異なりますが利便性を良くするためサロゲートが上下の順に並んでいるとき2つを合わせてデコードするフラグ引数を関数に追加します。

### Add test cases for `DBTREE::decode_char_number()`

