### PR TITLE
Iconv: Add convert() overload for passing output buffer

### DIFF
--- a/src/jdlib/jdiconv.h
+++ b/src/jdlib/jdiconv.h
@@ -30,6 +30,7 @@ namespace JDLIB
 
         // テキストの文字エンコーディングを変換する
         const std::string& convert( char* str_in, std::size_t size_in );
+        std::string& convert( char* str_in, std::size_t size_in, std::string& out_buf );
     };
 }
 

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1489,7 +1489,8 @@ std::string MISC::Iconv( const std::string& str, const std::string& coding_to, c
     std::string str_bk = str;
 
     JDLIB::Iconv libiconv( coding_to, coding_from );
-    std::string str_enc = libiconv.convert( str_bk.data(), str_bk.size() );
+    std::string str_enc;
+    libiconv.convert( str_bk.data(), str_bk.size(), str_enc );
 
     return str_enc;
 }

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -239,7 +239,7 @@ void Post::receive_finish()
     {
         const std::string charset = DBTREE::board_charset( m_url );
         JDLIB::Iconv libiconv( "UTF-8", charset );
-        m_return_html = libiconv.convert( m_rawdata.data(), m_rawdata.size() );
+        libiconv.convert( m_rawdata.data(), m_rawdata.size(), m_return_html );
     }
 
 #ifdef _DEBUG

--- a/src/skeleton/textloader.cpp
+++ b/src/skeleton/textloader.cpp
@@ -173,7 +173,7 @@ void TextLoader::receive_finish()
 
     // UTF-8に変換しておく
     JDLIB::Iconv libiconv( "UTF-8", get_charset() );
-    m_data = libiconv.convert( m_rawdata.data(), m_rawdata.size() );
+    libiconv.convert( m_rawdata.data(), m_rawdata.size(), m_data );
     clear();
 
     receive_cookies();


### PR DESCRIPTION
`JDLIB::Iconv`クラスが持つ内部バッファの代わりに出力用のバッファを渡す関数のオーバーロードを追加します。
さらにいくつかの`convert()`呼び出しを追加したオーバーロードに置き換えます。
