### PR TITLE
Split MISC::encoding_to_cstr() and encoding_to_iconv_cstr()

### DIFF
--- a/src/jdlib/jdiconv.cpp
+++ b/src/jdlib/jdiconv.cpp
@@ -42,8 +42,8 @@ Iconv::Iconv( const Encoding to, const Encoding from, const bool broken_sjis_be_
     , m_enc_from( from )
     , m_broken_sjis_be_utf8{ broken_sjis_be_utf8 }
 {
-    const char* from_str = MISC::encoding_to_cstr( ( from == Encoding::unknown ) ? to : from );
-    const char* to_str = MISC::encoding_to_cstr( ( to == Encoding::unknown ) ? from : to );
+    const char* from_str = MISC::encoding_to_iconv_cstr( ( from == Encoding::unknown ) ? to : from );
+    const char* to_str = MISC::encoding_to_iconv_cstr( ( to == Encoding::unknown ) ? from : to );
 
 #ifdef _DEBUG
     std::cout << "Iconv::Iconv coding = " << from_str << " to " << to_str << std::endl;
@@ -74,9 +74,9 @@ void Iconv::open_by_alternative_names( const char* to_str, const char* from_str 
 
     if( m_cd == ( GIConv ) -1 ){
         std::string msg = "can't open iconv coding = ";
-        msg += MISC::encoding_to_cstr( m_enc_from );
+        msg += MISC::encoding_to_iconv_cstr( m_enc_from );
         msg += " to ";
-        msg += MISC::encoding_to_cstr( m_enc_to );
+        msg += MISC::encoding_to_iconv_cstr( m_enc_to );
         MISC::ERRMSG( msg );
     }
 }

--- a/src/jdlib/misccharcode.h
+++ b/src/jdlib/misccharcode.h
@@ -32,6 +32,7 @@ namespace MISC
     };
 
     const char* encoding_to_cstr( const Encoding encoding );
+    const char* encoding_to_iconv_cstr( const Encoding encoding );
     Encoding encoding_from_sv( std::string_view encoding );
     bool is_eucjp( std::string_view input, std::size_t read_byte );
     bool is_jis( std::string_view input, std::size_t& read_byte );

--- a/test/gtest_jdlib_misccharcode.cpp
+++ b/test/gtest_jdlib_misccharcode.cpp
@@ -21,7 +21,7 @@ TEST_F(MISC_EncodingToCstrTest, ascii)
 
 TEST_F(MISC_EncodingToCstrTest, eucjp)
 {
-    EXPECT_STREQ( "EUCJP-MS", MISC::encoding_to_cstr( Encoding::eucjp ) );
+    EXPECT_STREQ( "EUC-JP", MISC::encoding_to_cstr( Encoding::eucjp ) );
 }
 
 TEST_F(MISC_EncodingToCstrTest, jis)
@@ -31,7 +31,7 @@ TEST_F(MISC_EncodingToCstrTest, jis)
 
 TEST_F(MISC_EncodingToCstrTest, sjis)
 {
-    EXPECT_STREQ( "MS932", MISC::encoding_to_cstr( Encoding::sjis ) );
+    EXPECT_STREQ( "Shift_JIS", MISC::encoding_to_cstr( Encoding::sjis ) );
 }
 
 TEST_F(MISC_EncodingToCstrTest, utf8)
@@ -43,6 +43,45 @@ TEST_F(MISC_EncodingToCstrTest, invalid_enum)
 {
     EXPECT_STREQ( "ISO-8859-1", MISC::encoding_to_cstr( static_cast<Encoding>( -200 ) ) );
     EXPECT_STREQ( "ISO-8859-1", MISC::encoding_to_cstr( static_cast<Encoding>( 200 ) ) );
+}
+
+
+class MISC_EncodingToIconvCstrTest : public ::testing::Test {};
+
+TEST_F(MISC_EncodingToIconvCstrTest, unknown)
+{
+    EXPECT_STREQ( "ISO-8859-1", MISC::encoding_to_iconv_cstr( Encoding::unknown ) );
+}
+
+TEST_F(MISC_EncodingToIconvCstrTest, ascii)
+{
+    EXPECT_STREQ( "ASCII", MISC::encoding_to_iconv_cstr( Encoding::ascii ) );
+}
+
+TEST_F(MISC_EncodingToIconvCstrTest, eucjp)
+{
+    EXPECT_STREQ( "EUCJP-MS", MISC::encoding_to_iconv_cstr( Encoding::eucjp ) );
+}
+
+TEST_F(MISC_EncodingToIconvCstrTest, jis)
+{
+    EXPECT_STREQ( "ISO-2022-JP", MISC::encoding_to_iconv_cstr( Encoding::jis ) );
+}
+
+TEST_F(MISC_EncodingToIconvCstrTest, sjis)
+{
+    EXPECT_STREQ( "MS932", MISC::encoding_to_iconv_cstr( Encoding::sjis ) );
+}
+
+TEST_F(MISC_EncodingToIconvCstrTest, utf8)
+{
+    EXPECT_STREQ( "UTF-8", MISC::encoding_to_iconv_cstr( Encoding::utf8 ) );
+}
+
+TEST_F(MISC_EncodingToIconvCstrTest, invalid_enum)
+{
+    EXPECT_STREQ( "ISO-8859-1", MISC::encoding_to_iconv_cstr( static_cast<Encoding>( -200 ) ) );
+    EXPECT_STREQ( "ISO-8859-1", MISC::encoding_to_iconv_cstr( static_cast<Encoding>( 200 ) ) );
 }
 
 
@@ -61,6 +100,7 @@ TEST_F(MISC_EncodingFromSvTest, ascii)
 TEST_F(MISC_EncodingFromSvTest, eucjp_ms)
 {
     EXPECT_EQ( Encoding::eucjp, MISC::encoding_from_sv( "EUCJP-MS" ) );
+    EXPECT_EQ( Encoding::eucjp, MISC::encoding_from_sv( "EUC-JP" ) );
 }
 
 TEST_F(MISC_EncodingFromSvTest, iso_2022_jp)
@@ -71,6 +111,7 @@ TEST_F(MISC_EncodingFromSvTest, iso_2022_jp)
 TEST_F(MISC_EncodingFromSvTest, ms932)
 {
     EXPECT_EQ( Encoding::sjis, MISC::encoding_from_sv( "MS932" ) );
+    EXPECT_EQ( Encoding::sjis, MISC::encoding_from_sv( "Shift_JIS" ) );
 }
 
 TEST_F(MISC_EncodingFromSvTest, utf8)


### PR DESCRIPTION
`MISC::encoding_from_cstr()`が返す文字エンコーディング名の中には広く使われている名称ではなく特定の実装や拡張を表すものがあります。
エンコーディングの背景事情を知っていないと分かりにくいためUIや情報ファイルで使う文字エンコーディング名を返す関数と`JDLIB::Iconv`クラスで使う文字エンコーディング名を返す関数を分割します。

互換性のため`MISC::encoding_from_sv()`は両方の関数が返す文字列を解析するように修正します。

Add test cases for `MISC::encoding_to_iconv_cstr()`

### 互換性を破る変更
以下の2つのコミットは前方互換性が無くなります。
- edcd3bd2df13d72f49b93b872af955045735b758 (2023-03-04)
  Use enum `Encoding` for conversion functions and encoding settings (#1118)
- 93749e7cb271636373b63c0084ef7cfa998e09f3 (2023-03-04)
  `Iconv`: Remove unused constructors with `std::string` parameters (#1119)

これらのコミットは https://github.com/JDimproved/JDim/pull/1120 の修正がないため文字エンコーディング名の読み込みに失敗したときISO-8859-1を使うように設定されてしまいます。