### PR TITLE
NodeTreeBase: Implement sweep_buffer()

### DIFF
--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -294,6 +294,7 @@ namespace DBTREE
 
         void receive_data( std::string_view buf ) override;
         void receive_finish() override;
+        void sweep_buffer();
 
         // 拡張属性を取り出す
         virtual void parse_extattr( std::string_view str ) {};


### PR DESCRIPTION
保留された受信データをDATに変換する処理をメンバー関数にしてコードを整理します。

関連のissue: #76
