### PR TITLE
NodeTreeBase: Modify default name detection to ignore trailing whitespace

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1694,10 +1694,10 @@ void NodeTreeBase::parse_name( NODE* header, std::string_view str, const int col
     const bool ahref = false;
     NODE *node;
 
-    const bool defaultname{ m_default_noname.rfind( str, 0 ) == 0 };
-
     // 後ろの空白を除く
     while( str.size() > 0 && str.back() == ' ' ) str.remove_suffix( 1 );
+
+    const bool defaultname{ m_default_noname == str };
 
     // 文字列置換
     std::string str_name;


### PR DESCRIPTION
デフォルト名無しかどうか判定する比較で末尾の空白文字を無視して行うように修正します。
