### PR TITLE
Fix C-style pointer cast

### DIFF
--- a/src/jdlib/misctrip.cpp
+++ b/src/jdlib/misctrip.cpp
@@ -65,7 +65,7 @@ std::string create_sha1( const std::string& key )
     std::array< unsigned char, digest_length > digest;
 
     // unsigned char *SHA1( const unsigned char *, size_t, unsigned char * );
-    SHA1( (const unsigned char *)key.c_str(), key.length(), digest.data() );
+    SHA1( static_cast<const unsigned char*>(static_cast<const void*>( key.c_str() )), key.size(), digest.data() );
 
 #else // defined USE_GNUTLS
 


### PR DESCRIPTION
C言語のキャスト構文を使ったポインターの型変換をC++のキャストに
置き換えます。

cppcheck 2.10のレポート
```
src/jdlib/misctrip.cpp:66:12: style: C-style pointer casting detected.
C++ offers four different kinds of casts as replacements: static_cast,
const_cast, dynamic_cast and reinterpret_cast. A C-style cast could
evaluate to any of those automatically, thus it is considered safer if
the programmer explicitly states which kind of cast is expected.
See also: https://www.securecoding.cert.org/confluence/display/cplusplus/EXP05-CPP.+Do+not+use+C-style+casts. [cstyleCast]
    SHA1( (const unsigned char *)key.c_str(), key.length(), digest.data() );
           ^
```
