### PR TITLE
Core: Get rid of unused private field

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -105,8 +105,6 @@ namespace CORE
         std::string m_title;
 
         Gtk::MenuBar* m_menubar{};
-        Gtk::MenuItem* m_menuitem_prevview{};
-        Gtk::MenuItem* m_menuitem_nextview{};
 
         Glib::RefPtr< Gtk::ActionGroup > m_action_group;
         Glib::RefPtr< Gtk::UIManager > m_ui_manager;


### PR DESCRIPTION
未使用のprivateメンバー変数があるとclangに指摘されたため取り除きます。

clang 15のレポート
```
../src/core.h:108:24: error: private field 'm_menuitem_prevview' is not used [-Werror,-Wunused-private-field]
        Gtk::MenuItem* m_menuitem_prevview{};
                       ^
```
