### PR TITLE
Implement MISC::encoding_from_web_charset()

### DIFF
--- a/src/jdlib/misccharcode.h
+++ b/src/jdlib/misccharcode.h
@@ -34,6 +34,7 @@ namespace MISC
     const char* encoding_to_cstr( const Encoding encoding );
     const char* encoding_to_iconv_cstr( const Encoding encoding );
     Encoding encoding_from_sv( std::string_view encoding );
+    Encoding encoding_from_web_charset( std::string_view charset );
     bool is_eucjp( std::string_view input, std::size_t read_byte );
     bool is_jis( std::string_view input, std::size_t& read_byte );
     bool is_sjis( std::string_view input, std::size_t read_byte );

--- a/test/gtest_jdlib_misccharcode.cpp
+++ b/test/gtest_jdlib_misccharcode.cpp
@@ -136,6 +136,50 @@ TEST_F(MISC_EncodingFromSvTest, small_case_is_invalid)
 }
 
 
+class MISC_EncodingFromWebCharsetTest : public ::testing::Test {};
+
+TEST_F(MISC_EncodingFromWebCharsetTest, iso_8859_1)
+{
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_web_charset( "ISO-8859-1" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_web_charset( "latin1" ) );
+}
+
+TEST_F(MISC_EncodingFromWebCharsetTest, us_ascii)
+{
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_web_charset( "ASCII" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_web_charset( "US-ASCII" ) );
+}
+
+TEST_F(MISC_EncodingFromWebCharsetTest, euc_jp)
+{
+    EXPECT_EQ( Encoding::eucjp, MISC::encoding_from_web_charset( "EUC-JP" ) );
+    EXPECT_EQ( Encoding::eucjp, MISC::encoding_from_web_charset( "x-euc-jp" ) );
+}
+
+TEST_F(MISC_EncodingFromWebCharsetTest, iso_2022_jp)
+{
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_web_charset( "ISO-2022-JP" ) );
+}
+
+TEST_F(MISC_EncodingFromWebCharsetTest, shift_jis)
+{
+    EXPECT_EQ( Encoding::sjis, MISC::encoding_from_web_charset( "Shift_JIS" ) );
+    EXPECT_EQ( Encoding::sjis, MISC::encoding_from_web_charset( "Shift-JIS" ) );
+    EXPECT_EQ( Encoding::sjis, MISC::encoding_from_web_charset( "Windows-31J" ) );
+    EXPECT_EQ( Encoding::sjis, MISC::encoding_from_web_charset( "sjis" ) );
+    EXPECT_EQ( Encoding::sjis, MISC::encoding_from_web_charset( "x-sjis" ) );
+
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_web_charset( "MS_Kanji" ) );
+    EXPECT_EQ( Encoding::unknown, MISC::encoding_from_web_charset( "MS932" ) );
+}
+
+TEST_F(MISC_EncodingFromWebCharsetTest, utf8)
+{
+    EXPECT_EQ( Encoding::utf8, MISC::encoding_from_web_charset( "UTF-8" ) );
+    EXPECT_EQ( Encoding::utf8, MISC::encoding_from_web_charset( "utf8" ) );
+}
+
+
 class IsEucjpTest : public ::testing::Test {};
 
 TEST_F(IsEucjpTest, null_data)


### PR DESCRIPTION
Webで使われる文字エンコーディングのラベルから`Encoding`列挙型を取得する関数を実装します。
入力文字列とラベルの比較は繋ぎの記号(`-`, `_`)を取り除き大文字小文字を無視して行います。
`Encoding`の列挙子と一致しない文字列が渡されたときは`Encoding::unknown`を返します。

Add test cases for `MISC::encoding_from_web_charset()`

#### 参考文献
https://encoding.spec.whatwg.org/#names-and-labels
