### PR TITLE
Css_Manager: Change get_classid() parameter type to use std::string_view

### DIFF
--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -94,7 +94,7 @@ std::string Css_Manager::get_color( int colorid ) const
 //
 // クラス名からID取得
 //
-int Css_Manager::get_classid( const std::string& classname ) const
+int Css_Manager::get_classid( std::string_view classname ) const
 {
     int id = 0;
 

--- a/src/cssmanager.h
+++ b/src/cssmanager.h
@@ -7,10 +7,11 @@
 #ifndef _CSSMANAGER_H
 #define _CSSMANAGER_H
 
-#include <map>
 #include <list>
-#include <vector>
+#include <map>
 #include <string>
+#include <string_view>
+#include <vector>
 
 #include "jdlib/heap.h"
 
@@ -156,7 +157,7 @@ namespace CORE
         std::vector< std::string >& get_colors() { return m_colors; }
 
         // クラス名からID取得
-        int get_classid( const std::string& classname ) const;
+        int get_classid( std::string_view classname ) const;
 
         // プロパティ取得
         CSS_PROPERTY get_property( const int id );


### PR DESCRIPTION
`get_classid()`に渡す文字列の型を`const std::string&`から`std::string_view`に変更して文字列リテラルを渡したときにコピーが発生しないように変更します。
