### PR TITLE
Add correct_character_reference option to about:config

### DIFF
--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -297,6 +297,7 @@ void AboutConfig::append_rows()
 #endif
     append_row( "FIFOの作成などにエラーがあったらダイアログを表示する", get_confitem()->show_diag_fifo_error, CONF_SHOW_DIAG_FIFO_ERROR );
     append_row( "指定した分ごとにセッションを自動保存 (0: 保存しない)", get_confitem()->save_session, CONF_SAVE_SESSION );
+    append_row( "不正な数値文字参照(サロゲートペア)をデコードする", get_confitem()->correct_character_reference, CONF_CORRECT_CHAR_REFERENCE );
 }
 
 

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -591,6 +591,9 @@ bool ConfigItems::load( const bool restore )
     migemodict_path = cf.get_option_str( "migemodict_path", CONF_MIGEMO_PATH );
 #endif
 
+    // 不正な数値文字参照(サロゲートペア)をデコードする
+    correct_character_reference = cf.get_option_bool( "correct_character_reference", CONF_CORRECT_CHAR_REFERENCE );
+
     m_loaded = true;
 
     // 設定値に壊れている物がある
@@ -932,6 +935,8 @@ void ConfigItems::save_impl( const std::string& path )
 #ifdef HAVE_MIGEMO_H
     cf.update( "migemodict_path", migemodict_path );
 #endif
+
+    cf.update( "correct_character_reference", correct_character_reference );
 
     cf.save();
 }

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -536,6 +536,9 @@ namespace CONFIG
         std::string migemodict_path;
 #endif
 
+        /// 不正な数値文字参照(サロゲートペア)をデコードする
+        bool correct_character_reference{};
+
         /////////////////////////
 
 

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -163,6 +163,7 @@ namespace CONFIG
         CONF_MAX_RESNUMBER = 65536, //最大表示可能レス数
         CONF_SHOW_DIAG_FIFO_ERROR = 1, // FIFOの作成などにエラーがあったらダイアログを表示する
         CONF_SAVE_SESSION = 0, // 指定した分ごとにセッションを自動保存 (0: 保存しない)
+        CONF_CORRECT_CHAR_REFERENCE = 0, ///< 不正な数値文字参照(サロゲートペア)をデコードする
     };
 
 // browsers.cpp のデフォルトのラベル番号

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -619,3 +619,10 @@ int CONFIG::get_save_session(){ return get_confitem()->save_session; }
 #ifdef HAVE_MIGEMO_H
 const std::string& CONFIG::get_migemodict_path() { return get_confitem()->migemodict_path; }
 #endif
+
+// 不正な数値文字参照(サロゲートペア)をデコードする
+bool CONFIG::get_correct_character_reference(){
+    auto item = get_confitem();
+    return item ? item->correct_character_reference : false;
+}
+void CONFIG::set_correct_character_reference( const bool set ){ get_confitem()->correct_character_reference = set; }

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -616,6 +616,10 @@ namespace CONFIG
     // migemo-dictの場所
     const std::string& get_migemodict_path();
 #endif
+
+    // 不正な数値文字参照(サロゲートペア)をデコードする
+    bool get_correct_character_reference();
+    void set_correct_character_reference( const bool set );
 }
 
 

--- a/src/dbtree/spchar_decoder.cpp
+++ b/src/dbtree/spchar_decoder.cpp
@@ -7,6 +7,7 @@
 #include "spchar_tbl.h"
 #include "node.h"
 
+#include "config/globalconf.h"
 #include "jdlib/misccharcode.h"
 #include "jdlib/miscutil.h"
 
@@ -123,7 +124,7 @@ int DBTREE::decode_char( const char* in_char, int& n_in, JDLIB::span<char> out_c
     // 数字文字参照 &#数字;
     if( in_char[ 1 ] == '#' ) {
         return DBTREE::decode_char_number( in_char, n_in, out_char, n_out,
-                                           false );
+                                           CONFIG::get_correct_character_reference() );
     }
 
     // 文字実体参照 &名前;


### PR DESCRIPTION
### Add correct_character_reference option to about:config
about:coifig に不正な数値文字参照をデコードするオプションを追加します。
「はい」に設定するとサロゲートを表す数値文字参照が上下の順に並んでいるとき2つを合わせてデコード処理を行います。
デフォルト設定「いいえ」のときは不正な値としてそれぞれ U+FFFD REPLACEMENT CHARACTER に変換されます。

