### PR TITLE
Loadable: Change receive_data() parameters to use std::string_view

### DIFF
--- a/src/dbimg/img.h
+++ b/src/dbimg/img.h
@@ -8,6 +8,8 @@
 #include "skeleton/loadable.h"
 
 #include <string>
+#include <string_view>
+
 
 namespace Gtk
 {
@@ -123,7 +125,7 @@ namespace DBIMG
         
       private:
 
-        void receive_data( const char* data, size_t size ) override;
+        void receive_data( std::string_view buf ) override;
         void receive_finish() override;
 
         // ロード待ち状態セット/リセット

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1056,14 +1056,14 @@ void BoardBase::create_loaderdata( JDLIB::LOADERDATA& data )
 //
 // ローダよりsubject.txt受信
 //
-void BoardBase::receive_data( const char* data, size_t size )
+void BoardBase::receive_data( std::string_view buf )
 {
-    if( ! size ) return;
+    if( buf.empty() ) return;
 
     if( m_rawdata.capacity() < bb::kSizeOfRawData ) {
         m_rawdata.reserve( bb::kSizeOfRawData );
     }
-    m_rawdata.append( data, size );
+    m_rawdata.append( buf );
 
     if( m_read_url_boardbase ) return; // url_boardbase をロードして移転が起きたかチェック中
 
@@ -1078,7 +1078,7 @@ void BoardBase::receive_data( const char* data, size_t size )
     if( get_code() != HTTP_OK ) set_encoding( m_encoding_bak );
     if( ! m_iconv ) m_iconv = std::make_unique<JDLIB::Iconv>( Encoding::utf8, get_encoding() );
 
-    m_rawdata_left.append( data, size );
+    m_rawdata_left.append( buf );
 
     std::size_t byte_in = m_rawdata_left.rfind( '\n' );
     if( byte_in != std::string::npos ) {
@@ -1092,7 +1092,7 @@ void BoardBase::receive_data( const char* data, size_t size )
         m_rawdata_left.erase( 0, byte_in );
 
 #ifdef _DEBUG
-        std::cout << "BoardBase::receive_data rawdata.size = " << m_rawdata.size() << " size = " << size
+        std::cout << "BoardBase::receive_data rawdata.size = " << m_rawdata.size() << " size = " << buf.size()
                   << " byte_in = " << byte_in << " byte_out = " << rawdata_utf8.size()
                   << " rawdata_left.size = " << m_rawdata_left.size() << std::endl;
 #endif
@@ -1249,7 +1249,7 @@ void BoardBase::receive_finish()
 
         std::vector<char> rawdata( bb::kSizeOfRawData );
         const std::size_t lng = CACHE::load_rawdata( path_subject, rawdata.data(), bb::kSizeOfRawData );
-        receive_data( rawdata.data(), lng );
+        receive_data( std::string_view{ rawdata.data(), lng } );
     }
 
 #ifdef _DEBUG

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -15,6 +15,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 
@@ -595,7 +596,7 @@ namespace DBTREE
         virtual bool is_valid( const std::string& filename ) const { return false; }
 
         virtual void create_loaderdata( JDLIB::LOADERDATA& data );
-        void receive_data( const char* data, size_t size ) override;
+        void receive_data( std::string_view buf ) override;
         void receive_finish() override;
 
         // url_boardbase をロードして移転したかどうか解析開始

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -292,7 +292,7 @@ namespace DBTREE
             return rawlines;
         }
 
-        void receive_data( const char* data, size_t size ) override;
+        void receive_data( std::string_view buf ) override;
         void receive_finish() override;
 
         // 拡張属性を取り出す

--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -325,7 +325,7 @@ const char* NodeTreeMachi::raw2dat( char* rawlines, int& byte )
 //
 // ローダからデータ受け取り
 //
-void NodeTreeMachi::receive_data( const char* data, size_t size )
+void NodeTreeMachi::receive_data( std::string_view buf )
 {
     // dat落ち判定用処理。 receive_finish() も参照
     if( ! is_checking_update() && get_code() == HTTP_OK && m_buffer_for_200.empty() ) {
@@ -333,11 +333,10 @@ void NodeTreeMachi::receive_data( const char* data, size_t size )
         std::cout << "NodeTreeMachi::receive_data : save some bytes\n";
 #endif
 
-        const int lng = MIN( size, BUF_SIZE_200 );
-        m_buffer_for_200.append( data, lng );
+        m_buffer_for_200.append( buf.substr( 0, BUF_SIZE_200 ) );
     }
 
-    NodeTreeBase::receive_data( data, size );
+    NodeTreeBase::receive_data( buf );
 }
 
 

--- a/src/dbtree/nodetreemachi.h
+++ b/src/dbtree/nodetreemachi.h
@@ -10,6 +10,7 @@
 #include "nodetreebase.h"
 
 #include <memory>
+#include <string_view>
 
 
 namespace JDLIB
@@ -46,7 +47,7 @@ namespace DBTREE
         char* process_raw_lines( char* rawlines ) override;
         const char* raw2dat( char* rawlines, int& byte ) override;
 
-        void receive_data( const char* data, size_t size ) override;
+        void receive_data( std::string_view buf ) override;
         void receive_finish() override;
     };
 }

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -343,9 +343,9 @@ void Root::download_bbsmenu()
 // bbsmenu 受信中
 //
 // virtual
-void Root::receive_data( const char* data, size_t size )
+void Root::receive_data( std::string_view buf )
 {
-    m_rawdata.append( data, size );
+    m_rawdata.append( buf );
 }
 
 

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <string_view>
 
 
 namespace DBTREE
@@ -155,7 +156,7 @@ namespace DBTREE
 
         // bbsmenuのダウンロード用関数
         void clear();
-        void receive_data( const char* data, size_t size ) override;
+        void receive_data( std::string_view buf ) override;
         void receive_finish() override;
         void bbsmenu2xml( const std::string& menu );
 

--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -298,7 +298,6 @@ bool ChunkedDecoder::decode( char* buf, std::size_t& read_size )
                     // 最後のチャンク(長さ0)に達したら終了してトレーラー部は無視する
                     if( m_lng_leftdata == 0 ) {
                         read_size = decoded_size;
-                        buf[read_size] = '\0';
                         m_state = State::completed;
                         return true;
                     }
@@ -357,7 +356,6 @@ bool ChunkedDecoder::decode( char* buf, std::size_t& read_size )
         // バッファ終わり
         if( pos_chunk == read_size || m_state == State::completed ) {
             read_size = decoded_size;
-            buf[read_size] = '\0';
             // 処理の途中または完了したので m_state は変更しない
             return true;
         }
@@ -1024,7 +1022,8 @@ void Loader::run_main()
     m_data.size_data = 0;    
     do{
         // 読み込み
-        size_t read_size = 0;
+        std::size_t read_size = 0; // m_buf に読み込んだデータの長さ
+        // m_buf に格納したデータの末尾に '\0' は追加されないため read_size を使う
         while( read_size < m_lng_buf - mrg && !m_stop ){
 
             ssize_t tmpsize;
@@ -1090,8 +1089,6 @@ void Loader::run_main()
             }
 
         }
-
-        m_buf[ read_size ] = '\0';
 
         // 停止指定
         if( m_stop ) break;
@@ -1359,8 +1356,7 @@ int Loader::receive_header( char* buf, size_t& read_size )
     std::cout << "Loader::receive_header : read_size = " << read_size << std::endl;
 #endif
 
-    buf[ read_size ] = '\0';
-    m_data.str_header = buf;
+    m_data.str_header.assign( buf, read_size );
     size_t lng_header = m_data.str_header.find( "\r\n\r\n" );
     if( lng_header != std::string::npos ) lng_header += 4;
     else{

--- a/src/login2ch.cpp
+++ b/src/login2ch.cpp
@@ -119,13 +119,13 @@ void Login2ch::start_login()
 //
 // データ受信
 //
-void Login2ch::receive_data( const char* data, size_t size )
+void Login2ch::receive_data( std::string_view buf )
 {
 #ifdef _DEBUG
     std::cout << "Login2ch::receive_data\n";
 #endif
 
-    m_rawdata.append( data, size );
+    m_rawdata.append( buf );
 }
 
 

--- a/src/login2ch.h
+++ b/src/login2ch.h
@@ -12,6 +12,7 @@
 #include "skeleton/login.h"
 
 #include <string>
+#include <string_view>
 
 
 namespace CORE
@@ -30,7 +31,7 @@ namespace CORE
 
       private:
 
-        void receive_data( const char* , size_t ) override;
+        void receive_data( std::string_view buf ) override;
         void receive_finish() override;
     };
 

--- a/src/loginbe.cpp
+++ b/src/loginbe.cpp
@@ -123,15 +123,15 @@ void LoginBe::start_login()
 //
 // データ受信
 //
-void LoginBe::receive_data( const char* data, size_t size )
+void LoginBe::receive_data( std::string_view buf )
 {
 #ifdef _DEBUG
     std::cout << "LoginBe::receive_data\n";
 #endif
 
-    if( m_rawdata.size() + size < SIZE_OF_RAWDATA ){
+    if( m_rawdata.size() + buf.size() < SIZE_OF_RAWDATA ){
 
-        m_rawdata.append( data, size );
+        m_rawdata.append( buf );
     }
 }
 

--- a/src/loginbe.h
+++ b/src/loginbe.h
@@ -12,6 +12,7 @@
 #include "skeleton/login.h"
 
 #include <string>
+#include <string_view>
 
 
 namespace CORE
@@ -30,7 +31,7 @@ namespace CORE
 
       private:
 
-        void receive_data( const char* , size_t ) override;
+        void receive_data( std::string_view buf ) override;
         void receive_finish() override;
     };
 

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -218,11 +218,11 @@ void Post::post_msg()
 //
 // ローダからデータを受け取る
 //
-void Post::receive_data( const char* data, size_t size )
+void Post::receive_data( std::string_view buf )
 {
     if( get_code() != HTTP_OK ) return;
 
-    m_rawdata.append( data, size );
+    m_rawdata.append( buf );
 }
 
 

--- a/src/message/post.h
+++ b/src/message/post.h
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 
 
 namespace SKELETON
@@ -76,7 +77,7 @@ namespace MESSAGE
         void emit_sigfin();
         void slot_response( int id );
 
-        void receive_data( const char* data, size_t size ) override;
+        void receive_data( std::string_view buf ) override;
         void receive_finish() override;
     };
     

--- a/src/skeleton/loadable.cpp
+++ b/src/skeleton/loadable.cpp
@@ -180,7 +180,7 @@ void Loadable::receive( const char* data, size_t size )
         }
     }
 
-    receive_data( data, size );
+    receive_data( std::string_view{ data, size } );
 }
 
 

--- a/src/skeleton/loadable.h
+++ b/src/skeleton/loadable.h
@@ -52,6 +52,7 @@
 #include <ctime>
 #include <list>
 #include <memory>
+#include <string_view>
 
 
 namespace JDLIB
@@ -147,7 +148,7 @@ namespace SKELETON
         
       private:
 
-        virtual void receive_data( const char* , size_t ){};
+        virtual void receive_data( std::string_view ) {}
         virtual void receive_finish(){};
 
         void callback_dispatch() override;

--- a/src/skeleton/textloader.cpp
+++ b/src/skeleton/textloader.cpp
@@ -118,10 +118,10 @@ void TextLoader::download_text( const Encoding encoding )
 //
 // ローダよりデータ受信
 //
-void TextLoader::receive_data( const char* data, size_t size )
+void TextLoader::receive_data( std::string_view buf )
 {
-    if( m_rawdata.size() + size < tl::kSizeOfRawData ){
-        m_rawdata.append( data, size );
+    if( m_rawdata.size() + buf.size() < tl::kSizeOfRawData ){
+        m_rawdata.append( buf );
     }
     else{
         MISC::ERRMSG( "TextLoader : received failed ( BOF )\n" );

--- a/src/skeleton/textloader.h
+++ b/src/skeleton/textloader.h
@@ -13,6 +13,8 @@
 #include "loadable.h"
 
 #include <string>
+#include <string_view>
+
 
 namespace JDLIB
 {
@@ -61,7 +63,7 @@ namespace SKELETON
         void init();
         void clear();
 
-        void receive_data( const char* data, size_t size ) override;
+        void receive_data( std::string_view buf ) override;
         void receive_finish() override;
 
         // HTTP応答ヘッダーのクッキーを取り扱う場合は派生クラスでoverrideする

--- a/test/gtest_jdlib_loader.cpp
+++ b/test/gtest_jdlib_loader.cpp
@@ -5,6 +5,7 @@
 #include "gtest/gtest.h"
 
 #include <cstring>
+#include <string_view>
 
 
 namespace {
@@ -25,7 +26,7 @@ TEST_F(JDLIB_ChunkedDecoder_Decode, empty)
     char buf[] = "";
     std::size_t size = 0;
     EXPECT_TRUE( decoder.decode( buf, size ) );
-    EXPECT_STREQ( buf, "" );
+    EXPECT_EQ( std::string_view( buf, size ), "" );
     EXPECT_EQ( size, 0 );
     EXPECT_FALSE( decoder.is_completed() );
 }
@@ -36,7 +37,7 @@ TEST_F(JDLIB_ChunkedDecoder_Decode, last_chunk_only)
     char buf[] = "0\r\n";
     std::size_t size = 3;
     EXPECT_TRUE( decoder.decode( buf, size ) );
-    EXPECT_STREQ( buf, "" );
+    EXPECT_EQ( std::string_view( buf, size ), "" );
     EXPECT_EQ( size, 0 );
     EXPECT_TRUE( decoder.is_completed() );
 }
@@ -47,7 +48,7 @@ TEST_F(JDLIB_ChunkedDecoder_Decode, one_chunk)
     char buf[] = "a\r\nhelloworld\r\n0\r\n\r\n";
     std::size_t size = std::strlen( buf );
     EXPECT_TRUE( decoder.decode( buf, size ) );
-    EXPECT_STREQ( buf, "helloworld" );
+    EXPECT_EQ( std::string_view( buf, size ), "helloworld" );
     EXPECT_EQ( size, 10 );
     EXPECT_TRUE( decoder.is_completed() );
 }
@@ -58,7 +59,7 @@ TEST_F(JDLIB_ChunkedDecoder_Decode, one_chunk_including_crlf)
     char buf[] = "C\r\nhello\r\nworld\r\n0\r\n\r\n";
     std::size_t size = std::strlen( buf );
     EXPECT_TRUE( decoder.decode( buf, size ) );
-    EXPECT_STREQ( buf, "hello\r\nworld" );
+    EXPECT_EQ( std::string_view( buf, size ), "hello\r\nworld" );
     EXPECT_EQ( size, 12 );
     EXPECT_TRUE( decoder.is_completed() );
 }
@@ -69,7 +70,7 @@ TEST_F(JDLIB_ChunkedDecoder_Decode, multiple_chunks)
     char buf[] = "5\r\nhello\r\n5\r\nworld\r\n0\r\n\r\n";
     std::size_t size = std::strlen( buf );
     EXPECT_TRUE( decoder.decode( buf, size ) );
-    EXPECT_STREQ( buf, "helloworld" );
+    EXPECT_EQ( std::string_view( buf, size ), "helloworld" );
     EXPECT_EQ( size, 10 );
     EXPECT_TRUE( decoder.is_completed() );
 }
@@ -80,7 +81,7 @@ TEST_F(JDLIB_ChunkedDecoder_Decode, chunk_ext)
     char buf[] = "5;foo=bar\r\nhello\r\n5;baz\r\nworld\r\n0\r\n\r\n";
     std::size_t size = std::strlen( buf );
     EXPECT_TRUE( decoder.decode( buf, size ) );
-    EXPECT_STREQ( buf, "helloworld" );
+    EXPECT_EQ( std::string_view( buf, size ), "helloworld" );
     EXPECT_EQ( size, 10 );
     EXPECT_TRUE( decoder.is_completed() );
 }
@@ -91,7 +92,7 @@ TEST_F(JDLIB_ChunkedDecoder_Decode, traier_part)
     char buf[] = "5\r\nhello\r\n5\r\nworld\r\n0\r\nAdditional: Data\r\n\r\n";
     std::size_t size = std::strlen( buf );
     EXPECT_TRUE( decoder.decode( buf, size ) );
-    EXPECT_STREQ( buf, "helloworld" );
+    EXPECT_EQ( std::string_view( buf, size ), "helloworld" );
     EXPECT_EQ( size, 10 );
     EXPECT_TRUE( decoder.is_completed() );
 }
@@ -110,7 +111,7 @@ TEST_F(JDLIB_ChunkedDecoder_Decode, multiple_time_feed_chunks)
         std::strcpy( buf, input );
         size = std::strlen( buf );
         EXPECT_TRUE( decoder.decode( buf, size ) );
-        EXPECT_STREQ( buf, output );
+        EXPECT_EQ( std::string_view( buf, size ), output );
         EXPECT_EQ( size, output_size );
         EXPECT_EQ( decoder.is_completed(), is_completed );
     }
@@ -131,7 +132,7 @@ TEST_F(JDLIB_ChunkedDecoder_Decode, multiple_time_feed_crlf_fragmentation)
         std::strcpy( buf, input );
         size = std::strlen( buf );
         EXPECT_TRUE( decoder.decode( buf, size ) );
-        EXPECT_STREQ( buf, output );
+        EXPECT_EQ( std::string_view( buf, size ), output );
         EXPECT_EQ( size, output_size );
         EXPECT_EQ( decoder.is_completed(), is_completed );
     }
@@ -154,7 +155,7 @@ TEST_F(JDLIB_ChunkedDecoder_Decode, multiple_time_feed_body_fragmentation)
         std::strcpy( buf, input );
         size = std::strlen( buf );
         EXPECT_TRUE( decoder.decode( buf, size ) );
-        EXPECT_STREQ( buf, output );
+        EXPECT_EQ( std::string_view( buf, size ), output );
         EXPECT_EQ( size, output_size );
         EXPECT_EQ( decoder.is_completed(), is_completed );
     }
@@ -209,7 +210,7 @@ TEST_F(JDLIB_ChunkedDecoder_Decode, call_again_after_completed)
         std::strcpy( buf, input );
         size = std::strlen( buf );
         EXPECT_TRUE( decoder.decode( buf, size ) );
-        EXPECT_STREQ( buf, output );
+        EXPECT_EQ( std::string_view( buf, size ), output );
         EXPECT_EQ( size, output_size );
         EXPECT_TRUE( decoder.is_completed() );
     }


### PR DESCRIPTION
`Loadable::receive_data()`の引数を`std::string_view`を使うように変更します。
この変更で入力バッファはヌル終端の保証が無くなるため、ヌル終端が前提になっている実装やテストのコードを修正します。

`DBIMG::Img`クラスのダウンロード処理で画像でないデータを受信したときに行う404 Not Foundを探す処理を以下の条件に変更します。

- 404 -> Not -> Found の順に単語が並んでいる
- Not は Not, NOT, not, nOT のどれかに一致する
- Found は Found, FOUND, found, fOUND のどれかに一致する
