### PR TITLE
Modify MISC::utf8_trim() parameter to use std::string_view

### DIFF
--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -2672,7 +2672,7 @@ void BBSListViewBase::replace_thread( const std::string& url, const std::string&
 #ifdef _DEBUG
                         std::cout << "name_row = " << ustr_name << std::endl;
 #endif
-                        if( MISC::utf8_trim( ustr_name ) == name_old ){
+                        if( MISC::utf8_trim( ustr_name.raw() ) == name_old ){
 #ifdef _DEBUG
                             std::cout << "replace name\n";
 #endif

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -519,7 +519,7 @@ void Preferences::slot_ok_clicked()
     if( m_proxy_frame.rd_disable.get_active() ) mode = DBTREE::PROXY_DISABLE;
     else if( m_proxy_frame.rd_local.get_active() ) mode = DBTREE::PROXY_LOCAL;
     DBTREE::board_set_mode_local_proxy( get_url(), mode );
-    DBTREE::board_set_local_proxy( get_url(), MISC::utf8_trim( m_proxy_frame.entry_host.get_text() ) );
+    DBTREE::board_set_local_proxy( get_url(), MISC::utf8_trim( m_proxy_frame.entry_host.get_text().raw() ) );
     DBTREE::board_set_local_proxy_port( get_url(), atoi( m_proxy_frame.entry_port.get_text().c_str() ) );
 
     mode = DBTREE::PROXY_GLOBAL;
@@ -527,7 +527,7 @@ void Preferences::slot_ok_clicked()
     else if( m_proxy_frame_w.rd_local.get_active() ) mode = DBTREE::PROXY_LOCAL;
 
     DBTREE::board_set_mode_local_proxy_w( get_url(), mode );
-    DBTREE::board_set_local_proxy_w( get_url(), MISC::utf8_trim( m_proxy_frame_w.entry_host.get_text() ) );
+    DBTREE::board_set_local_proxy_w( get_url(), MISC::utf8_trim( m_proxy_frame_w.entry_host.get_text().raw() ) );
     DBTREE::board_set_local_proxy_port_w( get_url(), atoi( m_proxy_frame_w.entry_port.get_text().c_str() ) );
 
     // 書き込み設定

--- a/src/browserpref.h
+++ b/src/browserpref.h
@@ -28,7 +28,7 @@ namespace CORE
         void slot_ok_clicked() override
         {
             CONFIG::set_browsercombo_id( m_combo.get_active_row_number() );
-            CONFIG::set_command_openurl( MISC::utf8_trim( m_entry_browser.get_text() ) );
+            CONFIG::set_command_openurl( MISC::utf8_trim( m_entry_browser.get_text().raw() ) );
         }
 
         // コンボボックスが変わった

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -312,34 +312,31 @@ std::string MISC::concat_with_suffix( const std::list<std::string>& list_in, cha
  * @param[in] str トリミングする文字列
  * @return トリミングした結果
  */
-std::string MISC::utf8_trim( const std::string& str )
+std::string MISC::utf8_trim( std::string_view str )
 {
-    constexpr const char* str_space = u8"\u3000"; // "\xE3\x80\x80" 全角スペース
-    constexpr size_t lng_space = 3;
+    constexpr std::string_view str_space = "\xE3\x80\x80"; // U+3000 全角スペース
+    constexpr std::size_t lng_space = str_space.size();
 
-    size_t lng = str.length();
-    
-    if( lng == 0 ) return str;
+    if( str.empty() ) return std::string{};
     // TODO: 半角スペースがなくてもトリミングしたほうがよいか検証する
-    if( str.find( ' ' ) == std::string::npos ) return str;
+    if( str.find( ' ' ) == std::string_view::npos ) return std::string{ str };
 
     // 前
-    size_t i = 0;
-    while( i < lng ){
+    std::size_t i = 0;
+    while( i < str.size() ) {
 
         // 半角
         if( str[ i ] == ' ' ) ++i;
 
         // 全角
-        else if( str[ i ] == str_space[ 0 ] &&
-                 str[ i +1 ] == str_space[ 1 ] &&
-                 str[ i +2 ] == str_space[ 2 ] ) i += lng_space;
+        else if( str.compare( i, lng_space, str_space ) == 0 ) i += lng_space;
+
         else break;
     }
-    if (i >= lng) return "";
+    if( i >= str.size() ) return std::string{};
 
     // 後
-    size_t i2 = lng -1;
+    std::size_t i2 = str.size() -1;
     while( 1 ){
 
         // 半角
@@ -347,13 +344,12 @@ std::string MISC::utf8_trim( const std::string& str )
 
         // 全角
         else if( i2 +1 >= lng_space &&
-                 str[ i2 - lng_space +1 ] == str_space[ 0 ] &&
-                 str[ i2 - lng_space +2 ] == str_space[ 1 ] &&
-                 str[ i2 - lng_space +3 ] == str_space[ 2 ] ) i2 -= lng_space;
+                str.compare( i2 - lng_space + 1, lng_space, str_space ) == 0 ) i2 -= lng_space;
+
         else break;
     }
 
-    return str.substr( i, i2 - i + 1 );
+    return std::string{ str.begin() + i, str.begin() + i2 + 1 };
 }
 
 

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -75,7 +75,7 @@ namespace MISC
     std::string concat_with_suffix( const std::list<std::string>& list_in, char suffix );
 
     /// str前後の半角スペース(U+0020)と全角スペース(U+3000)を削除
-    std::string utf8_trim( const std::string& str );
+    std::string utf8_trim( std::string_view str );
 
     /// str前後の改行(\r, \\n)、タブ(\t)、スペース(U+0020)を削除
     std::string ascii_trim( const std::string& str );

--- a/src/passwdpref.h
+++ b/src/passwdpref.h
@@ -97,12 +97,12 @@ namespace CORE
         void slot_ok_clicked() override
         {
             // 2ch
-            CORE::get_login2ch()->set_username( MISC::utf8_trim( m_frame_2ch.entry_id.get_text() ) );
-            CORE::get_login2ch()->set_passwd( MISC::utf8_trim( m_frame_2ch.entry_passwd.get_text() ) );
+            CORE::get_login2ch()->set_username( MISC::utf8_trim( m_frame_2ch.entry_id.get_text().raw() ) );
+            CORE::get_login2ch()->set_passwd( MISC::utf8_trim( m_frame_2ch.entry_passwd.get_text().raw() ) );
 
             // BE
-            CORE::get_loginbe()->set_username( MISC::utf8_trim( m_frame_be.entry_id.get_text() ) );
-            CORE::get_loginbe()->set_passwd( MISC::utf8_trim( m_frame_be.entry_passwd.get_text() ) );
+            CORE::get_loginbe()->set_username( MISC::utf8_trim( m_frame_be.entry_id.get_text().raw() ) );
+            CORE::get_loginbe()->set_passwd( MISC::utf8_trim( m_frame_be.entry_passwd.get_text().raw() ) );
         }
 
       public:

--- a/src/proxypref.h
+++ b/src/proxypref.h
@@ -73,19 +73,19 @@ namespace CORE
             // 2ch
             CONFIG::set_use_proxy_for2ch( m_frame_2ch.ckbt.get_active() );
             CONFIG::set_send_cookie_to_proxy_for2ch( m_frame_2ch.send_cookie_check.get_active() );
-            CONFIG::set_proxy_for2ch( MISC::utf8_trim( m_frame_2ch.entry_host.get_text() ) );
+            CONFIG::set_proxy_for2ch( MISC::utf8_trim( m_frame_2ch.entry_host.get_text().raw() ) );
             CONFIG::set_proxy_port_for2ch( atoi( m_frame_2ch.entry_port.get_text().c_str() ) );
 
             // 2ch書き込み用
             CONFIG::set_use_proxy_for2ch_w( m_frame_2ch_w.ckbt.get_active() );
             CONFIG::set_send_cookie_to_proxy_for2ch_w( m_frame_2ch_w.send_cookie_check.get_active() );
-            CONFIG::set_proxy_for2ch_w( MISC::utf8_trim( m_frame_2ch_w.entry_host.get_text() ) );
+            CONFIG::set_proxy_for2ch_w( MISC::utf8_trim( m_frame_2ch_w.entry_host.get_text().raw() ) );
             CONFIG::set_proxy_port_for2ch_w( atoi( m_frame_2ch_w.entry_port.get_text().c_str() ) );
 
             // 一般
             CONFIG::set_use_proxy_for_data( m_frame_data.ckbt.get_active() );
             CONFIG::set_send_cookie_to_proxy_for_data( m_frame_data.send_cookie_check.get_active() );
-            CONFIG::set_proxy_for_data( MISC::utf8_trim( m_frame_data.entry_host.get_text() ) );
+            CONFIG::set_proxy_for_data( MISC::utf8_trim( m_frame_data.entry_host.get_text().raw() ) );
             CONFIG::set_proxy_port_for_data( atoi( m_frame_data.entry_port.get_text().c_str() ) );
         }
 

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -120,6 +120,15 @@ TEST_F(Utf8TrimTest, remove_doublequote)
     EXPECT_EQ( expect, MISC::utf8_trim( "\u3000 \"\"\u3000 " ) );
 }
 
+TEST_F(Utf8TrimTest, input_length_is_shorter_than_u3000)
+{
+    std::string expect = "a";
+    EXPECT_EQ( expect, MISC::utf8_trim( " a" ) );
+
+    expect = "b";
+    EXPECT_EQ( expect, MISC::utf8_trim( "b " ) );
+}
+
 
 class AsciiTrimTest : public ::testing::Test {};
 


### PR DESCRIPTION
`MISC::utf8_trim()`に渡す文字列を複製しなくても長さや範囲を調整できるようにするため関数の引数を`std::string_view`に変更します。
