### PR TITLE
Rename MISC::encoding_from_cstr() to encoding_from_sv()

### DIFF
--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -1929,7 +1929,7 @@ void ArticleBase::read_info()
         // charset
         GET_INFOVALUE( str_tmp, "charset = " );
         if( ! str_tmp.empty() ) {
-            if( const Encoding enc = MISC::encoding_from_cstr( str_tmp.c_str() );
+            if( const Encoding enc = MISC::encoding_from_sv( str_tmp );
                     enc != Encoding::unknown ) {
                 set_encoding( enc );
             }

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1982,7 +1982,7 @@ void BoardBase::read_board_info()
     m_show_oldlog = cf.get_option_bool( "show_oldlog", false );
 
     std::string charset = cf.get_option_str( "charset", MISC::encoding_to_cstr( get_encoding() ) );
-    if( const Encoding enc = MISC::encoding_from_cstr( charset.c_str() );
+    if( const Encoding enc = MISC::encoding_from_sv( charset );
             enc != Encoding::unknown ) {
         set_encoding( enc );
     }

--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -7,7 +7,6 @@
 
 #include "jdiconv.h"
 
-#include <cstring>
 #include <cstdint>
 
 
@@ -32,17 +31,17 @@ const char* MISC::encoding_to_cstr( const Encoding encoding )
 }
 
 
-/** @brief 文字エンコーディングを表すヌル終端文字列から`Encoding`を取得する
+/** @brief 文字エンコーディングを表す文字列から`Encoding`を取得する
  *
  * @param[in] encoding 文字エンコーディング名 (not null)
- * @return 文字列と一致する列挙型。見つからなければ `Encoding::unknown` を返す。
+ * @return 文字列に対応する列挙型。見つからなければ `Encoding::unknown` を返す。
  */
-Encoding MISC::encoding_from_cstr( const char* encoding )
+Encoding MISC::encoding_from_sv( std::string_view encoding )
 {
-    assert( encoding );
+    assert( encoding.data() );
 
     for( std::size_t i = sizeof(encoding_string) / sizeof(char*) - 1; i > 0; --i ){
-        if( std::strcmp( encoding_string[i], encoding ) == 0 ) return static_cast<Encoding>( i );
+        if( encoding == encoding_string[i] ) return static_cast<Encoding>( i );
     }
     return Encoding::unknown;
 }

--- a/src/jdlib/misccharcode.h
+++ b/src/jdlib/misccharcode.h
@@ -32,7 +32,7 @@ namespace MISC
     };
 
     const char* encoding_to_cstr( const Encoding encoding );
-    Encoding encoding_from_cstr( const char* encoding );
+    Encoding encoding_from_sv( std::string_view encoding );
     bool is_eucjp( std::string_view input, std::size_t read_byte );
     bool is_jis( std::string_view input, std::size_t& read_byte );
     bool is_sjis( std::string_view input, std::size_t read_byte );

--- a/test/gtest_jdlib_misccharcode.cpp
+++ b/test/gtest_jdlib_misccharcode.cpp
@@ -46,52 +46,52 @@ TEST_F(MISC_EncodingToCstrTest, invalid_enum)
 }
 
 
-class MISC_EncodingFromCstr : public ::testing::Test {};
+class MISC_EncodingFromSvTest : public ::testing::Test {};
 
-TEST_F(MISC_EncodingFromCstr, iso_8859_1)
+TEST_F(MISC_EncodingFromSvTest, iso_8859_1)
 {
-    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "ISO-8859-1" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_sv( "ISO-8859-1" ) );
 }
 
-TEST_F(MISC_EncodingFromCstr, ascii)
+TEST_F(MISC_EncodingFromSvTest, ascii)
 {
-    EXPECT_EQ( Encoding::ascii, MISC::encoding_from_cstr( "ASCII" ) );
+    EXPECT_EQ( Encoding::ascii, MISC::encoding_from_sv( "ASCII" ) );
 }
 
-TEST_F(MISC_EncodingFromCstr, eucjp_ms)
+TEST_F(MISC_EncodingFromSvTest, eucjp_ms)
 {
-    EXPECT_EQ( Encoding::eucjp, MISC::encoding_from_cstr( "EUCJP-MS" ) );
+    EXPECT_EQ( Encoding::eucjp, MISC::encoding_from_sv( "EUCJP-MS" ) );
 }
 
-TEST_F(MISC_EncodingFromCstr, iso_2022_jp)
+TEST_F(MISC_EncodingFromSvTest, iso_2022_jp)
 {
-    EXPECT_EQ( Encoding::jis, MISC::encoding_from_cstr( "ISO-2022-JP" ) );
+    EXPECT_EQ( Encoding::jis, MISC::encoding_from_sv( "ISO-2022-JP" ) );
 }
 
-TEST_F(MISC_EncodingFromCstr, ms932)
+TEST_F(MISC_EncodingFromSvTest, ms932)
 {
-    EXPECT_EQ( Encoding::sjis, MISC::encoding_from_cstr( "MS932" ) );
+    EXPECT_EQ( Encoding::sjis, MISC::encoding_from_sv( "MS932" ) );
 }
 
-TEST_F(MISC_EncodingFromCstr, utf8)
+TEST_F(MISC_EncodingFromSvTest, utf8)
 {
-    EXPECT_EQ( Encoding::utf8, MISC::encoding_from_cstr( "UTF-8" ) );
+    EXPECT_EQ( Encoding::utf8, MISC::encoding_from_sv( "UTF-8" ) );
 }
 
-TEST_F(MISC_EncodingFromCstr, invalid_encoding_name)
+TEST_F(MISC_EncodingFromSvTest, invalid_encoding_name)
 {
-    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "" ) );
-    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "INVALID-ENCODING-NAME" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_sv( "" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_sv( "INVALID-ENCODING-NAME" ) );
 }
 
-TEST_F(MISC_EncodingFromCstr, small_case_is_invalid)
+TEST_F(MISC_EncodingFromSvTest, small_case_is_invalid)
 {
-    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "iso-8859-1" ) );
-    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "ascii" ) );
-    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "eucjp-ms" ) );
-    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "iso-2022-jp" ) );
-    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "ms932" ) );
-    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_cstr( "utf-8" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_sv( "iso-8859-1" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_sv( "ascii" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_sv( "eucjp-ms" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_sv( "iso-2022-jp" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_sv( "ms932" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_sv( "utf-8" ) );
 }
 
 


### PR DESCRIPTION
関数の引数を`const char*`から`std::string_view`に変更して関数の名称も更新します。
