### PR TITLE
Add support for using HTML tag-specified text color in thread view

### DIFF
--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -276,6 +276,9 @@ bool ConfigItems::load( const bool restore )
     // スレビューの選択色でgtkrcの設定を使用するか
     use_select_gtkrc = cf.get_option_bool( "use_select_gtkrc", CONF_USE_SELECT_GTKRC );
 
+    // スレビューでHTMLタグ指定の色を使用するか
+    use_color_html = cf.get_option_bool( "use_color_html", CONF_USE_COLOR_HTML );
+
     // ツリービューの行間スペース
     tree_ypad = cf.get_option_int( "tree_ypad", CONF_TREE_YPAD, 0, 64 );
 
@@ -799,6 +802,7 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "use_message_gtktheme", use_message_gtktheme );
     cf.update( "use_tree_gtkrc", use_tree_gtkrc );
     cf.update( "use_select_gtkrc", use_select_gtkrc );
+    cf.update( "use_color_html", use_color_html );
 
     cf.update( "tree_ypad", tree_ypad );
     cf.update( "tree_show_expanders", tree_show_expanders );

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -229,6 +229,9 @@ namespace CONFIG
         // スレビューの選択色でgtkrcの設定を使用するか
         bool use_select_gtkrc{};
 
+        /// スレビューでHTMLタグ指定の色を使用するか
+        bool use_color_html{};
+
         // ツリービューの行間スペース
         int tree_ypad{};
 

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -44,6 +44,7 @@ namespace CONFIG
         CONF_USE_MESSAGE_GTKTHEME = 0, // 書き込みビューでGTKテーマの設定を使用するか (GTK3版のみ)
         CONF_USE_TREE_GTKRC = 0,    // ツリービューでgtkrcの設定を使用するか
         CONF_USE_SELECT_GTKRC = 0,  // スレビューの選択色でgtkrcの設定を使用するか
+        CONF_USE_COLOR_HTML = 1,    ///< スレビューでHTMLタグ指定の色を使用するか
         CONF_TREE_YPAD = 1,         // ツリービューの行間スペース
         CONF_TREE_SHOW_EXPANDERS = 1, // ツリービューにエクスパンダを表示
         CONF_TREE_LEVEL_INDENT = 0, // ツリービューのレベルインデント調整量(ピクセル)

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -97,6 +97,9 @@ void CONFIG::set_use_tree_gtkrc( const bool use ){ get_confitem()->use_tree_gtkr
 bool CONFIG::get_use_select_gtkrc(){ return get_confitem()->use_select_gtkrc; }
 void CONFIG::set_use_select_gtkrc( const bool use ){ get_confitem()->use_select_gtkrc = use; }
 
+bool CONFIG::get_use_color_html(){ return get_confitem()->use_color_html; }
+void CONFIG::set_use_color_html( const bool use ){ get_confitem()->use_color_html = use; }
+
 // ツリービューの行間スペース
 int CONFIG::get_tree_ypad(){ return get_confitem()->tree_ypad; }
 

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -56,6 +56,10 @@ namespace CONFIG
     bool get_use_select_gtkrc();
     void set_use_select_gtkrc( const bool use );
 
+    // スレビューでHTMLタグ指定の色を使用するか
+    bool get_use_color_html();
+    void set_use_color_html( const bool use );
+
     // ツリービューの行間スペース
     int get_tree_ypad();
 

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -232,6 +232,10 @@ void FontColorPref::pack_widget()
     m_chk_use_gtkrc_selection.set_active( CONFIG::get_use_select_gtkrc() );
     m_vbox_color.pack_start( m_chk_use_gtkrc_selection, Gtk::PACK_SHRINK );
 
+    m_chk_use_html_color.add_label( "スレビューで HTML タグで指定された文字色を用いる(_H)", true );
+    m_chk_use_html_color.set_active( CONFIG::get_use_color_html() );
+    m_vbox_color.pack_start( m_chk_use_html_color, Gtk::PACK_SHRINK );
+
     m_bt_reset_all_colors.signal_clicked().connect( sigc::mem_fun( *this, &FontColorPref::slot_reset_all_colors ) );
     m_vbox_color.pack_end( m_bt_reset_all_colors, Gtk::PACK_SHRINK );
 
@@ -262,12 +266,18 @@ void FontColorPref::slot_ok_clicked()
     CONFIG::set_use_message_gtktheme( m_chk_use_gtktheme_message.property_active() );
     CONFIG::set_use_tree_gtkrc( m_chk_use_gtkrc_tree.property_active() );
     CONFIG::set_use_select_gtkrc( m_chk_use_gtkrc_selection.property_active() );
+    const char* completely = "";
+    const bool use_color = m_chk_use_html_color.property_active();
+    if( use_color != CONFIG::get_use_color_html() ) {
+        CONFIG::set_use_color_html( use_color );
+        completely = "completely";
+    }
 
     CORE::core_set_command( "relayout_all_bbslist" );
     CORE::core_set_command( "relayout_all_board" );
 
     CORE::core_set_command( "init_font_all_article" );
-    CORE::core_set_command( "relayout_all_article" );
+    CORE::core_set_command( "relayout_all_article", "", completely );
 
     CORE::core_set_command( "relayout_all_message" );
 }
@@ -505,6 +515,7 @@ void FontColorPref::slot_reset_all_colors()
     m_chk_use_gtktheme_message.set_active( CONFIG::CONF_USE_MESSAGE_GTKTHEME );
     m_chk_use_gtkrc_tree.set_active( CONFIG::CONF_USE_TREE_GTKRC );
     m_chk_use_gtkrc_selection.set_active( CONFIG::CONF_USE_SELECT_GTKRC );
+    m_chk_use_html_color.set_active( CONFIG::CONF_USE_COLOR_HTML );
 
     CONFIG::reset_colors();
 

--- a/src/fontcolorpref.h
+++ b/src/fontcolorpref.h
@@ -67,6 +67,7 @@ namespace CORE
         Gtk::CheckButton m_chk_use_gtktheme_message;
         Gtk::CheckButton m_chk_use_gtkrc_tree;
         Gtk::CheckButton m_chk_use_gtkrc_selection;
+        Gtk::CheckButton m_chk_use_html_color;
 
         Gtk::TreeView m_treeview_color;
         Glib::RefPtr< Gtk::ListStore > m_liststore_color;


### PR DESCRIPTION
スレビューでHTMLタグで指定された文字色・背景色を使用するための処理と設定を追加します。

関連のissue: #76
