### PR TITLE
Fix implicit narrowing conversion for floating point literal

### DIFF
--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -1896,7 +1896,7 @@ void BBSListViewBase::slot_row_exp( const Gtk::TreeModel::iterator&, const Gtk::
     }
 
     m_treeview.set_cursor( path );
-    if( CONFIG::get_scroll_tree() ) m_treeview.scroll_to_row( path, 0.1 );
+    if( CONFIG::get_scroll_tree() ) m_treeview.scroll_to_row( path, 0.1f );
     show_status();
 }
 
@@ -2798,7 +2798,7 @@ void BBSListViewBase::exec_search()
         // カーソル移動
         if( hit ){
             m_treeview.expand_parents( path );
-            m_treeview.scroll_to_row( path, 0.1 );
+            m_treeview.scroll_to_row( path, 0.1f );
             m_treeview.set_cursor( path );
             show_status();
             break;

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -269,7 +269,7 @@ void EditTreeView::clock_in()
 #endif
 
             Gtk::TreeRow row = get_row( m_jump_path );
-            if( row ) scroll_to_row( m_jump_path, 0.5 );
+            if( row ) scroll_to_row( m_jump_path, 0.5f );
 
             m_pre_adjust_upper = 0;
             m_jump_path = Gtk::TreePath();
@@ -1243,7 +1243,7 @@ void EditTreeView::undo()
         Gtk::TreeRow row = get_row( data[ i ].path_renamed );
         if( row ){
 
-            scroll_to_row( data[ i ].path_renamed, 0.5 );  // ツリー構造に変化は無いのですぐにスクロールする
+            scroll_to_row( data[ i ].path_renamed, 0.5f );  // ツリー構造に変化は無いのですぐにスクロールする
             set_cursor( data[ i ].path_renamed );
             if( ! data[ i ].name_before.empty() ) row[ m_columns.m_name ] = data[ i ].name_before;
         }
@@ -1290,7 +1290,7 @@ void EditTreeView::redo()
         Gtk::TreeRow row = get_row( item.path_renamed );
         if( row ){
 
-            scroll_to_row( item.path_renamed, 0.5 );  // ツリー構造に変化は無いのですぐにスクロールする
+            scroll_to_row( item.path_renamed, 0.5f );  // ツリー構造に変化は無いのですぐにスクロールする
             set_cursor( item.path_renamed );
             if( ! item.name_new.empty() ) row[ m_columns.m_name ] = item.name_new;
         }


### PR DESCRIPTION
浮動点少数リテラルがfloat型に暗黙変換されて精度が下がるとコンパイラーに警告されたためリテラルをfloat型に書き換えて修正します。

gcc 12のレポート
```
../src/bbslist/bbslistviewbase.cpp:1899:69: warning: conversion from ‘double’ to ‘float’ changes value from ‘1.0000000000000001e-1’ to ‘1.00000001e-1f’ [-Wfloat-conversion]
 1899 |     if( CONFIG::get_scroll_tree() ) m_treeview.scroll_to_row( path, 0.1 );
      |                                                                     ^~~
../src/bbslist/bbslistviewbase.cpp:2801:45: warning: conversion from ‘double’ to ‘float’ changes value from ‘1.0000000000000001e-1’ to ‘1.00000001e-1f’ [-Wfloat-conversion]
 2801 |             m_treeview.scroll_to_row( path, 0.1 );
      |                                             ^~~
```
