### PR TITLE
Css_Manager: Implement get_property() function returning const reference

### DIFF
--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -523,6 +523,19 @@ CSS_PROPERTY Css_Manager::get_property( const int id )
 }
 
 
+/** @brief CSS プロパティのconst参照を取得する
+ *
+ * @details CSS_PROPERTY の構造体はサイズが大きいため参照を返すことでコピーを回避できる。
+ * @param[in] id register_class() で登録したCSS classのID
+ * @return CSS プロパティのconst参照
+ * @throw std::out_of_range 存在しないIDを指定すると例外が発生する
+ */
+const CSS_PROPERTY& Css_Manager::get_property( const int id ) const
+{
+    return m_css.at( id );
+}
+
+
 //
 // プロパティをセット
 //

--- a/src/cssmanager.h
+++ b/src/cssmanager.h
@@ -160,6 +160,7 @@ namespace CORE
 
         // プロパティ取得
         CSS_PROPERTY get_property( const int id );
+        const CSS_PROPERTY& get_property( const int id ) const;
 
         // 文字の高さを与えてemをセット
         void set_size( CSS_PROPERTY* css, double height ) const;

--- a/src/image/imageviewpopup.cpp
+++ b/src/image/imageviewpopup.cpp
@@ -38,11 +38,11 @@ ImageViewPopup::ImageViewPopup( const std::string& url )
     Gdk::RGBA border_color{ "black" };
     Gdk::RGBA bg_color{ CONFIG::get_color( COLOR_BACK ) };
     Gdk::RGBA text_color{ CONFIG::get_color( COLOR_CHAR ) };
-    auto manager = CORE::get_css_manager();
+    const auto manager = CORE::get_css_manager();
     const int classid = manager->get_classid( "imgpopup" );
     if( classid >= 0 ){
         // jd.cssの設定を読み込む
-        CORE::CSS_PROPERTY css = manager->get_property( classid );
+        const CORE::CSS_PROPERTY& css = manager->get_property( classid );
         border_width = css.border_left_width_px;
         margin = css.mrg_left_px;
         if( css.border_left_color >= 0 ) border_color.set( manager->get_color( css.border_left_color ) );
@@ -269,10 +269,11 @@ void ImageViewPopup::show_view_impl()
     }
 
     // マージンやボーダーの分を幅と高さに加える
-    const int classid = CORE::get_css_manager()->get_classid( "imgpopup" );
+    const CORE::Css_Manager* const manager = CORE::get_css_manager();
+    const int classid = manager->get_classid( "imgpopup" );
     if( classid >= 0 ){
 
-        CORE::CSS_PROPERTY css = CORE::get_css_manager()->get_property( classid );
+        const CORE::CSS_PROPERTY& css = manager->get_property( classid );
         const int border_width = css.border_left_width_px;
         const int margin = css.mrg_left_px;
         set_width_client( width_client() + margin*2 + border_width*2 );

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1106,10 +1106,10 @@ std::string MISC::to_markup( const std::string& html )
                 markuptxt += "<span";
 
                 if( classname.size() ) {
-                    CORE::Css_Manager* mgr = CORE::get_css_manager();
+                    const CORE::Css_Manager* const mgr = CORE::get_css_manager();
                     const int classid = mgr->get_classid( classname );
                     if( classid != -1 ) {
-                        CORE::CSS_PROPERTY css = mgr->get_property( classid );
+                        const CORE::CSS_PROPERTY& css = mgr->get_property( classid );
                         if( css.color != -1 ) markuptxt += " color=\"" + mgr->get_color( css.color ) + "\"";
                         if( css.bg_color != -1 ) markuptxt += " background=\"" + mgr->get_color( css.bg_color ) + "\"";
                     }


### PR DESCRIPTION
const参照でCSSプロパティを返すメンバー関数を実装します。
また、実装した関数を使いCSSプロパティを使う箇所をconst参照に変えてコピーしないように修正します。
