### PR TITLE
Fix compiler warnings for useless cast

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -3186,7 +3186,7 @@ void DrawAreaBase::exec_scroll()
 
                     const int mode = CONFIG::get_live_mode();
                     if( mode == LIVE_SCRMODE_VARIABLE ) y = ( int ) ( current_y + m_scrollinfo.live_speed );
-                    else if( mode == LIVE_SCRMODE_STEADY ) y = ( int ) ( current_y + CONFIG::get_live_speed() );
+                    else if( mode == LIVE_SCRMODE_STEADY ) y = current_y + CONFIG::get_live_speed();
                 }
 
                 // 行単位スクロール

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -30,14 +30,14 @@
 
 
 std::string ENVIRONMENT::get_progname() { return "JDim"; }
-std::string ENVIRONMENT::get_jdcomments(){ return std::string( JDCOMMENT ); }
-std::string ENVIRONMENT::get_jdcopyright(){ return std::string( JDCOPYRIGHT ); }
-std::string ENVIRONMENT::get_jdbbs(){ return std::string( JDBBS ); }
-std::string ENVIRONMENT::get_jd2chlog(){ return std::string( JD2CHLOG ); }
-std::string ENVIRONMENT::get_jdhelp(){ return std::string( JDHELP ); }
-std::string ENVIRONMENT::get_jdhelpcmd(){ return std::string( JDHELPCMD ); }
+std::string ENVIRONMENT::get_jdcomments(){ return JDCOMMENT; }
+std::string ENVIRONMENT::get_jdcopyright(){ return JDCOPYRIGHT; }
+std::string ENVIRONMENT::get_jdbbs(){ return JDBBS; }
+std::string ENVIRONMENT::get_jd2chlog(){ return JD2CHLOG; }
+std::string ENVIRONMENT::get_jdhelp(){ return JDHELP; }
+std::string ENVIRONMENT::get_jdhelpcmd(){ return JDHELPCMD; }
 std::string ENVIRONMENT::get_jdhelpreplstr() { return JDHELPREPLSTR; }
-std::string ENVIRONMENT::get_jdlicense(){ return std::string( JDLICENSE ); }
+std::string ENVIRONMENT::get_jdlicense(){ return JDLICENSE; }
 
 
 static ENVIRONMENT::DesktopType window_manager = ENVIRONMENT::DesktopType::unknown;

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -268,7 +268,7 @@ void EditTreeView::clock_in()
             std::cout << "scroll to " << m_jump_path.to_string() << std::endl;
 #endif
 
-            Gtk::TreeRow row = get_row( Gtk::TreePath( m_jump_path ) );
+            Gtk::TreeRow row = get_row( m_jump_path );
             if( row ) scroll_to_row( m_jump_path, 0.5 );
 
             m_pre_adjust_upper = 0;


### PR DESCRIPTION
役に立たないキャストを行っているとgccに指摘されたため修正します。

gcc 12のレポート
```
../src/article/drawareabase.cpp:3189:64: warning: useless cast to type ‘int’ [-Wuseless-cast]
 3189 |                     else if( mode == LIVE_SCRMODE_STEADY ) y = ( int ) ( current_y + CONFIG::get_live_speed() );
      |                                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/skeleton/edittreeview.cpp:271:46: warning: useless cast to type ‘class Gtk::TreePath’ [-Wuseless-cast]
  271 |             Gtk::TreeRow row = get_row( Gtk::TreePath( m_jump_path ) );
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~
../src/environment.cpp:35:51: warning: useless cast to type ‘std::string’ {(snip)} [-Wuseless-cast]
   35 | std::string ENVIRONMENT::get_jdbbs(){ return std::string( JDBBS ); }
      |                                                   ^~~~~~~~~~~~~~~
../src/environment.cpp:36:54: warning: useless cast to type ‘std::string’ {(snip)} [-Wuseless-cast]
   36 | std::string ENVIRONMENT::get_jd2chlog(){ return std::string( JD2CHLOG ); }
      |                                                      ^~~~~~~~~~~~~~~~~~
../src/environment.cpp:35:51: warning: useless cast to type ‘std::string’ {(snip)} [-Wuseless-cast]
   35 | std::string ENVIRONMENT::get_jdbbs(){ return std::string( JDBBS ); }
      |                                                   ^~~~~~~~~~~~~~~
../src/environment.cpp:36:54: warning: useless cast to type ‘std::string’ {(snip)} [-Wuseless-cast]
   36 | std::string ENVIRONMENT::get_jd2chlog(){ return std::string( JD2CHLOG ); }
      |                                                      ^~~~~~~~~~~~~~~~~~
```
