### PR TITLE
Add override keyword to virtual function declarations

### DIFF
--- a/src/control/mousekeypref.h
+++ b/src/control/mousekeypref.h
@@ -57,10 +57,10 @@ namespace CONTROL
 
       private:
 
-        virtual bool on_key_press_event (GdkEventKey* event);
-        virtual bool on_button_press_event( GdkEventButton* event );
-        virtual bool on_button_release_event( GdkEventButton* event );
-        virtual bool on_motion_notify_event( GdkEventMotion* event );
+        bool on_key_press_event (GdkEventKey* event) override;
+        bool on_button_press_event( GdkEventButton* event ) override;
+        bool on_button_release_event( GdkEventButton* event ) override;
+        bool on_motion_notify_event( GdkEventMotion* event ) override;
     };
 
 

--- a/src/skeleton/menubutton.h
+++ b/src/skeleton/menubutton.h
@@ -59,7 +59,7 @@ namespace SKELETON
       // false の時はボタンのどこを押してもメニューを表示する
       void set_enable_sig_clicked( const bool enable ){ m_enable_sig_clicked = enable; }
 
-      void on_clicked();
+      void on_clicked() override;
 
       protected:
 


### PR DESCRIPTION
overrideしている仮想関数にキーワードを追加します。

gcc 12のレポート
```
In file included from ../src/bbslist/toolbar.cpp:11:
../src/skeleton/menubutton.h:62:12: warning: ‘virtual void SKELETON::MenuButton::on_clicked()’ can be marked override [-Wsuggest-override]
   62 |       void on_clicked();
      |            ^~~~~~~~~~
In file included from ../src/control/keypref.h:11,
                 from ../src/prefdiagfactory.cpp:33:
../src/control/mousekeypref.h:60:22: warning: ‘virtual bool CONTROL::InputDiag::on_key_press_event(GdkEventKey*)’ can be marked override [-Wsuggest-override]
   60 |         virtual bool on_key_press_event (GdkEventKey* event);
      |                      ^~~~~~~~~~~~~~~~~~
../src/control/mousekeypref.h:61:22: warning: ‘virtual bool CONTROL::InputDiag::on_button_press_event(GdkEventButton*)’ can be marked override [-Wsuggest-override]
   61 |         virtual bool on_button_press_event( GdkEventButton* event );
      |                      ^~~~~~~~~~~~~~~~~~~~~
../src/control/mousekeypref.h:62:22: warning: ‘virtual bool CONTROL::InputDiag::on_button_release_event(GdkEventButton*)’ can be marked override [-Wsuggest-override]
   62 |         virtual bool on_button_release_event( GdkEventButton* event );
      |                      ^~~~~~~~~~~~~~~~~~~~~~~
../src/control/mousekeypref.h:63:22: warning: ‘virtual bool CONTROL::InputDiag::on_motion_notify_event(GdkEventMotion*)’ can be marked override [-Wsuggest-override]
   63 |         virtual bool on_motion_notify_event( GdkEventMotion* event );
      |                      ^~~~~~~~~~~~~~~~~~~~~~
```
