### PR TITLE
Apply MISC::url_encode_plus() to encode HTML form data

### DIFF
--- a/src/dbtree/article2ch.cpp
+++ b/src/dbtree/article2ch.cpp
@@ -35,13 +35,13 @@ std::string Article2ch::create_write_message( const std::string& name, const std
     const std::string charset = DBTREE::board_charset( get_url() );
 
     std::stringstream ss_post;
-    ss_post << "FROM=" << MISC::url_encode( name, charset )
-            << "&mail=" << MISC::url_encode( mail, charset )
-            << "&MESSAGE=" << MISC::url_encode( msg, charset )
+    ss_post << "FROM=" << MISC::url_encode_plus( name, charset )
+            << "&mail=" << MISC::url_encode_plus( mail, charset )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, charset )
             << "&bbs=" << DBTREE::board_id( get_url() )
             << "&key=" << get_key()
             << "&time=" << get_time_modified()
-            << "&submit=" << MISC::url_encode( "書き込む", charset )
+            << "&submit=" << MISC::url_encode_plus( "書き込む", charset )
             // XXX: ブラウザの種類に関係なく含めて問題ないか？
             << "&oekaki_thread1=";
 
@@ -52,7 +52,7 @@ std::string Article2ch::create_write_message( const std::string& name, const std
     // ログイン中
     if( CORE::get_login2ch()->login_now() ){
                 std::string sid = CORE::get_login2ch()->get_sessionid();
-                ss_post << "&sid=" << MISC::url_encode( sid );
+                ss_post << "&sid=" << MISC::url_encode_plus( sid );
     }
 
 #ifdef _DEBUG

--- a/src/dbtree/article2chcompati.cpp
+++ b/src/dbtree/article2chcompati.cpp
@@ -49,10 +49,10 @@ std::string Article2chCompati::create_write_message( const std::string& name, co
     ss_post << "bbs="      << DBTREE::board_id( get_url() )
             << "&key="     << get_key()
             << "&time="    << get_time_modified()
-            << "&submit="  << MISC::url_encode( "書き込む", charset )
-            << "&FROM="    << MISC::url_encode( name, charset )
-            << "&mail="    << MISC::url_encode( mail, charset )
-            << "&MESSAGE=" << MISC::url_encode( msg, charset );
+            << "&submit="  << MISC::url_encode_plus( "書き込む", charset )
+            << "&FROM="    << MISC::url_encode_plus( name, charset )
+            << "&mail="    << MISC::url_encode_plus( mail, charset )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, charset );
 
 #ifdef _DEBUG
     std::cout << "Article2chCompati::create_write_message " << ss_post.str() << std::endl;

--- a/src/dbtree/articlejbbs.cpp
+++ b/src/dbtree/articlejbbs.cpp
@@ -48,10 +48,10 @@ std::string ArticleJBBS::create_write_message( const std::string& name, const st
             << "&KEY="     << get_key()
             << "&DIR="     << dir
             << "&TIME="    << get_time_modified()
-            << "&submit="  << MISC::url_encode( "書き込む", charset )
-            << "&NAME="    << MISC::url_encode( name, charset )
-            << "&MAIL="    << MISC::url_encode( mail, charset )
-            << "&MESSAGE=" << MISC::url_encode( msg, charset );
+            << "&submit="  << MISC::url_encode_plus( "書き込む", charset )
+            << "&NAME="    << MISC::url_encode_plus( name, charset )
+            << "&MAIL="    << MISC::url_encode_plus( mail, charset )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, charset );
 
 #ifdef _DEBUG
     std::cout << "Articlejbbs::create_write_message " << ss_post.str() << std::endl;

--- a/src/dbtree/articlemachi.cpp
+++ b/src/dbtree/articlemachi.cpp
@@ -44,10 +44,10 @@ std::string ArticleMachi::create_write_message( const std::string& name, const s
     ss_post << "BBS="      << DBTREE::board_id( get_url() )
             << "&KEY="     << get_key()
             << "&TIME="    << get_time_modified()
-            << "&submit="  << MISC::url_encode( "書き込む", charset )
-            << "&NAME="    << MISC::url_encode( name, charset )
-            << "&MAIL="    << MISC::url_encode( mail, charset )
-            << "&MESSAGE=" << MISC::url_encode( msg, charset );
+            << "&submit="  << MISC::url_encode_plus( "書き込む", charset )
+            << "&NAME="    << MISC::url_encode_plus( name, charset )
+            << "&MAIL="    << MISC::url_encode_plus( mail, charset )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, charset );
 
 #ifdef _DEBUG
     std::cout << "ArticleMachi::create_write_message " << ss_post.str() << std::endl;

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -220,11 +220,11 @@ std::string Board2ch::create_newarticle_message( const std::string& subject, con
     }
 
     std::stringstream ss_post;
-    ss_post << "submit="   << MISC::url_encode( "新規スレッド作成", get_charset() )
-            << "&subject=" << MISC::url_encode( subject, get_charset() )
-            << "&FROM="    << MISC::url_encode( name, get_charset() )
-            << "&mail="    << MISC::url_encode( mail, get_charset() )
-            << "&MESSAGE=" << MISC::url_encode( msg, get_charset() )
+    ss_post << "submit="   << MISC::url_encode_plus( "新規スレッド作成", get_charset() )
+            << "&subject=" << MISC::url_encode_plus( subject, get_charset() )
+            << "&FROM="    << MISC::url_encode_plus( name, get_charset() )
+            << "&mail="    << MISC::url_encode_plus( mail, get_charset() )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_charset() )
             << "&bbs="     << get_id()
             << "&time="    << m_frontloader->get_time_modified();
 
@@ -236,7 +236,7 @@ std::string Board2ch::create_newarticle_message( const std::string& subject, con
     // sidを送る
     if( CORE::get_login2ch()->login_now() ){
         std::string sid = CORE::get_login2ch()->get_sessionid();
-        ss_post << "&sid=" << MISC::url_encode( sid );
+        ss_post << "&sid=" << MISC::url_encode_plus( sid );
     }
 
 #ifdef _DEBUG

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -117,9 +117,9 @@ std::string Board2chCompati::analyze_keyword_impl( const std::string& html, bool
 
         // キーワード取得
         if( ! keyword.empty() ) keyword.push_back( '&' );
-        keyword.append( MISC::url_encode( d.name, get_charset() ) );
+        keyword.append( MISC::url_encode_plus( d.name, get_charset() ) );
         keyword.push_back( '=' );
-        keyword.append( MISC::url_encode( d.value, get_charset() ) );
+        keyword.append( MISC::url_encode_plus( d.value, get_charset() ) );
     }
 #ifdef _DEBUG
     std::cout << "Board2chCompati::analyze_keyword_impl form data = " << keyword << std::endl;
@@ -185,12 +185,12 @@ std::string Board2chCompati::create_newarticle_message( const std::string& subje
     std::stringstream ss_post;
     ss_post.clear();
     ss_post << "bbs="      << get_id()
-            << "&subject=" << MISC::url_encode( subject, get_charset() )
+            << "&subject=" << MISC::url_encode_plus( subject, get_charset() )
             << "&time="    << get_time_modified()
-            << "&submit="  << MISC::url_encode( "新規スレッド作成", get_charset() )
-            << "&FROM="    << MISC::url_encode( name, get_charset() )
-            << "&mail="    << MISC::url_encode( mail, get_charset() )
-            << "&MESSAGE=" << MISC::url_encode( msg, get_charset() );
+            << "&submit="  << MISC::url_encode_plus( "新規スレッド作成", get_charset() )
+            << "&FROM="    << MISC::url_encode_plus( name, get_charset() )
+            << "&mail="    << MISC::url_encode_plus( mail, get_charset() )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_charset() );
 
 #ifdef _DEBUG
     std::cout << "Board2chCompati::create_newarticle_message " << ss_post.str() << std::endl;

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -111,11 +111,11 @@ std::string BoardJBBS::create_newarticle_message( const std::string& subject, co
 
     std::stringstream ss_post;
     ss_post.clear();
-    ss_post << "SUBJECT="  << MISC::url_encode( subject, get_charset() )
-            << "&submit="  << MISC::url_encode( "新規書き込み", get_charset() )
-            << "&NAME="    << MISC::url_encode( name, get_charset() )
-            << "&MAIL="    << MISC::url_encode( mail, get_charset() )
-            << "&MESSAGE=" << MISC::url_encode( msg, get_charset() )
+    ss_post << "SUBJECT="  << MISC::url_encode_plus( subject, get_charset() )
+            << "&submit="  << MISC::url_encode_plus( "新規書き込み", get_charset() )
+            << "&NAME="    << MISC::url_encode_plus( name, get_charset() )
+            << "&MAIL="    << MISC::url_encode_plus( mail, get_charset() )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_charset() )
             << "&DIR="     << dir
             << "&BBS="     << bbs
             << "&TIME="    << get_time_modified();

--- a/src/dbtree/nodetree2ch.cpp
+++ b/src/dbtree/nodetree2ch.cpp
@@ -158,7 +158,7 @@ void NodeTree2ch::create_loaderdata( JDLIB::LOADERDATA& data )
            << regex.str( 4 ) << regex.str( 5 );
 
         std::string sid = CORE::get_login2ch()->get_sessionid();
-        ss << "/?sid=" << MISC::url_encode( sid );
+        ss << "/?sid=" << MISC::url_encode_plus( sid );
 
         // レジューム設定
         // レジュームを有りにして、サーバが range を無視して送ってきた場合と同じ処理をする

--- a/src/loginbe.cpp
+++ b/src/loginbe.cpp
@@ -108,9 +108,9 @@ void LoginBe::start_login()
     data.url = CONFIG::get_url_loginbe();
 
     data.contenttype = "application/x-www-form-urlencoded";
-    data.str_post = "m=" + MISC::url_encode( get_username() );
-    data.str_post += "&p=" + MISC::url_encode( get_passwd() );
-    data.str_post += "&submit=" + MISC::url_encode( "登録", "EUC-JP" );
+    data.str_post = "m=" + MISC::url_encode_plus( get_username() );
+    data.str_post += "&p=" + MISC::url_encode_plus( get_passwd() );
+    data.str_post += "&submit=" + MISC::url_encode_plus( "登録", "EUC-JP" );
 
     logout();
     if( m_rawdata.capacity() < SIZE_OF_RAWDATA ) m_rawdata.reserve( SIZE_OF_RAWDATA );


### PR DESCRIPTION
HTMLフォームのデータ(application/x-www-form-urlencoded)を作成する処理ではより適切にパーセント符号化する`MISC::url_encode_plus()`を使うように変更します。
