### PR TITLE
Get rid of size limitation for std::string

### DIFF
--- a/src/loginbe.cpp
+++ b/src/loginbe.cpp
@@ -129,10 +129,7 @@ void LoginBe::receive_data( std::string_view buf )
     std::cout << "LoginBe::receive_data\n";
 #endif
 
-    if( m_rawdata.size() + buf.size() < SIZE_OF_RAWDATA ){
-
-        m_rawdata.append( buf );
-    }
+    m_rawdata.append( buf );
 }
 
 

--- a/src/skeleton/textloader.cpp
+++ b/src/skeleton/textloader.cpp
@@ -120,12 +120,7 @@ void TextLoader::download_text( const Encoding encoding )
 //
 void TextLoader::receive_data( std::string_view buf )
 {
-    if( m_rawdata.size() + buf.size() < tl::kSizeOfRawData ){
-        m_rawdata.append( buf );
-    }
-    else{
-        MISC::ERRMSG( "TextLoader : received failed ( BOF )\n" );
-    }
+    m_rawdata.append( buf );
 }
 
 


### PR DESCRIPTION
`Loadable`から派生したクラスで受信したデータを格納するために使われるバッファは`std::string`に変更されているためデータを追加するとバッファのサイズが拡張されます。
そのためバッファのサイズ制限を取り除いてコードを整理します。
