### PR TITLE
Loadable: Add character encoding detection by HTML meta element

### DIFF
--- a/src/skeleton/loadable.cpp
+++ b/src/skeleton/loadable.cpp
@@ -19,6 +19,7 @@ using namespace SKELETON;
 enum class Loadable::CharsetDetection
 {
     parse_header, ///< HTTP header を解析する
+    parse_body,   ///< HTML body 要素を解析する
     finished,     ///< 検出を終えた
 };
 
@@ -149,8 +150,34 @@ void Loadable::receive( const char* data, size_t size )
 
     if( m_charset_det == CharsetDetection::parse_header ) {
         const Encoding enc = get_loader_content_charset();
-        if( enc != Encoding::unknown ) set_encoding( enc );
-        m_charset_det = CharsetDetection::finished;
+        if( enc != Encoding::unknown ) {
+            set_encoding( enc );
+            // The HTTP header has a higher precedence than the in-HTML <meta> elements.
+            m_charset_det = CharsetDetection::finished;
+        }
+        else if( m_loader &&
+                 MISC::ascii_ignore_case_find( m_loader->data().contenttype, "html" ) != std::string::npos ) {
+            // If the content MIME type is text/html or application/xhtml+xml,
+            // find charset from <meta> elements.
+            m_charset_det = CharsetDetection::parse_body;
+        }
+        else {
+            m_charset_det = CharsetDetection::finished;
+        }
+    }
+    if( m_charset_det == CharsetDetection::parse_body ) {
+        std::string buf( data, size );
+        const std::string charset = MISC::parse_charset_from_html_meta( buf );
+        if( ! charset.empty() ) {
+            const Encoding enc = MISC::encoding_from_web_charset( charset );
+            if( enc != Encoding::unknown ) set_encoding( enc );
+            m_charset_det = CharsetDetection::finished;
+        }
+        else if( m_current_length >= 1024 ) {
+            // <meta> elements which declare a character encoding must be located
+            // entirely within the first 1024 bytes of the document.
+            m_charset_det = CharsetDetection::finished;
+        }
     }
 
     receive_data( data, size );

--- a/src/skeleton/loadable.cpp
+++ b/src/skeleton/loadable.cpp
@@ -19,7 +19,7 @@ using namespace SKELETON;
 enum class Loadable::CharsetDetection
 {
     parse_header, ///< HTTP header を解析する
-    parse_body,   ///< HTML body 要素を解析する
+    parse_meta,   ///< HTML meta 要素を解析する
     finished,     ///< 検出を終えた
 };
 
@@ -159,13 +159,13 @@ void Loadable::receive( const char* data, size_t size )
                  MISC::ascii_ignore_case_find( m_loader->data().contenttype, "html" ) != std::string::npos ) {
             // If the content MIME type is text/html or application/xhtml+xml,
             // find charset from <meta> elements.
-            m_charset_det = CharsetDetection::parse_body;
+            m_charset_det = CharsetDetection::parse_meta;
         }
         else {
             m_charset_det = CharsetDetection::finished;
         }
     }
-    if( m_charset_det == CharsetDetection::parse_body ) {
+    if( m_charset_det == CharsetDetection::parse_meta ) {
         std::string buf( data, size );
         const std::string charset = MISC::parse_charset_from_html_meta( buf );
         if( ! charset.empty() ) {


### PR DESCRIPTION
`SKELETON::Loadable`クラスの文字エンコーディング検出を拡張してHTML meta要素のcharsetを解析しテキストの文字エンコーディングを検出する機能を追加します。

Webの規格に合わせるためHTTPヘッダーのContent-TypeにcharsetがありJDimで利用できるときはヘッダーの値を優先して使います。

MIME typeがHTMLでないコンテンツやHTML meta要素のcharsetがJDimで利用できないエンコーディング、
またはHTMLの先頭1024バイト以内にmeta要素がなかったときは解析を打ち切り`Loadable`クラスに設定されたデフォルト値を使います。

#### 参考文献
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
