### PR TITLE
NodeTreeBase: Get rid of freeing memory from init_loading() to reuse buffers

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1123,7 +1123,7 @@ void NodeTreeBase::set_resume_data( const char* data, size_t length )
 //
 void NodeTreeBase::init_loading()
 {
-    clear();
+    m_buffer_lines.clear();
 
     // 一時バッファ作成
     if( m_buffer_lines.capacity() < MAXSISE_OF_LINES ) {


### PR DESCRIPTION
確保したバッファを再利用するためロード実行前に呼ぶ初期化関数からメモリを開放する処理を取り除きます。
