### PR TITLE
DrawAreaBase: Fix memory leak for PangoFontMetrics

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -393,9 +393,9 @@ void DrawAreaBase::init_fontinfo( FONTINFO& fi, std::string& fontname )
     m_pango_layout->set_font_description( fi.pfd );
 
     // フォント情報取得
-    Pango::FontMetrics metrics = m_context->get_metrics( fi.pfd );
-    fi.ascent = PANGO_PIXELS( metrics.get_ascent() );
-    fi.descent = PANGO_PIXELS( metrics.get_descent() );
+    PangoFontMetrics* metrics = pango_context_get_metrics( m_context->gobj(), fi.pfd.gobj(), nullptr );
+    fi.ascent = PANGO_PIXELS( pango_font_metrics_get_ascent( metrics ) );
+    fi.descent = PANGO_PIXELS( pango_font_metrics_get_descent( metrics ) );
     fi.height = fi.ascent + fi.descent;
 
     // 改行高さ ( トップからの距離 )
@@ -405,8 +405,10 @@ void DrawAreaBase::init_fontinfo( FONTINFO& fi, std::string& fontname )
     m_pango_layout->set_text( wstr );
 
     // リンクの下線の位置 ( トップからの距離 )
-    fi.underline_pos = PANGO_PIXELS( ( metrics.get_ascent() - metrics.get_underline_position() )
-                                  * CONFIG::get_adjust_underline_pos() );
+    fi.underline_pos = PANGO_PIXELS( ( pango_font_metrics_get_ascent( metrics )
+                                       - pango_font_metrics_get_underline_position( metrics ) )
+                                     * CONFIG::get_adjust_underline_pos() );
+    pango_font_metrics_unref( metrics );
 
     // 左右padding取得
     // マージン幅は真面目にやると大変そうなので文字列 wstr の平均を取る


### PR DESCRIPTION
AddressSanitizerを有効にしてスレビューを表示したときに`Pango::FontMetrics`のオブジェクトが開放されずメモリリークが発生したためC APIに書き直して修正します。

AddressSanitizerのレポート
```
Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7fd2d34decaf in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7fd2d1fa1948 in g_malloc (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x5f948) (BuildId: 88d7a1c8d79fc1becb2737be566dd98523394d55)
    #2 0x55c83a6e64a6 in ARTICLE::DrawAreaBase::init_font() ../src/article/drawareabase.cpp:357
    #3 0x55c83a6f14b7 in ARTICLE::DrawAreaBase::clear_screen() ../src/article/drawareabase.cpp:742
(snip)

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7fd2d34decaf in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7fd2d1fa1948 in g_malloc (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x5f948) (BuildId: 88d7a1c8d79fc1becb2737be566dd98523394d55)
    #2 0x55c83a6e64a6 in ARTICLE::DrawAreaBase::init_font() ../src/article/drawareabase.cpp:357
    #3 0x55c83a6df61b in ARTICLE::DrawAreaBase::setup(bool, bool, bool) ../src/article/drawareabase.cpp:211
(snip)
```

Fixes #1176
