### PR TITLE
Iconv: Add about:config option that wrong sjis assumes to be utf8

### DIFF
--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -297,6 +297,7 @@ void AboutConfig::append_rows()
 #endif
     append_row( "FIFOの作成などにエラーがあったらダイアログを表示する", get_confitem()->show_diag_fifo_error, CONF_SHOW_DIAG_FIFO_ERROR );
     append_row( "指定した分ごとにセッションを自動保存 (0: 保存しない)", get_confitem()->save_session, CONF_SAVE_SESSION );
+    append_row( "不正なMS932文字列をUTF-8と見なす", get_confitem()->broken_sjis_be_utf8, CONF_BROKEN_SJIS_BE_UTF8 );
     append_row( "不正な数値文字参照(サロゲートペア)をデコードする", get_confitem()->correct_character_reference, CONF_CORRECT_CHAR_REFERENCE );
 }
 

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -591,6 +591,9 @@ bool ConfigItems::load( const bool restore )
     migemodict_path = cf.get_option_str( "migemodict_path", CONF_MIGEMO_PATH );
 #endif
 
+    // 不正なMS932文字列をUTF-8と見なす
+    broken_sjis_be_utf8 = cf.get_option_bool( "broken_sjis_be_utf8", CONF_BROKEN_SJIS_BE_UTF8 );
+
     // 不正な数値文字参照(サロゲートペア)をデコードする
     correct_character_reference = cf.get_option_bool( "correct_character_reference", CONF_CORRECT_CHAR_REFERENCE );
 
@@ -936,6 +939,7 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "migemodict_path", migemodict_path );
 #endif
 
+    cf.update( "broken_sjis_be_utf8", broken_sjis_be_utf8 );
     cf.update( "correct_character_reference", correct_character_reference );
 
     cf.save();

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -536,6 +536,9 @@ namespace CONFIG
         std::string migemodict_path;
 #endif
 
+        /// 不正なMS932文字列をUTF-8と見なす
+        bool broken_sjis_be_utf8{};
+
         /// 不正な数値文字参照(サロゲートペア)をデコードする
         bool correct_character_reference{};
 

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -163,6 +163,7 @@ namespace CONFIG
         CONF_MAX_RESNUMBER = 65536, //最大表示可能レス数
         CONF_SHOW_DIAG_FIFO_ERROR = 1, // FIFOの作成などにエラーがあったらダイアログを表示する
         CONF_SAVE_SESSION = 0, // 指定した分ごとにセッションを自動保存 (0: 保存しない)
+        CONF_BROKEN_SJIS_BE_UTF8 = 0, ///< 不正なMS932文字列をUTF-8と見なす
         CONF_CORRECT_CHAR_REFERENCE = 0, ///< 不正な数値文字参照(サロゲートペア)をデコードする
     };
 

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -620,6 +620,13 @@ int CONFIG::get_save_session(){ return get_confitem()->save_session; }
 const std::string& CONFIG::get_migemodict_path() { return get_confitem()->migemodict_path; }
 #endif
 
+// 不正なMS932文字列をUTF-8と見なす
+bool CONFIG::get_broken_sjis_be_utf8(){
+    auto item = get_confitem();
+    return item ? item->broken_sjis_be_utf8 : false;
+}
+void CONFIG::set_broken_sjis_be_utf8( const bool set ){ get_confitem()->broken_sjis_be_utf8 = set; }
+
 // 不正な数値文字参照(サロゲートペア)をデコードする
 bool CONFIG::get_correct_character_reference(){
     auto item = get_confitem();

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -617,6 +617,10 @@ namespace CONFIG
     const std::string& get_migemodict_path();
 #endif
 
+    // 不正なMS932文字列をUTF-8と見なす
+    bool get_broken_sjis_be_utf8();
+    void set_broken_sjis_be_utf8( const bool set );
+
     // 不正な数値文字参照(サロゲートペア)をデコードする
     bool get_correct_character_reference();
     void set_correct_character_reference( const bool set );

--- a/src/jdlib/jdiconv.h
+++ b/src/jdlib/jdiconv.h
@@ -20,10 +20,12 @@ namespace JDLIB
 
         std::string m_coding_from; ///< 変換元の文字エンコーディング
         bool m_coding_to_is_utf8; ///< 変換先の文字エンコーディングがUTF-8ならtrue
+        bool m_broken_sjis_be_utf8; ///< trueなら不正なMS932文字列をUTF-8と見なす (MS932 -> UTF-8の変換限定)
 
     public:
-        
+
         Iconv( const std::string& coding_to, const std::string& coding_from );
+        Iconv( const std::string& coding_to, const std::string& coding_from, const bool broken_sjis_be_utf8 );
         ~Iconv();
 
         // テキストの文字エンコーディングを変換する

--- a/test/gtest_jdlib_jdiconv.cpp
+++ b/test/gtest_jdlib_jdiconv.cpp
@@ -185,4 +185,20 @@ TEST_F(Iconv_ToUtf8FromMs932, mapping_error)
     EXPECT_EQ( 12, size_out );
 }
 
+TEST_F(Iconv_ToUtf8FromMs932, broken_sjis_be_utf8)
+{
+    char input[] = "\x82\xa0\x82\xa2\x82\xa4 "
+                   "\xe5\x85\xa5\xe3\x82\x8c\xe6\x9b\xbf\xe3\x82\x8f"
+                   "\xe3\x81\xa3\xe3\x81\xa6\xe3\x82\x8b\xe3\x80\x9c?"
+                   " \x82\xa6\x82\xa8";
+    int size_out;
+    constexpr bool broken_sjis_be_utf8 = true;
+
+    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
+    const char* result = icv.convert( input, std::strlen(input), size_out );
+
+    EXPECT_STREQ( "あいう <span class=\"BROKEN_SJIS\">入れ替わってる〜</span>? えお", result );
+    EXPECT_EQ( 28 - 2 + 7 + 9 * 3 + 5 * 3, size_out );
+}
+
 } // namespace

--- a/test/gtest_jdlib_jdiconv.cpp
+++ b/test/gtest_jdlib_jdiconv.cpp
@@ -18,8 +18,9 @@ TEST_F(Iconv_ToAsciiFromUtf8, empty)
 {
     char input[] = "";
     int size_out;
+    constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "ASCII", "UTF-8" );
+    JDLIB::Iconv icv( "ASCII", "UTF-8", broken_sjis_be_utf8 );
     const char* result = icv.convert( input, std::strlen(input), size_out );
 
     EXPECT_STREQ( "", result );
@@ -30,8 +31,9 @@ TEST_F(Iconv_ToAsciiFromUtf8, helloworld)
 {
     char input[] = "hello world!\n";
     int size_out;
+    constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "ASCII", "UTF-8" );
+    JDLIB::Iconv icv( "ASCII", "UTF-8", broken_sjis_be_utf8 );
     const char* result = icv.convert( input, std::strlen(input), size_out );
 
     EXPECT_STREQ( "hello world!\n", result );
@@ -42,8 +44,9 @@ TEST_F(Iconv_ToAsciiFromUtf8, hiragana)
 {
     char input[] = "あいうえお";
     int size_out;
+    constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "ASCII", "UTF-8" );
+    JDLIB::Iconv icv( "ASCII", "UTF-8", broken_sjis_be_utf8 );
     const char* result = icv.convert( input, std::strlen(input), size_out );
 
     EXPECT_STREQ( "&#12354;&#12356;&#12358;&#12360;&#12362;", result );
@@ -55,8 +58,9 @@ TEST_F(Iconv_ToAsciiFromUtf8, subdivision_flag)
     // :england: JDLIB::Iconv::convert()のコメントを参照
     char input[] = "\U0001F3F4\U000E0067\U000E0062\U000E0065\U000E006E\U000E0067\U000E007F";
     int size_out;
+    constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "ASCII", "UTF-8" );
+    JDLIB::Iconv icv( "ASCII", "UTF-8", broken_sjis_be_utf8 );
     const char* result = icv.convert( input, std::strlen(input), size_out );
     EXPECT_STREQ( "&#127988;&#917607;&#917602;&#917605;&#917614;&#917607;&#917631;", result );
     EXPECT_EQ( 63, size_out );
@@ -70,8 +74,9 @@ TEST_F(Iconv_ToUtf8FromAscii, replacement_character_to_utf8_is_uFFFD)
     // テストは網羅してない
     char input[] = "\x80\x91\xA2\xB3\xC4\xD5\xE6\xF7";
     int size_out;
+    constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "ASCII" );
+    JDLIB::Iconv icv( "UTF-8", "ASCII", broken_sjis_be_utf8 );
     const char* result = icv.convert( input, std::strlen(input), size_out );
 
     // UTF-8へ変換するとき入力エンコーディングで無効なバイト列は U+FFFD に置き換える
@@ -87,8 +92,9 @@ TEST_F(Iconv_ToUtf8FromMs932, empty)
 {
     char input[] = "";
     int size_out;
+    constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "MS932" );
+    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
     const char* result = icv.convert( input, std::strlen(input), size_out );
 
     EXPECT_STREQ( "", result );
@@ -99,8 +105,9 @@ TEST_F(Iconv_ToUtf8FromMs932, helloworld)
 {
     char input[] = "hello world!\n";
     int size_out;
+    constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "MS932" );
+    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
     const char* result = icv.convert( input, std::strlen(input), size_out );
 
     EXPECT_STREQ( "hello world!\n", result );
@@ -111,8 +118,9 @@ TEST_F(Iconv_ToUtf8FromMs932, hiragana)
 {
     char input[] = "\x82\xA0\x82\xA2\x82\xA4\x82\xA6\x82\xA8";
     int size_out;
+    constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "MS932" );
+    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
     const char* result = icv.convert( input, std::strlen(input), size_out );
 
     EXPECT_STREQ( "あいうえお", result );
@@ -123,8 +131,9 @@ TEST_F(Iconv_ToUtf8FromMs932, hex_a0)
 {
     char input[] = "hello\xa0world!\n";
     int size_out;
+    constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "MS932" );
+    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
     const char* result = icv.convert( input, std::strlen(input), size_out );
 
     EXPECT_STREQ( "hello world!\n", result );
@@ -137,8 +146,9 @@ TEST_F(Iconv_ToUtf8FromMs932, mojibake_fix_inequality_sign_pattern1)
     // エンコーディングがMS932のスレにUTF-8で書き込み文字化けした場合をテスト
     char input[] = "<>test テスト<>";
     int size_out;
+    constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "MS932" );
+    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
     const char* result = icv.convert( input, std::strlen(input), size_out );
 
     EXPECT_STREQ( "<>test \xE7\xB9\x9D\xE2\x96\xA1\xE3\x81\x9B\xE7\xB9\x9D?<>", result );
@@ -151,8 +161,9 @@ TEST_F(Iconv_ToUtf8FromMs932, mojibake_fix_inequality_sign_pattern2)
     // エンコーディングがMS932のスレにUTF-8で書き込み文字化けした場合をテスト
     char input[] = "<> test テスト <>";
     int size_out;
+    constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "MS932" );
+    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
     const char* result = icv.convert( input, std::strlen(input), size_out );
 
     EXPECT_STREQ( "<> test \xE7\xB9\x9D\xE2\x96\xA1\xE3\x81\x9B\xE7\xB9\x9D\xE2\x96\xA1<>", result );
@@ -165,8 +176,9 @@ TEST_F(Iconv_ToUtf8FromMs932, mapping_error)
     // テストは網羅してない
     char input[] = "\x81\xAD\x82\x40\x88\x90\x98\x90";
     int size_out;
+    constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "MS932" );
+    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
     const char* result = icv.convert( input, std::strlen(input), size_out );
 
     EXPECT_STREQ( "\u25A1\u25A1\u25A1\u25A1", result );


### PR DESCRIPTION
### Iconv: Add about:config option that wrong sjis assumes to be utf8
不正なShift_JIS(MS932)文字列をUTF-8と見なすオプションを about:config に追加します。

### Add test case for Iconv::convert() broken_sjis_be_utf8

関連のissue: #76
