### PR TITLE
Login2ch: Fix compile error about unused const variable

### DIFF
--- a/src/login2ch.cpp
+++ b/src/login2ch.cpp
@@ -19,9 +19,11 @@
 #include <cstring>
 
 
+#if 0 // サイトの更新に対応していないためサポートを中止
 namespace CORE::ch {
 constexpr std::size_t kSizeOfRawData = 64 * 1024;
 }
+#endif
 
 
 CORE::Login2ch* instance_login2ch = nullptr;


### PR DESCRIPTION
未使用の変数があるとclang 16に指摘されたため `#if 0` ... `#endif` でコメントアウトしてコンパイラー警告を抑制します。

clang-16のレポート
```
[244/323] Compiling C++ object src/jdim.p/login2ch.cpp.o
../src/login2ch.cpp:23:23: warning: unused variable 'kSizeOfRawData' [-Wunused-const-variable]
constexpr std::size_t kSizeOfRawData = 64 * 1024;
                      ^
1 warning generated.
[283/323] Compiling C++ object test/gtest_jdim.p/.._src_login2ch.cpp.o
../src/login2ch.cpp:23:23: warning: unused variable 'kSizeOfRawData' [-Wunused-const-variable]
constexpr std::size_t kSizeOfRawData = 64 * 1024;
                      ^
1 warning generated.
```
