### PR TITLE
Implement MISC::encoding_to_cstr()

### DIFF
--- a/src/jdencoding.h
+++ b/src/jdencoding.h
@@ -13,9 +13,9 @@
  */
 enum class Encoding
 {
-    unknown = 0, ///< 不明
+    unknown = 0, ///< 不明. エンコーディング名は LATIN1 (ISO-8859-1) として扱う
     ascii, ///< ASCII
-    eucjp, ///< EUC-JP
+    eucjp, ///< WindowsのShift_JISに合わせたEUC-JP (EUCJP-MS)
     jis,   ///< JISコード (ISO-2022-JP)
     sjis,  ///< WindowsのShift_JIS (MS932)
     utf8,  ///< UTF-8

--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -12,6 +12,24 @@
 // チェックする最大バイト数
 #define CHECK_LIMIT 1024
 
+
+static constexpr const char* encoding_string[] = { "ISO-8859-1", "ASCII", "EUCJP-MS", "ISO-2022-JP", "MS932", "UTF-8" };
+
+
+/** @brief `Encoding` から文字エンコーディングを表すヌル終端文字列を取得する
+ *
+ * @param[in] encoding 文字エンコーディング
+ * @return encodingと一致する文字列。
+ * `Encoding::unknown` のとき、または不正な値のなら `"ISO-8859-1"` (Latin1) を返す。
+ */
+const char* MISC::encoding_to_cstr( const Encoding encoding )
+{
+    Encoding enc = encoding;
+    if( enc > Encoding::utf8 || enc < Encoding::unknown ) enc = Encoding::unknown;
+    return encoding_string[ static_cast<int>( enc ) ];
+}
+
+
 /*--- 制御文字とASCII -----------------------------------------------*/
 
 // [ 制御文字 ] 0x00〜0x1F 0x7F

--- a/src/jdlib/misccharcode.h
+++ b/src/jdlib/misccharcode.h
@@ -31,6 +31,7 @@ namespace MISC
         WinToUnix, ///< Windows から Unix へ
     };
 
+    const char* encoding_to_cstr( const Encoding encoding );
     bool is_eucjp( std::string_view input, std::size_t read_byte );
     bool is_jis( std::string_view input, std::size_t& read_byte );
     bool is_sjis( std::string_view input, std::size_t read_byte );

--- a/test/gtest_jdlib_misccharcode.cpp
+++ b/test/gtest_jdlib_misccharcode.cpp
@@ -7,6 +7,45 @@
 
 namespace {
 
+class MISC_EncodingToCstrTest : public ::testing::Test {};
+
+TEST_F(MISC_EncodingToCstrTest, unknown)
+{
+    EXPECT_STREQ( "ISO-8859-1", MISC::encoding_to_cstr( Encoding::unknown ) );
+}
+
+TEST_F(MISC_EncodingToCstrTest, ascii)
+{
+    EXPECT_STREQ( "ASCII", MISC::encoding_to_cstr( Encoding::ascii ) );
+}
+
+TEST_F(MISC_EncodingToCstrTest, eucjp)
+{
+    EXPECT_STREQ( "EUCJP-MS", MISC::encoding_to_cstr( Encoding::eucjp ) );
+}
+
+TEST_F(MISC_EncodingToCstrTest, jis)
+{
+    EXPECT_STREQ( "ISO-2022-JP", MISC::encoding_to_cstr( Encoding::jis ) );
+}
+
+TEST_F(MISC_EncodingToCstrTest, sjis)
+{
+    EXPECT_STREQ( "MS932", MISC::encoding_to_cstr( Encoding::sjis ) );
+}
+
+TEST_F(MISC_EncodingToCstrTest, utf8)
+{
+    EXPECT_STREQ( "UTF-8", MISC::encoding_to_cstr( Encoding::utf8 ) );
+}
+
+TEST_F(MISC_EncodingToCstrTest, invalid_enum)
+{
+    EXPECT_STREQ( "ISO-8859-1", MISC::encoding_to_cstr( static_cast<Encoding>( -200 ) ) );
+    EXPECT_STREQ( "ISO-8859-1", MISC::encoding_to_cstr( static_cast<Encoding>( 200 ) ) );
+}
+
+
 class IsEucjpTest : public ::testing::Test {};
 
 TEST_F(IsEucjpTest, null_data)


### PR DESCRIPTION
`Encoding`列挙型から文字エンコーディングを表すヌル終端文字列を取得する関数を実装します。
`Encoding`の列挙子にない値が指定されたときは "ISO-8859-1" (LATIN1) を返します。

Add test cases `MISC::encoding_to_cstr()`
