### PR TITLE
NodeTreeBase: Suppress code analysis report about invalid lifetime

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1054,7 +1054,7 @@ NODE* NodeTreeBase::append_html( const std::string& html )
 
     const bool digitlink = false;
     const bool bold = false;
-    parse_html( html, COLOR_CHAR, digitlink, bold );
+    parse_html( html.data(), html.size(), COLOR_CHAR, digitlink, bold );
 
     clear();
 
@@ -1631,7 +1631,7 @@ const char* NodeTreeBase::add_one_dat_line( const char* datline )
 
         constexpr bool digitlink = false;
         constexpr bool bold = false;
-        parse_html( str, COLOR_CHAR, digitlink, bold );
+        parse_html( str.data(), str.size(), COLOR_CHAR, digitlink, bold );
     }
 
     // 壊れている
@@ -1650,7 +1650,7 @@ const char* NodeTreeBase::add_one_dat_line( const char* datline )
         constexpr bool digitlink = false;
         constexpr bool bold = true;
         constexpr std::string_view message = "<br> <br> 壊れています<br>";
-        parse_html( message, COLOR_CHAR, digitlink, bold, FONT_MAIL );
+        parse_html( message.data(), message.size(), COLOR_CHAR, digitlink, bold, FONT_MAIL );
 
         constexpr const char str_broken[] = "ここ";
         create_node_link( str_broken, PROTO_BROKEN, COLOR_CHAR_LINK, COLOR_NONE, false );
@@ -1741,7 +1741,7 @@ void NodeTreeBase::parse_name( NODE* header, std::string_view str, const int col
     if( defaultname ){
         constexpr bool digitlink = false;
         constexpr bool bold = true;
-        parse_html( str, color_name, digitlink, bold, FONT_MAIL );
+        parse_html( str.data(), str.size(), color_name, digitlink, bold, FONT_MAIL );
     }
     else{
 
@@ -1767,7 +1767,7 @@ void NodeTreeBase::parse_name( NODE* header, std::string_view str, const int col
                 // デフォルト名無しと同じときはアンカーを作らない
                 const bool digitlink{ m_default_noname.rfind( str.substr( pos, i - pos ), 0 ) != 0 };
                 constexpr bool bold = true;
-                parse_html( str.substr( pos, i - pos ), color_name, digitlink, bold, FONT_MAIL );
+                parse_html( str.data() + pos, i - pos, color_name, digitlink, bold, FONT_MAIL );
             }
             if( i >= str.size() ) break;
             pos = i;
@@ -1793,7 +1793,7 @@ void NodeTreeBase::parse_name( NODE* header, std::string_view str, const int col
             constexpr bool digitlink = false; // 数字が入ってもリンクしない
             // NOTE: webブラウザでは bold 表示ではないが互換性のため既存の挙動を維持する
             constexpr bool bold = true;
-            parse_html( str.substr( pos, pos_end - pos ), COLOR_CHAR_NAME_B, digitlink, bold, FONT_MAIL );
+            parse_html( str.data() + pos, pos_end - pos, COLOR_CHAR_NAME_B, digitlink, bold, FONT_MAIL );
 
             pos = pos_end;
         }
@@ -1848,7 +1848,7 @@ void NodeTreeBase::parse_mail( NODE* header, std::string_view str )
         const bool bold = false;
 
         create_node_text( "[", color, false, FONT_MAIL );
-        parse_html( str, color, digitlink, bold, FONT_MAIL );
+        parse_html( str.data(), str.size(), color, digitlink, bold, FONT_MAIL );
         create_node_text( "]", color, false, FONT_MAIL );
     }
 }
@@ -1911,7 +1911,7 @@ void NodeTreeBase::parse_date_id( NODE* header, std::string_view str )
 
             // フラッシュ
             if( lng_text ){
-                parse_html( str.substr( 0, lng_text ), COLOR_CHAR, digitlink, bold, FONT_MAIL );
+                parse_html( str.data(), lng_text, COLOR_CHAR, digitlink, bold, FONT_MAIL );
             }
 
             std::size_t offset = 0;
@@ -1959,7 +1959,7 @@ void NodeTreeBase::parse_date_id( NODE* header, std::string_view str )
 
             // フラッシュ
             if( lng_text ) {
-                parse_html( str.substr( 0, lng_text ), COLOR_CHAR, digitlink, bold, FONT_MAIL );
+                parse_html( str.data(), lng_text, COLOR_CHAR, digitlink, bold, FONT_MAIL );
             }
 
             // id 取得
@@ -1996,7 +1996,7 @@ void NodeTreeBase::parse_date_id( NODE* header, std::string_view str )
 
             // フラッシュ
             if( lng_text ) {
-                parse_html( str.substr( 0, lng_text ), COLOR_CHAR, digitlink, bold, FONT_MAIL );
+                parse_html( str.data(), lng_text, COLOR_CHAR, digitlink, bold, FONT_MAIL );
             }
 
             // </a>までブロックの長さを伸ばす
@@ -2013,7 +2013,7 @@ void NodeTreeBase::parse_date_id( NODE* header, std::string_view str )
             }
             node->fontid = FONT_MAIL;
 
-            parse_html( str.substr( start_block, lng_block ), COLOR_CHAR, digitlink, bold, FONT_MAIL );
+            parse_html( str.data() + start_block, lng_block, COLOR_CHAR, digitlink, bold, FONT_MAIL );
 
             // 次のブロックへ移動
             str = str.substr( start_block + lng_block );
@@ -2034,7 +2034,7 @@ void NodeTreeBase::parse_date_id( NODE* header, std::string_view str )
             if( ( no_date || lng_block == 1 ) && ! header->headinfo->block[ BLOCK_ID_NAME ] ) {
                 if( lng_text ) {
                     // フラッシュ
-                    parse_html( str.substr( 0, lng_text ), COLOR_CHAR, digitlink, bold, FONT_MAIL );
+                    parse_html( str.data(), lng_text, COLOR_CHAR, digitlink, bold, FONT_MAIL );
                     lng_text = 0;
                 }
 
@@ -2054,7 +2054,7 @@ void NodeTreeBase::parse_date_id( NODE* header, std::string_view str )
     if( lng_text ) {
         // 末端の空白を削ってフラッシュ
         while( lng_text > 0 && str[ lng_text - 1 ] == ' ' ) --lng_text;
-        parse_html( str.substr( 0, lng_text ), COLOR_CHAR, digitlink, bold, FONT_MAIL );
+        parse_html( str.data(), lng_text, COLOR_CHAR, digitlink, bold, FONT_MAIL );
     }
 }
 
@@ -2065,6 +2065,7 @@ void NodeTreeBase::parse_date_id( NODE* header, std::string_view str )
  *          多重に呼び出したり、複数のスレッドから呼び出すと編集中のデータが壊れて正常に動作しない。
  *          この関数を呼び出す関数は同じく再入不可能になるので注意。
  * @param[in] str        DATやHTMLのデータ
+ * @param[in] lng_str    DATやHTMLのデータの長さ
  * @param[in] color_text スレビューで使用する色のID (see colorid.h)
  * @param[in] digitlink  true の時は先頭に数字が現れたらアンカーにする( parse_name() などで使う )<br>
  *                       false なら数字の前に >> がついてるときだけアンカーにする
@@ -2077,11 +2078,11 @@ void NodeTreeBase::parse_date_id( NODE* header, std::string_view str )
 // Thanks to 「パッチ投稿スレ」の28氏
 // http://jd4linux.sourceforge.jp/cgi-bin/bbs/test/read.cgi/support/1151836078/28
 //
-void NodeTreeBase::parse_html( std::string_view str, const int color_text,
+void NodeTreeBase::parse_html( const char* str, std::size_t lng_str, const int color_text,
                                bool digitlink, const bool bold, char fontid )
 {
-    const char* pos = str.data();
-    const char* pos_end = str.data() + str.size();
+    const char* pos = str;
+    const char* const pos_end = str + lng_str;
     int fgcolor = color_text;
     int fgcolor_bak = color_text;
     int bgcolor = COLOR_NONE;
@@ -2166,7 +2167,7 @@ create_multispace:
                     ++pos;
                 }
 
-                std::string_view a_link = str.substr( pos - str.data() );
+                std::string_view a_link = std::string_view( pos, pos_end - pos );
 
                 while( pos < pos_end && *pos != attr_separator && *pos != '>' ) { ++pos; }
                 if( pos >= pos_end ) continue;
@@ -2176,7 +2177,7 @@ create_multispace:
                 if( pos >= pos_end ) continue;
                 ++pos;
 
-                std::string_view a_str = str.substr( pos - str.data() );
+                std::string_view a_str = std::string_view( pos, pos_end - pos );
 
                 while( pos < pos_end
                         && ( *pos != '<' || pos[1] != '/' || ( pos[2] != 'a' && pos[2] != 'A' ) || pos[3] != '>' ) ) {

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -338,7 +338,7 @@ namespace DBTREE
         // digitlink : true の時は先頭に数字が現れたらアンカーにする( parse_name() などで使う )
         //             false なら数字の前に >> がついてるときだけアンカーにする
         // bold : ボールド表示
-        void parse_html( std::string_view str, const int color_text,
+        void parse_html( const char* str, std::size_t lng_str, const int color_text,
                          bool digitlink, const bool bold, const char fontid = FONT_MAIN );
 
         // 書き込みログ比較用文字列作成


### PR DESCRIPTION
`std::string_view`からポインターを取得する箇所でスコープ外のローカル変数を示すポインターを使用していると指摘されたため引数を`const char*`と`std::size_t`に分けてメンバー関数に渡すようにコードを書き換えてcppcheckのレポートを抑制します。

cppcheck 2.10のレポート
```
src/dbtree/nodetreebase.cpp:2083:31: error: Using object that points
to local variable 'str_mail' that is out of scope. [invalidLifetime]
(snip)
```
