### PR TITLE
NodeTreeBase: Convert relative URLs in HTML <a> elements

### DIFF
--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -45,6 +45,7 @@ namespace DBTREE
         SIG_UPDATED m_sig_finished;
 
         std::string m_url;
+        std::string m_url_readcgi;
         std::string m_default_noname;
 
         // コード変換前の生データのサイズ ( byte )


### PR DESCRIPTION
HTMLを解析してノードツリーを構築する処理を更新してHTML`<a>`要素が相対URLのときは絶対URLに変換するように変更します。
また、JavaScript疑似プロトコルのBE linkも同じく変換します。

関連のissue: #76
