### PR TITLE
Use enum Encoding for conversion functions and encoding settings

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -2375,19 +2375,11 @@ void ArticleViewBase::slot_on_url( const std::string& url, const std::string& im
 
             switch( enc )
             {
+                case Encoding::sjis:
                 case Encoding::eucjp:
-
-                    status_url = MISC::Iconv( tmp, "UTF-8", "EUC-JP" );
-                    break;
-
                 case Encoding::jis:
 
-                    status_url = MISC::Iconv( tmp, "UTF-8", "ISO-2022-JP" );
-                    break;
-
-                case Encoding::sjis:
-
-                    status_url = MISC::Iconv( tmp, "UTF-8", "MS932" );
+                    status_url = MISC::Iconv( tmp, Encoding::utf8, enc );
                     break;
 
                 case Encoding::ascii:

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -10,8 +10,9 @@
 
 #include "skeleton/msgdiag.h"
 
-#include "jdlib/miscutil.h"
+#include "jdlib/misccharcode.h"
 #include "jdlib/misctime.h"
+#include "jdlib/miscutil.h"
 
 #include "config/globalconf.h"
 
@@ -113,7 +114,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
         str_cookies = "クッキー:\n未取得\n";
     }
     else {
-        str_cookies = "クッキー:\n" + MISC::Iconv( temp_cookies, "UTF-8", DBTREE::board_charset( get_url() ) ) + "\n";
+        str_cookies = "クッキー:\n" + MISC::Iconv( temp_cookies, Encoding::utf8, DBTREE::board_encoding( get_url() ) ) + "\n";
     }
 
     std::string keyword = DBTREE::board_keyword_for_write( get_url() );

--- a/src/dbtree/article2ch.cpp
+++ b/src/dbtree/article2ch.cpp
@@ -7,8 +7,9 @@
 #include "nodetree2ch.h"
 #include "interface.h"
 
-#include "jdlib/miscutil.h"
+#include "jdlib/misccharcode.h"
 #include "jdlib/misctime.h"
+#include "jdlib/miscutil.h"
 
 #include "config/globalconf.h"
 
@@ -19,8 +20,8 @@
 using namespace DBTREE;
 
 
-Article2ch::Article2ch( const std::string& datbase, const std::string& id, bool cached )
-    : Article2chCompati( datbase, id, cached )
+Article2ch::Article2ch( const std::string& datbase, const std::string& id, bool cached, const Encoding enc )
+    : Article2chCompati( datbase, id, cached, enc )
 {}
 
 
@@ -32,16 +33,14 @@ std::string Article2ch::create_write_message( const std::string& name, const std
 {
     if( msg.empty() ) return std::string();
 
-    const std::string charset = DBTREE::board_charset( get_url() );
-
     std::stringstream ss_post;
-    ss_post << "FROM=" << MISC::url_encode_plus( name, charset )
-            << "&mail=" << MISC::url_encode_plus( mail, charset )
-            << "&MESSAGE=" << MISC::url_encode_plus( msg, charset )
+    ss_post << "FROM=" << MISC::url_encode_plus( name, get_encoding() )
+            << "&mail=" << MISC::url_encode_plus( mail, get_encoding() )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_encoding() )
             << "&bbs=" << DBTREE::board_id( get_url() )
             << "&key=" << get_key()
             << "&time=" << get_time_modified()
-            << "&submit=" << MISC::url_encode_plus( "書き込む", charset )
+            << "&submit=" << MISC::url_encode_plus( "書き込む", get_encoding() )
             // XXX: ブラウザの種類に関係なく含めて問題ないか？
             << "&oekaki_thread1=";
 
@@ -51,8 +50,8 @@ std::string Article2ch::create_write_message( const std::string& name, const std
 
     // ログイン中
     if( CORE::get_login2ch()->login_now() ){
-                std::string sid = CORE::get_login2ch()->get_sessionid();
-                ss_post << "&sid=" << MISC::url_encode_plus( sid );
+        const std::string sid = CORE::get_login2ch()->get_sessionid();
+        ss_post << "&sid=" << MISC::url_encode_plus( sid );
     }
 
 #ifdef _DEBUG

--- a/src/dbtree/article2ch.h
+++ b/src/dbtree/article2ch.h
@@ -15,7 +15,7 @@ namespace DBTREE
     {
       public:
 
-        Article2ch( const std::string& datbase, const std::string& id, bool cached );
+        Article2ch( const std::string& datbase, const std::string& id, bool cached, const Encoding enc );
         ~Article2ch() noexcept;
 
         // 書き込みメッセージ変換

--- a/src/dbtree/article2chcompati.cpp
+++ b/src/dbtree/article2chcompati.cpp
@@ -16,8 +16,9 @@
 
 using namespace DBTREE;
 
-Article2chCompati::Article2chCompati( const std::string& datbase, const std::string& _id, bool cached )
-    : ArticleBase( datbase, _id, cached )
+Article2chCompati::Article2chCompati( const std::string& datbase, const std::string& _id, bool cached,
+                                      const Encoding enc )
+    : ArticleBase( datbase, _id, cached, enc )
 {
     assert( ! get_id().empty() );
 
@@ -42,17 +43,15 @@ std::string Article2chCompati::create_write_message( const std::string& name, co
 {
     if( msg.empty() ) return std::string();
 
-    std::string charset = DBTREE::board_charset( get_url() );
-
     std::stringstream ss_post;
     ss_post.clear();
     ss_post << "bbs="      << DBTREE::board_id( get_url() )
             << "&key="     << get_key()
             << "&time="    << get_time_modified()
-            << "&submit="  << MISC::url_encode_plus( "書き込む", charset )
-            << "&FROM="    << MISC::url_encode_plus( name, charset )
-            << "&mail="    << MISC::url_encode_plus( mail, charset )
-            << "&MESSAGE=" << MISC::url_encode_plus( msg, charset );
+            << "&submit="  << MISC::url_encode_plus( "書き込む", get_encoding() )
+            << "&FROM="    << MISC::url_encode_plus( name, get_encoding() )
+            << "&mail="    << MISC::url_encode_plus( mail, get_encoding() )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_encoding() );
 
 #ifdef _DEBUG
     std::cout << "Article2chCompati::create_write_message " << ss_post.str() << std::endl;

--- a/src/dbtree/article2chcompati.h
+++ b/src/dbtree/article2chcompati.h
@@ -15,7 +15,7 @@ namespace DBTREE
     {
       public:
 
-        Article2chCompati( const std::string& datbase, const std::string& id, bool cached );
+        Article2chCompati( const std::string& datbase, const std::string& id, bool cached, const Encoding enc );
         ~Article2chCompati() noexcept;
 
         // 書き込みメッセージ変換

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -9,10 +9,11 @@
 
 #include "skeleton/msgdiag.h"
 
-#include "jdlib/miscutil.h"
-#include "jdlib/misctime.h"
-#include "jdlib/miscmsg.h"
 #include "jdlib/jdregex.h"
+#include "jdlib/misccharcode.h"
+#include "jdlib/miscmsg.h"
+#include "jdlib/misctime.h"
+#include "jdlib/miscutil.h"
 #include "jdlib/tfidf.h"
 
 #include "dbimg/imginterface.h"
@@ -63,11 +64,12 @@ if( it2 != lines.end() ){ \
 
 
 
-ArticleBase::ArticleBase( const std::string& datbase, const std::string& id, bool cached )
+ArticleBase::ArticleBase( const std::string& datbase, const std::string& id, bool cached, const Encoding enc )
     : SKELETON::Lockable()
     , m_id( id )
     , m_code( HTTP_INIT )
     , m_status( STATUS_UNKNOWN )
+    , m_encoding( enc )
     , m_abone_board( true )
     , m_abone_global( true )
     , m_cached( cached )
@@ -1924,6 +1926,10 @@ void ArticleBase::read_info()
         GET_INFOVALUE( str_tmp, "status = " );
         if( ! str_tmp.empty() ) m_status = atoi( str_tmp.c_str() );
 
+        // charset
+        GET_INFOVALUE( str_tmp, "charset = " );
+        if( ! str_tmp.empty() ) set_encoding( MISC::encoding_from_cstr( str_tmp.c_str() ) );
+
         // あぼーん ID
         GET_INFOVALUE( str_tmp, "aboneid = " );
         if( ! str_tmp.empty() ) m_list_abone_id = MISC::strtolist( str_tmp );
@@ -2090,6 +2096,7 @@ void ArticleBase::read_info()
               << "writefixname = " << m_write_fixname << std::endl
               << "writefixmail = " << m_write_fixmail << std::endl
               << "status = " << m_status << std::endl
+              << "encoding = " << MISC::encoding_to_cstr( get_encoding() ) << std::endl
               << "transparent_abone = " << m_abone_transparent << std::endl
               << "bookmarked_thread = " << m_bookmarked_thread << std::endl
     ;
@@ -2217,6 +2224,7 @@ void ArticleBase::save_info( const bool force )
          << "writefixname = " << m_write_fixname << std::endl
          << "writefixmail = " << m_write_fixmail << std::endl
          << "status = " << m_status << std::endl
+         << "charset = " << MISC::encoding_to_cstr( get_encoding() ) << std::endl
          << "aboneid = " << str_abone_id << std::endl
          << "abonename = " << str_abone_name << std::endl
          << "bookmark = " << ss_bookmark.str() << std::endl

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -9,6 +9,8 @@
 #ifndef _ARTICLEBASE_H
 #define _ARTICLEBASE_H
 
+#include "jdencoding.h"
+
 #include "skeleton/lockable.h"
 
 #include <ctime>
@@ -46,6 +48,8 @@ namespace DBTREE
         std::string m_str_code;      // HTTPコード(文字列)
         std::string m_ext_err;       // HTTPコード以外のエラーメッセージ
         int m_status;                // 状態 ( global.h で定義 )
+
+        Encoding m_encoding;         // 文字エンコーディング
 
         // 移転する前にこのスレがあった旧ホスト名( 移転していないなら m_url に含まれているホスト名と同じ )
         // 詳しくはコンストラクタの説明を参照せよ
@@ -121,7 +125,7 @@ namespace DBTREE
 
       public:
 
-        ArticleBase( const std::string& datbase, const std::string& id, bool cached );
+        ArticleBase( const std::string& datbase, const std::string& id, bool cached, const Encoding enc );
         ~ArticleBase();
 
         bool empty() const noexcept { return m_url.empty(); }
@@ -151,6 +155,10 @@ namespace DBTREE
         int get_number_load() const noexcept { return m_number_load; }
         int get_number_seen() const noexcept {  return m_number_seen; }
         int get_number_max() const noexcept { return m_number_max; }
+
+        // 文字エンコーディング
+        Encoding get_encoding() const noexcept { return m_encoding; }
+        void set_encoding( const Encoding encoding ){ m_encoding = encoding; }
 
         // スレ速度
         int get_speed() const;

--- a/src/dbtree/articlejbbs.cpp
+++ b/src/dbtree/articlejbbs.cpp
@@ -14,8 +14,8 @@
 
 using namespace DBTREE;
 
-ArticleJBBS::ArticleJBBS( const std::string& datbase, const std::string& _id, bool cached )
-    : ArticleBase( datbase, _id, cached )
+ArticleJBBS::ArticleJBBS( const std::string& datbase, const std::string& _id, bool cached, const Encoding enc )
+    : ArticleBase( datbase, _id, cached, enc )
 {
     assert( ! get_id().empty() );
 
@@ -34,8 +34,6 @@ std::string ArticleJBBS::create_write_message( const std::string& name, const st
 {
     if( msg.empty() ) return std::string();
 
-    std::string charset = DBTREE::board_charset( get_url() );
-
     // DIR と BBS を分離する( ID = DIR/BBS )
     std::string boardid = DBTREE::board_id( get_url() );
     int i = boardid.find( '/' );
@@ -48,10 +46,10 @@ std::string ArticleJBBS::create_write_message( const std::string& name, const st
             << "&KEY="     << get_key()
             << "&DIR="     << dir
             << "&TIME="    << get_time_modified()
-            << "&submit="  << MISC::url_encode_plus( "書き込む", charset )
-            << "&NAME="    << MISC::url_encode_plus( name, charset )
-            << "&MAIL="    << MISC::url_encode_plus( mail, charset )
-            << "&MESSAGE=" << MISC::url_encode_plus( msg, charset );
+            << "&submit="  << MISC::url_encode_plus( "書き込む", get_encoding() )
+            << "&NAME="    << MISC::url_encode_plus( name, get_encoding() )
+            << "&MAIL="    << MISC::url_encode_plus( mail, get_encoding() )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_encoding() );
 
 #ifdef _DEBUG
     std::cout << "Articlejbbs::create_write_message " << ss_post.str() << std::endl;

--- a/src/dbtree/articlejbbs.h
+++ b/src/dbtree/articlejbbs.h
@@ -17,7 +17,7 @@ namespace DBTREE
     {
       public:
 
-        ArticleJBBS( const std::string& datbase, const std::string& id, bool cached );
+        ArticleJBBS( const std::string& datbase, const std::string& id, bool cached, const Encoding enc );
         ~ArticleJBBS() noexcept;
 
         // 書き込みメッセージ変換

--- a/src/dbtree/articlelocal.cpp
+++ b/src/dbtree/articlelocal.cpp
@@ -10,8 +10,8 @@
 using namespace DBTREE;
 
 
-ArticleLocal::ArticleLocal( const std::string& datbase, const std::string& id )
-    : Article2chCompati( datbase, id, true )
+ArticleLocal::ArticleLocal( const std::string& datbase, const std::string& id, const Encoding enc )
+    : Article2chCompati( datbase, id, true, enc )
 {
 #ifdef _DEBUG
     std::cout << "ArticleLocal::ArticleLocal datbase = " << datbase

--- a/src/dbtree/articlelocal.h
+++ b/src/dbtree/articlelocal.h
@@ -15,7 +15,7 @@ namespace DBTREE
     {
       public:
 
-        ArticleLocal( const std::string& datbase, const std::string& id );
+        ArticleLocal( const std::string& datbase, const std::string& id, const Encoding enc );
         ~ArticleLocal();
 
         // ID がこのスレのものかどうか

--- a/src/dbtree/articlemachi.cpp
+++ b/src/dbtree/articlemachi.cpp
@@ -17,8 +17,8 @@
 using namespace DBTREE;
 
 
-ArticleMachi::ArticleMachi( const std::string& datbase, const std::string& _id, bool cached )
-    : ArticleBase( datbase, _id, cached )
+ArticleMachi::ArticleMachi( const std::string& datbase, const std::string& _id, bool cached, const Encoding enc )
+    : ArticleBase( datbase, _id, cached, enc )
 {
     assert( !get_id().empty() );
 
@@ -37,17 +37,15 @@ std::string ArticleMachi::create_write_message( const std::string& name, const s
 {
     if( msg.empty() ) return std::string();
 
-    std::string charset = DBTREE::board_charset( get_url() );
-
     std::stringstream ss_post;
     ss_post.clear();
     ss_post << "BBS="      << DBTREE::board_id( get_url() )
             << "&KEY="     << get_key()
             << "&TIME="    << get_time_modified()
-            << "&submit="  << MISC::url_encode_plus( "書き込む", charset )
-            << "&NAME="    << MISC::url_encode_plus( name, charset )
-            << "&MAIL="    << MISC::url_encode_plus( mail, charset )
-            << "&MESSAGE=" << MISC::url_encode_plus( msg, charset );
+            << "&submit="  << MISC::url_encode_plus( "書き込む", get_encoding() )
+            << "&NAME="    << MISC::url_encode_plus( name, get_encoding() )
+            << "&MAIL="    << MISC::url_encode_plus( mail, get_encoding() )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_encoding() );
 
 #ifdef _DEBUG
     std::cout << "ArticleMachi::create_write_message " << ss_post.str() << std::endl;

--- a/src/dbtree/articlemachi.h
+++ b/src/dbtree/articlemachi.h
@@ -17,7 +17,7 @@ namespace DBTREE
     {
       public:
 
-        ArticleMachi( const std::string& datbase, const std::string& id, bool cached );
+        ArticleMachi( const std::string& datbase, const std::string& id, bool cached, const Encoding enc );
         ~ArticleMachi() noexcept;
 
         // 書き込みメッセージ変換

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -202,7 +202,7 @@ void Board2ch::download_front()
 {
     if( ! m_frontloader ) m_frontloader = std::make_unique<FrontLoader>( url_boardbase() );
     m_frontloader->reset();
-    m_frontloader->download_text();
+    m_frontloader->download_text( get_encoding() );
 }
 
 
@@ -220,11 +220,11 @@ std::string Board2ch::create_newarticle_message( const std::string& subject, con
     }
 
     std::stringstream ss_post;
-    ss_post << "submit="   << MISC::url_encode_plus( "新規スレッド作成", get_charset() )
-            << "&subject=" << MISC::url_encode_plus( subject, get_charset() )
-            << "&FROM="    << MISC::url_encode_plus( name, get_charset() )
-            << "&mail="    << MISC::url_encode_plus( mail, get_charset() )
-            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_charset() )
+    ss_post << "submit="   << MISC::url_encode_plus( "新規スレッド作成", get_encoding() )
+            << "&subject=" << MISC::url_encode_plus( subject, get_encoding() )
+            << "&FROM="    << MISC::url_encode_plus( name, get_encoding() )
+            << "&mail="    << MISC::url_encode_plus( mail, get_encoding() )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_encoding() )
             << "&bbs="     << get_id()
             << "&time="    << m_frontloader->get_time_modified();
 
@@ -296,7 +296,7 @@ ArticleBase* Board2ch::append_article( const std::string& datbase, const std::st
 {
     if( empty() ) return get_article_null();
 
-    ArticleBase* article = insert( std::make_unique<DBTREE::Article2ch>( datbase, id, cached ) );
+    ArticleBase* article = insert( std::make_unique<DBTREE::Article2ch>( datbase, id, cached, get_encoding() ) );
 
     if( ! article ) return get_article_null();
     return article;

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -9,9 +9,10 @@
 #include "settingloader.h"
 #include "ruleloader.h"
 
-#include "jdlib/miscutil.h"
-#include "jdlib/miscmsg.h"
 #include "jdlib/jdregex.h"
+#include "jdlib/misccharcode.h"
+#include "jdlib/miscmsg.h"
+#include "jdlib/miscutil.h"
 
 #include "config/globalconf.h"
 
@@ -47,7 +48,7 @@ Board2chCompati::Board2chCompati( const std::string& root, const std::string& pa
     set_subjecttxt( "subject.txt" );
     set_ext( ".dat" );
     set_id( path_board.substr( 1 ) ); // 先頭の '/' を除く
-    set_charset( "MS932" );
+    set_encoding( Encoding::sjis );
 
     BoardBase::set_basicauth( basicauth );
 }
@@ -117,9 +118,9 @@ std::string Board2chCompati::analyze_keyword_impl( const std::string& html, bool
 
         // キーワード取得
         if( ! keyword.empty() ) keyword.push_back( '&' );
-        keyword.append( MISC::url_encode_plus( d.name, get_charset() ) );
+        keyword.append( MISC::url_encode_plus( d.name, get_encoding() ) );
         keyword.push_back( '=' );
-        keyword.append( MISC::url_encode_plus( d.value, get_charset() ) );
+        keyword.append( MISC::url_encode_plus( d.value, get_encoding() ) );
     }
 #ifdef _DEBUG
     std::cout << "Board2chCompati::analyze_keyword_impl form data = " << keyword << std::endl;
@@ -185,12 +186,12 @@ std::string Board2chCompati::create_newarticle_message( const std::string& subje
     std::stringstream ss_post;
     ss_post.clear();
     ss_post << "bbs="      << get_id()
-            << "&subject=" << MISC::url_encode_plus( subject, get_charset() )
+            << "&subject=" << MISC::url_encode_plus( subject, get_encoding() )
             << "&time="    << get_time_modified()
-            << "&submit="  << MISC::url_encode_plus( "新規スレッド作成", get_charset() )
-            << "&FROM="    << MISC::url_encode_plus( name, get_charset() )
-            << "&mail="    << MISC::url_encode_plus( mail, get_charset() )
-            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_charset() );
+            << "&submit="  << MISC::url_encode_plus( "新規スレッド作成", get_encoding() )
+            << "&FROM="    << MISC::url_encode_plus( name, get_encoding() )
+            << "&mail="    << MISC::url_encode_plus( mail, get_encoding() )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_encoding() );
 
 #ifdef _DEBUG
     std::cout << "Board2chCompati::create_newarticle_message " << ss_post.str() << std::endl;
@@ -236,7 +237,7 @@ ArticleBase* Board2chCompati::append_article( const std::string& datbase, const 
 {
     if( empty() ) return get_article_null();
 
-    ArticleBase* article = insert( std::make_unique<DBTREE::Article2chCompati>( datbase, id, cached ) );
+    ArticleBase* article = insert( std::make_unique<DBTREE::Article2chCompati>( datbase, id, cached, get_encoding() ) );
 
     if( ! article ) return get_article_null();
     return article;
@@ -485,10 +486,10 @@ void Board2chCompati::load_rule_setting()
 #endif
 
     if( ! m_ruleloader ) m_ruleloader = std::make_unique<RuleLoader>( url_boardbase() );
-    m_ruleloader->load_text();
+    m_ruleloader->load_text( get_encoding() );
 
     if( ! m_settingloader ) m_settingloader = std::make_unique<SettingLoader>( url_boardbase() );
-    m_settingloader->load_text();
+    m_settingloader->load_text( get_encoding() );
 }
 
 
@@ -504,10 +505,10 @@ void Board2chCompati::download_rule_setting()
 #endif
 
     if( ! m_ruleloader ) m_ruleloader = std::make_unique<RuleLoader>( url_boardbase() );
-    m_ruleloader->download_text();
+    m_ruleloader->download_text( get_encoding() );
 
     if( ! m_settingloader ) m_settingloader = std::make_unique<SettingLoader>( url_boardbase() );
-    m_settingloader->download_text();
+    m_settingloader->download_text( get_encoding() );
 }
 
 

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -107,7 +107,6 @@ namespace DBTREE
         // m_subjecttxt = "subject.txt"
         // m_ext = ".dat"
         // m_id = "hogeboard"
-        // m_charset = "MS932"
         //
         // 先頭に'/'を付けて最後に '/' は付けないことにフォーマットを統一
         //
@@ -120,7 +119,6 @@ namespace DBTREE
         std::string m_subjecttxt;
         std::string m_ext;
         std::string m_id;
-        std::string m_charset;
         std::string m_name; // 板名
 
         // dat型のurlに変換する時のquery ( url_dat()で使用する )
@@ -179,6 +177,7 @@ namespace DBTREE
         std::unique_ptr<JDLIB::Iconv> m_iconv;
         std::string m_rawdata;
         std::string m_rawdata_left;
+        Encoding m_encoding_bak;
 
         // 情報ファイルを読みこんだらtrueにして2度読みしないようにする
         bool m_read_info{};
@@ -232,7 +231,6 @@ namespace DBTREE
         void set_subjecttxt( const std::string& str ){ m_subjecttxt = str; }
         void set_ext( const std::string& str ){ m_ext = str; }
         void set_id( const std::string& str ){ m_id = str; }
-        void set_charset( const std::string& str ){ m_charset = str; }
 
         // articleがスレあぼーんされているか
         bool is_abone_thread( ArticleBase* article );
@@ -300,7 +298,6 @@ namespace DBTREE
         const std::string& get_path_board() const { return m_path_board; }
         const std::string& get_ext() const { return m_ext; }
         const std::string& get_id() const { return m_id; }
-        const std::string& get_charset() const { return m_charset; }
         const std::string& get_name() const { return m_name; }
         void update_name( const std::string& name );
         const std::string& get_subjecttxt() const { return m_subjecttxt; }

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -37,7 +37,7 @@ BoardJBBS::BoardJBBS( const std::string& root, const std::string& path_board, co
     set_subjecttxt( "subject.txt" );
     set_ext( "" );
     set_id( path_board.substr( 1 ) ); // 先頭の '/' を除く  
-    set_charset( "EUCJP-WIN" );
+    set_encoding( Encoding::eucjp );
 }
 
 
@@ -75,7 +75,7 @@ ArticleBase* BoardJBBS::append_article( const std::string& datbase, const std::s
 {
     if( empty() ) return get_article_null();
 
-    ArticleBase* article = insert( std::make_unique<DBTREE::ArticleJBBS>( datbase, id, cached ) );
+    ArticleBase* article = insert( std::make_unique<DBTREE::ArticleJBBS>( datbase, id, cached, get_encoding() ) );
 
     if( ! article ) return get_article_null();
     return article;
@@ -111,11 +111,11 @@ std::string BoardJBBS::create_newarticle_message( const std::string& subject, co
 
     std::stringstream ss_post;
     ss_post.clear();
-    ss_post << "SUBJECT="  << MISC::url_encode_plus( subject, get_charset() )
-            << "&submit="  << MISC::url_encode_plus( "新規書き込み", get_charset() )
-            << "&NAME="    << MISC::url_encode_plus( name, get_charset() )
-            << "&MAIL="    << MISC::url_encode_plus( mail, get_charset() )
-            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_charset() )
+    ss_post << "SUBJECT="  << MISC::url_encode_plus( subject, get_encoding() )
+            << "&submit="  << MISC::url_encode_plus( "新規書き込み", get_encoding() )
+            << "&NAME="    << MISC::url_encode_plus( name, get_encoding() )
+            << "&MAIL="    << MISC::url_encode_plus( mail, get_encoding() )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_encoding() )
             << "&DIR="     << dir
             << "&BBS="     << bbs
             << "&TIME="    << get_time_modified();
@@ -214,11 +214,11 @@ std::string BoardJBBS::url_settingtxt() const
 //
 void BoardJBBS::load_rule_setting()
 {
-    if( ! m_ruleloader ) m_ruleloader = std::make_unique<RuleLoader>( url_boardbase(), "MS932" );
-    m_ruleloader->load_text();
+    if( ! m_ruleloader ) m_ruleloader = std::make_unique<RuleLoader>( url_boardbase() );
+    m_ruleloader->load_text( Encoding::sjis );
 
     if( ! m_settingloader ) m_settingloader = std::make_unique<SettingLoader>( url_boardbase() );
-    m_settingloader->load_text();
+    m_settingloader->load_text( get_encoding() );
 }
 
 
@@ -230,11 +230,11 @@ void BoardJBBS::load_rule_setting()
 //
 void BoardJBBS::download_rule_setting()
 {
-    if( ! m_ruleloader ) m_ruleloader = std::make_unique<RuleLoader>( url_boardbase(), "MS932" );
-    m_ruleloader->download_text();
+    if( ! m_ruleloader ) m_ruleloader = std::make_unique<RuleLoader>( url_boardbase() );
+    m_ruleloader->download_text( Encoding::sjis );
 
     if( ! m_settingloader ) m_settingloader = std::make_unique<SettingLoader>( url_boardbase() );
-    m_settingloader->download_text();
+    m_settingloader->download_text( get_encoding() );
 }
 
 

--- a/src/dbtree/boardlocal.cpp
+++ b/src/dbtree/boardlocal.cpp
@@ -83,7 +83,7 @@ ArticleBase* BoardLocal::append_article( const std::string& datbase, const std::
               << ", id = " << id << std::endl;
 #endif
 
-    ArticleBase* article = insert( std::make_unique<DBTREE::ArticleLocal>( datbase, id ) );
+    ArticleBase* article = insert( std::make_unique<DBTREE::ArticleLocal>( datbase, id, get_encoding() ) );
     if( article ){
         // subject にも追加する
         get_list_subject().push_back( article );

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -34,7 +34,7 @@ BoardMachi::BoardMachi( const std::string& root, const std::string& path_board, 
     set_subjecttxt( "subject.txt" );
     set_ext( "" );
     set_id( path_board.substr( 1 ) ); // 先頭の '/' を除く  
-    set_charset( "MS932" );
+    set_encoding( Encoding::sjis );
 }
 
 
@@ -78,7 +78,7 @@ ArticleBase* BoardMachi::append_article( const std::string& datbase, const std::
 {
     if( empty() ) return get_article_null();
 
-    ArticleBase* article = insert( std::make_unique<DBTREE::ArticleMachi>( datbase, id, cached ) );
+    ArticleBase* article = insert( std::make_unique<DBTREE::ArticleMachi>( datbase, id, cached, get_encoding() ) );
 
     if( ! article ) return get_article_null();
     return article;

--- a/src/dbtree/frontloader.cpp
+++ b/src/dbtree/frontloader.cpp
@@ -23,12 +23,6 @@ FrontLoader::FrontLoader( const std::string& url_boadbase )
 }
 
 
-std::string FrontLoader::get_charset() const
-{
-    return DBTREE::board_charset( m_url_boadbase );
-}
-
-
 // ロード用データ作成
 void FrontLoader::create_loaderdata( JDLIB::LOADERDATA& data )
 {

--- a/src/dbtree/frontloader.h
+++ b/src/dbtree/frontloader.h
@@ -30,7 +30,6 @@ namespace DBTREE
 
         std::string get_url() const override { return m_url_boadbase; }
         std::string get_path() const override { return {}; } // キャッシュには保存しない
-        std::string get_charset() const override;
 
         // ロード用データ作成
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -293,9 +293,15 @@ std::string DBTREE::board_subjecttxt( const std::string& url )
 }
 
 
-std::string DBTREE::board_charset( const std::string& url )
+Encoding DBTREE::board_encoding( const std::string& url )
 {
-    return DBTREE::get_board( url )->get_charset();
+    return DBTREE::get_board( url )->get_encoding();
+}
+
+
+void DBTREE::board_set_encoding( const std::string& url, const Encoding enc )
+{
+    return DBTREE::get_board( url )->set_encoding( enc );
 }
 
 
@@ -888,7 +894,19 @@ void DBTREE::article_set_date_modified( const std::string& url, const std::strin
     DBTREE::get_article( url )->set_date_modified( date );
 }
 
-int  DBTREE::article_hour( const std::string& url )
+// スレの文字コード
+Encoding DBTREE::article_encoding( const std::string& url )
+{
+    return DBTREE::get_article( url )->get_encoding();
+}
+
+// スレの文字コードをセット
+void DBTREE::article_set_encoding( const std::string& url, const Encoding enc )
+{
+    DBTREE::get_article( url )->set_encoding( enc );
+}
+
+int DBTREE::article_hour( const std::string& url )
 {
     return DBTREE::get_article( url )->get_hour();
 }

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -8,6 +8,7 @@
 #define _INTERFACE_H
 
 #include "etcboardinfo.h"
+#include "jdencoding.h"
 
 #include <string>
 #include <list>
@@ -104,7 +105,8 @@ namespace DBTREE
     void board_set_modified_setting( const std::string& url, const std::string& modified );
     std::string board_name( const std::string& url );
     std::string board_subjecttxt( const std::string& url );
-    std::string board_charset( const std::string& url );
+    Encoding board_encoding( const std::string& url );
+    void board_set_encoding( const std::string& url, const Encoding enc );
     std::string board_cookie_by_host( const std::string& url );
     std::string board_cookie_for_request( const std::string& url );
     std::string board_cookie_for_post( const std::string& url );
@@ -220,6 +222,8 @@ namespace DBTREE
     time_t article_time_modified( const std::string& url ); // スレの更新時間( time_t )
     std::string article_date_modified( const std::string& url ); // スレの更新時間( 文字列 )
     void article_set_date_modified( const std::string& url, const std::string& date ); // スレの更新時間( 文字列 )をセット
+    Encoding article_encoding( const std::string& url );
+    void article_set_encoding( const std::string& url, const Encoding enc );
     int article_hour( const std::string& url );
     time_t article_write_time( const std::string& url );
     std::string article_write_date( const std::string& url );

--- a/src/dbtree/nodetree2chcompati.cpp
+++ b/src/dbtree/nodetree2chcompati.cpp
@@ -69,8 +69,7 @@ void NodeTree2chCompati::init_loading()
     NodeTreeBase::init_loading();
 
     // iconv 初期化
-    std::string charset = DBTREE::board_charset( get_url() );
-    if( ! m_iconv ) m_iconv = std::make_unique<JDLIB::Iconv>( "UTF-8", charset );
+    if( ! m_iconv ) m_iconv = std::make_unique<JDLIB::Iconv>( Encoding::utf8, DBTREE::article_encoding( get_url() ) );
 }
 
 

--- a/src/dbtree/nodetreejbbs.cpp
+++ b/src/dbtree/nodetreejbbs.cpp
@@ -80,8 +80,7 @@ void NodeTreeJBBS::init_loading()
     NodeTreeBase::init_loading();
 
     // iconv 初期化
-    std::string charset = DBTREE::board_charset( get_url() );
-    if( ! m_iconv ) m_iconv = std::make_unique<JDLIB::Iconv>( "UTF-8", charset );
+    if( ! m_iconv ) m_iconv = std::make_unique<JDLIB::Iconv>( Encoding::utf8, DBTREE::article_encoding( get_url() ) );
 
     // 予め領域を確保する
     if( m_decoded_lines.capacity() < kBufSizeDecodedLines ) {

--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -9,6 +9,7 @@
 #include "jdlib/jdiconv.h"
 #include "jdlib/jdregex.h"
 #include "jdlib/loaderdata.h"
+#include "jdlib/misccharcode.h"
 #include "jdlib/miscutil.h"
 
 #include "config/globalconf.h"
@@ -84,8 +85,7 @@ void NodeTreeMachi::init_loading()
     if( ! m_regex ) m_regex = std::make_unique<JDLIB::Regex>();
 
     // iconv 初期化
-    std::string charset = DBTREE::board_charset( get_url() );
-    if( ! m_iconv ) m_iconv = std::make_unique<JDLIB::Iconv>( "UTF-8", charset );
+    if( ! m_iconv ) m_iconv = std::make_unique<JDLIB::Iconv>( Encoding::utf8, DBTREE::article_encoding( get_url() ) );
 
     m_buffer_for_200.clear();
 
@@ -191,10 +191,9 @@ char* NodeTreeMachi::process_raw_lines( char* rawlines )
                 std::string reg_subject( "<title>([^<]*)</title>" );
                 if( m_regex->exec( reg_subject, line, offset, icase, newline, usemigemo, wchar ) ){
 
-                    const std::string charset = DBTREE::board_charset( get_url() );
-                    m_subject_machi = MISC::Iconv( m_regex->str( 1 ), "UTF-8", charset );
+                    m_subject_machi = MISC::Iconv( m_regex->str( 1 ), Encoding::utf8, get_encoding() );
 #ifdef _DEBUG
-                    std::cout << "NodeTreeMachi::process_raw_lines\n";
+                    std::cout << "NodeTreeMachi::process_raw_lines" << std::endl;
                     std::cout << "subject = " << m_subject_machi << std::endl;
 #endif
                 }

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -398,7 +398,7 @@ void Root::receive_finish()
     }
 
     // 文字コードを変換してXML作成
-    JDLIB::Iconv libiconv{ "UTF-8", "MS932" };
+    JDLIB::Iconv libiconv{ Encoding::utf8, Encoding::sjis };
     const std::string& rawdata_utf8 = libiconv.convert( m_rawdata.data(), m_rawdata.size() );
     bbsmenu2xml( rawdata_utf8 );
 

--- a/src/dbtree/ruleloader.cpp
+++ b/src/dbtree/ruleloader.cpp
@@ -17,10 +17,9 @@
 
 using namespace DBTREE;
 
-RuleLoader::RuleLoader( const std::string& url_boadbase, const char* override_charset )
+RuleLoader::RuleLoader( const std::string& url_boadbase )
     : SKELETON::TextLoader()
     , m_url_boadbase( url_boadbase )
-    , m_override_charset{ override_charset }
 {
 #ifdef _DEBUG
     std::cout << "RuleLoader::RuleLoader : " << RuleLoader::get_url() << std::endl;
@@ -47,12 +46,6 @@ std::string RuleLoader::get_url() const
 std::string RuleLoader::get_path() const
 {
     return CACHE::path_board_root( m_url_boadbase ) + HEAD_TXT;
-}
-
-
-std::string RuleLoader::get_charset() const
-{
-    return m_override_charset ? m_override_charset : DBTREE::board_charset( m_url_boadbase );
 }
 
 

--- a/src/dbtree/ruleloader.h
+++ b/src/dbtree/ruleloader.h
@@ -20,20 +20,16 @@ namespace DBTREE
     class RuleLoader : public SKELETON::TextLoader
     {
         std::string m_url_boadbase;
-        // スレ本文とエンコーディングが異なる板があるため指定可能にする
-        // 文字列の寿命は呼び出し元が責任を持つこと
-        const char* m_override_charset;
 
       public:
 
-        explicit RuleLoader( const std::string& url_boardbase, const char* override_charset = nullptr );
+        explicit RuleLoader( const std::string& url_boardbase );
         ~RuleLoader();
 
       protected:
 
         std::string get_url() const override;
         std::string get_path() const override;
-        std::string get_charset() const override;
 
         // ロード用データ作成
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;

--- a/src/dbtree/settingloader.cpp
+++ b/src/dbtree/settingloader.cpp
@@ -48,12 +48,6 @@ std::string SettingLoader::get_path() const
 }
 
 
-std::string SettingLoader::get_charset() const
-{
-    return DBTREE::board_charset( m_url_boadbase );
-}
-
-
 // ロード用データ作成
 void SettingLoader::create_loaderdata( JDLIB::LOADERDATA& data )
 {

--- a/src/dbtree/settingloader.h
+++ b/src/dbtree/settingloader.h
@@ -50,7 +50,6 @@ namespace DBTREE
 
         std::string get_url() const override;
         std::string get_path() const override;
-        std::string get_charset() const override;
 
         // ロード用データ作成
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;

--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -5,6 +5,8 @@
 
 #include "misccharcode.h"
 
+#include "jdiconv.h"
+
 #include <cstring>
 #include <cstdint>
 
@@ -533,4 +535,24 @@ std::string MISC::utf8_fix_wavedash( const std::string& str, const MISC::WaveDas
     }
 
     return result;
+}
+
+
+/** @brief 入力の文字エンコーディングを from から to に変換
+ *
+ * @details 遅いので連続的な処理が必要な時は使わないこと
+ * @param[in] str  変換するテキスト
+ * @param[in] to   変換先の文字エンコーディング
+ * @param[in] from str の文字エンコーディング
+ * @return 変換した結果
+ */
+std::string MISC::Iconv( const std::string& str, const Encoding to, const Encoding from )
+{
+    if( from == to ) return str;
+
+    JDLIB::Iconv icv( to, from );
+    std::string tmp_str{ str };
+    std::string encoded;
+    icv.convert( tmp_str.data(), tmp_str.size(), encoded );
+    return encoded;
 }

--- a/src/jdlib/misccharcode.h
+++ b/src/jdlib/misccharcode.h
@@ -58,6 +58,10 @@ namespace MISC
 
     /// WAVE DASH(U+301C)などのWindows系UTF-8文字をUnix系文字と相互変換
     std::string utf8_fix_wavedash( const std::string& str, const WaveDashFix mode );
+
+    // 入力の文字エンコーディングを from から to に変換
+    // 遅いので連続的な処理が必要な時は使わないこと
+    std::string Iconv( const std::string& str, const Encoding to, const Encoding from );
 }
 
 #endif

--- a/src/jdlib/misctrip.cpp
+++ b/src/jdlib/misctrip.cpp
@@ -7,6 +7,8 @@
 #endif
 
 #include "misctrip.h"
+
+#include "misccharcode.h"
 #include "miscutil.h"
 
 #include <sstream>
@@ -244,19 +246,18 @@ std::string create_trip_conventional( const std::string& key )
 }
 
 
-/*--------------------------------------------------------------------*/
-// トリップを取得
-//
-// param1: 元となる文字列(最初の"#"を含まない。UTF-8 であること)
-// param2: 書き込む掲示板の文字コード
-// return: トリップ文字列
-/*--------------------------------------------------------------------*/
-std::string MISC::get_trip( const std::string& str, const std::string& charset )
+/** @brief トリップを取得 (SHA1等の新方式対応)
+ *
+ * @param[in] utf8str  元となる文字列(最初の"#"を含まない。UTF-8 であること)
+ * @param[in] encoding 書き込む掲示板の文字コード
+ * @return トリップ文字列
+ */
+std::string MISC::get_trip( const std::string& utf8str, const Encoding encoding )
 {
-    if( str.empty() ) return std::string();
+    if( utf8str.empty() ) return std::string();
 
-    // str の文字コードを UTF-8 から charset に変更して key に代入する
-    std::string key = MISC::Iconv( str, charset, "UTF-8" );
+    // utf8str の文字コードを UTF-8 から変更して key に代入する
+    std::string key = MISC::Iconv( utf8str, encoding, Encoding::utf8 );
 
     std::string trip;
 
@@ -272,7 +273,7 @@ std::string MISC::get_trip( const std::string& str, const std::string& charset )
     }
 
 #ifdef _DEBUG
-    std::cout << "MISC::get_trip : " << str << " -> " << trip << std::endl;
+    std::cout << "MISC::get_trip : " << utf8str << " -> " << trip << std::endl;
 #endif
 
     return trip;

--- a/src/jdlib/misctrip.h
+++ b/src/jdlib/misctrip.h
@@ -5,12 +5,14 @@
 #ifndef _MISCTRIP_H
 #define _MISCTRIP_H
 
+#include "jdencoding.h"
+
 #include <string>
 
 namespace MISC
 {
     // トリップを取得 (SHA1等の新方式対応)
-    std::string get_trip( const std::string& str, const std::string& charset );
+    std::string get_trip( const std::string& utf8str, const Encoding encoding );
 }
 
 #endif

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -3,12 +3,13 @@
 //#define _DEBUG
 #include "jddebug.h"
 
+#include "miscutil.h"
+
 #include "hkana.h"
 #include "jdiconv.h"
 #include "jdregex.h"
 #include "misccharcode.h"
 #include "miscmsg.h"
-#include "miscutil.h"
 
 #include "dbtree/spchar_decoder.h"
 #include "dbtree/node.h"
@@ -17,10 +18,11 @@
 
 #include <glib.h>
 
-#include <sstream>
-#include <cstring>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <sstream>
 
 
 //
@@ -1358,7 +1360,7 @@ std::string MISC::url_decode( std::string_view url )
  *
  * @param[in] str 入力文字列 (文字エンコーディングは任意)
  * @return パーセント符号化された文字列
- * @see MISC::url_encode( const std::string& utf8str, const std::string& encoding )
+ * @see MISC::url_encode( const std::string& utf8str, const Encoding encoding )
 */
 std::string MISC::url_encode( std::string_view str )
 {
@@ -1384,16 +1386,16 @@ std::string MISC::url_encode( std::string_view str )
  *
  * @details `utf8str` を `encoding` で指定した文字エンコーディングに変換してから符号化する。
  * @param[in] utf8str 入力文字列 (文字エンコーディングはUTF-8)
- * @param[in] encoding 変換先の文字エンコーディング名
+ * @param[in] encoding 変換先の文字エンコーディング
  * @return パーセント符号化された文字列
  * @see MISC::url_encode( std::string_view str )
 */
-std::string MISC::url_encode( const std::string& utf8str, const std::string& encoding )
+std::string MISC::url_encode( const std::string& utf8str, const Encoding encoding )
 {
-    if( encoding.empty() || encoding == "UTF-8" ) return MISC::url_encode( utf8str );
+    if( encoding == Encoding::utf8 ) return MISC::url_encode( utf8str );
 
-    const std::string str_enc = MISC::Iconv( utf8str, encoding, "UTF-8" );
-    return  MISC::url_encode( str_enc );
+    const std::string str_enc = MISC::Iconv( utf8str, encoding, Encoding::utf8 );
+    return MISC::url_encode( str_enc );
 }
 
 
@@ -1408,7 +1410,7 @@ std::string MISC::url_encode( const std::string& utf8str, const std::string& enc
  *
  * @param[in] str 入力文字列 (文字エンコーディングは任意)
  * @return パーセント符号化された文字列
- * @see MISC::url_encode_plus( const std::string& utf8str, const std::string& encoding )
+ * @see MISC::url_encode_plus( const std::string& utf8str, const Encoding encoding )
 */
 std::string MISC::url_encode_plus( std::string_view str )
 {
@@ -1444,14 +1446,14 @@ std::string MISC::url_encode_plus( std::string_view str )
  * @return パーセント符号化された文字列
  * @see MISC::url_encode_plus( std::string_view str )
 */
-std::string MISC::url_encode_plus( const std::string& utf8str, const std::string& encoding )
+std::string MISC::url_encode_plus( const std::string& utf8str, const Encoding encoding )
 {
-    if( encoding.empty() || encoding == "UTF-8" ) {
+    if( encoding == Encoding::utf8 ) {
         return MISC::url_encode_plus( utf8str );
     }
 
-    const std::string str_enc = MISC::Iconv( utf8str, encoding, "UTF-8" );
-    return  MISC::url_encode_plus( str_enc );
+    const std::string str_enc = MISC::Iconv( utf8str, encoding, Encoding::utf8 );
+    return MISC::url_encode_plus( str_enc );
 }
 
 
@@ -1500,26 +1502,6 @@ std::string MISC::base64( const std::string& str )
     return out;
 }
 
-
-
-
-//
-// 文字コードを coding_from から coding_to に変換
-//
-// 遅いので連続的な処理が必要な時は使わないこと
-//
-std::string MISC::Iconv( const std::string& str, const std::string& coding_to, const std::string& coding_from )
-{
-    if( coding_from == coding_to ) return str;
-
-    std::string str_bk = str;
-
-    JDLIB::Iconv libiconv( coding_to, coding_from );
-    std::string str_enc;
-    libiconv.convert( str_bk.data(), str_bk.size(), str_enc );
-
-    return str_enc;
-}
 
 
 //

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -5,6 +5,7 @@
 #ifndef _MISCUTIL_H
 #define _MISCUTIL_H
 
+#include "jdencoding.h"
 
 #include <glibmm.h>
 
@@ -178,20 +179,16 @@ namespace MISC
     std::string url_encode( std::string_view str );
 
     /// UTF-8文字列をエンコーディング変換してからパーセント符号化して返す
-    std::string url_encode( const std::string& utf8str, const std::string& encoding );
+    std::string url_encode( const std::string& utf8str, const Encoding encoding );
 
     /// application/x-www-form-urlencoded の形式でパーセント符号化する
     std::string url_encode_plus( std::string_view str );
 
     /// UTF-8文字列をエンコーディング変換してから application/x-www-form-urlencoded の形式でパーセント符号化する
-    std::string url_encode_plus( const std::string& utf8str, const std::string& encoding );
+    std::string url_encode_plus( const std::string& utf8str, const Encoding encoding );
 
     // BASE64
     std::string base64( const std::string& str );
-
-    // 文字コードを coding_from から coding_to に変換
-    // 遅いので連続的な処理が必要な時は使わないこと
-    std::string Iconv( const std::string& str, const std::string& coding_to, const std::string& coding_from );
 
     // 「&#数字;」形式の数字参照文字列の中の「数字」部分の文字列長
     //

--- a/src/loginbe.cpp
+++ b/src/loginbe.cpp
@@ -110,7 +110,7 @@ void LoginBe::start_login()
     data.contenttype = "application/x-www-form-urlencoded";
     data.str_post = "m=" + MISC::url_encode_plus( get_username() );
     data.str_post += "&p=" + MISC::url_encode_plus( get_passwd() );
-    data.str_post += "&submit=" + MISC::url_encode_plus( "登録", "EUC-JP" );
+    data.str_post += "&submit=" + MISC::url_encode_plus( "登録", Encoding::eucjp );
 
     logout();
     if( m_rawdata.capacity() < SIZE_OF_RAWDATA ) m_rawdata.reserve( SIZE_OF_RAWDATA );

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -15,11 +15,12 @@
 #include "skeleton/editview.h"
 #include "skeleton/detaildiag.h"
 
-#include "jdlib/miscutil.h"
-#include "jdlib/misctime.h"
-#include "jdlib/misctrip.h"
 #include "jdlib/jdiconv.h"
 #include "jdlib/jdregex.h"
+#include "jdlib/misccharcode.h"
+#include "jdlib/misctime.h"
+#include "jdlib/misctrip.h"
+#include "jdlib/miscutil.h"
 
 #include "dbtree/interface.h"
 
@@ -77,7 +78,7 @@ MessageViewBase::MessageViewBase( const std::string& url )
     m_max_line = DBTREE::line_number( get_url() ) * 2;
     m_max_str = DBTREE::message_count( get_url() );
 
-    m_iconv = std::make_unique<JDLIB::Iconv>( DBTREE::board_charset( get_url() ), "UTF-8" );;
+    m_iconv = std::make_unique<JDLIB::Iconv>( DBTREE::board_encoding( get_url() ), Encoding::utf8 );
 
     m_lng_iconv = m_max_str * 3;
     if( ! m_lng_iconv ) m_lng_iconv = MAX_STR_ICONV;
@@ -891,7 +892,7 @@ void MessageViewBase::slot_switch_page( Gtk::Widget*, guint page )
             std::string trip;
             if( trip_pos != std::string::npos )
             {
-                trip = MISC::get_trip( name_field.substr( trip_pos + 1 ), DBTREE::board_charset( get_url() ) );
+                trip = MISC::get_trip( name_field.substr( trip_pos + 1 ), DBTREE::board_encoding( get_url() ) );
             }
 
             ss << name;
@@ -914,7 +915,7 @@ void MessageViewBase::slot_switch_page( Gtk::Widget*, guint page )
             if( DBTREE::get_unicode( get_url() ) == "change" ){
                 // MS932等に無い文字を数値文字参照にするために文字コードを変換する
                 const std::string& str_enc = m_iconv->convert( msg.data(), msg.size() );
-                msg = MISC::Iconv( str_enc, "UTF-8", DBTREE::board_charset( get_url() ) );
+                msg = MISC::Iconv( str_enc, Encoding::utf8, DBTREE::board_encoding( get_url() ) );
             }
             else{
                 constexpr bool completely = true;

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -237,8 +237,7 @@ void Post::receive_finish()
 #endif
 
     {
-        const std::string charset = DBTREE::board_charset( m_url );
-        JDLIB::Iconv libiconv( "UTF-8", charset );
+        JDLIB::Iconv libiconv( Encoding::utf8, DBTREE::board_encoding( m_url ) );
         libiconv.convert( m_rawdata.data(), m_rawdata.size(), m_return_html );
     }
 

--- a/src/searchloader.cpp
+++ b/src/searchloader.cpp
@@ -4,10 +4,14 @@
 #include "jddebug.h"
 
 #include "searchloader.h"
+
+#include "jdencoding.h"
 #include "usrcmdmanager.h"
 
 #include "jdlib/loaderdata.h"
-#include "jdlib/miscutil.h"
+#ifdef _DEBUG
+#include "jdlib/misccharcode.h"
+#endif
 
 #include "config/globalconf.h"
 
@@ -19,19 +23,21 @@ SearchLoader::SearchLoader()
 {
     std::string url = CONFIG::get_url_search_title();
 
-    m_charset = "UTF-8";
+    Encoding enc = Encoding::utf8;
 
     // 結果のエンコード指定を、検索結果のエンコードに設定する
-    if( url.find( "$OUTU" ) != std::string::npos ) m_charset = "UTF-8";
-    else if( url.find( "$OUTX" ) != std::string::npos ) m_charset = "EUC-JP";
-    else if( url.find( "$OUTE" ) != std::string::npos ) m_charset = "MS932";
+    if( url.find( "$OUTU" ) != std::string::npos ) enc = Encoding::utf8;
+    else if( url.find( "$OUTX" ) != std::string::npos ) enc = Encoding::eucjp;
+    else if( url.find( "$OUTE" ) != std::string::npos ) enc = Encoding::sjis;
 
     // 結果のエンコード指定がない場合は、検索クエリのエンコードを検索結果のエンコードに設定する
-    else if( url.find( "$TEXTX" ) != std::string::npos ) m_charset = "EUC-JP";
-    else if( url.find( "$TEXTE" ) != std::string::npos ) m_charset = "MS932";
+    else if( url.find( "$TEXTX" ) != std::string::npos ) enc = Encoding::eucjp;
+    else if( url.find( "$TEXTE" ) != std::string::npos ) enc = Encoding::sjis;
+
+    set_encoding( enc );
 
 #ifdef _DEBUG
-    std::cout << "SearchLoader::SearchLoader charset = " << m_charset << std::endl;;
+    std::cout << "SearchLoader::SearchLoader encoding = " << MISC::encoding_to_cstr( enc ) << std::endl;;
 #endif
 }
 
@@ -64,7 +70,7 @@ void SearchLoader::search( const std::string& query )
     m_query = query;
 
     reset();
-    download_text();
+    download_text( get_encoding() );
 }
 
 

--- a/src/searchloader.h
+++ b/src/searchloader.h
@@ -19,7 +19,6 @@ namespace CORE
 
         SIG_SEARCH_FIN m_sig_search_fin;
 
-        std::string m_charset;
         std::string m_query;
 
       public:
@@ -35,7 +34,6 @@ namespace CORE
 
         std::string get_url() const override;
         std::string get_path() const override { return {}; }
-        std::string get_charset() const override { return m_charset; }
 
         // ロード用データ作成
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;

--- a/src/skeleton/loadable.cpp
+++ b/src/skeleton/loadable.cpp
@@ -7,12 +7,16 @@
 
 #include "jdlib/loader.h"
 #include "jdlib/misctime.h"
+#ifdef _DEBUG
+#include "jdlib/misccharcode.h"
+#endif
 
 #include "httpcode.h"
 
 using namespace SKELETON;
 
 Loadable::Loadable()
+    : m_encoding( Encoding::unknown )
 {
     clear_load_data();
 }
@@ -180,6 +184,7 @@ void Loadable::callback_dispatch()
     std::cout << "location = " << m_location << std::endl;
     std::cout << "total_length = " << m_total_length << std::endl;
     std::cout << "current length = " << m_current_length << std::endl;
+    std::cout << "charset = " << MISC::encoding_to_cstr( get_encoding() ) << std::endl;
 #endif
 
     receive_finish();

--- a/src/skeleton/loadable.h
+++ b/src/skeleton/loadable.h
@@ -44,6 +44,7 @@
 #ifndef _LOADABLE_H
 #define _LOADABLE_H
 
+#include "jdencoding.h"
 #include "dispatchable.h"
 
 #include <gtkmm.h>
@@ -68,6 +69,8 @@ namespace SKELETON
 
         bool m_low_priority{};
 
+        Encoding m_encoding;
+
         // ローダからコピーしたデータ
         int m_code;
         std::string m_str_code;
@@ -88,6 +91,9 @@ namespace SKELETON
 
         // ロード中かどうか
         bool is_loading() const;
+
+        Encoding get_encoding() const { return m_encoding; }
+        void set_encoding( const Encoding encoding ){ m_encoding = encoding; }
 
         int get_code() const { return m_code; }
         void set_code( int code ) { m_code = code; }

--- a/src/skeleton/textloader.cpp
+++ b/src/skeleton/textloader.cpp
@@ -65,23 +65,29 @@ void TextLoader::reset()
 }
 
 
-//
-// キャッシュからロード
-//
-void TextLoader::load_text()
+/** @brief キャッシュからロード
+ *
+ * @details 読み込んだキャッシュはUTF-8に変換する。
+ * @param[in] encoding キャッシュの文字エンコーディング
+ */
+void TextLoader::load_text( const Encoding encoding )
 {
     if( get_path().empty() ) return;
 
     init();
     set_code( HTTP_INIT );
+    set_encoding( encoding );
     receive_finish();
 }
 
 
-//
-// ダウンロード開始
-//
-void TextLoader::download_text()
+/** @brief ダウンロードを開始する
+ *
+ * @details ダウンロードしたテキストはUTF-8に変換する。
+ * HTTP 304 Not Modified の時はキャッシュから読み込む。
+ * @param[in] encoding ダウンロードしたテキストの文字エンコーディング
+ */
+void TextLoader::download_text( const Encoding encoding )
 {
 #ifdef _DEBUG
     std::cout << "TextLoader::download_text url = " << get_url() << std::endl;
@@ -90,7 +96,7 @@ void TextLoader::download_text()
     if( is_loading() ) return;
     if( m_loaded ) return; // 読み込み済み
     if( ! SESSION::is_online() ){
-        load_text();
+        load_text( encoding );
         return;
     }
 
@@ -101,6 +107,7 @@ void TextLoader::download_text()
     JDLIB::LOADERDATA data;
 
     init();
+    set_encoding( encoding );
     create_loaderdata( data );
     if( data.url.empty() ) return;
     if( ! start_load( data ) ) clear();
@@ -172,7 +179,7 @@ void TextLoader::receive_finish()
     set_str_code( std::string() );
 
     // UTF-8に変換しておく
-    JDLIB::Iconv libiconv( "UTF-8", get_charset() );
+    JDLIB::Iconv libiconv( Encoding::utf8, get_encoding() );
     libiconv.convert( m_rawdata.data(), m_rawdata.size(), m_data );
     clear();
 

--- a/src/skeleton/textloader.h
+++ b/src/skeleton/textloader.h
@@ -9,6 +9,7 @@
 #ifndef _TEXTLODER_H
 #define _TEXTLODER_H
 
+#include "jdencoding.h"
 #include "loadable.h"
 
 #include <string>
@@ -38,17 +39,16 @@ namespace SKELETON
         void reset();
 
         // キャッシュからロード
-        void load_text();
+        void load_text( const Encoding encoding );
 
-        // ダウンロード開始
-        // not modifiedの時はキャッシュから読み込む
-        void download_text();
+        // ダウンロードを開始する
+        // HTTP 304 Not Modified の時はキャッシュから読み込む
+        void download_text( const Encoding encoding );
 
       protected:
 
         virtual std::string get_url() const = 0;
         virtual std::string get_path() const = 0;
-        virtual std::string get_charset() const = 0;
 
         // ロード用データ作成
         virtual void create_loaderdata( JDLIB::LOADERDATA& data ) = 0;

--- a/src/usrcmdmanager.cpp
+++ b/src/usrcmdmanager.cpp
@@ -288,15 +288,15 @@ std::string Usrcmd_Manager::replace_cmd( const std::string& cmd,
 
     if( cmd_out.find( "$TEXTIU" ) != std::string::npos ){
         if( ! show_replacetextdiag( texti, "$TEXTIU" ) ) return std::string();
-        cmd_out = MISC::replace_str( cmd_out, "$TEXTIU", MISC::url_encode_plus( texti, "UTF-8" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$TEXTIU", MISC::url_encode_plus( texti, Encoding::utf8 ) );
     }
     if( cmd_out.find( "$TEXTIX" ) != std::string::npos ){
         if( ! show_replacetextdiag( texti, "$TEXTIX" ) ) return std::string();
-        cmd_out = MISC::replace_str( cmd_out, "$TEXTIX", MISC::url_encode_plus( texti, "EUC-JP" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$TEXTIX", MISC::url_encode_plus( texti, Encoding::eucjp ) );
     }
     if( cmd_out.find( "$TEXTIE" ) != std::string::npos ){
         if( ! show_replacetextdiag( texti, "$TEXTIE" ) ) return std::string();
-        cmd_out = MISC::replace_str( cmd_out, "$TEXTIE", MISC::url_encode_plus( texti, "MS932" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$TEXTIE", MISC::url_encode_plus( texti, Encoding::sjis ) );
     }
     if( cmd_out.find( "$TEXTI" ) != std::string::npos ){
         if( ! show_replacetextdiag( texti, "$TEXTI" ) ) return std::string();
@@ -304,13 +304,13 @@ std::string Usrcmd_Manager::replace_cmd( const std::string& cmd,
     }
 
     if( cmd_out.find( "$TEXTU" ) != std::string::npos ){
-        cmd_out = MISC::replace_str( cmd_out, "$TEXTU", MISC::url_encode_plus( texti, "UTF-8" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$TEXTU", MISC::url_encode_plus( texti, Encoding::utf8 ) );
     }
     if( cmd_out.find( "$TEXTX" ) != std::string::npos ){
-        cmd_out = MISC::replace_str( cmd_out, "$TEXTX", MISC::url_encode_plus( texti, "EUC-JP" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$TEXTX", MISC::url_encode_plus( texti, Encoding::eucjp ) );
     }
     if( cmd_out.find( "$TEXTE" ) != std::string::npos ){
-        cmd_out = MISC::replace_str( cmd_out, "$TEXTE", MISC::url_encode_plus( texti, "MS932" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$TEXTE", MISC::url_encode_plus( texti, Encoding::sjis ) );
     }
     if( cmd_out.find( "$TEXT" ) != std::string::npos ){
         cmd_out = MISC::replace_str( cmd_out, "$TEXT",  texti );
@@ -321,15 +321,15 @@ std::string Usrcmd_Manager::replace_cmd( const std::string& cmd,
 
     if( cmd_out.find( "$INPUTU" ) != std::string::npos ){
         if( ! show_replacetextdiag( input, "$INPUTU" ) ) return std::string();
-        cmd_out = MISC::replace_str( cmd_out, "$INPUTU", MISC::url_encode_plus( input, "UTF-8" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$INPUTU", MISC::url_encode_plus( input, Encoding::utf8 ) );
     }
     if( cmd_out.find( "$INPUTX" ) != std::string::npos ){
         if( ! show_replacetextdiag( input, "$INPUTX" ) ) return std::string();
-        cmd_out = MISC::replace_str( cmd_out, "$INPUTX", MISC::url_encode_plus( input, "EUC-JP" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$INPUTX", MISC::url_encode_plus( input, Encoding::eucjp ) );
     }
     if( cmd_out.find( "$INPUTE" ) != std::string::npos ){
         if( ! show_replacetextdiag( input, "$INPUTE" ) ) return std::string();
-        cmd_out = MISC::replace_str( cmd_out, "$INPUTE", MISC::url_encode_plus( input, "MS932" ) );
+        cmd_out = MISC::replace_str( cmd_out, "$INPUTE", MISC::url_encode_plus( input, Encoding::sjis ) );
     }
     if( cmd_out.find( "$INPUT" ) != std::string::npos ){
         if( ! show_replacetextdiag( input, "$INPUT" ) ) return std::string();

--- a/test/gtest_jdlib_jdiconv.cpp
+++ b/test/gtest_jdlib_jdiconv.cpp
@@ -1,5 +1,6 @@
 // License: GPL2
 
+#include "jdencoding.h"
 #include "jdlib/jdiconv.h"
 
 #include "gtest/gtest.h"
@@ -19,7 +20,7 @@ TEST_F(Iconv_ToAsciiFromUtf8, empty)
     char input[] = "";
     constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "ASCII", "UTF-8", broken_sjis_be_utf8 );
+    JDLIB::Iconv icv( Encoding::ascii, Encoding::utf8, broken_sjis_be_utf8 );
     const std::string& result = icv.convert( input, std::strlen(input) );
 
     EXPECT_EQ( "", result );
@@ -31,7 +32,7 @@ TEST_F(Iconv_ToAsciiFromUtf8, helloworld)
     char input[] = "hello world!\n";
     constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "ASCII", "UTF-8", broken_sjis_be_utf8 );
+    JDLIB::Iconv icv( Encoding::ascii, Encoding::utf8, broken_sjis_be_utf8 );
     const std::string& result = icv.convert( input, std::strlen(input) );
 
     EXPECT_EQ( "hello world!\n", result );
@@ -43,7 +44,7 @@ TEST_F(Iconv_ToAsciiFromUtf8, hiragana)
     char input[] = "あいうえお";
     constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "ASCII", "UTF-8", broken_sjis_be_utf8 );
+    JDLIB::Iconv icv( Encoding::ascii, Encoding::utf8, broken_sjis_be_utf8 );
     const std::string& result = icv.convert( input, std::strlen(input) );
 
     EXPECT_EQ( "&#12354;&#12356;&#12358;&#12360;&#12362;", result );
@@ -56,8 +57,9 @@ TEST_F(Iconv_ToAsciiFromUtf8, subdivision_flag)
     char input[] = "\U0001F3F4\U000E0067\U000E0062\U000E0065\U000E006E\U000E0067\U000E007F";
     constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "ASCII", "UTF-8", broken_sjis_be_utf8 );
+    JDLIB::Iconv icv( Encoding::ascii, Encoding::utf8, broken_sjis_be_utf8 );
     const std::string& result = icv.convert( input, std::strlen(input) );
+
     EXPECT_EQ( "&#127988;&#917607;&#917602;&#917605;&#917614;&#917607;&#917631;", result );
     EXPECT_EQ( 63, result.size() );
 }
@@ -71,7 +73,7 @@ TEST_F(Iconv_ToUtf8FromAscii, replacement_character_to_utf8_is_uFFFD)
     char input[] = "\x80\x91\xA2\xB3\xC4\xD5\xE6\xF7";
     constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "ASCII", broken_sjis_be_utf8 );
+    JDLIB::Iconv icv( Encoding::utf8, Encoding::ascii, broken_sjis_be_utf8 );
     const std::string& result = icv.convert( input, std::strlen(input) );
 
     // UTF-8へ変換するとき入力エンコーディングで無効なバイト列は U+FFFD に置き換える
@@ -88,7 +90,7 @@ TEST_F(Iconv_ToUtf8FromMs932, empty)
     char input[] = "";
     constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
+    JDLIB::Iconv icv( Encoding::utf8, Encoding::sjis, broken_sjis_be_utf8 );
     const std::string& result = icv.convert( input, std::strlen(input) );
 
     EXPECT_EQ( "", result );
@@ -100,7 +102,7 @@ TEST_F(Iconv_ToUtf8FromMs932, helloworld)
     char input[] = "hello world!\n";
     constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
+    JDLIB::Iconv icv( Encoding::utf8, Encoding::sjis, broken_sjis_be_utf8 );
     const std::string& result = icv.convert( input, std::strlen(input) );
 
     EXPECT_EQ( "hello world!\n", result );
@@ -112,7 +114,7 @@ TEST_F(Iconv_ToUtf8FromMs932, hiragana)
     char input[] = "\x82\xA0\x82\xA2\x82\xA4\x82\xA6\x82\xA8";
     constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
+    JDLIB::Iconv icv( Encoding::utf8, Encoding::sjis, broken_sjis_be_utf8 );
     const std::string& result = icv.convert( input, std::strlen(input) );
 
     EXPECT_EQ( "あいうえお", result );
@@ -124,7 +126,7 @@ TEST_F(Iconv_ToUtf8FromMs932, hex_a0)
     char input[] = "hello\xa0world!\n";
     constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
+    JDLIB::Iconv icv( Encoding::utf8, Encoding::sjis, broken_sjis_be_utf8 );
     const std::string& result = icv.convert( input, std::strlen(input) );
 
     EXPECT_EQ( "hello world!\n", result );
@@ -138,7 +140,7 @@ TEST_F(Iconv_ToUtf8FromMs932, mojibake_fix_inequality_sign_pattern1)
     char input[] = "<>test テスト<>";
     constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
+    JDLIB::Iconv icv( Encoding::utf8, Encoding::sjis, broken_sjis_be_utf8 );
     const std::string& result = icv.convert( input, std::strlen(input) );
 
     EXPECT_EQ( "<>test \xE7\xB9\x9D\xE2\x96\xA1\xE3\x81\x9B\xE7\xB9\x9D?<>", result );
@@ -152,7 +154,7 @@ TEST_F(Iconv_ToUtf8FromMs932, mojibake_fix_inequality_sign_pattern2)
     char input[] = "<> test テスト <>";
     constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
+    JDLIB::Iconv icv( Encoding::utf8, Encoding::sjis, broken_sjis_be_utf8 );
     const std::string& result = icv.convert( input, std::strlen(input) );
 
     EXPECT_EQ( "<> test \xE7\xB9\x9D\xE2\x96\xA1\xE3\x81\x9B\xE7\xB9\x9D\xE2\x96\xA1<>", result );
@@ -166,7 +168,7 @@ TEST_F(Iconv_ToUtf8FromMs932, mapping_error)
     char input[] = "\x81\xAD\x82\x40\x88\x90\x98\x90";
     constexpr bool broken_sjis_be_utf8 = false;
 
-    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
+    JDLIB::Iconv icv( Encoding::utf8, Encoding::sjis, broken_sjis_be_utf8 );
     const std::string& result = icv.convert( input, std::strlen(input) );
 
     EXPECT_EQ( "\u25A1\u25A1\u25A1\u25A1", result );
@@ -181,7 +183,7 @@ TEST_F(Iconv_ToUtf8FromMs932, broken_sjis_be_utf8)
                    " \x82\xa6\x82\xa8";
     constexpr bool broken_sjis_be_utf8 = true;
 
-    JDLIB::Iconv icv( "UTF-8", "MS932", broken_sjis_be_utf8 );
+    JDLIB::Iconv icv( Encoding::utf8, Encoding::sjis, broken_sjis_be_utf8 );
     const std::string& result = icv.convert( input, std::strlen(input) );
 
     EXPECT_EQ( "あいう <span class=\"BROKEN_SJIS\">入れ替わってる〜</span>? えお", result );

--- a/test/gtest_jdlib_misctrip.cpp
+++ b/test/gtest_jdlib_misctrip.cpp
@@ -17,7 +17,7 @@ class GetTripTest : public ::testing::Test {};
 // ヘルパー関数
 inline static std::string get_trip_sjis( std::string u8key )
 {
-    return MISC::get_trip( u8key, "Shift_JIS" );
+    return MISC::get_trip( u8key, Encoding::sjis );
 }
 
 TEST_F(GetTripTest, trip8_sjis_empty)

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -1895,37 +1895,37 @@ class MISC_UrlEncodeWithEncodingTest : public ::testing::Test {};
 TEST_F(MISC_UrlEncodeWithEncodingTest, empty_string)
 {
     std::string input = "";
-    EXPECT_EQ( "", MISC::url_encode( input, "MS932" ) );
+    EXPECT_EQ( "", MISC::url_encode( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodeWithEncodingTest, unencoded_ascii_characters)
 {
     std::string input = "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz*-._";
-    EXPECT_EQ( input, MISC::url_encode( input, "MS932" ) );
+    EXPECT_EQ( input, MISC::url_encode( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodeWithEncodingTest, u0020)
 {
     std::string input = " ";
-    EXPECT_EQ( "%20", MISC::url_encode( input, "MS932" ) );
+    EXPECT_EQ( "%20", MISC::url_encode( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodeWithEncodingTest, u000A)
 {
     std::string input = "quick\nbrown\n\nfox";
-    EXPECT_EQ( "quick%0Abrown%0A%0Afox", MISC::url_encode( input, "MS932" ) );
+    EXPECT_EQ( "quick%0Abrown%0A%0Afox", MISC::url_encode( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodeWithEncodingTest, u000D)
 {
     std::string input = "quick\rbrown\r\rfox";
-    EXPECT_EQ( "quick%0Dbrown%0D%0Dfox", MISC::url_encode( input, "MS932" ) );
+    EXPECT_EQ( "quick%0Dbrown%0D%0Dfox", MISC::url_encode( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodeWithEncodingTest, u000D_u000A)
 {
     std::string input = "quick\r\nbrown\r\n\r\nfox";
-    EXPECT_EQ( "quick%0D%0Abrown%0D%0A%0D%0Afox", MISC::url_encode( input, "MS932" ) );
+    EXPECT_EQ( "quick%0D%0Abrown%0D%0A%0D%0Afox", MISC::url_encode( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodeWithEncodingTest, encoded_ascii_characters)
@@ -1933,21 +1933,21 @@ TEST_F(MISC_UrlEncodeWithEncodingTest, encoded_ascii_characters)
     std::string input = "!\"#$%&\'()_+,_/_:;<=>?@_[\\]^_`_{|}~";
     std::string_view result = "%21%22%23%24%25%26%27%28%29_%2B%2C_%2F_"
                               "%3A%3B%3C%3D%3E%3F%40_%5B%5C%5D%5E_%60_%7B%7C%7D%7E";
-    EXPECT_EQ( result, MISC::url_encode( input, "MS932" ) );
+    EXPECT_EQ( result, MISC::url_encode( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodeWithEncodingTest, encoded_to_ms932)
 {
     std::string input = "\xE3\x81\x82"; // U+3042
     std::string_view result = "%82%A0";
-    EXPECT_EQ( result, MISC::url_encode( input, "MS932" ) );
+    EXPECT_EQ( result, MISC::url_encode( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodeWithEncodingTest, encoded_to_eucjp)
 {
     std::string input = "\xE3\x81\x82"; // U+3042
     std::string_view result = "%A4%A2";
-    EXPECT_EQ( result, MISC::url_encode( input, "EUCJP-MS" ) );
+    EXPECT_EQ( result, MISC::url_encode( input, Encoding::eucjp ) );
 }
 
 TEST_F(MISC_UrlEncodeWithEncodingTest, url_to_ms932)
@@ -1955,7 +1955,7 @@ TEST_F(MISC_UrlEncodeWithEncodingTest, url_to_ms932)
     std::string input = "https://jdim.test/い ろ/は?に=ほ&へ=と z";
     std::string_view result = "https%3A%2F%2Fjdim.test%2F%82%A2%20%82%EB%2F"
                               "%82%CD%3F%82%C9%3D%82%D9%26%82%D6%3D%82%C6%20z";
-    EXPECT_EQ( result, MISC::url_encode( input, "MS932" ) );
+    EXPECT_EQ( result, MISC::url_encode( input, Encoding::sjis ) );
 }
 
 
@@ -2033,37 +2033,37 @@ class MISC_UrlEncodePlusWithEncodingTest : public ::testing::Test {};
 TEST_F(MISC_UrlEncodePlusWithEncodingTest, empty_string)
 {
     std::string input = "";
-    EXPECT_EQ( "", MISC::url_encode_plus( input, "MS932" ) );
+    EXPECT_EQ( "", MISC::url_encode_plus( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodePlusWithEncodingTest, unencoded_ascii_characters)
 {
     std::string input = "0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz*-._";
-    EXPECT_EQ( input, MISC::url_encode_plus( input, "MS932" ) );
+    EXPECT_EQ( input, MISC::url_encode_plus( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodePlusWithEncodingTest, single_u0020)
 {
     std::string input = " ";
-    EXPECT_EQ( "+", MISC::url_encode_plus( input, "MS932" ) );
+    EXPECT_EQ( "+", MISC::url_encode_plus( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodePlusWithEncodingTest, u000A)
 {
     std::string input = "quick\nbrown\n\nfox";
-    EXPECT_EQ( "quick%0D%0Abrown%0D%0A%0D%0Afox", MISC::url_encode_plus( input, "MS932" ) );
+    EXPECT_EQ( "quick%0D%0Abrown%0D%0A%0D%0Afox", MISC::url_encode_plus( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodePlusWithEncodingTest, u000D)
 {
     std::string input = "quick\rbrown\r\rfox";
-    EXPECT_EQ( "quickbrownfox", MISC::url_encode_plus( input, "MS932" ) );
+    EXPECT_EQ( "quickbrownfox", MISC::url_encode_plus( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodePlusWithEncodingTest, u000D_u000A)
 {
     std::string input = "quick\r\nbrown\r\n\r\nfox";
-    EXPECT_EQ( "quick%0D%0Abrown%0D%0A%0D%0Afox", MISC::url_encode_plus( input, "MS932" ) );
+    EXPECT_EQ( "quick%0D%0Abrown%0D%0A%0D%0Afox", MISC::url_encode_plus( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodePlusWithEncodingTest, words_separated_by_u0020)
@@ -2071,7 +2071,7 @@ TEST_F(MISC_UrlEncodePlusWithEncodingTest, words_separated_by_u0020)
     // U+3000 won't be converted to '+'
     std::string input = "Quick Brown　Fox い ろ　は";
     std::string_view result = "Quick+Brown%81%40Fox+%82%A2+%82%EB%81%40%82%CD";
-    EXPECT_EQ( result, MISC::url_encode_plus( input, "MS932" ) );
+    EXPECT_EQ( result, MISC::url_encode_plus( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodePlusWithEncodingTest, encoded_ascii_characters)
@@ -2079,21 +2079,21 @@ TEST_F(MISC_UrlEncodePlusWithEncodingTest, encoded_ascii_characters)
     std::string input = "!\"#$%&\'()_+,_/_:;<=>?@_[\\]^_`_{|}~";
     std::string_view result = "%21%22%23%24%25%26%27%28%29_%2B%2C_%2F_"
                               "%3A%3B%3C%3D%3E%3F%40_%5B%5C%5D%5E_%60_%7B%7C%7D%7E";
-    EXPECT_EQ( result, MISC::url_encode_plus( input, "MS932" ) );
+    EXPECT_EQ( result, MISC::url_encode_plus( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodePlusWithEncodingTest, encoded_to_ms932)
 {
     std::string input = "\xE3\x81\x82"; // U+3042
     std::string_view result = "%82%A0";
-    EXPECT_EQ( result, MISC::url_encode_plus( input, "MS932" ) );
+    EXPECT_EQ( result, MISC::url_encode_plus( input, Encoding::sjis ) );
 }
 
 TEST_F(MISC_UrlEncodePlusWithEncodingTest, encoded_to_eucjp)
 {
     std::string input = "\xE3\x81\x82"; // U+3042
     std::string_view result = "%A4%A2";
-    EXPECT_EQ( result, MISC::url_encode_plus( input, "EUCJP-MS" ) );
+    EXPECT_EQ( result, MISC::url_encode_plus( input, Encoding::eucjp ) );
 }
 
 TEST_F(MISC_UrlEncodePlusWithEncodingTest, url_to_ms932)
@@ -2101,7 +2101,7 @@ TEST_F(MISC_UrlEncodePlusWithEncodingTest, url_to_ms932)
     std::string input = "https://jdim.test/い ろ/は?に=ほ&へ=と z";
     std::string_view result = "https%3A%2F%2Fjdim.test%2F%82%A2+%82%EB%2F"
                               "%82%CD%3F%82%C9%3D%82%D9%26%82%D6%3D%82%C6+z";
-    EXPECT_EQ( result, MISC::url_encode_plus( input, "MS932" ) );
+    EXPECT_EQ( result, MISC::url_encode_plus( input, Encoding::sjis ) );
 }
 
 


### PR DESCRIPTION
スレッド、板、ローダーなど文字エンコーディング変換を扱うクラスを拡張してテキストのエンコーディングを個別に設定できるようにします。
エンコーディングのデータは文字列のかわりにenum `Encoding`を使用します。
通信を行うクラスは基底クラスの`SKELETON::Loadable`がエンコーディングのデータを保持します。

文字エンコーディングの変換を扱う関数は文字列のかわりにenum `Encoding`を使ってエンコーディングを指定するように引数を変更します。
- `MISC::Iconv()`
- `MISC::url_encode()`
- `MISC::url_encode_plus()`
- `MISC::get_trip()`
