### PR TITLE
Fix compile errors on Unity build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,3 +97,31 @@ C++17で追加された標準ライブラリのうちg++ 8またはclang++ 7が[
 [cpp17sets]: https://en.cppreference.com/w/cpp/container/set/merge
 [cpp17conv]: https://en.cppreference.com/w/cpp/header/charconv
 [cpp17fspathhash]: https://en.cppreference.com/w/cpp/filesystem/path/hash
+
+#### :chains: Unity buildの注意
+ビルドツールMesonは複数のソースファイルを1つに結合してコンパイルする
+[Unity build][meson-unity-build] という機能があります(デフォルトは無効)。
+機能を有効に設定してソースファイルを結合するとマクロや変数などの名前が衝突してコンパイルに失敗することがあります。
+
+ビルドの問題を見つけたときはバグ報告や修正のPull requestをいただけると幸いです。
+
+* 名前が衝突したときは名称を変更したり入れ子の名前空間の中に入れるなどで衝突を回避できます。
+  ```cpp
+  // 入れ子の名前空間の例
+  namespace Outer::priv { constexpr int kBufferSize = 1024; }
+
+  using namespace Outer;
+  use_value( priv::kBufferSize );
+  ```
+* `#define`マクロによる意図しない定義変更(上書き)に注意してください。
+  コンパイラーがマクロの警告を出したときはマクロ以外の方法が使えないかチェックしてみてください。
+
+##### Unity buildの使い方
+setupサブコマンドで`-Dunity=on`を指定します。
+ビルドオプション`-Dunity_size=N`で1つに結合するファイル数を変更できます。
+```sh
+meson setup builddir -Dunity=on -Dunity_size=10
+ninja -C builddir
+```
+
+[meson-unity-build]: https://mesonbuild.com/Unity-builds.html

--- a/src/bbslist/favoriteview.cpp
+++ b/src/bbslist/favoriteview.cpp
@@ -11,8 +11,11 @@
 #include "cache.h"
 #include "type.h"
 
-// ルート要素名( bookmark.xml )
-#define ROOT_NODE_NAME "favorite"
+namespace BBSLIST::fv {
+/// ルート要素名( bookmark.xml )
+constexpr const char* kRootNodeName = "favorite";
+}
+
 
 using namespace BBSLIST;
 
@@ -45,7 +48,7 @@ FavoriteListView::~FavoriteListView()
 void FavoriteListView::save_xml()
 {
     const std::string file = CACHE::path_xml_favorite();
-    save_xml_impl( file, ROOT_NODE_NAME, "" );
+    save_xml_impl( file, fv::kRootNodeName, "" );
 }
 
 
@@ -60,7 +63,7 @@ void FavoriteListView::show_view()
 
     CACHE::load_rawdata( file_in, xml );
 
-    xml2tree( std::string( ROOT_NODE_NAME ), xml );
+    xml2tree( std::string( fv::kRootNodeName ), xml );
 
     update_urls();
 }

--- a/src/bbslist/historyview.cpp
+++ b/src/bbslist/historyview.cpp
@@ -12,8 +12,11 @@
 #include "type.h"
 #include "global.h"
 
-// ルート要素名
-#define ROOT_NODE_NAME "history"
+namespace BBSLIST::hv {
+/// ルート要素名
+constexpr const char* kRootNodeName = "history";
+}
+
 
 using namespace BBSLIST;
 
@@ -39,7 +42,7 @@ void HistoryViewBase::show_view()
 {
     std::string xml;
     CACHE::load_rawdata( m_file_xml, xml );
-    xml2tree( std::string( ROOT_NODE_NAME ), xml );
+    xml2tree( std::string( hv::kRootNodeName ), xml );
     update_urls();
 }
 
@@ -47,7 +50,7 @@ void HistoryViewBase::show_view()
 // xml保存
 void HistoryViewBase::save_xml()
 {
-    save_xml_impl( m_file_xml, ROOT_NODE_NAME, "" );
+    save_xml_impl( m_file_xml, hv::kRootNodeName, "" );
 }
 
 

--- a/src/login2ch.cpp
+++ b/src/login2ch.cpp
@@ -18,10 +18,11 @@
 
 #include <cstring>
 
-enum
-{
-    SIZE_OF_RAWDATA = 64 * 1024
-};
+
+namespace CORE::ch {
+constexpr std::size_t kSizeOfRawData = 64 * 1024;
+}
+
 
 CORE::Login2ch* instance_login2ch = nullptr;
 
@@ -111,7 +112,7 @@ void Login2ch::start_login()
     data.str_post += get_passwd();
 
     logout();
-    if( m_rawdata.capacity() < SIZE_OF_RAWDATA ) m_rawdata.reserve( SIZE_OF_RAWDATA );
+    if( m_rawdata.capacity() < ch::kSizeOfRawData ) m_rawdata.reserve( ch::kSizeOfRawData );
     m_rawdata.clear();
 
     start_load( data );

--- a/src/loginbe.cpp
+++ b/src/loginbe.cpp
@@ -17,10 +17,11 @@
 #include "jdlib/miscutil.h"
 #include "jdlib/jdregex.h"
 
-enum
-{
-    SIZE_OF_RAWDATA = 64 * 1024
-};
+
+namespace CORE::be {
+constexpr std::size_t kSizeOfRawData = 64 * 1024;
+}
+
 
 CORE::LoginBe* instance_loginbe = nullptr;
 
@@ -113,7 +114,7 @@ void LoginBe::start_login()
     data.str_post += "&submit=" + MISC::url_encode_plus( "登録", Encoding::eucjp );
 
     logout();
-    if( m_rawdata.capacity() < SIZE_OF_RAWDATA ) m_rawdata.reserve( SIZE_OF_RAWDATA );
+    if( m_rawdata.capacity() < be::kSizeOfRawData ) m_rawdata.reserve( be::kSizeOfRawData );
     m_rawdata.clear();
 
     start_load( data );

--- a/src/skeleton/editview.cpp
+++ b/src/skeleton/editview.cpp
@@ -221,7 +221,7 @@ void EditTextView::slot_buffer_changed()
 
     if( size ){
 
-        UNDO_DATA udata;
+        UndoDatum udata;
         udata.pos = 0;
         udata.append = false;
 
@@ -273,8 +273,8 @@ void EditTextView::undo()
         return;
     }
 
-    UNDO_DATA udata = m_undo_tree[ m_undo_pos-- ];
-    
+    UndoDatum udata = m_undo_tree[ m_undo_pos-- ];
+
 #ifdef _DEBUG
     std::cout << "EditTextView::undo pos = " << m_undo_pos << " size = " << m_undo_tree.size() << std::endl;
     std::cout << "offset = " << udata.pos << " cursor = " << udata.pos_cursor;

--- a/src/skeleton/editview.h
+++ b/src/skeleton/editview.h
@@ -19,7 +19,7 @@ namespace SKELETON
     typedef sigc::signal< bool, GdkEventButton* > SIG_BUTTON_PRESS;
 
     // undo 用のバッファ
-    struct UNDO_DATA
+    struct UndoDatum
     {
         Glib::ustring str_diff;
         unsigned int pos;
@@ -39,7 +39,7 @@ namespace SKELETON
         CONTROL::Control m_control;
 
         // undo 用
-        std::vector< UNDO_DATA > m_undo_tree;
+        std::vector<UndoDatum> m_undo_tree;
         int m_undo_pos{};
         Glib::ustring m_pre_text;
         bool m_cancel_change{};

--- a/src/skeleton/tabswitchmenu.h
+++ b/src/skeleton/tabswitchmenu.h
@@ -2,6 +2,8 @@
 //
 // タブの切り替えメニュー
 //
+#ifndef SKELETON_TABSWITCHMENU_H
+#define SKELETON_TABSWITCHMENU_H
 
 #include <gtkmm.h>
 
@@ -43,3 +45,5 @@ namespace SKELETON
         void alloc_items();
     };
 }
+
+#endif

--- a/src/skeleton/undobuffer.h
+++ b/src/skeleton/undobuffer.h
@@ -1,6 +1,8 @@
 // ライセンス: GPL2
 
 // UNDO用バッファ
+#ifndef SKELETON_UNDOBUFFER_H
+#define SKELETON_UNDOBUFFER_H
 
 #include "sharedbuffer.h"
 
@@ -88,3 +90,5 @@ namespace SKELETON
     };
 
 }
+
+#endif

--- a/src/xml/document.cpp
+++ b/src/xml/document.cpp
@@ -6,10 +6,10 @@
 #include "document.h"
 #include "jdlib/miscutil.h"
 
-enum
-{
-    SIZE_OF_RAWDATA = 2 * 1024 * 1024
-};
+
+namespace XML::dc {
+constexpr std::size_t kSizeOfRawData = 2 * 1024 * 1024;
+}
 
 
 using namespace XML;
@@ -75,7 +75,7 @@ void Document::init( Glib::RefPtr< Gtk::TreeStore > treestore, SKELETON::EditCol
 //
 std::string Document::remove_comments( const std::string& str )
 {
-    if( str.size() > SIZE_OF_RAWDATA ) return std::string();
+    if( str.size() > dc::kSizeOfRawData ) return std::string();
 
     std::string out_str = str;
 

--- a/src/xml/dom.cpp
+++ b/src/xml/dom.cpp
@@ -13,10 +13,11 @@
 
 #include <sstream>
 
-enum
-{
-    SIZE_OF_RAWDATA = 2 * 1024 * 1024
-};
+
+namespace XML::dm {
+constexpr std::size_t kSizeOfRawData = 2 * 1024 * 1024;
+}
+
 
 using namespace XML;
 
@@ -84,7 +85,7 @@ void Dom::clear() noexcept
 //
 void Dom::parse( const std::string& str )
 {
-    if( str.empty() || str.size() > SIZE_OF_RAWDATA ) return;
+    if( str.empty() || str.size() > dm::kSizeOfRawData ) return;
 
     size_t current_pos = 0;
     const size_t str_length = str.length();


### PR DESCRIPTION
Mesonを使った[Unity build][unitybuild]をサポートするためコンパイラーを修正します。

関連のissue: #1177

#### Put constant in nested namespace to avoid declaration confliction
複数のソースファイルを結合してコンパイルするunity buildを実行すると無名enumの列挙子が衝突してコンパイルエラーになるためenumをconstexpr定数に変更して入れ子の名前空間の中に置くことで修正します。

#### Rename struct `UNDO_DATA` with UndoDatum to avoid redefinition error
複数のソースファイルを1つに結合してコンパイルするunity buildを実行すると型の名前が衝突してコンパイルエラーになるため構造体の名前を変更して修正します。

#### Add include guard to avoid redefinition error
複数のソースファイルを1つに結合してコンパイルするunity buildを実行すると同じヘッダーファイルを複数回includeして定義エラーになるためインクルードガードを追加して修正します。

#### Put constant in nested namespace to avoid macro redefinition
複数のソースファイルを1つに結合してコンパイルするunity buildを実行するとマクロが再定義されてコンパイラー警告がでたためマクロをconstexpr定数に変更して入れ子の名前空間の中に置くことで修正します。

#### Add notes for Unity build to CONTRIBUTING.md
ビルドツールMesonの機能Unity buildを利用するときの注意をガイドに追加します。

[unitybuild]: https://mesonbuild.com/Unity-builds.html
