### PR TITLE
NodeTreeBase: Use std::string& for process_raw_lines() parameter type

### DIFF
--- a/src/dbtree/nodetree2ch.cpp
+++ b/src/dbtree/nodetree2ch.cpp
@@ -61,9 +61,9 @@ NodeTree2ch::~NodeTree2ch()
 //
 // 先頭にrawモードのステータスが入っていたら取り除く
 //
-char* NodeTree2ch::process_raw_lines( char* rawlines )
+char* NodeTree2ch::process_raw_lines( std::string& rawlines )
 {
-    char* pos = rawlines;
+    char* pos = rawlines.data();
 
     if( m_mode == MODE_OFFLAW ){
         // rokka独自のステータスが入っている

--- a/src/dbtree/nodetree2ch.h
+++ b/src/dbtree/nodetree2ch.h
@@ -31,7 +31,7 @@ namespace DBTREE
 
       protected:
 
-        char* process_raw_lines( char* rawlines ) override;
+        char* process_raw_lines( std::string& rawlines ) override;
 
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;
 

--- a/src/dbtree/nodetree2chcompati.cpp
+++ b/src/dbtree/nodetree2chcompati.cpp
@@ -79,9 +79,9 @@ void NodeTree2chCompati::init_loading()
 //
 // 先頭にrawモードのステータスが入っていたら取り除く
 //
-char* NodeTree2chCompati::process_raw_lines( char* rawlines )
+char* NodeTree2chCompati::process_raw_lines( std::string& rawlines )
 {
-    char* pos = rawlines;
+    char* pos = rawlines.data();
 
     if( *pos == '+' || *pos == '-' || *pos == 'E' ){
 

--- a/src/dbtree/nodetree2chcompati.h
+++ b/src/dbtree/nodetree2chcompati.h
@@ -32,7 +32,7 @@ namespace DBTREE
 
         void clear() override;
         void init_loading() override;
-        char* process_raw_lines( char* rawlines ) override;
+        char* process_raw_lines( std::string& rawlines ) override;
         const char* raw2dat( char* rawlines, int& byte ) override;
 
         char* skip_status_line( char* pos, int status );

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1413,7 +1413,7 @@ void NodeTreeBase::add_raw_lines( std::string& buffer_lines )
     }
 
     // 保存前にrawデータを加工
-    char* rawlines = process_raw_lines( buffer_lines.data() );
+    char* rawlines = process_raw_lines( buffer_lines );
 
     size_t lng = strlen( rawlines );
     if( ! lng ) return;

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -283,7 +283,7 @@ namespace DBTREE
 
         // 保存前にrawデータを加工
         // デフォルトでは何もしない
-        virtual char* process_raw_lines( char* rawlines ){ return rawlines; }
+        virtual char* process_raw_lines( std::string& rawlines ){ return rawlines.data(); }
 
         // raw データを dat に変換
         // デフォルトでは何もしない

--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -147,10 +147,10 @@ void NodeTreeMachi::create_loaderdata( JDLIB::LOADERDATA& data )
 //
 // キャッシュに保存する前の前処理
 //
-char* NodeTreeMachi::process_raw_lines( char* rawlines )
+char* NodeTreeMachi::process_raw_lines( std::string& rawlines )
 {
     // オフラインか offlaw 形式を使用する場合はそのまま返す
-    if( ! is_loading() || CONFIG::get_use_machi_offlaw() ) return rawlines;
+    if( ! is_loading() || CONFIG::get_use_machi_offlaw() ) return rawlines.data();
 
     const size_t offset = 0;
     const bool icase = false;

--- a/src/dbtree/nodetreemachi.h
+++ b/src/dbtree/nodetreemachi.h
@@ -44,7 +44,7 @@ namespace DBTREE
         void clear() override;
         void init_loading() override;
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;
-        char* process_raw_lines( char* rawlines ) override;
+        char* process_raw_lines( std::string& rawlines ) override;
         const char* raw2dat( char* rawlines, int& byte ) override;
 
         void receive_data( std::string_view buf ) override;


### PR DESCRIPTION
`process_raw_lines()`の引数を`std::string&`に置き換えてコードを整理します。
