### PR TITLE
Change MISC::charset_url_encode_split() to HTML form compliant

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1408,7 +1408,7 @@ std::string MISC::charset_url_encode( const std::string& utf8str, const std::str
  *
  * @param[in] str 入力文字列 (文字エンコーディングは任意)
  * @return パーセント符号化された文字列
- * @see MISC::charset_url_encode_split( const std::string& str, const std::string& charset )
+ * @see MISC::charset_url_encode_split( const std::string& utf8str, const std::string& encoding )
 */
 std::string MISC::url_encode_plus( std::string_view str )
 {
@@ -1436,21 +1436,22 @@ std::string MISC::url_encode_plus( std::string_view str )
 }
 
 
-//
-// 文字コード変換して url エンコード
-//
-// ただし半角スペースのところを+に置き換えて区切る
-//
-std::string MISC::charset_url_encode_split( const std::string& str, const std::string& charset )
+/** @brief UTF-8文字列をエンコーディング変換してから application/x-www-form-urlencoded の形式でパーセント符号化する
+ *
+ * @details `utf8str` を `encoding` で指定した文字エンコーディングに変換してから符号化する。
+ * @param[in] utf8str 入力文字列 (文字エンコーディングはUTF-8)
+ * @param[in] encoding 変換先の文字エンコーディング名
+ * @return パーセント符号化された文字列
+ * @see MISC::url_encode_plus( std::string_view str )
+*/
+std::string MISC::charset_url_encode_split( const std::string& utf8str, const std::string& encoding )
 {
-    std::list< std::string > list_str = MISC::split_line( str );
-    std::string str_out;
-    for( const std::string& s : list_str ) {
-        if( ! str_out.empty() ) str_out.push_back( '+' );
-        str_out.append( MISC::charset_url_encode( s, charset ) );
+    if( encoding.empty() || encoding == "UTF-8" ) {
+        return MISC::url_encode_plus( utf8str );
     }
 
-    return str_out;
+    const std::string str_enc = MISC::Iconv( utf8str, encoding, "UTF-8" );
+    return  MISC::url_encode_plus( str_enc );
 }
 
 

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -183,9 +183,8 @@ namespace MISC
     /// application/x-www-form-urlencoded の形式でパーセント符号化する
     std::string url_encode_plus( std::string_view str );
 
-    // 文字コード変換して url エンコード
-    // ただし半角スペースのところを+に置き換えて区切る
-    std::string charset_url_encode_split( const std::string& str, const std::string& charset );
+    /// UTF-8文字列をエンコーディング変換してから application/x-www-form-urlencoded の形式でパーセント符号化する
+    std::string charset_url_encode_split( const std::string& utf8str, const std::string& encoding );
 
     // BASE64
     std::string base64( const std::string& str );

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -2045,19 +2045,19 @@ TEST_F(MISC_CharsetUrlEncodeSplitTest, unencoded_ascii_characters)
 TEST_F(MISC_CharsetUrlEncodeSplitTest, single_u0020)
 {
     std::string input = " ";
-    EXPECT_EQ( "", MISC::charset_url_encode_split( input, "MS932" ) );
+    EXPECT_EQ( "+", MISC::charset_url_encode_split( input, "MS932" ) );
 }
 
 TEST_F(MISC_CharsetUrlEncodeSplitTest, u000A)
 {
     std::string input = "quick\nbrown\n\nfox";
-    EXPECT_EQ( "quick%0Abrown%0A%0Afox", MISC::charset_url_encode_split( input, "MS932" ) );
+    EXPECT_EQ( "quick%0D%0Abrown%0D%0A%0D%0Afox", MISC::charset_url_encode_split( input, "MS932" ) );
 }
 
 TEST_F(MISC_CharsetUrlEncodeSplitTest, u000D)
 {
     std::string input = "quick\rbrown\r\rfox";
-    EXPECT_EQ( "quick%0Dbrown%0D%0Dfox", MISC::charset_url_encode_split( input, "MS932" ) );
+    EXPECT_EQ( "quickbrownfox", MISC::charset_url_encode_split( input, "MS932" ) );
 }
 
 TEST_F(MISC_CharsetUrlEncodeSplitTest, u000D_u000A)
@@ -2066,10 +2066,11 @@ TEST_F(MISC_CharsetUrlEncodeSplitTest, u000D_u000A)
     EXPECT_EQ( "quick%0D%0Abrown%0D%0A%0D%0Afox", MISC::charset_url_encode_split( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeSplitTest, words_separated_by_spaces)
+TEST_F(MISC_CharsetUrlEncodeSplitTest, words_separated_by_u0020)
 {
-    std::string input = "Quick Brown　Fox い ろ　は"; // space U+0020 or U+3000
-    std::string_view result = "Quick+Brown+Fox+%82%A2+%82%EB+%82%CD";
+    // U+3000 won't be converted to '+'
+    std::string input = "Quick Brown　Fox い ろ　は";
+    std::string_view result = "Quick+Brown%81%40Fox+%82%A2+%82%EB%81%40%82%CD";
     EXPECT_EQ( result, MISC::charset_url_encode_split( input, "MS932" ) );
 }
 


### PR DESCRIPTION
webブラウザのform要素と動作を合わせるため `MISC::charset_url_encode_split()` のパーセント符号化処理を変更します。

変更点
- 入力の先頭にある半角空白 (U+0020) を `+` に変換する
- 全角空白 (U+3000) を `+` ではなくパーセント符号化する
- 改行CR (U+000D) は読み飛ばして無視する
