### PR TITLE
Change MISC::url_encode() behavior to decode @ mark

### DIFF
--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -174,12 +174,11 @@ namespace MISC
     /// URLに含まれるパーセントエンコーディングをバイト列にデコードする
     std::string url_decode( std::string_view url );
 
-    // urlエンコード
-    std::string url_encode( std::string_view str );
+    /// 文字列(バイト列)をパーセント符号化して返す
+    std::string url_encode( std::string_view byte_str );
 
-    // 文字コードを変換して url エンコード
-    // str は UTF-8 であること
-    std::string charset_url_encode( const std::string& str, const std::string& charset );
+    /// UTF-8文字列をエンコーディング変換してからパーセント符号化して返す
+    std::string charset_url_encode( const std::string& utf8str, const std::string& charset );
 
     // 文字コード変換して url エンコード
     // ただし半角スペースのところを+に置き換えて区切る

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -1831,7 +1831,7 @@ TEST_F(MISC_UrlEncodeTest, empty_string)
 
 TEST_F(MISC_UrlEncodeTest, unencoded_ascii_characters)
 {
-    std::string_view input = "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz*-._@";
+    std::string_view input = "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz*-._";
     EXPECT_EQ( input, MISC::url_encode( input ) );
 }
 
@@ -1863,7 +1863,7 @@ TEST_F(MISC_UrlEncodeTest, encoded_ascii_characters)
 {
     std::string_view input = "!\"#$%&\'()_+,_/_:;<=>?@_[\\]^_`_{|}~";
     std::string_view result = "%21%22%23%24%25%26%27%28%29_%2B%2C_%2F_"
-                              "%3A%3B%3C%3D%3E%3F@_%5B%5C%5D%5E_%60_%7B%7C%7D%7E";
+                              "%3A%3B%3C%3D%3E%3F%40_%5B%5C%5D%5E_%60_%7B%7C%7D%7E";
     EXPECT_EQ( result, MISC::url_encode( input ) );
 }
 
@@ -1900,7 +1900,7 @@ TEST_F(MISC_CharsetUrlEncodeTest, empty_string)
 
 TEST_F(MISC_CharsetUrlEncodeTest, unencoded_ascii_characters)
 {
-    std::string input = "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz*-._@";
+    std::string input = "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz*-._";
     EXPECT_EQ( input, MISC::charset_url_encode( input, "MS932" ) );
 }
 
@@ -1932,7 +1932,7 @@ TEST_F(MISC_CharsetUrlEncodeTest, encoded_ascii_characters)
 {
     std::string input = "!\"#$%&\'()_+,_/_:;<=>?@_[\\]^_`_{|}~";
     std::string_view result = "%21%22%23%24%25%26%27%28%29_%2B%2C_%2F_"
-                              "%3A%3B%3C%3D%3E%3F@_%5B%5C%5D%5E_%60_%7B%7C%7D%7E";
+                              "%3A%3B%3C%3D%3E%3F%40_%5B%5C%5D%5E_%60_%7B%7C%7D%7E";
     EXPECT_EQ( result, MISC::charset_url_encode( input, "MS932" ) );
 }
 
@@ -1969,7 +1969,7 @@ TEST_F(MISC_CharsetUrlEncodeSplitTest, empty_string)
 
 TEST_F(MISC_CharsetUrlEncodeSplitTest, unencoded_ascii_characters)
 {
-    std::string input = "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz*-._@";
+    std::string input = "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz*-._";
     EXPECT_EQ( input, MISC::charset_url_encode_split( input, "MS932" ) );
 }
 
@@ -2008,7 +2008,7 @@ TEST_F(MISC_CharsetUrlEncodeSplitTest, encoded_ascii_characters)
 {
     std::string input = "!\"#$%&\'()_+,_/_:;<=>?@_[\\]^_`_{|}~";
     std::string_view result = "%21%22%23%24%25%26%27%28%29_%2B%2C_%2F_"
-                              "%3A%3B%3C%3D%3E%3F@_%5B%5C%5D%5E_%60_%7B%7C%7D%7E";
+                              "%3A%3B%3C%3D%3E%3F%40_%5B%5C%5D%5E_%60_%7B%7C%7D%7E";
     EXPECT_EQ( result, MISC::charset_url_encode_split( input, "MS932" ) );
 }
 


### PR DESCRIPTION
[URLの規格][1]を参考にして`@`(U+0040)をパーセント符号化するように関数の動作を変更します。

> The application/x-www-form-urlencoded percent-encode set contains all code points, except the ASCII alphanumeric, U+002A (*), U+002D (-), U+002E (.), and U+005F (_).

[1]: https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set
