### PR TITLE
dbtree: Modify HTTP request range for checking DAT update

### DIFF
--- a/src/dbtree/nodetree2ch.cpp
+++ b/src/dbtree/nodetree2ch.cpp
@@ -207,6 +207,8 @@ void NodeTree2ch::create_loaderdata( JDLIB::LOADERDATA& data )
         // 1byte前からレジュームして '\n' が返ってこなかったらあぼーんがあったってこと
         if( get_lng_dat() ) {
             data.byte_readfrom = get_lng_dat() -1;
+            // 更新チェックのときは未取得の範囲を指定する
+            if( is_checking_update() ) data.byte_readfrom += 1;
             set_resume( true );
         }
         else set_resume( false );

--- a/src/dbtree/nodetree2chcompati.cpp
+++ b/src/dbtree/nodetree2chcompati.cpp
@@ -156,6 +156,8 @@ void NodeTree2chCompati::create_loaderdata( JDLIB::LOADERDATA& data )
     // 1byte前からレジュームして '\n' が返ってこなかったらあぼーんがあったってこと
     if( get_lng_dat() ) {
         data.byte_readfrom = get_lng_dat() -1;
+        // 更新チェックのときは未取得の範囲を指定する
+        if( is_checking_update() ) data.byte_readfrom += 1;
         set_resume( true );
     }
     else set_resume( false );


### PR DESCRIPTION
DATデータの続きがあるか更新チェックを行うためHTTP HEADでリクエストするときは取得したDATデータより後ろの部分を要求するように範囲を調整します。

2ch系の掲示板でDATデータの続きを取得するときは1byte前からレジュームして '\n' が返ってこなかったらあぼーんがあったと判定しています。

関連のissue: #76
