### PR TITLE
docs: Fix doxygen warnings

### DIFF
--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -1084,10 +1084,8 @@ std::string Loader::create_msg_send() const
 
 /** @brief サーバから送られてきた生データからヘッダ取得
  *
- * @param[in] buf     生データ
- * @param[in] bufsize 生データサイズ
- * @param[out] buf     ヘッダーが取り除かれたデータ
- * @param[out] bufsize 出力データーサイズ
+ * @param[in,out] buf        (in) 生データ, (out) ヘッダーが取り除かれたデータ
+ * @param[in,out] read_size  (in) 生データサイズ, (out) 出力データーサイズ
  * @return ヘッダーの解析状況
  * @retval HeaderParse::success      成功
  * @retval HeaderParse::failure      失敗

--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -192,7 +192,7 @@ bool MISC::is_eucjp( std::string_view input, std::size_t read_byte )
 //
 /** @brief 文字列のエンコーディングがISO-2022-JPか簡易判定する
  *
- * エスケープシーケンス(ESC = \x1B)の有無と該当しないバイトが含まれるかチェックする。
+ * エスケープシーケンス(ESC = \\x1B)の有無と該当しないバイトが含まれるかチェックする。
  * 呼び出し元の処理のため空文字列に対する返り値は他の`is_*`関数と逆(false)になっている。
  * @param[in] input 入力
  * @param[in,out] byte チェックを開始する位置、チェックを打ち切った位置を返す

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -353,7 +353,7 @@ std::string MISC::utf8_trim( std::string_view str )
 }
 
 
-/** @brief str前後の改行(\r, \\n)、タブ(\t)、スペース(U+0020)を削除
+/** @brief str前後の改行(\\r, \\n)、タブ(\\t)、スペース(U+0020)を削除
  *
  * @param[in] str トリミングする文字列
  * @return トリミングした結果
@@ -534,7 +534,7 @@ std::list<std::string> MISC::replace_str_list( const std::list<std::string>& lis
 
 /** @brief str に含まれる改行文字(`\r\n`)を replace に置き換え
  *
- * @param[in] str_in 処理する文字列
+ * @param[in] str 処理する文字列
  * @param[in] replace マッチした改行文字と置き換える内容
  * @return 置き換えを実行した結果。str や replace が空文字列のときは str をそのまま返す。
  */
@@ -1068,7 +1068,7 @@ std::string MISC::to_plain( const std::string& html )
 
 /** @brief HTMLをPango markupテキストに変換する
  *
- * @details <mark>と<span>タグの色を設定して文字参照をデコードして返す。
+ * @details `<mark>`と`<span>`タグの色を設定して文字参照をデコードして返す。
  * @param[in] html Pango markupテキストに変換する入力
  * @return 変換した結果
  */
@@ -1593,14 +1593,14 @@ static char32_t transform_7f_9f( char32_t raw_point )
 }
 
 
-/** @brief 「&#数字;」形式の数値文字参照をコードポイント(char32_t)に変換する
+/** @brief 「`&#数字;`」形式の数値文字参照をコードポイント(char32_t)に変換する
  *
  * @details 数値文字参照の解析エラーとなる値もそのまま返す
  * (Unicodeの範囲外、サロゲート、非文字など)
  * @param[in] in_char 入力文字列、 `in_char[0] == "&" && in_char[1] == "#"` であること (not null)
  * @param[in] offset  spchar_number_ln() の戻り値
  * @param[in] lng     spchar_number_ln() の戻り値
- * @return 「&#数字;」の中の数字(char32_t型)
+ * @return 「`&#数字;`」の中の数字(char32_t型)
  * @remarks 最初に MISC::spchar_number_ln() を呼び出して `offset` と `lng` を取得すること
  */
 char32_t MISC::decode_spchar_number_raw( const char* in_char, const int offset, const int lng )
@@ -1620,13 +1620,13 @@ char32_t MISC::decode_spchar_number_raw( const char* in_char, const int offset, 
 }
 
 
-/** @brief 「&#数字;」形式の数値文字参照をコードポイント(char32_t)に変換する
+/** @brief 「`&#数字;`」形式の数値文字参照をコードポイント(char32_t)に変換する
  *
  * @details 数値文字参照の解析エラーとなる値は規定の値に変換して返す
  * @param[in] in_char 入力文字列、 `in_char[0] == "&" && in_char[1] == "#"` であること (not null)
  * @param[in] offset  spchar_number_ln() の戻り値
  * @param[in] lng     spchar_number_ln() の戻り値
- * @return 「&#数字;」の中の数字(char32_t型)
+ * @return 「`&#数字;`」の中の数字(char32_t型)
  * @remarks 最初に MISC::spchar_number_ln() を呼び出して `offset` と `lng` を取得すること
  */
 char32_t MISC::decode_spchar_number( const char* in_char, const int offset, const int lng )

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -77,7 +77,7 @@ namespace MISC
     /// str前後の半角スペース(U+0020)と全角スペース(U+3000)を削除
     std::string utf8_trim( std::string_view str );
 
-    /// str前後の改行(\r, \\n)、タブ(\t)、スペース(U+0020)を削除
+    /// str前後の改行(\\r, \\n)、タブ(\\t)、スペース(U+0020)を削除
     std::string ascii_trim( const std::string& str );
 
     /// strからpatternで示された文字列を除く

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -342,7 +342,7 @@ bool App::slot_option_geometry( const Glib::ustring& option_name, const Glib::us
 
 
 /**
- * @brief {Gtk,Gio}::Application で排他制御を行わないためスタートアップは必ず実行される
+ * @brief Gtk::Application, Gio::Application の機能を使って排他制御を行わないためスタートアップは必ず実行される
  */
 void App::slot_startup()
 {


### PR DESCRIPTION
doxygenによるHTML生成を実行したときに出る警告を修正します。

doxygenのレポート
```
/home/ma8ma/var/repos/JDim/src/jdlib/misccharcode.cpp:195: warning: Found unknown command '\x1B'
/home/ma8ma/var/repos/JDim/src/jdlib/miscutil.cpp:537: warning: argument 'str_in' of command @param is not found in the argument list of MISC::replace_newlines_to_str(const std::string &str, std::string_view replace)
/home/ma8ma/var/repos/JDim/src/jdlib/miscutil.cpp:537: warning: The following parameter of MISC::replace_newlines_to_str(const std::string &str, std::string_view replace) is not documented:
  parameter 'str'
/home/ma8ma/var/repos/JDim/src/jdlib/miscutil.cpp:1071: warning: Unsupported xml/html tag <mark> found
/home/ma8ma/var/repos/JDim/src/jdlib/miscutil.cpp:1596: warning: explicit link request to '数字' could not be resolved
/home/ma8ma/var/repos/JDim/src/jdlib/miscutil.cpp:1603: warning: explicit link request to '数字' could not be resolved
/home/ma8ma/var/repos/JDim/src/jdlib/miscutil.cpp:1623: warning: explicit link request to '数字' could not be resolved
/home/ma8ma/var/repos/JDim/src/jdlib/miscutil.cpp:1629: warning: explicit link request to '数字' could not be resolved
/home/ma8ma/var/repos/JDim/src/jdlib/miscutil.h:80: warning: Found unknown command '\r'
/home/ma8ma/var/repos/JDim/src/jdlib/miscutil.h:80: warning: Found unknown command '\t'
/home/ma8ma/var/repos/JDim/src/jdlib/loader.cpp:1087: warning: argument 'bufsize' of command @param is not found in the argument list of JDLIB::Loader::receive_header(char *buf, size_t &read_size)
/home/ma8ma/var/repos/JDim/src/jdlib/loader.cpp:1087: warning: argument 'buf' from the argument list of JDLIB::Loader::receive_header has multiple @param documentation sections
/home/ma8ma/var/repos/JDim/src/jdlib/loader.cpp:1087: warning: The following parameter of JDLIB::Loader::receive_header(char *buf, size_t &read_size) is not documented:
  parameter 'read_size'
/home/ma8ma/var/repos/JDim/src/main.cpp:345: warning: explicit link request to 'Application' could not be resolved
```
