### PR TITLE
Update character encoding enumeration to Encoding

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -78,6 +78,7 @@ noinst_HEADERS = \
 	maintoolbar.h \
 	cache.h \
 	jddebug.h \
+	jdencoding.h \
 	global.h \
 	jdversion.h \
 	command.h \

--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -2371,27 +2371,27 @@ void ArticleViewBase::slot_on_url( const std::string& url, const std::string& im
         {
             std::string tmp = MISC::url_decode( url );
 
-            const int char_code = MISC::judge_char_code( tmp );
+            const auto enc = MISC::detect_encoding( tmp );
 
-            switch( char_code )
+            switch( enc )
             {
-                case MISC::CHARCODE_EUC_JP:
+                case Encoding::eucjp:
 
                     status_url = MISC::Iconv( tmp, "UTF-8", "EUC-JP" );
                     break;
 
-                case MISC::CHARCODE_JIS:
+                case Encoding::jis:
 
                     status_url = MISC::Iconv( tmp, "UTF-8", "ISO-2022-JP" );
                     break;
 
-                case MISC::CHARCODE_SJIS:
+                case Encoding::sjis:
 
                     status_url = MISC::Iconv( tmp, "UTF-8", "MS932" );
                     break;
 
-                case MISC::CHARCODE_ASCII:
-                case MISC::CHARCODE_UTF:
+                case Encoding::ascii:
+                case Encoding::utf8:
 
                     status_url = tmp;
                     break;

--- a/src/jdencoding.h
+++ b/src/jdencoding.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/** @file jdencoding.h
+ *
+ * @details 文字エンコーディングを表す列挙型
+ */
+
+#ifndef JDENCODING_H
+#define JDENCODING_H
+
+/** @brief 文字エンコーディングを表す列挙型
+ *
+ * @details 日本語の文章に使われている文字エンコーディングをリストする
+ */
+enum class Encoding
+{
+    unknown = 0, ///< 不明
+    ascii, ///< ASCII
+    eucjp, ///< EUC-JP
+    jis,   ///< JISコード (ISO-2022-JP)
+    sjis,  ///< WindowsのShift_JIS (MS932)
+    utf8,  ///< UTF-8
+};
+
+#endif

--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -270,31 +270,32 @@ bool MISC::is_utf8( std::string_view input, std::size_t read_byte )
 }
 
 
-//
-// 日本語文字コードの判定
-//
-// 各コードの判定でtrueの間は文字数分繰り返されるので
-// 速度の求められる繰り返し処理などで使わない事
-//
-int MISC::judge_char_code( const std::string& str )
+/** @brief 日本語文字エンコーディングの検出
+ *
+ * @note 各エンコーディングの判定でtrueの間は文字数分繰り返されるので
+ * 速度の求められる繰り返し処理などで使わない事
+ * @param[in] str エンコーディングを検出するテキスト
+ * @return 検出結果
+ */
+Encoding MISC::detect_encoding( std::string_view str )
 {
-    int code = CHARCODE_UNKNOWN;
+    Encoding code = Encoding::unknown;
 
     if( str.empty() ) return code;
 
     size_t read_byte = 0;
 
     // JISの判定
-    if( is_jis( str, read_byte ) ) code = CHARCODE_JIS;
+    if( is_jis( str, read_byte ) ) code = Encoding::jis;
     // JISの判定で最後まで進んでいたら制御文字かアスキー
-    else if( read_byte == str.length() ) code = CHARCODE_ASCII;
+    else if( read_byte == str.length() ) code = Encoding::ascii;
     // is_jis()でASCII範囲外のバイトが現れた箇所から判定する
     // UTF-8の範囲
-    else if( is_utf8( str, read_byte ) ) code = CHARCODE_UTF;
+    else if( is_utf8( str, read_byte ) ) code = Encoding::utf8;
     // EUC-JPの範囲
-    else if( is_eucjp( str, read_byte ) ) code = CHARCODE_EUC_JP;
+    else if( is_eucjp( str, read_byte ) ) code = Encoding::eucjp;
     // Shift_JISの範囲
-    else if( is_sjis( str, read_byte ) ) code = CHARCODE_SJIS;
+    else if( is_sjis( str, read_byte ) ) code = Encoding::sjis;
 
     return code;
 }

--- a/src/jdlib/misccharcode.h
+++ b/src/jdlib/misccharcode.h
@@ -5,22 +5,15 @@
 #ifndef _MISCCHARCODE_H
 #define _MISCCHARCODE_H
 
+#include "jdencoding.h"
+
 #include <string>
 #include <string_view>
 
 
+
 namespace MISC
 {
-    enum CodeSet
-    {
-        CHARCODE_UNKNOWN = -1,
-        CHARCODE_ASCII = 0,
-        CHARCODE_EUC_JP,
-        CHARCODE_JIS,
-        CHARCODE_SJIS,
-        CHARCODE_UTF
-    };
-
     /// @brief get_unicodeblock() の戻り値
     enum class UnicodeBlock
     {
@@ -42,7 +35,7 @@ namespace MISC
     bool is_jis( std::string_view input, std::size_t& read_byte );
     bool is_sjis( std::string_view input, std::size_t read_byte );
     bool is_utf8( std::string_view input, std::size_t read_byte );
-    int judge_char_code( const std::string& str );
+    Encoding detect_encoding( std::string_view str );
 
     /// utf-8文字のbyte数を返す
     int utf8bytes( const char* utf8str );


### PR DESCRIPTION
文字エンコーディングを表す列挙型`CodeSet`をスコープを持つ列挙型(enum class)`Encoding`に更新します。
また、テキストから文字エンコーディングを検出する関数の名称を`detect_encoding()`に変更して返り値を`int`から`Encoding`にします。

ソースコードの文字エンコーディングを表す識別子には encoding や charset を使います。

関連のissue: #76