### PR TITLE
Add URL Percent-Encoding decoding option to about:config

### DIFF
--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -207,6 +207,7 @@ void AboutConfig::append_rows()
     append_row( "レスを引用コピーするときに前に付ける引用文字", get_confitem()->ref_prefix, CONF_REF_PREFIX );
     append_row( "引用文字の後のスペース数", get_confitem()->ref_prefix_space, CONF_REF_PREFIX_SPACE );
     append_row( "RFC規定外の文字(^など)もURL判定に用いる", get_confitem()->loose_url, CONF_LOOSE_URL );
+    append_row( "URLのパーセントエンコーディングをデコードして表示する", get_confitem()->percent_decode, CONF_PERCENT_DECODE );
     append_row( "再読み込みボタンを押したときに全タブを更新する", get_confitem()->reload_allthreads, CONF_RELOAD_ALLTHREAD );
     append_row( "発言(同一ID)数をカウントする", get_confitem()->check_id, CONF_CHECK_ID );
     append_row( "レス参照数で色を変える回数(高)", get_confitem()->num_reference_high, CONF_NUM_REFERENCE_HIGH );

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -455,6 +455,9 @@ bool ConfigItems::load( const bool restore )
     // datのパース時にURL判定を甘くする(^なども含める)
     loose_url = cf.get_option_bool( "loose_url", CONF_LOOSE_URL );
 
+    // URLのパーセントエンコーディングをデコードして表示する
+    percent_decode = cf.get_option_bool( "percent_decode", CONF_PERCENT_DECODE );
+
     // ユーザーコマンドで選択できない項目を非表示にする
     hide_usrcmd = cf.get_option_bool( "hide_usrcmd", CONF_HIDE_USRCMD );
 
@@ -876,6 +879,8 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "num_id_low", num_id_low );
 
     cf.update( "loose_url", loose_url );
+
+    cf.update( "percent_decode", percent_decode );
 
     cf.update( "hide_usrcmd", hide_usrcmd );
     cf.update( "reload_allthreads", reload_allthreads );

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -408,6 +408,9 @@ namespace CONFIG
         // datのパース時にURL判定を甘くする(^なども含める)
         bool loose_url{};
 
+        /// URLのパーセントエンコーディングをデコードして表示する
+        bool percent_decode{};
+
         // ユーザーコマンドで選択できない項目を非表示にする
         bool hide_usrcmd{};
 

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -102,6 +102,7 @@ namespace CONFIG
         CONF_NUM_ID_HIGH = 4,       // 発言数で色を変える回数 (高)
         CONF_NUM_ID_LOW = 2,        // 発言数で色を変える回数 (低)
         CONF_LOOSE_URL = 1,         // datのパース時にURL判定を甘くする(^なども含める)
+        CONF_PERCENT_DECODE = 0,    ///< URLのパーセントエンコーディングをデコードして表示する
         CONF_HIDE_USRCMD = 0, // ユーザーコマンドで選択できない項目を非表示にする
         CONF_RELOAD_ALLTHREAD = 0,  // スレビューで再読み込みボタンを押したときに全タブを更新する
         CONF_TAB_MIN_STR = 4, // タブに表示する文字列の最小値

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -443,6 +443,8 @@ int CONFIG::get_num_id_low(){ return get_confitem()->num_id_low; }
 
 bool CONFIG::get_loose_url(){ return get_confitem()->loose_url; }
 
+bool CONFIG::get_percent_decode(){ return get_confitem()->percent_decode; }
+
 bool CONFIG::get_hide_usrcmd(){ return get_confitem()->hide_usrcmd; }
 void CONFIG::set_hide_usrcmd( const bool hide ){ get_confitem()->hide_usrcmd = hide; }
 

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -467,6 +467,9 @@ namespace CONFIG
     // datのパース時にURL判定を甘くする(^なども含める)
     bool get_loose_url();
 
+    /// URLのパーセントエンコーディングをデコードして表示する
+    bool get_percent_decode();
+
     // ユーザーコマンドで選択できない項目を非表示にする
     bool get_hide_usrcmd();
     void set_hide_usrcmd( const bool hide );


### PR DESCRIPTION
URLのパーセントエンコーディングをデコードして表示するスレビューのオプションをabout:configに追加します。

関連のissue: #76
