### PR TITLE
Rename MISC::charset_url_encode_split() with url_encode_plus()

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1408,7 +1408,7 @@ std::string MISC::charset_url_encode( const std::string& utf8str, const std::str
  *
  * @param[in] str 入力文字列 (文字エンコーディングは任意)
  * @return パーセント符号化された文字列
- * @see MISC::charset_url_encode_split( const std::string& utf8str, const std::string& encoding )
+ * @see MISC::url_encode_plus( const std::string& utf8str, const std::string& encoding )
 */
 std::string MISC::url_encode_plus( std::string_view str )
 {
@@ -1444,7 +1444,7 @@ std::string MISC::url_encode_plus( std::string_view str )
  * @return パーセント符号化された文字列
  * @see MISC::url_encode_plus( std::string_view str )
 */
-std::string MISC::charset_url_encode_split( const std::string& utf8str, const std::string& encoding )
+std::string MISC::url_encode_plus( const std::string& utf8str, const std::string& encoding )
 {
     if( encoding.empty() || encoding == "UTF-8" ) {
         return MISC::url_encode_plus( utf8str );

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -184,7 +184,7 @@ namespace MISC
     std::string url_encode_plus( std::string_view str );
 
     /// UTF-8文字列をエンコーディング変換してから application/x-www-form-urlencoded の形式でパーセント符号化する
-    std::string charset_url_encode_split( const std::string& utf8str, const std::string& encoding );
+    std::string url_encode_plus( const std::string& utf8str, const std::string& encoding );
 
     // BASE64
     std::string base64( const std::string& str );

--- a/src/usrcmdmanager.cpp
+++ b/src/usrcmdmanager.cpp
@@ -288,15 +288,15 @@ std::string Usrcmd_Manager::replace_cmd( const std::string& cmd,
 
     if( cmd_out.find( "$TEXTIU" ) != std::string::npos ){
         if( ! show_replacetextdiag( texti, "$TEXTIU" ) ) return std::string();
-        cmd_out = MISC::replace_str( cmd_out, "$TEXTIU", MISC::charset_url_encode_split( texti, "UTF-8" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$TEXTIU", MISC::url_encode_plus( texti, "UTF-8" ) );
     }
     if( cmd_out.find( "$TEXTIX" ) != std::string::npos ){
         if( ! show_replacetextdiag( texti, "$TEXTIX" ) ) return std::string();
-        cmd_out = MISC::replace_str( cmd_out, "$TEXTIX", MISC::charset_url_encode_split( texti, "EUC-JP" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$TEXTIX", MISC::url_encode_plus( texti, "EUC-JP" ) );
     }
     if( cmd_out.find( "$TEXTIE" ) != std::string::npos ){
         if( ! show_replacetextdiag( texti, "$TEXTIE" ) ) return std::string();
-        cmd_out = MISC::replace_str( cmd_out, "$TEXTIE", MISC::charset_url_encode_split( texti, "MS932" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$TEXTIE", MISC::url_encode_plus( texti, "MS932" ) );
     }
     if( cmd_out.find( "$TEXTI" ) != std::string::npos ){
         if( ! show_replacetextdiag( texti, "$TEXTI" ) ) return std::string();
@@ -304,13 +304,13 @@ std::string Usrcmd_Manager::replace_cmd( const std::string& cmd,
     }
 
     if( cmd_out.find( "$TEXTU" ) != std::string::npos ){
-        cmd_out = MISC::replace_str( cmd_out, "$TEXTU", MISC::charset_url_encode_split( texti, "UTF-8" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$TEXTU", MISC::url_encode_plus( texti, "UTF-8" ) );
     }
     if( cmd_out.find( "$TEXTX" ) != std::string::npos ){
-        cmd_out = MISC::replace_str( cmd_out, "$TEXTX", MISC::charset_url_encode_split( texti, "EUC-JP" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$TEXTX", MISC::url_encode_plus( texti, "EUC-JP" ) );
     }
     if( cmd_out.find( "$TEXTE" ) != std::string::npos ){
-        cmd_out = MISC::replace_str( cmd_out, "$TEXTE", MISC::charset_url_encode_split( texti, "MS932" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$TEXTE", MISC::url_encode_plus( texti, "MS932" ) );
     }
     if( cmd_out.find( "$TEXT" ) != std::string::npos ){
         cmd_out = MISC::replace_str( cmd_out, "$TEXT",  texti );
@@ -321,15 +321,15 @@ std::string Usrcmd_Manager::replace_cmd( const std::string& cmd,
 
     if( cmd_out.find( "$INPUTU" ) != std::string::npos ){
         if( ! show_replacetextdiag( input, "$INPUTU" ) ) return std::string();
-        cmd_out = MISC::replace_str( cmd_out, "$INPUTU", MISC::charset_url_encode_split( input, "UTF-8" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$INPUTU", MISC::url_encode_plus( input, "UTF-8" ) );
     }
     if( cmd_out.find( "$INPUTX" ) != std::string::npos ){
         if( ! show_replacetextdiag( input, "$INPUTX" ) ) return std::string();
-        cmd_out = MISC::replace_str( cmd_out, "$INPUTX", MISC::charset_url_encode_split( input, "EUC-JP" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$INPUTX", MISC::url_encode_plus( input, "EUC-JP" ) );
     }
     if( cmd_out.find( "$INPUTE" ) != std::string::npos ){
         if( ! show_replacetextdiag( input, "$INPUTE" ) ) return std::string();
-        cmd_out = MISC::replace_str( cmd_out, "$INPUTE", MISC::charset_url_encode_split( input, "MS932" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$INPUTE", MISC::url_encode_plus( input, "MS932" ) );
     }
     if( cmd_out.find( "$INPUT" ) != std::string::npos ){
         if( ! show_replacetextdiag( input, "$INPUT" ) ) return std::string();

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -2028,80 +2028,80 @@ TEST_F(MISC_UrlEncodePlusTest, url_utf8)
 }
 
 
-class MISC_CharsetUrlEncodeSplitTest : public ::testing::Test {};
+class MISC_UrlEncodePlusWithEncodingTest : public ::testing::Test {};
 
-TEST_F(MISC_CharsetUrlEncodeSplitTest, empty_string)
+TEST_F(MISC_UrlEncodePlusWithEncodingTest, empty_string)
 {
     std::string input = "";
-    EXPECT_EQ( "", MISC::charset_url_encode_split( input, "MS932" ) );
+    EXPECT_EQ( "", MISC::url_encode_plus( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeSplitTest, unencoded_ascii_characters)
+TEST_F(MISC_UrlEncodePlusWithEncodingTest, unencoded_ascii_characters)
 {
     std::string input = "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz*-._";
-    EXPECT_EQ( input, MISC::charset_url_encode_split( input, "MS932" ) );
+    EXPECT_EQ( input, MISC::url_encode_plus( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeSplitTest, single_u0020)
+TEST_F(MISC_UrlEncodePlusWithEncodingTest, single_u0020)
 {
     std::string input = " ";
-    EXPECT_EQ( "+", MISC::charset_url_encode_split( input, "MS932" ) );
+    EXPECT_EQ( "+", MISC::url_encode_plus( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeSplitTest, u000A)
+TEST_F(MISC_UrlEncodePlusWithEncodingTest, u000A)
 {
     std::string input = "quick\nbrown\n\nfox";
-    EXPECT_EQ( "quick%0D%0Abrown%0D%0A%0D%0Afox", MISC::charset_url_encode_split( input, "MS932" ) );
+    EXPECT_EQ( "quick%0D%0Abrown%0D%0A%0D%0Afox", MISC::url_encode_plus( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeSplitTest, u000D)
+TEST_F(MISC_UrlEncodePlusWithEncodingTest, u000D)
 {
     std::string input = "quick\rbrown\r\rfox";
-    EXPECT_EQ( "quickbrownfox", MISC::charset_url_encode_split( input, "MS932" ) );
+    EXPECT_EQ( "quickbrownfox", MISC::url_encode_plus( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeSplitTest, u000D_u000A)
+TEST_F(MISC_UrlEncodePlusWithEncodingTest, u000D_u000A)
 {
     std::string input = "quick\r\nbrown\r\n\r\nfox";
-    EXPECT_EQ( "quick%0D%0Abrown%0D%0A%0D%0Afox", MISC::charset_url_encode_split( input, "MS932" ) );
+    EXPECT_EQ( "quick%0D%0Abrown%0D%0A%0D%0Afox", MISC::url_encode_plus( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeSplitTest, words_separated_by_u0020)
+TEST_F(MISC_UrlEncodePlusWithEncodingTest, words_separated_by_u0020)
 {
     // U+3000 won't be converted to '+'
     std::string input = "Quick Brown　Fox い ろ　は";
     std::string_view result = "Quick+Brown%81%40Fox+%82%A2+%82%EB%81%40%82%CD";
-    EXPECT_EQ( result, MISC::charset_url_encode_split( input, "MS932" ) );
+    EXPECT_EQ( result, MISC::url_encode_plus( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeSplitTest, encoded_ascii_characters)
+TEST_F(MISC_UrlEncodePlusWithEncodingTest, encoded_ascii_characters)
 {
     std::string input = "!\"#$%&\'()_+,_/_:;<=>?@_[\\]^_`_{|}~";
     std::string_view result = "%21%22%23%24%25%26%27%28%29_%2B%2C_%2F_"
                               "%3A%3B%3C%3D%3E%3F%40_%5B%5C%5D%5E_%60_%7B%7C%7D%7E";
-    EXPECT_EQ( result, MISC::charset_url_encode_split( input, "MS932" ) );
+    EXPECT_EQ( result, MISC::url_encode_plus( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeSplitTest, encoded_to_ms932)
+TEST_F(MISC_UrlEncodePlusWithEncodingTest, encoded_to_ms932)
 {
     std::string input = "\xE3\x81\x82"; // U+3042
     std::string_view result = "%82%A0";
-    EXPECT_EQ( result, MISC::charset_url_encode_split( input, "MS932" ) );
+    EXPECT_EQ( result, MISC::url_encode_plus( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeSplitTest, encoded_to_eucjp)
+TEST_F(MISC_UrlEncodePlusWithEncodingTest, encoded_to_eucjp)
 {
     std::string input = "\xE3\x81\x82"; // U+3042
     std::string_view result = "%A4%A2";
-    EXPECT_EQ( result, MISC::charset_url_encode_split( input, "EUCJP-MS" ) );
+    EXPECT_EQ( result, MISC::url_encode_plus( input, "EUCJP-MS" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeSplitTest, url_to_ms932)
+TEST_F(MISC_UrlEncodePlusWithEncodingTest, url_to_ms932)
 {
     std::string input = "https://jdim.test/い ろ/は?に=ほ&へ=と z";
     std::string_view result = "https%3A%2F%2Fjdim.test%2F%82%A2+%82%EB%2F"
                               "%82%CD%3F%82%C9%3D%82%D9%26%82%D6%3D%82%C6+z";
-    EXPECT_EQ( result, MISC::charset_url_encode_split( input, "MS932" ) );
+    EXPECT_EQ( result, MISC::url_encode_plus( input, "MS932" ) );
 }
 
 


### PR DESCRIPTION
`MISC::charset_url_encode_split()`はsplitとついていますが返り値とは関係ない内部の操作を表していて分かりにくい名称になっています。
そのため関数の名称を変更してインターフェースをオーバーロードとしてまとめて整理します。
