### PR TITLE
Iconv: Change convert() return type to const std::string&

### DIFF
--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1079,17 +1079,16 @@ void BoardBase::receive_data( const char* data, size_t size )
     if( byte_in != std::string::npos ) {
         byte_in += 1; // 改行まで含める
 
-        int byte_out;
-        const char* rawdata_utf8 = m_iconv->convert( &*m_rawdata_left.begin(), byte_in, byte_out );
+        const std::string& rawdata_utf8 = m_iconv->convert( m_rawdata_left.data(), byte_in );
 
-        parse_subject( rawdata_utf8 );
+        parse_subject( rawdata_utf8.c_str() );
 
         // 残りを先頭に移動
         m_rawdata_left.erase( 0, byte_in );
 
 #ifdef _DEBUG
         std::cout << "BoardBase::receive_data rawdata.size = " << m_rawdata.size() << " size = " << size
-                  << " byte_in = " << byte_in << " byte_out = " << byte_out
+                  << " byte_in = " << byte_in << " byte_out = " << rawdata_utf8.size()
                   << " rawdata_left.size = " << m_rawdata_left.size() << std::endl;
 #endif
     }

--- a/src/dbtree/nodetree2chcompati.cpp
+++ b/src/dbtree/nodetree2chcompati.cpp
@@ -12,6 +12,9 @@
 
 #include "config/globalconf.h"
 
+#include <cstring>
+
+
 using namespace DBTREE;
 
 
@@ -115,8 +118,7 @@ char* NodeTree2chCompati::skip_status_line( char* pos, int status )
 
     // エラー
     if( status != 1 ){
-        int byte;
-        std::string ext_err = std::string( m_iconv->convert( pos_msg, pos - pos_msg, byte ) );
+        const std::string& ext_err = m_iconv->convert( pos_msg, pos - pos_msg );
         set_ext_err( ext_err );
         MISC::ERRMSG( ext_err );
     }
@@ -137,7 +139,9 @@ const char* NodeTree2chCompati::raw2dat( char* rawlines, int& byte )
     assert( m_iconv != nullptr );
 
     // バッファ自体はiconvクラスの中で持っているのでポインタだけもらう
-    return  m_iconv->convert( rawlines, strlen( rawlines ), byte );
+    const std::string& result = m_iconv->convert( rawlines, std::strlen( rawlines ) );
+    byte = result.size();
+    return result.c_str();
 }
 
 

--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -240,8 +240,7 @@ const char* NodeTreeMachi::raw2dat( char* rawlines, int& byte )
     std::string buffer;
 
     // 文字コード変換
-    int byte_lines;
-    const char* str_lines = m_iconv->convert( rawlines, strlen( rawlines ), byte_lines );
+    const std::string& str_lines = m_iconv->convert( rawlines, std::strlen( rawlines ) );
 
     std::list< std::string > lines = MISC::get_lines( str_lines );
     for( std::string& line : lines ) {
@@ -357,8 +356,7 @@ void NodeTreeMachi::receive_finish()
     if( m_buffer_for_200.size() >= 2 && m_buffer_for_200[ 0 ] == '<'
             && ( m_buffer_for_200[ 1 ] == 'E' || m_buffer_for_200[ 1 ] == 'h' ) ) {
 
-        int byte_lines;
-        std::string str_lines( m_iconv->convert( &*m_buffer_for_200.begin(), m_buffer_for_200.size(), byte_lines ) );
+        const std::string& str_lines = m_iconv->convert( m_buffer_for_200.data(), m_buffer_for_200.size() );
 
 #ifdef _DEBUG    
         std::cout << str_lines << std::endl;

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -399,8 +399,7 @@ void Root::receive_finish()
 
     // 文字コードを変換してXML作成
     JDLIB::Iconv libiconv{ "UTF-8", "MS932" };
-    int byte_out;
-    const std::string rawdata_utf8 = libiconv.convert( &*m_rawdata.begin(), m_rawdata.size(),  byte_out );
+    const std::string& rawdata_utf8 = libiconv.convert( m_rawdata.data(), m_rawdata.size() );
     bbsmenu2xml( rawdata_utf8 );
 
     if( m_xml_document.hasChildNodes() )

--- a/src/jdlib/jdiconv.cpp
+++ b/src/jdlib/jdiconv.cpp
@@ -88,17 +88,19 @@ Iconv::~Iconv()
  * @details UTF-8から別のエンコーディングに変換するときは表現できない文字をHTML数値文字参照(10進数表記)に置き換える。
  * @param[in] str_in    変換するテキストへのポインター
  * @param[in] size_in   変換するテキストの長さ
- * @param[out] size_out 変換した結果の長さ
- * @return 変換したテキストへのポインター。
- * @note 返り値は Iconv オブジェクトを破棄、または convert() を再び呼び出すとdangling pointerになる。
+ * @return 変換したテキストへの参照
+ * @note 返り値は Iconv オブジェクトを破棄、または convert() を再び呼び出すとdangling referenceになる。
  */
-const char* Iconv::convert( char* str_in, int size_in, int& size_out )
+const std::string& Iconv::convert( char* str_in, std::size_t size_in )
 {
 #ifdef _DEBUG
     std::cout << "Iconv::convert size_in = " << size_in << std::endl;
 #endif
 
-    if( m_cd == ( GIConv ) -1 ) return nullptr;
+    if( m_cd == ( GIConv ) -1 ) {
+        m_buf.clear();
+        return m_buf;
+    }
 
     if( const std::size_t size_in_x2 = size_in * 2;
             size_in_x2 >= m_buf.size() ) {
@@ -345,11 +347,11 @@ const char* Iconv::convert( char* str_in, int size_in, int& size_out )
 
     } while( buf_in_tmp < buf_in_end );
 
-    size_out = buf_out_tmp - m_buf.data();
-    *buf_out_tmp = '\0';
+    const std::size_t size_out = buf_out_tmp - m_buf.data();
+    m_buf.resize( size_out );
 
 #ifdef _DEBUG
     std::cout << "Iconv::convert size_out = " << size_out << std::endl;
 #endif
-    return m_buf.data();
+    return m_buf;
 }

--- a/src/jdlib/jdiconv.h
+++ b/src/jdlib/jdiconv.h
@@ -16,7 +16,7 @@ namespace JDLIB
     {
         GIConv m_cd; ///< iconv実装は環境で違いがあるためGlibのラッパーAPIを利用する
 
-        std::vector<char> m_buf; ///< 出力バッファ
+        std::string m_buf; ///< 出力バッファ
 
         std::string m_coding_from; ///< 変換元の文字エンコーディング
         bool m_coding_to_is_utf8; ///< 変換先の文字エンコーディングがUTF-8ならtrue
@@ -29,7 +29,7 @@ namespace JDLIB
         ~Iconv();
 
         // テキストの文字エンコーディングを変換する
-        const char* convert( char* str_in, int size_in, int& size_out );
+        const std::string& convert( char* str_in, std::size_t size_in );
     };
 }
 

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1489,9 +1489,7 @@ std::string MISC::Iconv( const std::string& str, const std::string& coding_to, c
     std::string str_bk = str;
 
     JDLIB::Iconv libiconv( coding_to, coding_from );
-    int byte_out;
-
-    std::string str_enc = libiconv.convert( &*str_bk.begin(), str_bk.size(), byte_out );
+    std::string str_enc = libiconv.convert( str_bk.data(), str_bk.size() );
 
     return str_enc;
 }

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -913,8 +913,7 @@ void MessageViewBase::slot_switch_page( Gtk::Widget*, guint page )
             // 対応していないUnicode文字を文字参照の形式(&#nnnn;)で表示する
             if( DBTREE::get_unicode( get_url() ) == "change" ){
                 // MS932等に無い文字を数値文字参照にするために文字コードを変換する
-                int byte_out;
-                const std::string str_enc = m_iconv->convert( msg.data(), msg.size(), byte_out );
+                const std::string& str_enc = m_iconv->convert( msg.data(), msg.size() );
                 msg = MISC::Iconv( str_enc, "UTF-8", DBTREE::board_charset( get_url() ) );
             }
             else{
@@ -994,8 +993,7 @@ void MessageViewBase::show_status()
     }
     else if( m_text_changed )
     {
-        int byte_out;
-        std::string str_enc = m_iconv->convert( message.data(), message.size(), byte_out );
+        const std::string& str_enc = m_iconv->convert( message.data(), message.size() );
         m_lng_str_enc = str_enc.length();
 
         // 特殊文字の文字数を計算

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -239,8 +239,7 @@ void Post::receive_finish()
     {
         const std::string charset = DBTREE::board_charset( m_url );
         JDLIB::Iconv libiconv( "UTF-8", charset );
-        int byte_out;
-        m_return_html = libiconv.convert( &*m_rawdata.begin(), m_rawdata.size(), byte_out );
+        m_return_html = libiconv.convert( m_rawdata.data(), m_rawdata.size() );
     }
 
 #ifdef _DEBUG

--- a/src/skeleton/textloader.cpp
+++ b/src/skeleton/textloader.cpp
@@ -173,8 +173,7 @@ void TextLoader::receive_finish()
 
     // UTF-8に変換しておく
     JDLIB::Iconv libiconv( "UTF-8", get_charset() );
-    int byte_out;
-    m_data = libiconv.convert( &*m_rawdata.begin(), m_rawdata.size(),  byte_out );
+    m_data = libiconv.convert( m_rawdata.data(), m_rawdata.size() );
     clear();
 
     receive_cookies();

--- a/test/gtest_jdlib_jdiconv.cpp
+++ b/test/gtest_jdlib_jdiconv.cpp
@@ -17,53 +17,49 @@ class Iconv_ToAsciiFromUtf8 : public ::testing::Test {};
 TEST_F(Iconv_ToAsciiFromUtf8, empty)
 {
     char input[] = "";
-    int size_out;
     constexpr bool broken_sjis_be_utf8 = false;
 
     JDLIB::Iconv icv( "ASCII", "UTF-8", broken_sjis_be_utf8 );
-    const char* result = icv.convert( input, std::strlen(input), size_out );
+    const std::string& result = icv.convert( input, std::strlen(input) );
 
-    EXPECT_STREQ( "", result );
-    EXPECT_EQ( 0, size_out );
+    EXPECT_EQ( "", result );
+    EXPECT_EQ( 0, result.size() );
 }
 
 TEST_F(Iconv_ToAsciiFromUtf8, helloworld)
 {
     char input[] = "hello world!\n";
-    int size_out;
     constexpr bool broken_sjis_be_utf8 = false;
 
     JDLIB::Iconv icv( "ASCII", "UTF-8", broken_sjis_be_utf8 );
-    const char* result = icv.convert( input, std::strlen(input), size_out );
+    const std::string& result = icv.convert( input, std::strlen(input) );
 
-    EXPECT_STREQ( "hello world!\n", result );
-    EXPECT_EQ( 13, size_out );
+    EXPECT_EQ( "hello world!\n", result );
+    EXPECT_EQ( 13, result.size() );
 }
 
 TEST_F(Iconv_ToAsciiFromUtf8, hiragana)
 {
     char input[] = "あいうえお";
-    int size_out;
     constexpr bool broken_sjis_be_utf8 = false;
 
     JDLIB::Iconv icv( "ASCII", "UTF-8", broken_sjis_be_utf8 );
-    const char* result = icv.convert( input, std::strlen(input), size_out );
+    const std::string& result = icv.convert( input, std::strlen(input) );
 
-    EXPECT_STREQ( "&#12354;&#12356;&#12358;&#12360;&#12362;", result );
-    EXPECT_EQ( 40, size_out );
+    EXPECT_EQ( "&#12354;&#12356;&#12358;&#12360;&#12362;", result );
+    EXPECT_EQ( 40, result.size() );
 }
 
 TEST_F(Iconv_ToAsciiFromUtf8, subdivision_flag)
 {
     // :england: JDLIB::Iconv::convert()のコメントを参照
     char input[] = "\U0001F3F4\U000E0067\U000E0062\U000E0065\U000E006E\U000E0067\U000E007F";
-    int size_out;
     constexpr bool broken_sjis_be_utf8 = false;
 
     JDLIB::Iconv icv( "ASCII", "UTF-8", broken_sjis_be_utf8 );
-    const char* result = icv.convert( input, std::strlen(input), size_out );
-    EXPECT_STREQ( "&#127988;&#917607;&#917602;&#917605;&#917614;&#917607;&#917631;", result );
-    EXPECT_EQ( 63, size_out );
+    const std::string& result = icv.convert( input, std::strlen(input) );
+    EXPECT_EQ( "&#127988;&#917607;&#917602;&#917605;&#917614;&#917607;&#917631;", result );
+    EXPECT_EQ( 63, result.size() );
 }
 
 
@@ -73,16 +69,15 @@ TEST_F(Iconv_ToUtf8FromAscii, replacement_character_to_utf8_is_uFFFD)
 {
     // テストは網羅してない
     char input[] = "\x80\x91\xA2\xB3\xC4\xD5\xE6\xF7";
-    int size_out;
     constexpr bool broken_sjis_be_utf8 = false;
 
     JDLIB::Iconv icv( "UTF-8", "ASCII", broken_sjis_be_utf8 );
-    const char* result = icv.convert( input, std::strlen(input), size_out );
+    const std::string& result = icv.convert( input, std::strlen(input) );
 
     // UTF-8へ変換するとき入力エンコーディングで無効なバイト列は U+FFFD に置き換える
-    EXPECT_STREQ( "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD"
-                  "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD", result );
-    EXPECT_EQ( 24, size_out );
+    EXPECT_EQ( "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD"
+               "\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD\xEF\xBF\xBD", result );
+    EXPECT_EQ( 24, result.size() );
 }
 
 
@@ -91,53 +86,49 @@ class Iconv_ToUtf8FromMs932 : public ::testing::Test {};
 TEST_F(Iconv_ToUtf8FromMs932, empty)
 {
     char input[] = "";
-    int size_out;
     constexpr bool broken_sjis_be_utf8 = false;
 
     JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
-    const char* result = icv.convert( input, std::strlen(input), size_out );
+    const std::string& result = icv.convert( input, std::strlen(input) );
 
-    EXPECT_STREQ( "", result );
-    EXPECT_EQ( 0, size_out );
+    EXPECT_EQ( "", result );
+    EXPECT_EQ( 0, result.size() );
 }
 
 TEST_F(Iconv_ToUtf8FromMs932, helloworld)
 {
     char input[] = "hello world!\n";
-    int size_out;
     constexpr bool broken_sjis_be_utf8 = false;
 
     JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
-    const char* result = icv.convert( input, std::strlen(input), size_out );
+    const std::string& result = icv.convert( input, std::strlen(input) );
 
-    EXPECT_STREQ( "hello world!\n", result );
-    EXPECT_EQ( 13, size_out );
+    EXPECT_EQ( "hello world!\n", result );
+    EXPECT_EQ( 13, result.size() );
 }
 
 TEST_F(Iconv_ToUtf8FromMs932, hiragana)
 {
     char input[] = "\x82\xA0\x82\xA2\x82\xA4\x82\xA6\x82\xA8";
-    int size_out;
     constexpr bool broken_sjis_be_utf8 = false;
 
     JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
-    const char* result = icv.convert( input, std::strlen(input), size_out );
+    const std::string& result = icv.convert( input, std::strlen(input) );
 
-    EXPECT_STREQ( "あいうえお", result );
-    EXPECT_EQ( 15, size_out );
+    EXPECT_EQ( "あいうえお", result );
+    EXPECT_EQ( 15, result.size() );
 }
 
 TEST_F(Iconv_ToUtf8FromMs932, hex_a0)
 {
     char input[] = "hello\xa0world!\n";
-    int size_out;
     constexpr bool broken_sjis_be_utf8 = false;
 
     JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
-    const char* result = icv.convert( input, std::strlen(input), size_out );
+    const std::string& result = icv.convert( input, std::strlen(input) );
 
-    EXPECT_STREQ( "hello world!\n", result );
-    EXPECT_EQ( 13, size_out );
+    EXPECT_EQ( "hello world!\n", result );
+    EXPECT_EQ( 13, result.size() );
 }
 
 TEST_F(Iconv_ToUtf8FromMs932, mojibake_fix_inequality_sign_pattern1)
@@ -145,14 +136,13 @@ TEST_F(Iconv_ToUtf8FromMs932, mojibake_fix_inequality_sign_pattern1)
     // DATのデータ区切り <> が文字化けするとスレが壊れるため変換を修正する
     // エンコーディングがMS932のスレにUTF-8で書き込み文字化けした場合をテスト
     char input[] = "<>test テスト<>";
-    int size_out;
     constexpr bool broken_sjis_be_utf8 = false;
 
     JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
-    const char* result = icv.convert( input, std::strlen(input), size_out );
+    const std::string& result = icv.convert( input, std::strlen(input) );
 
-    EXPECT_STREQ( "<>test \xE7\xB9\x9D\xE2\x96\xA1\xE3\x81\x9B\xE7\xB9\x9D?<>", result );
-    EXPECT_EQ( 22, size_out );
+    EXPECT_EQ( "<>test \xE7\xB9\x9D\xE2\x96\xA1\xE3\x81\x9B\xE7\xB9\x9D?<>", result );
+    EXPECT_EQ( 22, result.size() );
 }
 
 TEST_F(Iconv_ToUtf8FromMs932, mojibake_fix_inequality_sign_pattern2)
@@ -160,14 +150,13 @@ TEST_F(Iconv_ToUtf8FromMs932, mojibake_fix_inequality_sign_pattern2)
     // DATのデータ区切り <> が文字化けするとスレが壊れるため変換を修正する
     // エンコーディングがMS932のスレにUTF-8で書き込み文字化けした場合をテスト
     char input[] = "<> test テスト <>";
-    int size_out;
     constexpr bool broken_sjis_be_utf8 = false;
 
     JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
-    const char* result = icv.convert( input, std::strlen(input), size_out );
+    const std::string& result = icv.convert( input, std::strlen(input) );
 
-    EXPECT_STREQ( "<> test \xE7\xB9\x9D\xE2\x96\xA1\xE3\x81\x9B\xE7\xB9\x9D\xE2\x96\xA1<>", result );
-    EXPECT_EQ( 25, size_out );
+    EXPECT_EQ( "<> test \xE7\xB9\x9D\xE2\x96\xA1\xE3\x81\x9B\xE7\xB9\x9D\xE2\x96\xA1<>", result );
+    EXPECT_EQ( 25, result.size() );
 }
 
 TEST_F(Iconv_ToUtf8FromMs932, mapping_error)
@@ -175,14 +164,13 @@ TEST_F(Iconv_ToUtf8FromMs932, mapping_error)
     // MS932の符号として不正な2バイトコードは白四角(\x81\A0 == U+25A1)として処理する
     // テストは網羅してない
     char input[] = "\x81\xAD\x82\x40\x88\x90\x98\x90";
-    int size_out;
     constexpr bool broken_sjis_be_utf8 = false;
 
     JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
-    const char* result = icv.convert( input, std::strlen(input), size_out );
+    const std::string& result = icv.convert( input, std::strlen(input) );
 
-    EXPECT_STREQ( "\u25A1\u25A1\u25A1\u25A1", result );
-    EXPECT_EQ( 12, size_out );
+    EXPECT_EQ( "\u25A1\u25A1\u25A1\u25A1", result );
+    EXPECT_EQ( 12, result.size() );
 }
 
 TEST_F(Iconv_ToUtf8FromMs932, broken_sjis_be_utf8)
@@ -191,14 +179,13 @@ TEST_F(Iconv_ToUtf8FromMs932, broken_sjis_be_utf8)
                    "\xe5\x85\xa5\xe3\x82\x8c\xe6\x9b\xbf\xe3\x82\x8f"
                    "\xe3\x81\xa3\xe3\x81\xa6\xe3\x82\x8b\xe3\x80\x9c?"
                    " \x82\xa6\x82\xa8";
-    int size_out;
     constexpr bool broken_sjis_be_utf8 = true;
 
     JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
-    const char* result = icv.convert( input, std::strlen(input), size_out );
+    const std::string& result = icv.convert( input, std::strlen(input) );
 
-    EXPECT_STREQ( "あいう <span class=\"BROKEN_SJIS\">入れ替わってる〜</span>? えお", result );
-    EXPECT_EQ( 28 - 2 + 7 + 9 * 3 + 5 * 3, size_out );
+    EXPECT_EQ( "あいう <span class=\"BROKEN_SJIS\">入れ替わってる〜</span>? えお", result );
+    EXPECT_EQ( 28 - 2 + 7 + 9 * 3 + 5 * 3, result.size() );
 }
 
 } // namespace


### PR DESCRIPTION
`JDLIB::Iconv`クラスで使うバッファを`std::vector<char>`から`std::string`に変更します。
`convert()`の引数と戻り値を整理して内部バッファのconst参照を直接返すように修正します。
合わせて`convert()`を呼び出すコードを整理します。
