### PR TITLE
Loader: Fix proxy connection using IPv6

### DIFF
--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -666,16 +666,9 @@ bool Loader::run( SKELETON::Loadable* cb, const LOADERDATA& data_in )
     }
     m_data.protocol_proxy = static_cast<int>( proxy );
 
-    // プロキシのポート番号
-    if( data_in.port_proxy != 0 ) m_data.port_proxy = data_in.port_proxy;
-
-    // ホスト名の後に指定されている
-    if( i = m_data.host_proxy.rfind( ':' ); i != std::string::npos ){
-        m_data.port_proxy = std::atoi( m_data.host_proxy.c_str() + ( i + 1 ) );
-        m_data.host_proxy = m_data.host_proxy.substr( 0, i );
-    }
-
     if( ! m_data.host_proxy.empty() ){
+        m_data.port_proxy = data_in.port_proxy;
+        if( m_data.port_proxy == 0 ) m_data.port_proxy = 8080;
         m_data.basicauth_proxy = data_in.basicauth_proxy;
     }
 


### PR DESCRIPTION
IPv6を使用してプロキシ接続を行うと失敗する不具合を修正します。
変更を差し戻したためプロキシのホスト名からポート番号を解析する機能は削除されます。

修正にあたり不具合報告をしていただきありがとうございました。
https://next2ch.net/test/read.cgi/linux/1654053581/60-61

Fixes #1140
