### PR TITLE
Use logical and instead of bitwise and

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -605,8 +605,8 @@ void Core::run( const bool init, const bool skip_setupdiag )
 
     m_action_group->add( Gtk::ToggleAction::create( "RestoreViews", "前回開いていた各ビューを起動時に復元する(_R)", std::string(),
                                                     ( CONFIG::get_restore_board()
-                                                      & CONFIG::get_restore_article()
-                                                      & CONFIG::get_restore_image() ) ),
+                                                      && CONFIG::get_restore_article()
+                                                      && CONFIG::get_restore_image() ) ),
                          sigc::mem_fun( *this, &Core::slot_toggle_restore_views ) );
 
     m_action_group->add( Gtk::ToggleAction::create( "ToggleFoldMessage", "非アクティブ時に書き込みビューを折りたたむ(_C)", std::string(),

--- a/src/menuslots.cpp
+++ b/src/menuslots.cpp
@@ -589,7 +589,7 @@ void Core::slot_image_pref()
 //
 void Core::slot_toggle_restore_views()
 {
-    bool status = CONFIG::get_restore_board() & CONFIG::get_restore_article() & CONFIG::get_restore_image();
+    const bool status{ CONFIG::get_restore_board() && CONFIG::get_restore_article() && CONFIG::get_restore_image() };
 
     CONFIG::set_restore_board( ! status );
     CONFIG::set_restore_article( ! status );
@@ -957,7 +957,7 @@ void Core::slot_setup_abone_thread()
 //
 void Core::slot_toggle_abone_transp_chain()
 {
-    const bool status = CONFIG::get_abone_chain() & CONFIG::get_abone_transparent();
+    const bool status{ CONFIG::get_abone_chain() && CONFIG::get_abone_transparent() };
 
     CONFIG::set_abone_transparent( ! status );
     CONFIG::set_abone_chain( ! status );
@@ -973,7 +973,7 @@ void Core::slot_toggle_abone_transp_chain()
 //
 void Core::slot_toggle_abone_icase_wchar()
 {
-    const bool status = CONFIG::get_abone_icase() & CONFIG::get_abone_wchar();
+    const bool status{ CONFIG::get_abone_icase() && CONFIG::get_abone_wchar() };
 
     CONFIG::set_abone_icase( ! status );
     CONFIG::set_abone_wchar( ! status );


### PR DESCRIPTION
真偽値の論理積(`&&`)を行うべき式がビット単位のAND(`&`)になっている箇所があったため修正します。

clang-14 のレポート
```
../src/core.cpp:607:55: warning: use of bitwise '&' with boolean operands [-Wbitwise-instead-of-logical]
                                                    ( CONFIG::get_restore_board()
                                                    ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/menuslots.cpp:592:19: warning: use of bitwise '&' with boolean operands [-Wbitwise-instead-of-logical]
    bool status = CONFIG::get_restore_board() & CONFIG::get_restore_article() & CONFIG::get_restore_image();
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                              &&
```
