### PR TITLE
Fix comparing floating point with '==' or '!='

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -43,8 +43,9 @@
 #include "session.h"
 
 #include <cmath>
-#include <sstream>
 #include <cstring>
+#include <limits>
+#include <sstream>
 
 #ifndef USE_PANGOLAYOUT
 #include <pangomm/glyphstring.h>
@@ -2969,7 +2970,8 @@ bool DrawAreaBase::set_scroll( const int control )
                 break;
         }
 
-        if( dy ){
+        // 誤差を考慮した dy != 0
+        if( std::abs( dy ) > std::numeric_limits<double>::epsilon() ){
 
             m_scrollinfo.reset();
             m_scrollinfo.dy = ( int ) dy;
@@ -3014,7 +3016,8 @@ void DrawAreaBase::wheelscroll( GdkEventScroll* event )
 
             const int current_y = ( int ) adjust->get_value();
             if( event->direction == GDK_SCROLL_UP && current_y == 0 ) return;
-            if( event->direction == GDK_SCROLL_DOWN && current_y == adjust->get_upper() - adjust->get_page_size() ) return;
+            if( event->direction == GDK_SCROLL_DOWN
+                    && current_y == static_cast<int>( adjust->get_upper() - adjust->get_page_size() ) ) return;
 
             m_scrollinfo.reset();
             m_scrollinfo.mode = SCROLL_NORMAL;

--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -13,7 +13,9 @@
 #include "colorid.h"
 #include "cache.h"
 
+#include <cmath>
 #include <cstring>
+#include <limits>
 
 enum
 {
@@ -562,7 +564,8 @@ void Css_Manager::set_property( const std::string& classname, const CSS_PROPERTY
 void Css_Manager::set_size( CSS_PROPERTY* css, double height ) const
 {
     if( ! css ) return;
-    if( ! height ) return;
+    // 誤差を考慮した height == 0
+    if( std::abs( height ) < std::numeric_limits<double>::epsilon() ) return;
 
     css->padding_left = 0;
     css->padding_right = 0;

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -24,6 +24,10 @@
 #include "jdlib/miscutil.h"
 #include "jdlib/miscmsg.h"
 
+#include <cmath>
+#include <limits>
+
+
 IMAGE::ImageAdmin *instance_imageadmin = nullptr;
 
 IMAGE::ImageAdmin* IMAGE::get_admin()
@@ -968,7 +972,8 @@ void ImageAdmin::scroll_tab( int scroll )
         std::cout << "width = " << width << std::endl;
 #endif
 
-        if( upper == width ) return;
+        // 誤差を考慮した upper == width
+        if( std::abs( upper - width ) < std::numeric_limits<double>::epsilon() ) return;
 
         if( scroll == SCROLL_LEFT ) pos -= ICON_SIZE;
         else pos += ICON_SIZE;

--- a/src/jdlib/tfidf.cpp
+++ b/src/jdlib/tfidf.cpp
@@ -9,8 +9,9 @@
 
 #include "global.h"
 
+#include <cmath>
+#include <limits>
 #include <set>
-#include <math.h>
 
 
 //
@@ -95,7 +96,8 @@ void MISC::tfidf_calc_vec_tfifd( VEC_TFIDF& vec_tfidf, const Glib::ustring& docu
 
     for( int i = 0; i < n; ++i ){
 
-        if( total ){
+        // 誤差を考慮した total != 0
+        if( std::abs( total ) > std::numeric_limits<double>::epsilon() ) {
             vec_tfidf[ i ] /= total;
             vec_tfidf[ i ] *= vec_idf[ i ];
         }
@@ -127,8 +129,10 @@ double MISC::tfidf_cos_similarity( const VEC_TFIDF& vec_tfidf1, const VEC_TFIDF&
         lng2 += vec_tfidf2[ i ] * vec_tfidf2[ i ];
     }
 
-    if( lng1 == 0 ) return 0;
-    if( lng2 == 0 ) return 0;
+    // 誤差を考慮した lng1 == 0
+    if( std::abs( lng1 ) < std::numeric_limits<double>::epsilon() ) return 0;
+    // 誤差を考慮した lng2 == 0
+    if( std::abs( lng2 ) < std::numeric_limits<double>::epsilon() ) return 0;
 
     const double ret = product / sqrt( lng1 * lng2 );
 


### PR DESCRIPTION
比較演算子の'=='や'!='を使ってdouble型の数値が等しい、等しくないをチェックするのは安全でないとgccに指摘されたため絶対値と計算機イプシロンを使った比較に書き換えて修正します。
一部の比較式については整数にキャストして行います。

gcc 12のレポート
```
../src/article/drawareabase.cpp:2976:13: warning: comparing floating-point with ‘==’ or ‘!=’ is unsafe [-Wfloat-equal]
 2976 |         if( dy ){
      |             ^~
../src/article/drawareabase.cpp:3021:66: warning: comparing floating-point with ‘==’ or ‘!=’ is unsafe [-Wfloat-equal]
 3021 |             if( event->direction == GDK_SCROLL_DOWN && current_y == adjust->get_upper() - adjust->get_page_size() ) return;
      |                                                        ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/cssmanager.cpp:565:11: warning: comparing floating-point with ‘==’ or ‘!=’ is unsafe [-Wfloat-equal]
  565 |     if( ! height ) return;
      |           ^~~~~~
../src/image/imageadmin.cpp:971:19: warning: comparing floating-point with ‘==’ or ‘!=’ is unsafe [-Wfloat-equal]
  971 |         if( upper == width ) return;
      |             ~~~~~~^~~~~~~~
../src/jdlib/tfidf.cpp:98:13: warning: comparing floating-point with ‘==’ or ‘!=’ is unsafe [-Wfloat-equal]
   98 |         if( total ){
      |             ^~~~~
../src/jdlib/tfidf.cpp:130:14: warning: comparing floating-point with ‘==’ or ‘!=’ is unsafe [-Wfloat-equal]
  130 |     if( lng1 == 0 ) return 0;
      |         ~~~~~^~~~
../src/jdlib/tfidf.cpp:131:14: warning: comparing floating-point with ‘==’ or ‘!=’ is unsafe [-Wfloat-equal]
  131 |     if( lng2 == 0 ) return 0;
      |         ~~~~~^~~~
```
