### PR TITLE
dbtree: Get rid of buffer length limitation

### DIFF
--- a/src/dbtree/nodetreejbbs.cpp
+++ b/src/dbtree/nodetreejbbs.cpp
@@ -16,9 +16,12 @@
 #include <sstream>
 
 
+namespace {
+constexpr std::size_t kBufSizeDecodedLines = 512 * 1024;
+}
+
 #define APPEND_SECTION( num ) do {\
 if( lng_sec[ num ] ){ \
-assert( m_decoded_lines.size() + lng_sec[ num ] < BUF_SIZE_ICONV_OUT ); \
 m_decoded_lines.append( lines + pos_sec[ num ], lng_sec[ num ] ); \
 } } while( 0 )
 
@@ -79,8 +82,9 @@ void NodeTreeJBBS::init_loading()
     std::string charset = DBTREE::board_charset( get_url() );
     if( ! m_iconv ) m_iconv = std::make_unique<JDLIB::Iconv>( "UTF-8", charset );
 
-    if( m_decoded_lines.capacity() < BUF_SIZE_ICONV_OUT ) {
-        m_decoded_lines.reserve( BUF_SIZE_ICONV_OUT );
+    // 予め領域を確保する
+    if( m_decoded_lines.capacity() < kBufSizeDecodedLines ) {
+        m_decoded_lines.reserve( kBufSizeDecodedLines );
     }
 }
 

--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -10,7 +10,6 @@
 #include "jdlib/jdregex.h"
 #include "jdlib/loaderdata.h"
 #include "jdlib/miscutil.h"
-#include "jdlib/miscmsg.h"
 
 #include "config/globalconf.h"
 
@@ -215,11 +214,6 @@ char* NodeTreeMachi::process_raw_lines( char* rawlines )
         }
     }
 
-    if( buffer.length() > BUF_SIZE_ICONV_OUT ){
-        MISC::ERRMSG( "buffer over flow in NodeTreeMachi::process_raw_lines" );
-        buffer = std::string();
-    }
-
     m_buffer = std::move( buffer );
 
     return &*m_buffer.begin();
@@ -320,11 +314,6 @@ const char* NodeTreeMachi::raw2dat( char* rawlines, int& byte )
         else buffer += name + "<>" + mail + "<>" + date + "<> " + body + " <><>\n";
 
         ++next;
-    }
-
-    if( buffer.length() > BUF_SIZE_ICONV_OUT ){
-        MISC::ERRMSG( "buffer over flow in NodeTreeMachi::process_raw_lines" );
-        buffer = std::string();
     }
 
     m_decoded_lines = std::move( buffer );

--- a/src/jdlib/jdiconv.h
+++ b/src/jdlib/jdiconv.h
@@ -9,10 +9,6 @@
 #include <gmodule.h> // GIConv
 
 
-// iconv の内部で確保するバッファサイズ(バイト)
-constexpr int BUF_SIZE_ICONV_OUT = 512 * 1024;
-
-
 namespace JDLIB
 {
     /** @brief テキストの文字エンコーディングを変換するクラス */


### PR DESCRIPTION
固定長のバッファ(`char*`)から`std::string`へ置き換えたコードはバッファ長の制限を取り除きます。
