### PR TITLE
Remove Rokka support

### DIFF
--- a/src/login2ch.cpp
+++ b/src/login2ch.cpp
@@ -85,6 +85,8 @@ void Login2ch::start_login()
 
     set_str_code( "" );
 
+    finish();
+#if 0 // サイトの更新に対応していないためサポートを中止
     if( ! SESSION::is_online() ){
 
         // ディスパッチャ経由でreceive_finish()を呼ぶ
@@ -113,6 +115,7 @@ void Login2ch::start_login()
     m_rawdata.clear();
 
     start_load( data );
+#endif
 }
 
 
@@ -139,6 +142,7 @@ void Login2ch::receive_finish()
               << " rawdata size = " << m_rawdata.size() << std::endl;
 #endif
 
+#if 0 // サイトの更新に対応していないためサポートを中止
     bool show_err = true;
 
     if( ! m_rawdata.empty() && get_code() == HTTP_OK ){
@@ -196,6 +200,9 @@ void Login2ch::receive_finish()
         SKELETON::MsgDiag mdiag( nullptr, str_err );
         mdiag.run();  
     }
+#endif
+    SKELETON::MsgDiag mdiag( nullptr, "2chのログインは現在サポート中止しています。" );
+    mdiag.run();
 
     // コアに受信完了を知らせる
     CORE::core_set_command( "login2ch_finished", "" );

--- a/src/passwdpref.h
+++ b/src/passwdpref.h
@@ -30,9 +30,10 @@ namespace CORE
         SKELETON::LabelEntry entry_id;
         SKELETON::LabelEntry entry_passwd;
 
-      PasswdFrame2ch()
-      : m_label_sid_2ch( false, "SID： ", CORE::get_login2ch()->get_sessionid() ),
-        entry_id( true, "ユーザID(_I)： " ), entry_passwd( true, "パスワード(_P)： " )
+        PasswdFrame2ch()
+            : m_label_sid_2ch( false, "SID： ", "2chのログインは現在サポート中止しています。" )
+            , entry_id( true, "ユーザID(_I)： " )
+            , entry_passwd( true, "パスワード(_P)： " )
         {
             const int mrg = 8;
 


### PR DESCRIPTION
### NodeTree2ch: Remove processing which fetches logs using obsolete Rokka
2chやbbspinkのログ取得に使用されていたRokkaシステムは廃止されたため接続処理を削除してコードを整理します。

### Disable 2ch login and show message about unsupported it
2chログイン機能はサイトの更新に対応していないため現在機能していません。
そのためログイン処理を削除し、現在サポート中止していることを通知するメッセージを表示するように修正します。
