### PR TITLE
Use std::find_if() instead of for loops

### DIFF
--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1537,14 +1537,13 @@ bool BoardBase::is_abone_thread( ArticleBase* article )
     
     // スレあぼーん
     if( check_thread ){
-        for( const std::string& subject : m_list_abone_thread ) {
-            if( article->get_subject() == subject ){
-
-                // 対象スレがDat落ちした場合はあぼーんしなかったスレ名をリストから消去する
-                // remove_old_abone_thread() も参照
-                m_list_abone_thread_remove.push_back( subject );
-                return true;
-            }
+        auto it = std::find_if( m_list_abone_thread.cbegin(), m_list_abone_thread.cend(),
+                                [a = article](const std::string& subj) { return a->get_subject() == subj; } );
+        if( it != m_list_abone_thread.cend() ) {
+            // 対象スレがDat落ちした場合はあぼーんしなかったスレ名をリストから消去する
+            // remove_old_abone_thread() も参照
+            m_list_abone_thread_remove.push_back( *it );
+            return true;
         }
     }
 


### PR DESCRIPTION
forループを`std::find_if()`を使ったコードに書き換えます。

cppcheck 2.10のレポート
```
src/article/drawareabase.cpp:3650:29: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
        if( ( *it ).select ){
                            ^
src/dbtree/boardbase.cpp:1542:52: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
            if( article->get_subject() == subject ){
                                                   ^
```
