### PR TITLE
Implement MISC::parse_charset_from_html_meta()

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -2146,6 +2146,30 @@ std::string MISC::parse_html_form_action( const std::string& html )
 }
 
 
+/** @brief HTMLのmeta要素からテキストのエンコーディング(charset)を取得する
+ *
+ * @param[in] html HTMLの文字列
+ * @return 文字エンコーディングを表す文字列、見つからないときは空文字列を返す
+ */
+std::string MISC::parse_charset_from_html_meta( const std::string& html )
+{
+    constexpr const char* pattern = R"(<meta\s+(?:http-equiv=["']content-type["']\s+content=["'][^"']*)"
+                                    R"(charset=\s*([^"'\s]+)|charset=["']?\s*([^"'>\s]+)))";
+    JDLIB::Regex regex;
+    constexpr std::size_t offset = 0;
+    constexpr bool icase = true;   // 大文字小文字区別しない
+    constexpr bool newline = true; // . に改行をマッチさせる
+    constexpr bool usemigemo = false;
+    constexpr bool wchar = false;
+
+    if( regex.exec( pattern, html, offset, icase, newline, usemigemo, wchar ) ) {
+        if( regex.length( 1 ) > 0 ) return regex.str( 1 );
+        if( regex.length( 2 ) > 0 ) return regex.str( 2 );
+    }
+    return {};
+}
+
+
 /** @brief haystack の pos 以降から最初に needle と一致する位置を返す (ASCIIだけignore case)
  *
  * @param[in] haystack 検索する文字列

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -281,6 +281,9 @@ namespace MISC
     // 詳細は実装やテストコードを参照
     std::string parse_html_form_action( const std::string& html );
 
+    // HTMLのmeta要素からテキストのエンコーディング(charset)を取得する
+    std::string parse_charset_from_html_meta( const std::string& html );
+
     // haystack の pos 以降から最初に needle と一致する位置を返す (ASCIIだけignore case)
     // 見つからない場合は std::string::npos を返す、needle が空文字列なら pos を返す
     std::size_t ascii_ignore_case_find( const std::string& haystack, std::string_view needle, std::size_t pos = 0 );

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -1637,6 +1637,72 @@ TEST_F(MISC_ParseHtmlFormActionTest, https_url)
 }
 
 
+class MISC_ParseCharsetFromHtmlMetaTest : public ::testing::Test {};
+
+TEST_F(MISC_ParseCharsetFromHtmlMetaTest, empty_html)
+{
+    std::string result = MISC::parse_charset_from_html_meta( std::string{} );
+    EXPECT_EQ( result, std::string{} );
+}
+
+TEST_F(MISC_ParseCharsetFromHtmlMetaTest, http_equiv)
+{
+    const std::string html = R"(<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>)";
+    std::string result = MISC::parse_charset_from_html_meta( html );
+    EXPECT_EQ( result, "UTF-8" );
+}
+
+TEST_F(MISC_ParseCharsetFromHtmlMetaTest, http_equiv_uppercase)
+{
+    const std::string html = R"(<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="TEXT/HTML; CHARSET=Shift_JIS"/>)";
+    std::string result = MISC::parse_charset_from_html_meta( html );
+    EXPECT_EQ( result, "Shift_JIS" );
+}
+
+TEST_F(MISC_ParseCharsetFromHtmlMetaTest, http_equiv_trim)
+{
+    const std::string html = R"(<meta http-equiv="content-type" content="text/html; charset= EUC-JP "/>)";
+    std::string result = MISC::parse_charset_from_html_meta( html );
+    EXPECT_EQ( result, "EUC-JP" );
+}
+
+TEST_F(MISC_ParseCharsetFromHtmlMetaTest, charset)
+{
+    const std::string html = R"(<meta charset="UTF-8">)";
+    std::string result = MISC::parse_charset_from_html_meta( html );
+    EXPECT_EQ( result, "UTF-8" );
+}
+
+TEST_F(MISC_ParseCharsetFromHtmlMetaTest, charset_uppercase)
+{
+    const std::string html = R"(<META CHARSET="Shift_JIS">)";
+    std::string result = MISC::parse_charset_from_html_meta( html );
+    EXPECT_EQ( result, "Shift_JIS" );
+}
+
+TEST_F(MISC_ParseCharsetFromHtmlMetaTest, charset_trim)
+{
+    const std::string html = R"(<meta charset=" EUC-JP ">)";
+    std::string result = MISC::parse_charset_from_html_meta( html );
+    EXPECT_EQ( result, "EUC-JP" );
+}
+
+TEST_F(MISC_ParseCharsetFromHtmlMetaTest, charset_no_quote)
+{
+    const std::string html = R"(<meta charset=latin1>)";
+    std::string result = MISC::parse_charset_from_html_meta( html );
+    EXPECT_EQ( result, "latin1" );
+}
+
+TEST_F(MISC_ParseCharsetFromHtmlMetaTest, choose_first_meta_tag)
+{
+    const std::string html = R"(<meta http-equiv="Content-Type" content="text/html; charset=utf8">)"
+                             R"(<meta charset="x-sjis">)";
+    std::string result = MISC::parse_charset_from_html_meta( html );
+    EXPECT_EQ( result, "utf8" );
+}
+
+
 class ToPlainTest : public ::testing::Test {};
 
 TEST_F(ToPlainTest, empty)


### PR DESCRIPTION
HTMLのmeta要素からテキストのエンコーディング(charset)を表す文字列を取得する関数を実装します。
charsetが見つからないときは空文字列を返します。

Add test cases for `MISC::parse_charset_from_html_meta()`
