### PR TITLE
Bump version to 0.10.0-beta

### DIFF
--- a/docs/manual/2023.md
+++ b/docs/manual/2023.md
@@ -10,6 +10,99 @@ layout: default
 
 <a name="0.10.0-unreleased"></a>
 ### [0.10.0-unreleased](https://github.com/JDimproved/JDim/compare/2d85091f13...master) (unreleased)
+- ([#1185](https://github.com/JDimproved/JDim/pull/1185))
+  Bump version to 0.10.0-beta
+- ([#1184](https://github.com/JDimproved/JDim/pull/1184))
+  Fix comparing floating point with '==' or '!='
+- ([#1183](https://github.com/JDimproved/JDim/pull/1183))
+  Fix implicit narrowing conversion for floating point literal
+- ([#1182](https://github.com/JDimproved/JDim/pull/1182))
+  Fix snprintf() format mismatch by changing param type to unsigned int
+- ([#1181](https://github.com/JDimproved/JDim/pull/1181))
+  `Socket`: Fix casting of pointers to types with different alignments
+- ([#1180](https://github.com/JDimproved/JDim/pull/1180))
+  `DrawAreaBase`: Fix memory leak for `PangoFontMetrics`
+- ([#1179](https://github.com/JDimproved/JDim/pull/1179))
+  `NodeTreeBase`: Fix bug missing reply anchors in 5ch threads
+- ([#1175](https://github.com/JDimproved/JDim/pull/1175))
+  Fix compiler warnings for useless cast
+- ([#1174](https://github.com/JDimproved/JDim/pull/1174))
+  `NodeTreeBase`: Fix parameter name shadowing
+- ([#1173](https://github.com/JDimproved/JDim/pull/1173))
+  `NodeTreeBase`: Suppress code analysis report about invalid lifetime
+- ([#1172](https://github.com/JDimproved/JDim/pull/1172))
+  `NodeTreeBase`: Modify parsing HTML to unconditionally parse `<a>` elements
+- ([#1171](https://github.com/JDimproved/JDim/pull/1171))
+  Fix resource leak for logging
+- ([#1170](https://github.com/JDimproved/JDim/pull/1170))
+  `NodeTree2chCompati`: Get rid of raw mode processing
+- ([#1169](https://github.com/JDimproved/JDim/pull/1169))
+  Remove Rokka support
+- ([#1168](https://github.com/JDimproved/JDim/pull/1168))
+  Add blank lines between replies which are concatenated
+- ([#1167](https://github.com/JDimproved/JDim/pull/1167))
+  `NodeTreeBase`: Do not mark thread as broken on HTTP 416 error
+- ([#1166](https://github.com/JDimproved/JDim/pull/1166))
+  `Root`: Treat manually added 2ch/5ch boards as native boards
+- ([#1165](https://github.com/JDimproved/JDim/pull/1165))
+  `NodeTreeBase`: Update fucntion to parse date, ID, and BE link
+- ([#1164](https://github.com/JDimproved/JDim/pull/1164))
+  NodeTreeBase::parse_name(): Update loop condition and text copy
+- ([#1163](https://github.com/JDimproved/JDim/pull/1163))
+  `NodeTreeBase`: Update DAT/HTML parsing to add newline after `<ul>` tag
+- ([#1162](https://github.com/JDimproved/JDim/pull/1162))
+  Add URL Percent-Encoding decoding option to about:config
+- ([#1161](https://github.com/JDimproved/JDim/pull/1161))
+  `NodeTreeBase`: Refactor check anchor and link
+- ([#1160](https://github.com/JDimproved/JDim/pull/1160))
+  `Css_Manager`: Change `get_classid()` parameter type to use `std::string_view`
+- ([#1159](https://github.com/JDimproved/JDim/pull/1159))
+  Add support for using HTML tag-specified text color in thread view
+- ([#1158](https://github.com/JDimproved/JDim/pull/1158))
+  `NodeTreeBase`: Implement color display for HTML `<span>` and `<mark>` elements
+- ([#1157](https://github.com/JDimproved/JDim/pull/1157))
+  `Css_Manager`: Implement `get_property()` function returning const reference
+- ([#1156](https://github.com/JDimproved/JDim/pull/1156))
+  `NodeTreeBase`: Implement code for coloring via HTML and CSS
+- ([#1155](https://github.com/JDimproved/JDim/pull/1155))
+  `NodeTreeBase`: Convert relative URLs in HTML `<a>` elements
+- ([#1154](https://github.com/JDimproved/JDim/pull/1154))
+  `NodeTreeBase`: Implement bold display for text inside HTML `<b>` elements
+- ([#1153](https://github.com/JDimproved/JDim/pull/1153))
+  `NodeTreeBase`: Update whitespace handling in node tree construction
+- ([#1152](https://github.com/JDimproved/JDim/pull/1152))
+  `NodeTreeBase`: Get rid of freeing memory from `init_loading()` to reuse buffers
+- ([#1151](https://github.com/JDimproved/JDim/pull/1151))
+  `NodeTreeBase`: Modify default name detection to ignore trailing whitespace
+- ([#1150](https://github.com/JDimproved/JDim/pull/1150))
+  `NodeTreeBase`: Fix input data size adjustment in buffer copying
+- ([#1149](https://github.com/JDimproved/JDim/pull/1149))
+  `NodeTreeBase`: Implement `sweep_buffer()`
+- ([#1148](https://github.com/JDimproved/JDim/pull/1148))
+  `NodeTreeBase`: Update `receive_data()` to improve processing large data
+- ([#1147](https://github.com/JDimproved/JDim/pull/1147))
+  `NodeTreeBase`: Use `std::string&` for `process_raw_lines()` parameter type
+- ([#1146](https://github.com/JDimproved/JDim/pull/1146))
+  `NodeTreeBase`: Use `std::string&` for `add_raw_lines()` parameter type
+- ([#1145](https://github.com/JDimproved/JDim/pull/1145))
+  `NodeTreeBase`: Modify `parse_html()` to collect UTF-8 byte seq into buffer
+- ([#1144](https://github.com/JDimproved/JDim/pull/1144))
+  dbtree: Modify HTTP request range for checking DAT update
+- ([#1143](https://github.com/JDimproved/JDim/pull/1143))
+  `ArticleViewBase`: Support 12 chars ID in ID extraction view
+- ([#1142](https://github.com/JDimproved/JDim/pull/1142))
+  dbtree: Modify interface function return type to use const reference
+- ([#1141](https://github.com/JDimproved/JDim/pull/1141))
+  `Loader`: Fix proxy connection using IPv6
+- ([#1139](https://github.com/JDimproved/JDim/pull/1139))
+  `NodeTreeMachi`: Fix regex pattern for DAT conversion
+- ([#1138](https://github.com/JDimproved/JDim/pull/1138))
+  `BBSListViewBase`: Modify URL comparison for row selection
+- ([#1137](https://github.com/JDimproved/JDim/pull/1137))
+  Update network connection
+- ([#1136](https://github.com/JDimproved/JDim/pull/1136))
+  Update histories
+
 
 
 <a name="0.9.0-20230401"></a>

--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,7 @@
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 
 project('jdim', 'cpp',
-        version : '0.9.0',
+        version : '0.10.0-beta',
         license : 'GPL2',
         meson_version : '>= 0.53.0',
         default_options : ['warning_level=3', 'cpp_std=c++17'])

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -15,10 +15,10 @@
 // SEE ALSO: ENVIRONMENT::get_jdversion()
 
 #define MAJORVERSION 0
-#define MINORVERSION 9
+#define MINORVERSION 10
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20230401"
-#define JDTAG     ""
+#define JDDATE_FALLBACK    "20230617"
+#define JDTAG     "beta"
 
 //---------------------------------
 


### PR DESCRIPTION
### Update histories
### Bump version to 0.10.0-beta
機能フリーズ期間に入るためバージョン番号をベータ版に更新します。

関連のissue: #1135
