### PR TITLE
Ignore Encoding::unknown read from info file

### DIFF
--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -1928,7 +1928,12 @@ void ArticleBase::read_info()
 
         // charset
         GET_INFOVALUE( str_tmp, "charset = " );
-        if( ! str_tmp.empty() ) set_encoding( MISC::encoding_from_cstr( str_tmp.c_str() ) );
+        if( ! str_tmp.empty() ) {
+            if( const Encoding enc = MISC::encoding_from_cstr( str_tmp.c_str() );
+                    enc != Encoding::unknown ) {
+                set_encoding( enc );
+            }
+        }
 
         // あぼーん ID
         GET_INFOVALUE( str_tmp, "aboneid = " );

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1982,7 +1982,10 @@ void BoardBase::read_board_info()
     m_show_oldlog = cf.get_option_bool( "show_oldlog", false );
 
     std::string charset = cf.get_option_str( "charset", MISC::encoding_to_cstr( get_encoding() ) );
-    set_encoding( MISC::encoding_from_cstr( charset.c_str() ) );
+    if( const Encoding enc = MISC::encoding_from_cstr( charset.c_str() );
+            enc != Encoding::unknown ) {
+        set_encoding( enc );
+    }
 
     std::string str_tmp;
 


### PR DESCRIPTION
板やスレッドの情報を保存したファイルにある文字エンコーディング情報の互換性を確保するため設定の読み込みを修正します。

情報を保存したinfoファイルから読みこんだ文字エンコーディングの情報を`Encoding`列挙型に変換した結果が`Encoding::unknown`になるときは無視して設定しないように変更します。

この修正で`ISO-8859-1` (LATIN1)を利用する掲示板は文字エンコーディング設定を読み込めなくなります。
2ch互換のサイトでISO-8859-1は利用されていないため問題になる可能性は低いです。
