### PR TITLE
Weekly CI: Add logging for cloned muon repository and built version

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -62,10 +62,14 @@ jobs:
         run: |
           git clone --depth 1 https://git.sr.ht/~lattis/muon muon-src
         # Skip bootstrapping muon to do meson setup instead.
+      - name: git log -n1 muon
+        run: git -C muon-src log -n1
       - name: build muon
         run: |
           meson setup -Ddocs=disabled -Dlibarchive=disabled -Dlibcurl=disabled -Dlibpkgconf=enabled muon-build muon-src
           ninja -C muon-build
+      - name: muon version
+        run: ./muon-build/muon version
       - name: muon setup builddir
         run: ./muon-build/muon setup -Dcompat_cache_dir=disabled jdim-build
       - name: ninja -C jdim-build -k0


### PR DESCRIPTION
Weekly CIのmuonジョブを更新してgit cloneしたmuonリポジトリの情報とビルドしたmuonのバージョンをjobのログに出力するようにします。

関連のpull request: https://github.com/JDimproved/JDim/pull/1189
https://github.com/ma8ma/JDim/pull/78
