### PR TITLE
Clean up obsolete build option for regex

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,14 +132,6 @@ AS_IF(
 
 
 dnl
-dnl 正規表現ライブラリのオプションは廃止された
-dnl
-AC_ARG_WITH(regex,
-AS_HELP_STRING([--with-regex], [NO LONGER AVAILABLE]),
-[AC_MSG_ERROR([regex library options have been removed. see https://github.com/JDimproved/JDim/issues/697])])
-
-
-dnl
 dnl TLS
 dnl
 AC_MSG_CHECKING(for --with-tls)

--- a/meson.build
+++ b/meson.build
@@ -124,12 +124,6 @@ elif sessionlib_opt == 'no'
   configure_args += '\'--with-sessionlib=no\''
 endif
 
-# 正規表現ライブラリのオプションは廃止された
-regex_opt = get_option('regex')
-if regex_opt != ''
-  error('regex library options have been removed. see https://github.com/JDimproved/JDim/issues/697')
-endif
-
 # TLS
 tls_opt = get_option('tls')
 if tls_opt == 'gnutls'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,6 +7,5 @@ option('migemodict', type : 'string', value : '', description : 'Default path fo
 option('native', type : 'feature', value : 'disabled', description : 'Optimize to your machine')
 option('packager', type : 'string', value : '', description : 'String identifying the packager of this software')
 option('pangolayout', type : 'feature', value : 'disabled', description : 'Render text by PangoLayout')
-option('regex', type : 'string', value : '', description : 'NO LONGER AVAILABLE')
 option('sessionlib', type : 'combo', choices : ['xsmp', 'no'], value : 'xsmp', description : 'Use Session Management Protocol')
 option('tls', type : 'combo', choices : ['gnutls', 'openssl'], value : 'gnutls', description : 'SSL/TLS library to use')


### PR DESCRIPTION
廃止された正規表現のライブラリを選択するビルドオプションを消去します。

関連のissue: https://github.com/JDimproved/JDim/issues/697
