### PR TITLE
NodeTreeBase: Do not mark thread as broken on HTTP 416 error

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1373,7 +1373,7 @@ void NodeTreeBase::receive_finish()
 
         // Requested Range Not Satisfiable
         if( get_code() == HTTP_RANGE_ERR ){
-            m_broken = true;
+            // ネットワーク設定の変更などで読み込みが再開できる可能性があるためスレッドが壊れたとマークしない
             MISC::ERRMSG( "Requested Range Not Satisfiable" );
         }
 


### PR DESCRIPTION
スレッドの読み込みでHTTP 416 Range Not Satisfiableが返ってきたときはスレッドが壊れた(復旧不可能)と判定してエラーの表示になっていました。
しかし、ネットワーク設定の変更などで読み込みが再開できる可能性があるため416が返ってきてもスレッドが壊れたと判定しないように修正します。

関連のissue: #76
