### PR TITLE
dbtree: Modify interface function return type to use const reference

### DIFF
--- a/src/article/articleview.cpp
+++ b/src/article/articleview.cpp
@@ -630,7 +630,9 @@ void ArticleViewMain::create_status_message()
     if( is_broken() ) str_stat += "[ 壊れています ] ";
     if( is_overflow() ) str_stat += "[ レス数が最大表示可能数以上です ] ";
 
-    if( ! DBTREE::article_ext_err( url_article() ).empty() ) str_stat += "[ " + DBTREE::article_ext_err( url_article() ) + " ] ";
+    if( const std::string& err = DBTREE::article_ext_err( url_article() ); ! err.empty() ) {
+        str_stat += "[ " + err + " ] ";
+    }
 
     ss_tmp << " / 速度 " << DBTREE::article_get_speed( url_article() )
            << " / " << DBTREE::article_lng_dat( url_article() )/1024 << " K ] "

--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -2352,7 +2352,7 @@ void ArticleViewBase::slot_on_url( const std::string& url, const std::string& im
         // 板
         else if( ! boardbase.empty() ){
 
-            std::string tmpstr = DBTREE::board_name( url );
+            const std::string& tmpstr = DBTREE::board_name( url );
             args.arg1 = "[ " + tmpstr + " ] ";
 
             view_popup = CORE::ViewFactory( CORE::VIEW_ARTICLEPOPUPHTML, m_url_article, args );
@@ -3687,7 +3687,7 @@ void ArticleViewBase::slot_copy_res( bool ref )
 
     std::string tmpstr = m_url_tmp + "\n";
     if( ref ) tmpstr += CONFIG::get_ref_prefix();
-    std::string board_name = DBTREE::board_name( m_url_article );
+    const std::string& board_name = DBTREE::board_name( m_url_article );
     if( ! board_name.empty() ) tmpstr += "[ " + board_name + " ] ";
     tmpstr += MISC::to_plain( DBTREE::article_subject( m_url_article ) ) + "\n\n";
     tmpstr += m_article->get_res_str( atoi( m_str_num.c_str() ), ref );

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -117,11 +117,11 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
         str_cookies = "クッキー:\n" + MISC::Iconv( temp_cookies, Encoding::utf8, DBTREE::board_encoding( get_url() ) ) + "\n";
     }
 
-    std::string keyword = DBTREE::board_keyword_for_write( get_url() );
-    if( ! keyword.empty() ) str_cookies.append( "\n書き込み用キーワード: " + keyword + "\n" );
+    const std::string& kw_write = DBTREE::board_keyword_for_write( get_url() );
+    if( ! kw_write.empty() ) str_cookies.append( "\n書き込み用キーワード: " + kw_write + "\n" );
 
-    keyword = DBTREE::board_keyword_for_newarticle( get_url() );
-    if( ! keyword.empty() ) str_cookies.append( "\nスレ立て用キーワード: " + keyword + "\n" );
+    const std::string& kw_new = DBTREE::board_keyword_for_newarticle( get_url() );
+    if( ! kw_new.empty() ) str_cookies.append( "\nスレ立て用キーワード: " + kw_new + "\n" );
 
     m_edit_cookies.set_hexpand( true );
     m_edit_cookies.set_propagate_natural_height( true );

--- a/src/dbtree/article2ch.cpp
+++ b/src/dbtree/article2ch.cpp
@@ -45,7 +45,7 @@ std::string Article2ch::create_write_message( const std::string& name, const std
             << "&oekaki_thread1=";
 
     // キーワード( hana=mogera や suka=pontan など )
-    const std::string keyword = DBTREE::board_keyword_for_write( get_url() );
+    const std::string& keyword = DBTREE::board_keyword_for_write( get_url() );
     if( ! keyword.empty() ) ss_post << "&" << keyword;
 
     // ログイン中

--- a/src/dbtree/articlejbbs.cpp
+++ b/src/dbtree/articlejbbs.cpp
@@ -35,10 +35,10 @@ std::string ArticleJBBS::create_write_message( const std::string& name, const st
     if( msg.empty() ) return std::string();
 
     // DIR と BBS を分離する( ID = DIR/BBS )
-    std::string boardid = DBTREE::board_id( get_url() );
-    int i = boardid.find( '/' );
-    std::string dir = boardid.substr( 0, i );
-    std::string bbs = boardid.substr( i + 1 );
+    const std::string& boardid = DBTREE::board_id( get_url() );
+    auto i = boardid.find( '/' );
+    std::string_view dir = std::string_view{ boardid }.substr( 0, i );
+    std::string_view bbs = std::string_view{ boardid }.substr( i + 1 );
 
     std::stringstream ss_post;
     ss_post.clear();

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -218,7 +218,7 @@ void DBTREE::download_bbsmenu()
 
 
 // bbsmenuの更新時間( 文字列 )
-std::string DBTREE::get_date_modified()
+const std::string& DBTREE::get_date_modified()
 {
     return get_root()->get_date_modified();
 }
@@ -231,13 +231,13 @@ time_t DBTREE::get_time_modified()
 }
 
 
-std::string DBTREE::board_path( const std::string& url )
+const std::string& DBTREE::board_path( const std::string& url )
 {
     return DBTREE::get_board( url )->get_path_board();
 }
 
 
-std::string DBTREE::board_id( const std::string& url )
+const std::string& DBTREE::board_id( const std::string& url )
 {
     return DBTREE::get_board( url )->get_id();
 }
@@ -249,7 +249,7 @@ time_t DBTREE::board_time_modified( const std::string& url )
 }
 
 // 板の更新時間( 文字列 )
-std::string DBTREE::board_date_modified( const std::string& url )
+const std::string& DBTREE::board_date_modified( const std::string& url )
 {
     return DBTREE::get_board( url )->get_date_modified();
 }
@@ -281,13 +281,13 @@ void DBTREE::board_set_modified_setting( const std::string& url, const std::stri
 }
 
 
-std::string DBTREE::board_name( const std::string& url )
+const std::string& DBTREE::board_name( const std::string& url )
 {
     return DBTREE::get_board( url )->get_name();
 }
 
 
-std::string DBTREE::board_subjecttxt( const std::string& url )
+const std::string& DBTREE::board_subjecttxt( const std::string& url )
 {
     return DBTREE::get_board( url )->get_subjecttxt();
 }
@@ -333,7 +333,7 @@ void DBTREE::board_delete_cookies( const std::string& url )
     DBTREE::get_board( url )->delete_cookies();
 }
 
-std::string DBTREE::board_keyword_for_write( const std::string& url )
+const std::string& DBTREE::board_keyword_for_write( const std::string& url )
 {
     return DBTREE::get_board( url )->get_keyword_for_write();
 }
@@ -351,7 +351,7 @@ void DBTREE::board_analyze_keyword_for_write( const std::string& url, const std:
 }
 
 
-std::string DBTREE::board_keyword_for_newarticle( const std::string& url )
+const std::string& DBTREE::board_keyword_for_newarticle( const std::string& url )
 {
     return DBTREE::get_board( url )->get_keyword_for_newarticle();
 }
@@ -375,13 +375,13 @@ std::string DBTREE::board_parse_form_data( const std::string& url, const std::st
 }
 
 
-std::string DBTREE::board_basicauth( const std::string& url )
+const std::string& DBTREE::board_basicauth( const std::string& url )
 {
     return DBTREE::get_board( url )->get_basicauth();
 }
 
 
-std::string DBTREE::board_ext( const std::string& url )
+const std::string& DBTREE::board_ext( const std::string& url )
 {
     return DBTREE::get_board( url )->get_ext();
 }
@@ -399,7 +399,7 @@ int DBTREE::board_code( const std::string& url )
 }
 
 
-std::string DBTREE::board_str_code( const std::string& url )
+const std::string& DBTREE::board_str_code( const std::string& url )
 {
     return DBTREE::get_board( url )->get_str_code();
 }
@@ -843,21 +843,21 @@ bool DBTREE::article_is_cached( const std::string& url )
 
 
 // 拡張子付き
-std::string DBTREE::article_id( const std::string& url )
+const std::string& DBTREE::article_id( const std::string& url )
 {
     return DBTREE::get_article( url )->get_id();
 }
 
 
 // idから拡張子を取ったもの
-std::string DBTREE::article_key( const std::string& url )
+const std::string& DBTREE::article_key( const std::string& url )
 {
     return DBTREE::get_article( url )->get_key();
 }
 
 
 // 移転する前のオリジナルのURL
-std::string DBTREE::article_org_host( const std::string& url )
+const std::string& DBTREE::article_org_host( const std::string& url )
 {
     return DBTREE::get_article( url )->get_org_host();
 }
@@ -883,7 +883,7 @@ time_t DBTREE::article_time_modified( const std::string& url )
 
 
 // スレの更新時間( 文字列 )
-std::string DBTREE::article_date_modified( const std::string& url )
+const std::string& DBTREE::article_date_modified( const std::string& url )
 {
     return DBTREE::get_article( url )->get_date_modified();
 }
@@ -936,12 +936,12 @@ int DBTREE::article_code( const std::string& url )
     return DBTREE::get_article( url )->get_code();
 }
 
-std::string DBTREE::article_str_code( const std::string& url )
+const std::string& DBTREE::article_str_code( const std::string& url )
 {
     return DBTREE::get_article( url )->get_str_code();
 }
 
-std::string DBTREE::article_ext_err( const std::string& url )
+const std::string& DBTREE::article_ext_err( const std::string& url )
 {
     return DBTREE::get_article( url )->get_ext_err();
 }

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -90,21 +90,21 @@ namespace DBTREE
     bool remove_etc( const std::string& url, const std::string& name );
     void save_etc();
     void download_bbsmenu();
-    std::string get_date_modified(); // bbsmenuの更新時間( 文字列 )
+    const std::string& get_date_modified(); // bbsmenuの更新時間( 文字列 )
     time_t get_time_modified(); // bbsmenuの更新時間( time_t )
 
     // board 系
-    std::string board_path( const std::string& url );
-    std::string board_id( const std::string& url );
+    const std::string& board_path( const std::string& url );
+    const std::string& board_id( const std::string& url );
     time_t board_time_modified( const std::string& url ); // 板の更新時間( time_t )
-    std::string board_date_modified( const std::string& url ); // 板の更新時間( 文字列 )
+    const std::string& board_date_modified( const std::string& url ); // 板の更新時間( 文字列 )
     void board_set_date_modified( const std::string& url, const std::string& date ); // 板の更新時間( 文字列 )をセット
     const std::string& board_get_modified_localrule( const std::string& url );
     void board_set_modified_localrule( const std::string& url, const std::string& modified );
     const std::string& board_get_modified_setting( const std::string& url );
     void board_set_modified_setting( const std::string& url, const std::string& modified );
-    std::string board_name( const std::string& url );
-    std::string board_subjecttxt( const std::string& url );
+    const std::string& board_name( const std::string& url );
+    const std::string& board_subjecttxt( const std::string& url );
     Encoding board_encoding( const std::string& url );
     void board_set_encoding( const std::string& url, const Encoding enc );
     std::string board_cookie_by_host( const std::string& url );
@@ -112,18 +112,18 @@ namespace DBTREE
     std::string board_cookie_for_post( const std::string& url );
     void board_set_list_cookies( const std::string& url, const std::list< std::string>& list_cookies );
     void board_delete_cookies( const std::string& url );
-    std::string board_keyword_for_write( const std::string& url );
+    const std::string& board_keyword_for_write( const std::string& url );
     void board_set_keyword_for_write( const std::string& url, const std::string& keyword );
     void board_analyze_keyword_for_write( const std::string& url, const std::string& html );
-    std::string board_keyword_for_newarticle( const std::string& url );
+    const std::string& board_keyword_for_newarticle( const std::string& url );
     void board_set_keyword_for_newarticle( const std::string& url, const std::string& keyword );
     void board_analyze_keyword_for_newarticle( const std::string& url, const std::string& html );
     std::string board_parse_form_data( const std::string& url, const std::string& html );
-    std::string board_basicauth( const std::string& url );
-    std::string board_ext( const std::string& url );
+    const std::string& board_basicauth( const std::string& url );
+    const std::string& board_ext( const std::string& url );
     int board_status( const std::string& url );
     int board_code( const std::string& url );
-    std::string board_str_code( const std::string& url );
+    const std::string& board_str_code( const std::string& url );
     void board_save_info( const std::string& url );
     void board_download_front( const std::string& url );
     void board_download_subject( const std::string& url, const std::string& url_update_view );
@@ -214,13 +214,13 @@ namespace DBTREE
 
     // article 系
     bool article_is_cached( const std::string& url ); // キャッシュにあるかどうか
-    std::string article_id( const std::string& url ); // 拡張子込み "12345.dat" みたいに
-    std::string article_key( const std::string& url ); // idから拡張子を取ったもの。書き込み用
-    std::string article_org_host( const std::string& url ); // 移転する前のオリジナルのURL
+    const std::string& article_id( const std::string& url ); // 拡張子込み "12345.dat" みたいに
+    const std::string& article_key( const std::string& url ); // idから拡張子を取ったもの。書き込み用
+    const std::string& article_org_host( const std::string& url ); // 移転する前のオリジナルのURL
     time_t article_since_time( const std::string& url );
     std::string article_since_date( const std::string& url );
     time_t article_time_modified( const std::string& url ); // スレの更新時間( time_t )
-    std::string article_date_modified( const std::string& url ); // スレの更新時間( 文字列 )
+    const std::string& article_date_modified( const std::string& url ); // スレの更新時間( 文字列 )
     void article_set_date_modified( const std::string& url, const std::string& date ); // スレの更新時間( 文字列 )をセット
     Encoding article_encoding( const std::string& url );
     void article_set_encoding( const std::string& url, const Encoding enc );
@@ -229,8 +229,8 @@ namespace DBTREE
     std::string article_write_date( const std::string& url );
     int article_status( const std::string& url );
     int article_code( const std::string& url );
-    std::string article_str_code( const std::string& url );
-    std::string article_ext_err( const std::string& url );
+    const std::string& article_str_code( const std::string& url );
+    const std::string& article_ext_err( const std::string& url );
     const std::string& article_subject( const std::string& url );
     const std::string& article_modified_subject( const std::string& url, const bool renew = false );
     int article_number( const std::string& url );

--- a/src/usrcmdmanager.cpp
+++ b/src/usrcmdmanager.cpp
@@ -243,8 +243,8 @@ std::string Usrcmd_Manager::replace_cmd( const std::string& cmd,
                                          const int number ) const
 {
     std::string cmd_out = cmd;
-    const std::string oldhostl = DBTREE::article_org_host( link );
-    const std::string oldhost = DBTREE::article_org_host( url );
+    const std::string& oldhostl = DBTREE::article_org_host( link );
+    const std::string& oldhost = DBTREE::article_org_host( url );
 
     cmd_out = MISC::replace_str( cmd_out, "$URL", DBTREE::url_readcgi( url, 0, 0 ) );
     cmd_out = MISC::replace_str( cmd_out, "$DATURL", DBTREE::url_dat( url ) );


### PR DESCRIPTION
### dbtree: Modify interface function return type to use const reference
名前空間`DBTREE`のオブジェクトが保持している文字列データを返すインターフェース関数のうち一部を修正します。
戻り値の型を`const std::string&`に変更することで関数呼び出しでコピーが発生しないようにします。

### Avoid string copy from DBTREE interface function return value
`const std::string&`を返す`DBTREE`のインターフェース関数を呼び出す箇所では値ではなくconst参照を受け取るように修正しコピーを回避します。

関連のissue: #76
