### PR TITLE
NodeTreeBase: Update whitespace handling in node tree construction

### DIFF
--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -392,6 +392,10 @@ void LayoutTree::append_block( DBTREE::NODE* block, const int res_number, IMGDAT
                 tmplayout = create_layout_text( tmpnode->text, &tmpnode->color_text, tmpnode->bold );
                 break;
 
+            case DBTREE::NODE_SP: // 半角スペース
+                tmplayout = create_layout_text( " ", &tmpnode->color_text, tmpnode->bold );
+                break;
+
             case DBTREE::NODE_LINK:
                 tmplayout = create_layout_link( tmpnode->text, tmpnode->linkinfo->link,
                                                 &tmpnode->color_text, tmpnode->bold );

--- a/src/dbtree/node.h
+++ b/src/dbtree/node.h
@@ -29,11 +29,9 @@ namespace DBTREE
         NODE_DIV,   // div
         NODE_IMG,   // img
 
-        // スペース(幅0)
-        NODE_ZWSP,
-
-        // 連続半角スペース
-        NODE_MULTISP,
+        NODE_SP,    // スペース
+        NODE_ZWSP,  // スペース(幅0)
+        NODE_MULTISP, // 連続半角スペース
 
         // 水平タブ(0x09)
         NODE_HTAB,

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -309,7 +309,6 @@ namespace DBTREE
         NODE* create_node_hr();
         NODE* create_node_space( const int type );
         NODE* create_node_multispace( std::string_view text, const char fontid = FONT_MAIN );
-        NODE* create_node_htab();
         NODE* create_node_link( std::string_view text, std::string_view link,
                                 const int color_text, const bool bold, const char fontid = FONT_MAIN );
         NODE* create_node_anc( std::string_view text, std::string_view link,

--- a/src/dbtree/spchar_decoder.cpp
+++ b/src/dbtree/spchar_decoder.cpp
@@ -71,12 +71,19 @@ break_composition:
 
     switch( uch ){
 
-        //zwnj,zwj,lrm,rlm は今のところ無視(zwspにする)
+        case UCS_SP:
+        case UCS_LF: // LFはSPにする
+            ret = DBTREE::NODE_SP;
+            break;
+
+        case UCS_HT:
+            ret = DBTREE::NODE_HTAB;
+            break;
+
         case UCS_ZWSP:
-        case UCS_ZWNJ:
-        case UCS_ZWJ:
-        case UCS_LRM:
-        case UCS_RLM:
+        case UCS_CR: // CRを無視
+        case UCS_FF: // FFを無視
+        case UCS_PS: // PSを無視
             ret = DBTREE::NODE_ZWSP;
             break;
 
@@ -159,9 +166,8 @@ int DBTREE::decode_char_name( const char* in_char, int& n_in, JDLIB::span<char> 
 
             n_in = static_cast<int>( entity.size() ) + 1; // 先頭の '&' の分を+1する
 
-            // U+200B, U+200C(zwnj), U+200D(zwj), U+200E(lrm), U+200F(rlm)
-            // は今のところ空文字列にする(zwsp扱いにする)
-            if( utf8[0] == '\xE2' && utf8[1] == '\x80' && '\x8B' <= utf8[2] && utf8[2] <= '\x8F' ) {
+            // U+200B (zwsp)
+            if( utf8 == "\xE2\x80\x8B" ) {
                 ret = DBTREE::NODE_ZWSP;
             }
             else {

--- a/src/dbtree/spchar_tbl.h
+++ b/src/dbtree/spchar_tbl.h
@@ -2338,12 +2338,18 @@ static constexpr std::array<JDLIB::span<const UCSTBL>, 26> const ucstbl_upper = 
 
 enum
 {
+    UCS_HT      = 9,
+    UCS_LF      = 10,
+    UCS_FF      = 12,
+    UCS_CR      = 13,
+    UCS_SP      = 32,
     UCS_ZWSP    = 0x200B,
     UCS_ZWNJ    = 0x200C,
     UCS_ZWJ     = 0x200D,
     UCS_LRM     = 0x200E,
     UCS_RLM     = 0x200F,
     CP_LINE_SEPARATOR = 8232,
+    UCS_PS      = 0x2029,
     UCS_REPLACE = 0xFFFD,
 };
 

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -993,7 +993,7 @@ static std::string chref_decode_one( const char* str, int& n_in, const char pre_
     out_char.resize( n_out );
 
     // 改行、タブ、スペースの処理
-    if( type != DBTREE::NODE_NONE && ( out_char[0] == ' ' || out_char[0] == '\n' ) && pre_char != ' ' ) {
+    if( type == DBTREE::NODE_SP && pre_char != ' ' ) {
         out_char.assign( 1u, ' ' );
     }
     // 変換できない文字

--- a/test/gtest_dbtree_spchar_decoder.cpp
+++ b/test/gtest_dbtree_spchar_decoder.cpp
@@ -134,26 +134,25 @@ TEST_F(DBTREE_DecodeCharNumberTest, zwnj_zwj_lrm_rlm)
     int n_in;
     int n_out;
 
-    // zwnj(U+200C), zwj(U+200D), lrm(U+200E), rlm(U+200F) は今のところ空文字列にする(zwspにする)
-    EXPECT_EQ( DBTREE::NODE_ZWSP, DBTREE::decode_char_number( "&#X200C;", n_in, out_char, n_out, false ) );
+    EXPECT_EQ( DBTREE::NODE_TEXT, DBTREE::decode_char_number( "&#X200C;", n_in, out_char, n_out, false ) );
     EXPECT_EQ( 8, n_in );
-    EXPECT_STREQ( "", out_char );
-    EXPECT_EQ( 0, n_out );
+    EXPECT_STREQ( "\xE2\x80\x8C", out_char );
+    EXPECT_EQ( 3, n_out );
 
-    EXPECT_EQ( DBTREE::NODE_ZWSP, DBTREE::decode_char_number( "&#x200d;", n_in, out_char, n_out, false ) );
+    EXPECT_EQ( DBTREE::NODE_TEXT, DBTREE::decode_char_number( "&#x200d;", n_in, out_char, n_out, false ) );
     EXPECT_EQ( 8, n_in );
-    EXPECT_STREQ( "", out_char );
-    EXPECT_EQ( 0, n_out );
+    EXPECT_STREQ( "\xE2\x80\x8D", out_char );
+    EXPECT_EQ( 3, n_out );
 
-    EXPECT_EQ( DBTREE::NODE_ZWSP, DBTREE::decode_char_number( "&#x200E;", n_in, out_char, n_out, false ) );
+    EXPECT_EQ( DBTREE::NODE_TEXT, DBTREE::decode_char_number( "&#x200E;", n_in, out_char, n_out, false ) );
     EXPECT_EQ( 8, n_in );
-    EXPECT_STREQ( "", out_char );
-    EXPECT_EQ( 0, n_out );
+    EXPECT_STREQ( "\xE2\x80\x8E", out_char );
+    EXPECT_EQ( 3, n_out );
 
-    EXPECT_EQ( DBTREE::NODE_ZWSP, DBTREE::decode_char_number( "&#X200f;", n_in, out_char, n_out, false ) );
+    EXPECT_EQ( DBTREE::NODE_TEXT, DBTREE::decode_char_number( "&#X200f;", n_in, out_char, n_out, false ) );
     EXPECT_EQ( 8, n_in );
-    EXPECT_STREQ( "", out_char );
-    EXPECT_EQ( 0, n_out );
+    EXPECT_STREQ( "\xE2\x80\x8F", out_char );
+    EXPECT_EQ( 3, n_out );
 }
 
 TEST_F(DBTREE_DecodeCharNumberTest, line_separator_u2028)
@@ -487,26 +486,25 @@ TEST_F(DBTREE_DecodeCharNameTest, zwnj_zwj_lrm_rlm)
     int n_in;
     int n_out;
 
-    // zwnj(U+200C), zwj(U+200D), lrm(U+200E), rlm(U+200F) は今のところ空文字列にする(zwspにする)
-    EXPECT_EQ( DBTREE::NODE_ZWSP, DBTREE::decode_char_name( "&zwnj;", n_in, out_char, n_out ) );
+    EXPECT_EQ( DBTREE::NODE_TEXT, DBTREE::decode_char_name( "&zwnj;", n_in, out_char, n_out ) );
     EXPECT_EQ( 6, n_in );
-    EXPECT_STREQ( "", out_char );
-    EXPECT_EQ( 0, n_out );
+    EXPECT_STREQ( "\xE2\x80\x8C", out_char );
+    EXPECT_EQ( 3, n_out );
 
-    EXPECT_EQ( DBTREE::NODE_ZWSP, DBTREE::decode_char_name( "&zwj;", n_in, out_char, n_out ) );
+    EXPECT_EQ( DBTREE::NODE_TEXT, DBTREE::decode_char_name( "&zwj;", n_in, out_char, n_out ) );
     EXPECT_EQ( 5, n_in );
-    EXPECT_STREQ( "", out_char );
-    EXPECT_EQ( 0, n_out );
+    EXPECT_STREQ( "\xE2\x80\x8D", out_char );
+    EXPECT_EQ( 3, n_out );
 
-    EXPECT_EQ( DBTREE::NODE_ZWSP, DBTREE::decode_char_name( "&lrm;", n_in, out_char, n_out ) );
+    EXPECT_EQ( DBTREE::NODE_TEXT, DBTREE::decode_char_name( "&lrm;", n_in, out_char, n_out ) );
     EXPECT_EQ( 5, n_in );
-    EXPECT_STREQ( "", out_char );
-    EXPECT_EQ( 0, n_out );
+    EXPECT_STREQ( "\xE2\x80\x8E", out_char );
+    EXPECT_EQ( 3, n_out );
 
-    EXPECT_EQ( DBTREE::NODE_ZWSP, DBTREE::decode_char_name( "&rlm;", n_in, out_char, n_out ) );
+    EXPECT_EQ( DBTREE::NODE_TEXT, DBTREE::decode_char_name( "&rlm;", n_in, out_char, n_out ) );
     EXPECT_EQ( 5, n_in );
-    EXPECT_STREQ( "", out_char );
-    EXPECT_EQ( 0, n_out );
+    EXPECT_STREQ( "\xE2\x80\x8F", out_char );
+    EXPECT_EQ( 3, n_out );
 }
 
 TEST_F(DBTREE_DecodeCharNameTest, u200A)


### PR DESCRIPTION
ノードツリー構築のうち空白文字の処理を更新してゼロ幅(非)接合子と双方向テキストをテキスト表示に反映するようにします。
この修正で Emoji ZWJ Sequences (複数の絵文字を連結して1文字として見せる絵文字) の表示に対応します。

Shift\_JIS をはじめ Unicode と異なる符号化文字集合の文字エンコーディングが使われているwebサイトでは絵文字がHTML文字参照にエンコードされています。
GTK3 は Unicode(UTF-8) に対応していますがJDimの文字参照デコードの実装がzwjなどに未対応でした。

* 連続する空白をまとめるように変更します。

* U+200C(zwnj), U+200D(zwj), U+200E(lrm), U+200F(rlm) をテキスト表示に反映するように処理を変更します。

関連のissue: #76
