### PR TITLE
Loadable: Add character encoding detection by HTTP header Content-Type

### DIFF
--- a/src/skeleton/loadable.h
+++ b/src/skeleton/loadable.h
@@ -65,10 +65,13 @@ namespace SKELETON
 {
     class Loadable : public Dispatchable
     {
+        enum class CharsetDetection;
+
         std::unique_ptr<JDLIB::Loader> m_loader;
 
         bool m_low_priority{};
 
+        CharsetDetection m_charset_det; ///< HTTPやHTMLからテキストの文字エンコーディングを検出する処理の状態
         Encoding m_encoding;
 
         // ローダからコピーしたデータ
@@ -156,6 +159,7 @@ namespace SKELETON
         std::list< std::string > get_loader_cookies() const;
         std::string get_loader_location() const;
         size_t get_loader_length() const;
+        Encoding get_loader_content_charset() const;
     };
 }
 


### PR DESCRIPTION
HTTPヘッダーのContent-Typeを解析してテキストの文字エンコーディングを検出する機能を追加します。

関連のissue: https://github.com/JDimproved/JDim/issues/76