### PR TITLE
Iconv: Grow buffer size to continue iconv if output buffer is shortage

### DIFF
--- a/src/jdlib/jdiconv.h
+++ b/src/jdlib/jdiconv.h
@@ -10,32 +10,26 @@
 
 
 // iconv の内部で確保するバッファサイズ(バイト)
-//  BUF_SIZE_ICONV_IN を超える入力は扱えないので注意
-enum
-{
-    BUF_SIZE_ICONV_IN = 1024 * 1024,
-    BUF_SIZE_ICONV_OUT = BUF_SIZE_ICONV_IN /2 * 3
-};
+constexpr int BUF_SIZE_ICONV_OUT = 512 * 1024;
+
 
 namespace JDLIB
 {
+    /** @brief テキストの文字エンコーディングを変換するクラス */
     class Iconv
     {
-        GIConv m_cd; // iconv実装は環境で違いがあるためGlibのラッパーAPIを利用する
+        GIConv m_cd; ///< iconv実装は環境で違いがあるためGlibのラッパーAPIを利用する
 
-        size_t m_byte_left_in{};
-        std::vector<char> m_buf_in;
-        char* m_buf_in_tmp{};
+        std::vector<char> m_buf; ///< 出力バッファ
 
-        std::vector<char> m_buf_out;
-
-        std::string m_coding_from;
+        std::string m_coding_from; ///< 変換元の文字エンコーディング
 
     public:
         
         Iconv( const std::string& coding_to, const std::string& coding_from );
         ~Iconv();
 
+        // テキストの文字エンコーディングを変換する
         const char* convert( char* str_in, int size_in, int& size_out );
     };
 }


### PR DESCRIPTION
出力バッファの長さが不足したときサイズを拡大してiconvの変換処理を続行するように修正します。
出力バッファの初期サイズは入力に対して2倍以上の長さを確保します。
修正前は出力バッファの長さが不足したとき変換処理を中断して途中結果を返していました。

関連のissue: #76
