### PR TITLE
meson: Update version requirement for GTest (>= 1.10.0)

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -32,7 +32,7 @@
   ・alsa-lib (-Dalsa=enabled)
   ・openssl 1.1.1 以上 (-Dtls=openssl)
   ・migemo (-Dmigemo=enabled)
-  ・googletest (`test/RADME.md`を参照)
+  ・googletest 1.10.0 以上 (`test/RADME.md`を参照)
 
   WebPやAVIF画像の表示に必要なパッケージ
   インストールされていない環境では`.webp`や`.avif`で終わるURLは通常リンクになる。

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -44,7 +44,7 @@ layout: default
 - alsa-lib (`-Dalsa=enabled`)
 - openssl 1.1.1 以上 (`-Dtls=openssl`)
 - migemo (`-Dmigemo=enabled`)
-- googletest ([test/RADME.md][testreadme]を参照)
+- googletest 1.10.0 以上 ([test/RADME.md][testreadme]を参照)
 
 #### WebPやAVIF画像の表示に必要なパッケージ
 インストールされていない環境では`.webp`や`.avif`で終わるURLは通常リンクになる。

--- a/meson.build
+++ b/meson.build
@@ -151,9 +151,9 @@ endif
 build_tests_opt = get_option('build_tests')
 if not build_tests_opt.disabled()
   # ディストロのパッケージとmeson wrapに対応
-  gtest_main_dep = dependency('gtest',
-                              main : true,
+  gtest_main_dep = dependency('gtest_main',
                               fallback : ['gtest', 'gtest_main_dep'],
+                              version : '>= 1.10.0',
                               required : build_tests_opt)
   build_tests = gtest_main_dep.found()
 else


### PR DESCRIPTION
GTestの依存関係を探す処理を更新してバージョン要件を1.10.0以上にします。
また、ライブラリ `gtest_main` を使うようにmeson.buildを変更します。

変更前は `dependency()` の [`main` キーワード引数][1] を利用してGTestが提供する `main()` とリンクしていました。
GTest 1.10.0のころから pkg-config のサポートが追加されているため `main` キーワードを使わなくてもテストをビルドできるようになりました。

この修正でMeson実装の一つである [muon][2] を使ってJDimのビルドやテストが可能になります。
`dependency()` の `main` キーワードは今のところ古いGTestのサポート以外では使われていないようです。

[1]: https://mesonbuild.com/Dependencies.html#gtest-and-gmock
[2]: https://sr.ht/~lattis/muon/
