### PR TITLE
NodeTreeBase: Implement code for coloring via HTML and CSS

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -2129,7 +2129,10 @@ bool DrawAreaBase::draw_one_node( LAYOUT* layout, const CLIPINFO& ci )
             if( layout->rect ){
                 const int x = layout->rect->x;
                 const int y = layout->rect->y - ci.pos_y;
-                const int color_text = get_colorid_text();
+                int color_text = get_colorid_text();
+                if( color_text == COLOR_CHAR && layout->div && layout->div->css->color >= 0 ) {
+                    color_text = layout->div->css->color;
+                }
 
                 cairo_t* const cr = cairo_create( m_backscreen.get() );
                 gdk_cairo_set_source_rgba( cr, m_color[ color_text ].gobj() );
@@ -2504,7 +2507,8 @@ void DrawAreaBase::draw_one_text_node( LAYOUT* layout, const CLIPINFO& ci )
     if( color_text == COLOR_CHAR && layout->div && layout->div->css->color >= 0 ) color_text = layout->div->css->color;
 
     int color_back = get_colorid_back();
-    if( layout->div && layout->div->css->bg_color >= 0 ) color_back = layout->div->css->bg_color;
+    if( layout->node && layout->node->color_back != COLOR_NONE ) color_back = layout->node->color_back;
+    else if( layout->div && layout->div->css->bg_color >= 0 ) color_back = layout->div->css->bg_color;
     else if( layout->header && layout->header->css->bg_color >= 0 ) color_back = layout->header->css->bg_color;
 
     // 通常描画
@@ -2749,6 +2753,10 @@ void DrawAreaBase::draw_string( LAYOUT* node, const CLIPINFO& ci,
 
                 width_line = PANGO_PIXELS( width_line );
             }
+        }
+
+        if( const int sz = static_cast<int>( m_color.size() ); color >= sz || color_back >= sz ) {
+            init_color();
         }
 
         if( width_line ){

--- a/src/dbtree/node.h
+++ b/src/dbtree/node.h
@@ -115,6 +115,7 @@ namespace DBTREE
         
         char* text;
         unsigned char color_text; // 色
+        unsigned char color_back; ///< 背景色
         bool bold;
         char fontid; // fontid.h
         

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -308,10 +308,10 @@ namespace DBTREE
         NODE* create_node_idnum();
         NODE* create_node_br();
         NODE* create_node_hr();
-        NODE* create_node_space( const int type );
-        NODE* create_node_multispace( std::string_view text, const char fontid = FONT_MAIN );
-        NODE* create_node_link( std::string_view text, std::string_view link,
-                                const int color_text, const bool bold, const char fontid = FONT_MAIN );
+        NODE* create_node_space( const int type, const int bg );
+        NODE* create_node_multispace( std::string_view text, const int bg, const char fontid = FONT_MAIN );
+        NODE* create_node_link( std::string_view text, std::string_view link, const int color_text,
+                                const int color_back, const bool bold, const char fontid = FONT_MAIN );
         NODE* create_node_anc( std::string_view text, std::string_view link,
                                const int color_text, const bool bold,
                                const ANCINFO* ancinfo, const int lng_ancinfo, const char fontid = FONT_MAIN );
@@ -319,7 +319,8 @@ namespace DBTREE
         NODE* create_node_img( std::string_view text, std::string_view link, const int color_text,
                                const bool bold, const char fontid = FONT_MAIN );
         NODE* create_node_text( std::string_view text, const int color_text, const bool bold = false, const char fontid = FONT_MAIN );
-        NODE* create_node_ntext( const char* text, const int n, const int color_text, const bool bold = false, const char fontid = FONT_MAIN );
+        NODE* create_node_ntext( const char* text, const int n, const int color_text, const int color_back = 0,
+                                 const bool bold = false, const char fontid = FONT_MAIN );
         NODE* create_node_thumbnail( std::string_view text, std::string_view link, std::string_view thumb,
                                      const int color_text, const bool bold, const char fontid = FONT_MAIN );
 


### PR DESCRIPTION
HTMLを解析してノードツリーを構築する処理にHTMLタグやCSSで指定された文字色と背景色を表示に反映するためのコードを実装します。

関連のissue: #76
