### PR TITLE
Fix crash on NodeTreeBase::parse_date_id()

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -2016,7 +2016,12 @@ void NodeTreeBase::parse_date_id( NODE* header, std::string_view str )
             parse_html( str.data() + start_block, lng_block, COLOR_CHAR, digitlink, bold, FONT_MAIL );
 
             // 次のブロックへ移動
-            str = str.substr( start_block + lng_block );
+            if( const auto lng = start_block + lng_block; lng < str.size() ) {
+                str = str.substr( lng );
+            }
+            else {
+                str = std::string_view{};
+            }
             lng_text = 0;
         }
 


### PR DESCRIPTION
スレッド読み込み中に異常終了したため`std::string_view`の部分文字列を取得する処理を修正します。

gcc12.2 gdbのバックトレース
```cpp
#10 0x0000555555c32acf in std::__sv_check(unsigned long, unsigned long, char const*)
    (__size=243, __pos=244, __s=0x55555598ca42 "basic_string_view::substr") at /usr/include/c++/12/string_view:67
#11 0x0000555555c32fa2 in std::basic_string_view<char, std::char_traits<char> >::substr(unsigned long, unsigned long) const
    (this=0x7fffe97fe210, __pos=244, __n=18446744073709551615) at /usr/include/c++/12/string_view:311
#12 0x0000555555c7d072 in DBTREE::NodeTreeBase::parse_date_id(DBTREE::NODE*, std::basic_string_view<char, std::char_traits<char> >)
(gdb) frame 12
#12 0x0000555555c7d072 in DBTREE::NodeTreeBase::parse_date_id (this=0x5555577c19f0, header=0x555558e6bbe8,
2019                str = str.substr( start_block + lng_block );
(gdb) p str.size()
$3 = 243
(gdb) p start_block + lng_block
$4 = 244
```
