### PR TITLE
Add unsafe character encoding options

### DIFF
--- a/src/article/preference.cpp
+++ b/src/article/preference.cpp
@@ -4,8 +4,9 @@
 
 #include "dbtree/interface.h"
 
-#include "jdlib/miscutil.h"
+#include "jdlib/misccharcode.h"
 #include "jdlib/misctime.h"
+#include "jdlib/miscutil.h"
 
 #include "config/globalconf.h"
 
@@ -36,6 +37,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     , m_check_noidabone( "ID無しをあぼ〜ん" )
     , m_check_boardabone( "板レベルでのあぼ〜んを有効にする" )
     , m_check_globalabone( "全体レベルでのあぼ〜んを有効にする" )
+    , m_hbox_since{ Gtk::ORIENTATION_HORIZONTAL, 0 }
     , m_label_since( false, "スレ立て日時 : ", std::string() )
     , m_label_modified( false, "最終更新日時 : ", std::string() )
     , m_button_clearmodified( "日時クリア" )
@@ -77,6 +79,17 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     m_hbox_write.pack_start( m_label_write );
     m_hbox_write.pack_start( m_bt_clear_post_history, Gtk::PACK_SHRINK );    
 
+    // テキストエンコーディング
+    m_label_charset.set_text( "テキストエンコーディング : " );
+    m_combo_charset.append( MISC::encoding_to_cstr( Encoding::utf8 ) );
+    m_combo_charset.append( MISC::encoding_to_cstr( Encoding::sjis ) );
+    m_combo_charset.append( MISC::encoding_to_cstr( Encoding::eucjp ) );
+    m_combo_charset.set_active_text( MISC::encoding_to_cstr( DBTREE::article_encoding( get_url() ) ) );
+
+    m_hbox_since.pack_start( m_label_since );
+    m_hbox_since.pack_start( m_label_charset, Gtk::PACK_SHRINK );
+    m_hbox_since.pack_start( m_combo_charset, Gtk::PACK_SHRINK );
+
     // 最大レス数
     const int max_res = DBTREE::article_number_max( get_url() );
     m_spin_maxres.set_range( 0, CONFIG::get_max_resnumber() );
@@ -95,7 +108,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     m_vbox_info.pack_start( m_label_cache, Gtk::PACK_SHRINK );
     m_vbox_info.pack_start( m_hbox_size, Gtk::PACK_SHRINK );
 
-    m_vbox_info.pack_start( m_label_since, Gtk::PACK_SHRINK );
+    m_vbox_info.pack_start( m_hbox_since, Gtk::PACK_SHRINK );
     m_vbox_info.pack_start( m_hbox_modified, Gtk::PACK_SHRINK );
     m_vbox_info.pack_start( m_hbox_write, Gtk::PACK_SHRINK );
 
@@ -261,6 +274,16 @@ void Preferences::slot_ok_clicked()
 
     // 最大レス数
     DBTREE::article_set_number_max( get_url(), m_spin_maxres.get_value_as_int() );
+
+    // charset
+    const std::string tmpcharset = m_combo_charset.get_active_text();
+    const Encoding tmpencoding = MISC::encoding_from_sv( tmpcharset );
+    if( tmpencoding != DBTREE::article_encoding( get_url() ) ){
+        // Encodingを更新
+        DBTREE::article_set_encoding( get_url(), tmpencoding );
+        // Viewが開かれていない場合があるのでここでNodeTreeを削除する
+        DBTREE::article_clear_nodetree( get_url() );
+    }
 
     // viewの再レイアウト
     CORE::core_set_command( "relayout_article", get_url() );

--- a/src/article/preference.h
+++ b/src/article/preference.h
@@ -27,6 +27,10 @@ namespace ARTICLE
         Gtk::Label m_label_maxres;
         Gtk::SpinButton m_spin_maxres;
 
+        // テキストエンコーディング
+        Gtk::Label m_label_charset;
+        Gtk::ComboBoxText m_combo_charset;
+
         // あぼーん
         Gtk::VBox m_vbox_abone;
         Gtk::Notebook m_notebook_abone;
@@ -57,6 +61,7 @@ namespace ARTICLE
         // 全体レベルでのあぼーん
         Gtk::CheckButton m_check_globalabone;
 
+        Gtk::Box m_hbox_since;
         SKELETON::LabelEntry m_label_since;
 
         // 最終更新日時

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -160,14 +160,23 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     set_activate_entry( m_spin_live );
 
     // テキストエンコーディング
-    m_label_charset.set_text( "テキストエンコーディング : " );
-    m_combo_charset.append( MISC::encoding_to_cstr( Encoding::utf8 ) );
-    m_combo_charset.append( MISC::encoding_to_cstr( Encoding::sjis ) );
-    m_combo_charset.append( MISC::encoding_to_cstr( Encoding::eucjp ) );
-    m_combo_charset.set_active_text( MISC::encoding_to_cstr( DBTREE::board_encoding( get_url() ) ) );
+    const char* tmpcharset = MISC::encoding_to_cstr( DBTREE::board_encoding( get_url() ) );
+    if( CONFIG::get_choose_character_encoding() ) {
+        m_label_charset.set_text( "テキストエンコーディング : " );
+        m_combo_charset.append( MISC::encoding_to_cstr( Encoding::utf8 ) );
+        m_combo_charset.append( MISC::encoding_to_cstr( Encoding::sjis ) );
+        m_combo_charset.append( MISC::encoding_to_cstr( Encoding::eucjp ) );
+        m_combo_charset.set_active_text( tmpcharset );
 
-    m_hbox_live.pack_start( m_label_charset, Gtk::PACK_SHRINK );
-    m_hbox_live.pack_start( m_combo_charset, Gtk::PACK_SHRINK );
+        m_hbox_live.pack_start( m_label_charset, Gtk::PACK_SHRINK );
+        m_hbox_live.pack_start( m_combo_charset, Gtk::PACK_SHRINK );
+    }
+    else {
+        // エンコーディング設定は安全でないので無効のときは設定欄(コンボボックス)を表示しない
+        m_label_charset.set_text( Glib::ustring::compose( "テキストエンコーディング :  %1", tmpcharset ) );
+
+        m_hbox_live.pack_start( m_label_charset, Gtk::PACK_SHRINK );
+    }
 
     // 一般ページのパッキング
     m_label_max_line.set_text( std::to_string( DBTREE::line_number( get_url() ) * 2 ) );
@@ -535,8 +544,10 @@ void Preferences::slot_ok_clicked()
     DBTREE::board_set_write_mail( get_url(), tmpmail );
 
     // charset
-    const std::string tmpcharset = m_combo_charset.get_active_text();
-    DBTREE::board_set_encoding( get_url(), MISC::encoding_from_sv( tmpcharset ) );
+    if( m_combo_charset.get_mapped() ) {
+        const std::string tmpcharset = m_combo_charset.get_active_text();
+        DBTREE::board_set_encoding( get_url(), MISC::encoding_from_sv( tmpcharset ) );
+    }
 
     // 実況間隔
     int live_sec = 0;

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -155,9 +155,19 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     m_hbox_live.set_spacing( 4 );
     m_hbox_live.pack_start( m_label_live, Gtk::PACK_SHRINK );
     m_hbox_live.pack_start( m_spin_live, Gtk::PACK_SHRINK );
-    m_hbox_live.pack_start( m_check_live, Gtk::PACK_SHRINK );
+    m_hbox_live.pack_start( m_check_live );
 
     set_activate_entry( m_spin_live );
+
+    // テキストエンコーディング
+    m_label_charset.set_text( "テキストエンコーディング : " );
+    m_combo_charset.append( MISC::encoding_to_cstr( Encoding::utf8 ) );
+    m_combo_charset.append( MISC::encoding_to_cstr( Encoding::sjis ) );
+    m_combo_charset.append( MISC::encoding_to_cstr( Encoding::eucjp ) );
+    m_combo_charset.set_active_text( MISC::encoding_to_cstr( DBTREE::board_encoding( get_url() ) ) );
+
+    m_hbox_live.pack_start( m_label_charset, Gtk::PACK_SHRINK );
+    m_hbox_live.pack_start( m_combo_charset, Gtk::PACK_SHRINK );
 
     // 一般ページのパッキング
     m_label_max_line.set_text( std::to_string( DBTREE::line_number( get_url() ) * 2 ) );
@@ -523,6 +533,10 @@ void Preferences::slot_ok_clicked()
     if( tmpmail == CONFIG::get_write_mail() ) tmpmail = std::string();
     else if( tmpmail.empty() ) tmpmail = JD_MAIL_BLANK; // 空白の場合 JD_MAIL_BLANK をセットする
     DBTREE::board_set_write_mail( get_url(), tmpmail );
+
+    // charset
+    const std::string tmpcharset = m_combo_charset.get_active_text();
+    DBTREE::board_set_encoding( get_url(), MISC::encoding_from_sv( tmpcharset ) );
 
     // 実況間隔
     int live_sec = 0;

--- a/src/board/preference.h
+++ b/src/board/preference.h
@@ -80,6 +80,10 @@ namespace BOARD
         Gtk::CheckButton m_check_live;
         Gtk::SpinButton m_spin_live;
 
+        // テキストエンコーディング
+        Gtk::Label m_label_charset;
+        Gtk::ComboBoxText m_combo_charset;
+
         // ネットワーク設定
         Gtk::Box m_vbox_network;
 

--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -299,6 +299,7 @@ void AboutConfig::append_rows()
     append_row( "指定した分ごとにセッションを自動保存 (0: 保存しない)", get_confitem()->save_session, CONF_SAVE_SESSION );
     append_row( "不正なMS932文字列をUTF-8と見なす", get_confitem()->broken_sjis_be_utf8, CONF_BROKEN_SJIS_BE_UTF8 );
     append_row( "不正な数値文字参照(サロゲートペア)をデコードする", get_confitem()->correct_character_reference, CONF_CORRECT_CHAR_REFERENCE );
+    append_row( "(安全でない) スレ一覧とスレビューのプロパティにあるエンコーディング設定を有効にする", get_confitem()->choose_character_encoding, CONF_CHOOSE_CHAR_ENCODING );
 }
 
 

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -597,6 +597,9 @@ bool ConfigItems::load( const bool restore )
     // 不正な数値文字参照(サロゲートペア)をデコードする
     correct_character_reference = cf.get_option_bool( "correct_character_reference", CONF_CORRECT_CHAR_REFERENCE );
 
+    // スレ一覧とスレビューのプロパティにあるエンコーディング設定を有効にする (unsafe)
+    choose_character_encoding = cf.get_option_bool( "choose_character_encoding", CONF_CHOOSE_CHAR_ENCODING );
+
     m_loaded = true;
 
     // 設定値に壊れている物がある
@@ -941,6 +944,7 @@ void ConfigItems::save_impl( const std::string& path )
 
     cf.update( "broken_sjis_be_utf8", broken_sjis_be_utf8 );
     cf.update( "correct_character_reference", correct_character_reference );
+    cf.update( "choose_character_encoding", choose_character_encoding );
 
     cf.save();
 }

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -542,6 +542,9 @@ namespace CONFIG
         /// 不正な数値文字参照(サロゲートペア)をデコードする
         bool correct_character_reference{};
 
+        /// スレ一覧とスレビューのプロパティにあるエンコーディング設定を有効にする (unsafe)
+        bool choose_character_encoding{};
+
         /////////////////////////
 
 

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -165,6 +165,7 @@ namespace CONFIG
         CONF_SAVE_SESSION = 0, // 指定した分ごとにセッションを自動保存 (0: 保存しない)
         CONF_BROKEN_SJIS_BE_UTF8 = 0, ///< 不正なMS932文字列をUTF-8と見なす
         CONF_CORRECT_CHAR_REFERENCE = 0, ///< 不正な数値文字参照(サロゲートペア)をデコードする
+        CONF_CHOOSE_CHAR_ENCODING = 0, ///< スレ一覧とスレビューのプロパティにあるエンコーディング設定を有効にする (unsafe)
     };
 
 // browsers.cpp のデフォルトのラベル番号

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -633,3 +633,9 @@ bool CONFIG::get_correct_character_reference(){
     return item ? item->correct_character_reference : false;
 }
 void CONFIG::set_correct_character_reference( const bool set ){ get_confitem()->correct_character_reference = set; }
+
+// スレ一覧とスレビューのプロパティにあるエンコーディング設定を有効にする (unsafe)
+bool CONFIG::get_choose_character_encoding(){
+    auto item = get_confitem();
+    return item ? item->choose_character_encoding : false;
+}

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -624,6 +624,9 @@ namespace CONFIG
     // 不正な数値文字参照(サロゲートペア)をデコードする
     bool get_correct_character_reference();
     void set_correct_character_reference( const bool set );
+
+    // スレ一覧とスレビューのプロパティにあるエンコーディング設定を有効にする (unsafe)
+    bool get_choose_character_encoding();
 }
 
 


### PR DESCRIPTION
### Add unsafe character encoding option to Board preferences
板のプロパティにテキストエンコーディングを切り替える設定を追加します。
この設定は実験的なサポートで安全ではありません。

### Add unsafe character encoding option to Article preferences
スレビューのプロパティに文字エンコーディングを切り替える設定を追加します。
この設定は実験的なサポートで安全ではありません。

### Add the about:config setting that hides character encoding option
スレ一覧やスレビューのプロパティにあるテキストエンコーディングの設定は安全でないため about:config に設定欄の有効・無効を切り替える項目を追加します。(デフォルト設定では無効にする)
無効のときは設定欄(コンボボックス)を隠してエンコーディングの情報だけ表示します。

関連のissue: #76
