### PR TITLE
Rename MISC::charset_url_encode() with url_encode()

### DIFF
--- a/src/dbtree/article2ch.cpp
+++ b/src/dbtree/article2ch.cpp
@@ -35,13 +35,13 @@ std::string Article2ch::create_write_message( const std::string& name, const std
     const std::string charset = DBTREE::board_charset( get_url() );
 
     std::stringstream ss_post;
-    ss_post << "FROM=" << MISC::charset_url_encode( name, charset )
-            << "&mail=" << MISC::charset_url_encode( mail, charset )
-            << "&MESSAGE=" << MISC::charset_url_encode( msg, charset )
+    ss_post << "FROM=" << MISC::url_encode( name, charset )
+            << "&mail=" << MISC::url_encode( mail, charset )
+            << "&MESSAGE=" << MISC::url_encode( msg, charset )
             << "&bbs=" << DBTREE::board_id( get_url() )
             << "&key=" << get_key()
             << "&time=" << get_time_modified()
-            << "&submit=" << MISC::charset_url_encode( "書き込む", charset )
+            << "&submit=" << MISC::url_encode( "書き込む", charset )
             // XXX: ブラウザの種類に関係なく含めて問題ないか？
             << "&oekaki_thread1=";
 

--- a/src/dbtree/article2chcompati.cpp
+++ b/src/dbtree/article2chcompati.cpp
@@ -49,10 +49,10 @@ std::string Article2chCompati::create_write_message( const std::string& name, co
     ss_post << "bbs="      << DBTREE::board_id( get_url() )
             << "&key="     << get_key()
             << "&time="    << get_time_modified()
-            << "&submit="  << MISC::charset_url_encode( "書き込む", charset )
-            << "&FROM="    << MISC::charset_url_encode( name, charset )
-            << "&mail="    << MISC::charset_url_encode( mail, charset )
-            << "&MESSAGE=" << MISC::charset_url_encode( msg, charset );
+            << "&submit="  << MISC::url_encode( "書き込む", charset )
+            << "&FROM="    << MISC::url_encode( name, charset )
+            << "&mail="    << MISC::url_encode( mail, charset )
+            << "&MESSAGE=" << MISC::url_encode( msg, charset );
 
 #ifdef _DEBUG
     std::cout << "Article2chCompati::create_write_message " << ss_post.str() << std::endl;

--- a/src/dbtree/articlejbbs.cpp
+++ b/src/dbtree/articlejbbs.cpp
@@ -48,10 +48,10 @@ std::string ArticleJBBS::create_write_message( const std::string& name, const st
             << "&KEY="     << get_key()
             << "&DIR="     << dir
             << "&TIME="    << get_time_modified()
-            << "&submit="  << MISC::charset_url_encode( "書き込む", charset )
-            << "&NAME="    << MISC::charset_url_encode( name, charset )
-            << "&MAIL="    << MISC::charset_url_encode( mail, charset )
-            << "&MESSAGE=" << MISC::charset_url_encode( msg, charset );
+            << "&submit="  << MISC::url_encode( "書き込む", charset )
+            << "&NAME="    << MISC::url_encode( name, charset )
+            << "&MAIL="    << MISC::url_encode( mail, charset )
+            << "&MESSAGE=" << MISC::url_encode( msg, charset );
 
 #ifdef _DEBUG
     std::cout << "Articlejbbs::create_write_message " << ss_post.str() << std::endl;

--- a/src/dbtree/articlemachi.cpp
+++ b/src/dbtree/articlemachi.cpp
@@ -44,10 +44,10 @@ std::string ArticleMachi::create_write_message( const std::string& name, const s
     ss_post << "BBS="      << DBTREE::board_id( get_url() )
             << "&KEY="     << get_key()
             << "&TIME="    << get_time_modified()
-            << "&submit="  << MISC::charset_url_encode( "書き込む", charset )
-            << "&NAME="    << MISC::charset_url_encode( name, charset )
-            << "&MAIL="    << MISC::charset_url_encode( mail, charset )
-            << "&MESSAGE=" << MISC::charset_url_encode( msg, charset );
+            << "&submit="  << MISC::url_encode( "書き込む", charset )
+            << "&NAME="    << MISC::url_encode( name, charset )
+            << "&MAIL="    << MISC::url_encode( mail, charset )
+            << "&MESSAGE=" << MISC::url_encode( msg, charset );
 
 #ifdef _DEBUG
     std::cout << "ArticleMachi::create_write_message " << ss_post.str() << std::endl;

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -220,11 +220,11 @@ std::string Board2ch::create_newarticle_message( const std::string& subject, con
     }
 
     std::stringstream ss_post;
-    ss_post << "submit="   << MISC::charset_url_encode( "新規スレッド作成", get_charset() )
-            << "&subject=" << MISC::charset_url_encode( subject, get_charset() )
-            << "&FROM="    << MISC::charset_url_encode( name, get_charset() )
-            << "&mail="    << MISC::charset_url_encode( mail, get_charset() )
-            << "&MESSAGE=" << MISC::charset_url_encode( msg, get_charset() )
+    ss_post << "submit="   << MISC::url_encode( "新規スレッド作成", get_charset() )
+            << "&subject=" << MISC::url_encode( subject, get_charset() )
+            << "&FROM="    << MISC::url_encode( name, get_charset() )
+            << "&mail="    << MISC::url_encode( mail, get_charset() )
+            << "&MESSAGE=" << MISC::url_encode( msg, get_charset() )
             << "&bbs="     << get_id()
             << "&time="    << m_frontloader->get_time_modified();
 

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -117,9 +117,9 @@ std::string Board2chCompati::analyze_keyword_impl( const std::string& html, bool
 
         // キーワード取得
         if( ! keyword.empty() ) keyword.push_back( '&' );
-        keyword.append( MISC::charset_url_encode( d.name, get_charset() ) );
+        keyword.append( MISC::url_encode( d.name, get_charset() ) );
         keyword.push_back( '=' );
-        keyword.append( MISC::charset_url_encode( d.value, get_charset() ) );
+        keyword.append( MISC::url_encode( d.value, get_charset() ) );
     }
 #ifdef _DEBUG
     std::cout << "Board2chCompati::analyze_keyword_impl form data = " << keyword << std::endl;
@@ -185,12 +185,12 @@ std::string Board2chCompati::create_newarticle_message( const std::string& subje
     std::stringstream ss_post;
     ss_post.clear();
     ss_post << "bbs="      << get_id()
-            << "&subject=" << MISC::charset_url_encode( subject, get_charset() )
+            << "&subject=" << MISC::url_encode( subject, get_charset() )
             << "&time="    << get_time_modified()
-            << "&submit="  << MISC::charset_url_encode( "新規スレッド作成", get_charset() )
-            << "&FROM="    << MISC::charset_url_encode( name, get_charset() )
-            << "&mail="    << MISC::charset_url_encode( mail, get_charset() )
-            << "&MESSAGE=" << MISC::charset_url_encode( msg, get_charset() );
+            << "&submit="  << MISC::url_encode( "新規スレッド作成", get_charset() )
+            << "&FROM="    << MISC::url_encode( name, get_charset() )
+            << "&mail="    << MISC::url_encode( mail, get_charset() )
+            << "&MESSAGE=" << MISC::url_encode( msg, get_charset() );
 
 #ifdef _DEBUG
     std::cout << "Board2chCompati::create_newarticle_message " << ss_post.str() << std::endl;

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -111,11 +111,11 @@ std::string BoardJBBS::create_newarticle_message( const std::string& subject, co
 
     std::stringstream ss_post;
     ss_post.clear();
-    ss_post << "SUBJECT="  << MISC::charset_url_encode( subject, get_charset() )
-            << "&submit="  << MISC::charset_url_encode( "新規書き込み", get_charset() )
-            << "&NAME="    << MISC::charset_url_encode( name, get_charset() )
-            << "&MAIL="    << MISC::charset_url_encode( mail, get_charset() )
-            << "&MESSAGE=" << MISC::charset_url_encode( msg, get_charset() )
+    ss_post << "SUBJECT="  << MISC::url_encode( subject, get_charset() )
+            << "&submit="  << MISC::url_encode( "新規書き込み", get_charset() )
+            << "&NAME="    << MISC::url_encode( name, get_charset() )
+            << "&MAIL="    << MISC::url_encode( mail, get_charset() )
+            << "&MESSAGE=" << MISC::url_encode( msg, get_charset() )
             << "&DIR="     << dir
             << "&BBS="     << bbs
             << "&TIME="    << get_time_modified();

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1358,7 +1358,7 @@ std::string MISC::url_decode( std::string_view url )
  *
  * @param[in] str 入力文字列 (文字エンコーディングは任意)
  * @return パーセント符号化された文字列
- * @see MISC::charset_url_encode( const std::string& utf8str, const std::string& charset )
+ * @see MISC::url_encode( const std::string& utf8str, const std::string& encoding )
 */
 std::string MISC::url_encode( std::string_view str )
 {
@@ -1382,17 +1382,17 @@ std::string MISC::url_encode( std::string_view str )
 
 /** @brief UTF-8文字列をエンコーディング変換してからパーセント符号化して返す
  *
- * @details `utf8str` を `charset` で指定した文字エンコーディングに変換してから符号化する。
+ * @details `utf8str` を `encoding` で指定した文字エンコーディングに変換してから符号化する。
  * @param[in] utf8str 入力文字列 (文字エンコーディングはUTF-8)
- * @param[in] charset 変換先の文字エンコーディング名
+ * @param[in] encoding 変換先の文字エンコーディング名
  * @return パーセント符号化された文字列
  * @see MISC::url_encode( std::string_view str )
 */
-std::string MISC::charset_url_encode( const std::string& utf8str, const std::string& charset )
+std::string MISC::url_encode( const std::string& utf8str, const std::string& encoding )
 {
-    if( charset.empty() || charset == "UTF-8" ) return MISC::url_encode( utf8str );
+    if( encoding.empty() || encoding == "UTF-8" ) return MISC::url_encode( utf8str );
 
-    const std::string str_enc = MISC::Iconv( utf8str, charset, "UTF-8" );
+    const std::string str_enc = MISC::Iconv( utf8str, encoding, "UTF-8" );
     return  MISC::url_encode( str_enc );
 }
 

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -175,10 +175,10 @@ namespace MISC
     std::string url_decode( std::string_view url );
 
     /// 文字列(バイト列)をパーセント符号化して返す
-    std::string url_encode( std::string_view byte_str );
+    std::string url_encode( std::string_view str );
 
     /// UTF-8文字列をエンコーディング変換してからパーセント符号化して返す
-    std::string charset_url_encode( const std::string& utf8str, const std::string& charset );
+    std::string url_encode( const std::string& utf8str, const std::string& encoding );
 
     /// application/x-www-form-urlencoded の形式でパーセント符号化する
     std::string url_encode_plus( std::string_view str );

--- a/src/loginbe.cpp
+++ b/src/loginbe.cpp
@@ -110,7 +110,7 @@ void LoginBe::start_login()
     data.contenttype = "application/x-www-form-urlencoded";
     data.str_post = "m=" + MISC::url_encode( get_username() );
     data.str_post += "&p=" + MISC::url_encode( get_passwd() );
-    data.str_post += "&submit=" + MISC::charset_url_encode( "登録", "EUC-JP" );
+    data.str_post += "&submit=" + MISC::url_encode( "登録", "EUC-JP" );
 
     logout();
     if( m_rawdata.capacity() < SIZE_OF_RAWDATA ) m_rawdata.reserve( SIZE_OF_RAWDATA );

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -1890,72 +1890,72 @@ TEST_F(MISC_UrlEncodeTest, url_utf8)
 }
 
 
-class MISC_CharsetUrlEncodeTest : public ::testing::Test {};
+class MISC_UrlEncodeWithEncodingTest : public ::testing::Test {};
 
-TEST_F(MISC_CharsetUrlEncodeTest, empty_string)
+TEST_F(MISC_UrlEncodeWithEncodingTest, empty_string)
 {
     std::string input = "";
-    EXPECT_EQ( "", MISC::charset_url_encode( input, "MS932" ) );
+    EXPECT_EQ( "", MISC::url_encode( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeTest, unencoded_ascii_characters)
+TEST_F(MISC_UrlEncodeWithEncodingTest, unencoded_ascii_characters)
 {
     std::string input = "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz*-._";
-    EXPECT_EQ( input, MISC::charset_url_encode( input, "MS932" ) );
+    EXPECT_EQ( input, MISC::url_encode( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeTest, u0020)
+TEST_F(MISC_UrlEncodeWithEncodingTest, u0020)
 {
     std::string input = " ";
-    EXPECT_EQ( "%20", MISC::charset_url_encode( input, "MS932" ) );
+    EXPECT_EQ( "%20", MISC::url_encode( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeTest, u000A)
+TEST_F(MISC_UrlEncodeWithEncodingTest, u000A)
 {
     std::string input = "quick\nbrown\n\nfox";
-    EXPECT_EQ( "quick%0Abrown%0A%0Afox", MISC::charset_url_encode( input, "MS932" ) );
+    EXPECT_EQ( "quick%0Abrown%0A%0Afox", MISC::url_encode( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeTest, u000D)
+TEST_F(MISC_UrlEncodeWithEncodingTest, u000D)
 {
     std::string input = "quick\rbrown\r\rfox";
-    EXPECT_EQ( "quick%0Dbrown%0D%0Dfox", MISC::charset_url_encode( input, "MS932" ) );
+    EXPECT_EQ( "quick%0Dbrown%0D%0Dfox", MISC::url_encode( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeTest, u000D_u000A)
+TEST_F(MISC_UrlEncodeWithEncodingTest, u000D_u000A)
 {
     std::string input = "quick\r\nbrown\r\n\r\nfox";
-    EXPECT_EQ( "quick%0D%0Abrown%0D%0A%0D%0Afox", MISC::charset_url_encode( input, "MS932" ) );
+    EXPECT_EQ( "quick%0D%0Abrown%0D%0A%0D%0Afox", MISC::url_encode( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeTest, encoded_ascii_characters)
+TEST_F(MISC_UrlEncodeWithEncodingTest, encoded_ascii_characters)
 {
     std::string input = "!\"#$%&\'()_+,_/_:;<=>?@_[\\]^_`_{|}~";
     std::string_view result = "%21%22%23%24%25%26%27%28%29_%2B%2C_%2F_"
                               "%3A%3B%3C%3D%3E%3F%40_%5B%5C%5D%5E_%60_%7B%7C%7D%7E";
-    EXPECT_EQ( result, MISC::charset_url_encode( input, "MS932" ) );
+    EXPECT_EQ( result, MISC::url_encode( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeTest, encoded_to_ms932)
+TEST_F(MISC_UrlEncodeWithEncodingTest, encoded_to_ms932)
 {
     std::string input = "\xE3\x81\x82"; // U+3042
     std::string_view result = "%82%A0";
-    EXPECT_EQ( result, MISC::charset_url_encode( input, "MS932" ) );
+    EXPECT_EQ( result, MISC::url_encode( input, "MS932" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeTest, encoded_to_eucjp)
+TEST_F(MISC_UrlEncodeWithEncodingTest, encoded_to_eucjp)
 {
     std::string input = "\xE3\x81\x82"; // U+3042
     std::string_view result = "%A4%A2";
-    EXPECT_EQ( result, MISC::charset_url_encode( input, "EUCJP-MS" ) );
+    EXPECT_EQ( result, MISC::url_encode( input, "EUCJP-MS" ) );
 }
 
-TEST_F(MISC_CharsetUrlEncodeTest, url_to_ms932)
+TEST_F(MISC_UrlEncodeWithEncodingTest, url_to_ms932)
 {
     std::string input = "https://jdim.test/い ろ/は?に=ほ&へ=と z";
     std::string_view result = "https%3A%2F%2Fjdim.test%2F%82%A2%20%82%EB%2F"
                               "%82%CD%3F%82%C9%3D%82%D9%26%82%D6%3D%82%C6%20z";
-    EXPECT_EQ( result, MISC::charset_url_encode( input, "MS932" ) );
+    EXPECT_EQ( result, MISC::url_encode( input, "MS932" ) );
 }
 
 


### PR DESCRIPTION
`MISC::url_encode_plus()`の関数オーバーロードと同様に`MISC::charset_url_encode()`を`MISC::url_encode()`に名称変更してまとめることでコードを整理します。
