### PR TITLE
Bump version to 0.9.0-beta

### DIFF
--- a/docs/manual/2022.md
+++ b/docs/manual/2022.md
@@ -10,6 +10,76 @@ layout: default
 
 <a name="0.9.0-unreleased"></a>
 ### [0.9.0-unreleased](https://github.com/JDimproved/JDim/compare/660f4f6755...master) (unreleased)
+- ([#1084](https://github.com/JDimproved/JDim/pull/1084))
+  Bump version to 0.9.0-beta
+- ([#1083](https://github.com/JDimproved/JDim/pull/1083))
+  CI: Add a job which uses AddressSanitizer
+- ([#1082](https://github.com/JDimproved/JDim/pull/1082))
+  Add `correct_character_reference` option to about:config
+- ([#1081](https://github.com/JDimproved/JDim/pull/1081))
+  Add surrogate pair handling to `DBTREE::decode_char_number()`
+- ([#1080](https://github.com/JDimproved/JDim/pull/1080))
+  Implement `DBTREE::decode_char_name()`
+- ([#1079](https://github.com/JDimproved/JDim/pull/1079))
+  Fix crashes for testing `MISC::decode_spchar_number()`
+- ([#1077](https://github.com/JDimproved/JDim/pull/1077))
+  Implement `MISC::decode_spchar_number_raw()`
+- ([#1076](https://github.com/JDimproved/JDim/pull/1076))
+  Implement `MISC::sanitize_numeric_charref()`
+- ([#1075](https://github.com/JDimproved/JDim/pull/1075))
+  Use `std::thread` instead of `JDLIB::Thread`
+- ([#1074](https://github.com/JDimproved/JDim/pull/1074))
+  Change return type int with `char32_t` for `MISC::decode_spchar_number()`
+- ([#1073](https://github.com/JDimproved/JDim/pull/1073))
+  Meson: Create dependency to organize macro
+- ([#1072](https://github.com/JDimproved/JDim/pull/1072))
+  Improve entity reference table for `DBTREE::decode_char()`
+- ([#1071](https://github.com/JDimproved/JDim/pull/1071))
+  dbtree: Modify function parameters for `DBTREE::decode_char()`
+- ([#1070](https://github.com/JDimproved/JDim/pull/1070))
+  `DrawAreaBase`: Add null check to read `LAYOUT::rect`
+- ([#1069](https://github.com/JDimproved/JDim/pull/1069))
+  Get rid of unused headers
+- ([#1068](https://github.com/JDimproved/JDim/pull/1068))
+  `Loader`: Implement `GzipDecoder` class
+- ([#1067](https://github.com/JDimproved/JDim/pull/1067))
+  `DrawAreaBase`: Fix layout to wrap text if next node is not line feed
+- ([#1066](https://github.com/JDimproved/JDim/pull/1066))
+  Deprecate platforms where gcc version less than 8
+- ([#1065](https://github.com/JDimproved/JDim/pull/1065))
+  Prenotice end of support for Autotools
+- ([#1064](https://github.com/JDimproved/JDim/pull/1064))
+  `NodeTreeBase`: Add null checks
+- ([#1063](https://github.com/JDimproved/JDim/pull/1063))
+  `NodeTreeBase`: Fix parsing `<li>` tag
+- ([#1062](https://github.com/JDimproved/JDim/pull/1062))
+  `NodeTreeBase`: Use `std::string_view` instead of `std::string`
+- ([#1061](https://github.com/JDimproved/JDim/pull/1061))
+  `ArticleViewMain`: Reserve relayout if the view is not mapped
+- ([#1060](https://github.com/JDimproved/JDim/pull/1060))
+  `ReplaceStr`: Rebuild nodetree to relayout completely if ok clicked
+- ([#1059](https://github.com/JDimproved/JDim/pull/1059))
+  Modify `HEAP::clear()` to not free allocated blocks
+- ([#1058](https://github.com/JDimproved/JDim/pull/1058))
+  `TabNotebook`: Fix known condition true/false
+- ([#1057](https://github.com/JDimproved/JDim/pull/1057))
+  Use `std::string::resize()` instead of `substr()`
+- ([#1056](https://github.com/JDimproved/JDim/pull/1056))
+  Add const qualifier to local variables part2
+- ([#1055](https://github.com/JDimproved/JDim/pull/1055))
+  `BoardViewBase`: Add const qualifier to local variables
+- ([#1054](https://github.com/JDimproved/JDim/pull/1054))
+  `Root`: Avoid moving files if board root path source and dest are same
+- ([#1053](https://github.com/JDimproved/JDim/pull/1053))
+  `Root`: Decode HTML char reference for bbsmenu
+- ([#1052](https://github.com/JDimproved/JDim/pull/1052))
+  `NodeTree2ch`: Add `parse_extattr()` to parse the result of "!extend:"
+- ([#1051](https://github.com/JDimproved/JDim/pull/1051))
+  article: Add config for number of max res to thread property
+- ([#1050](https://github.com/JDimproved/JDim/pull/1050))
+  `ReplaceStrPref`: Add Unicode normalize option
+- ([#1049](https://github.com/JDimproved/JDim/pull/1049))
+  Update histories
 
 
 <a name="0.8.0-20221001"></a>

--- a/meson.build
+++ b/meson.build
@@ -43,7 +43,7 @@
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 
 project('jdim', 'cpp',
-        version : '0.8.0',
+        version : '0.9.0-beta',
         license : 'GPL2',
         meson_version : '>= 0.49.0',
         default_options : ['warning_level=3', 'cpp_std=c++17'])

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -15,10 +15,10 @@
 // SEE ALSO: ENVIRONMENT::get_jdversion()
 
 #define MAJORVERSION 0
-#define MINORVERSION 8
+#define MINORVERSION 9
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20221001"
-#define JDTAG     ""
+#define JDDATE_FALLBACK    "20221218"
+#define JDTAG     "beta"
 
 //---------------------------------
 


### PR DESCRIPTION
### Update hittories

### Bump version to 0.9.0-beta
機能フリーズ期間に入るためバージョン番号をベータ版に更新します。

関連のissue: #1017
