### PR TITLE
Implement MISC::encoding_from_cstr()

### DIFF
--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -30,6 +30,22 @@ const char* MISC::encoding_to_cstr( const Encoding encoding )
 }
 
 
+/** @brief 文字エンコーディングを表すヌル終端文字列から`Encoding`を取得する
+ *
+ * @param[in] encoding 文字エンコーディング名 (not null)
+ * @return 文字列と一致する列挙型。見つからなければ `Encoding::unknown` を返す。
+ */
+Encoding MISC::encoding_from_cstr( const char* encoding )
+{
+    assert( encoding );
+
+    for( std::size_t i = sizeof(encoding_string) / sizeof(char*) - 1; i > 0; --i ){
+        if( std::strcmp( encoding_string[i], encoding ) == 0 ) return static_cast<Encoding>( i );
+    }
+    return Encoding::unknown;
+}
+
+
 /*--- 制御文字とASCII -----------------------------------------------*/
 
 // [ 制御文字 ] 0x00〜0x1F 0x7F

--- a/src/jdlib/misccharcode.h
+++ b/src/jdlib/misccharcode.h
@@ -32,6 +32,7 @@ namespace MISC
     };
 
     const char* encoding_to_cstr( const Encoding encoding );
+    Encoding encoding_from_cstr( const char* encoding );
     bool is_eucjp( std::string_view input, std::size_t read_byte );
     bool is_jis( std::string_view input, std::size_t& read_byte );
     bool is_sjis( std::string_view input, std::size_t read_byte );

--- a/test/gtest_jdlib_misccharcode.cpp
+++ b/test/gtest_jdlib_misccharcode.cpp
@@ -46,6 +46,55 @@ TEST_F(MISC_EncodingToCstrTest, invalid_enum)
 }
 
 
+class MISC_EncodingFromCstr : public ::testing::Test {};
+
+TEST_F(MISC_EncodingFromCstr, iso_8859_1)
+{
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "ISO-8859-1" ) );
+}
+
+TEST_F(MISC_EncodingFromCstr, ascii)
+{
+    EXPECT_EQ( Encoding::ascii, MISC::encoding_from_cstr( "ASCII" ) );
+}
+
+TEST_F(MISC_EncodingFromCstr, eucjp_ms)
+{
+    EXPECT_EQ( Encoding::eucjp, MISC::encoding_from_cstr( "EUCJP-MS" ) );
+}
+
+TEST_F(MISC_EncodingFromCstr, iso_2022_jp)
+{
+    EXPECT_EQ( Encoding::jis, MISC::encoding_from_cstr( "ISO-2022-JP" ) );
+}
+
+TEST_F(MISC_EncodingFromCstr, ms932)
+{
+    EXPECT_EQ( Encoding::sjis, MISC::encoding_from_cstr( "MS932" ) );
+}
+
+TEST_F(MISC_EncodingFromCstr, utf8)
+{
+    EXPECT_EQ( Encoding::utf8, MISC::encoding_from_cstr( "UTF-8" ) );
+}
+
+TEST_F(MISC_EncodingFromCstr, invalid_encoding_name)
+{
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "INVALID-ENCODING-NAME" ) );
+}
+
+TEST_F(MISC_EncodingFromCstr, small_case_is_invalid)
+{
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "iso-8859-1" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "ascii" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "eucjp-ms" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "iso-2022-jp" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "ms932" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "utf-8" ) );
+}
+
+
 class IsEucjpTest : public ::testing::Test {};
 
 TEST_F(IsEucjpTest, null_data)


### PR DESCRIPTION
文字エンコーディングを表すヌル終端文字列から`Encoding`列挙型を取得する関数を実装します。
`Encoding`の列挙子と一致しない文字列が渡されたときは`Encoding::unknown` を返します。

Add test cases for MISC::encoding_from_cstr()
