### PR TITLE
Iconv: Use U+FFFD REPLACEMENT CHARACTER on converting to UTF-8

### DIFF
--- a/src/jdlib/jdiconv.cpp
+++ b/src/jdlib/jdiconv.cpp
@@ -22,6 +22,7 @@ using namespace JDLIB;
  */
 Iconv::Iconv( const std::string& coding_to, const std::string& coding_from )
     : m_coding_from( coding_from )
+    , m_coding_to_is_utf8{ coding_to == "UTF-8" }
 {
 #ifdef _DEBUG
     std::cout << "Iconv::Iconv coding = " << m_coding_from << " to " << coding_to << std::endl;
@@ -240,6 +241,15 @@ const char* Iconv::convert( char* str_in, int size_in, int& size_out )
                 // BOFの確認
                 if( ( buf_out_end - buf_out_tmp ) <= 3 ) {
                     grow();
+                }
+
+                // UTF-8へ変換する場合は U+FFFD REPLACEMENT CHARACTER に置き換える
+                if( m_coding_to_is_utf8 ){
+                    ++buf_in_tmp;
+                    *(buf_out_tmp++) = static_cast<char>( 0xef );
+                    *(buf_out_tmp++) = static_cast<char>( 0xbf );
+                    *(buf_out_tmp++) = static_cast<char>( 0xbd );
+                    continue;
                 }
 
                 //その他、1文字を?にして続行

--- a/src/jdlib/jdiconv.h
+++ b/src/jdlib/jdiconv.h
@@ -19,6 +19,7 @@ namespace JDLIB
         std::vector<char> m_buf; ///< 出力バッファ
 
         std::string m_coding_from; ///< 変換元の文字エンコーディング
+        bool m_coding_to_is_utf8; ///< 変換先の文字エンコーディングがUTF-8ならtrue
 
     public:
         

--- a/test/gtest_jdlib_jdiconv.cpp
+++ b/test/gtest_jdlib_jdiconv.cpp
@@ -62,6 +62,25 @@ TEST_F(Iconv_ToAsciiFromUtf8, subdivision_flag)
     EXPECT_EQ( 63, size_out );
 }
 
+
+class Iconv_ToUtf8FromAscii : public ::testing::Test {};
+
+TEST_F(Iconv_ToUtf8FromAscii, replacement_character_to_utf8_is_uFFFD)
+{
+    // テストは網羅してない
+    char input[] = "\x80\x91\xA2\xB3\xC4\xD5\xE6\xF7";
+    int size_out;
+
+    JDLIB::Iconv icv( "UTF-8", "ASCII" );
+    const char* result = icv.convert( input, std::strlen(input), size_out );
+
+    // UTF-8へ変換するとき入力エンコーディングで無効なバイト列は U+FFFD に置き換える
+    EXPECT_STREQ( "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD"
+                  "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD", result );
+    EXPECT_EQ( 24, size_out );
+}
+
+
 class Iconv_ToUtf8FromMs932 : public ::testing::Test {};
 
 TEST_F(Iconv_ToUtf8FromMs932, empty)
@@ -153,6 +172,5 @@ TEST_F(Iconv_ToUtf8FromMs932, mapping_error)
     EXPECT_STREQ( "\u25A1\u25A1\u25A1\u25A1", result );
     EXPECT_EQ( 12, size_out );
 }
-
 
 } // namespace


### PR DESCRIPTION
### Iconv: Use U+FFFD REPLACEMENT CHARACTER on converting to UTF-8

UTF-8へ変換する処理のとき変換できないバイト列を U+FFFD へ置き換えます。

### Add test case for Iconv::convert replacement character to utf8

関連のissue: #76
