### PR TITLE
CI: Add a job which uses AddressSanitizer

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -10,36 +10,22 @@ on:
 
 jobs:
 
-  compiler-18:
-    runs-on: ubuntu-18.04
-    # Ubuntu 18.04 runner image will be unsupported by 2022-12-01.
-    # Set continue on error to avoid job failed by planned brownout.
-    # https://github.com/actions/runner-images/issues/6002
-    continue-on-error: true
+  ASan-22:
+    runs-on: ubuntu-22.04
     env:
-      CC: ${{ matrix.sets.cc }}
-      CXX: ${{ matrix.sets.cxx }}
-    strategy:
-      matrix:
-        sets:
-          - cc: gcc-7
-            cxx: g++-7
-            package: g++-7
+      CC: gcc-11
+      CXX: g++-11
+      # Avoid crash for calling crypt_r() that is pointing invalid address.
+      # https://github.com/JDimproved/JDim/issues/943
+      AVOID_CRASH: -Wl,--push-state,--no-as-needed -lcrypt -Wl,--pop-state
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.6'
       - name: dependencies installation
         run: |
           sudo apt update
-          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev ninja-build zlib1g-dev ${{ matrix.sets.package }}
-      - name: install meson==0.49.0
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          pip install meson==0.49.0
-      - name: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
-        run: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
+          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev g++-11
+      - name: meson builddir -Db_sanitize=address,undefined -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dcpp_link_args="${AVOID_CRASH}"
+        run: meson builddir -Db_sanitize=address,undefined -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dcpp_link_args="${AVOID_CRASH}"
         # `compile` subcommand requires Meson 0.54 or later.
       - name: ninja -C builddir
         run: ninja -C builddir
@@ -104,6 +90,7 @@ jobs:
           - cc: gcc-11
             cxx: g++-11
             package: g++-11
+            # Omit gcc-12 due to jobs are too many.
           - cc: clang-11
             cxx: clang++-11
             package: clang-11


### PR DESCRIPTION
### CI: Add a job which uses AddressSanitizer
GitHub Actions の CI に AddressSanitizer を有効にしてテストする job を追加してかわりに Ubuntu 18.04 の job を取り除きます。

追加するjobの構成
* OS: Ubuntu 22.04
* Compiler: g++ 11

関連のissue: #1078
