### PR TITLE
NodeTree2ch: Update loading of past log DATs to enable resume mode

### DIFF
--- a/src/dbtree/nodetree2ch.cpp
+++ b/src/dbtree/nodetree2ch.cpp
@@ -140,8 +140,9 @@ void NodeTree2ch::create_loaderdata( JDLIB::LOADERDATA& data )
         // スレIDが 9桁の場合 -> https://サーバ/板ID/oyster/IDの上位3桁/ID.dat
         ss << regex.str( 1 ) << regex.str( 2 ) << "/oyster/" << ( id / 1000000 ) << regex.str( 3 ) << ".dat";
 
-        // レジュームは無し
-        set_resume( false );
+        // レジューム設定
+        // DATを読み込んでいた場合はレジュームを有りにして、DATの未取得部分を追加するように処理する
+        set_resume( get_lng_dat() > 0 );
 
         data.url = ss.str();
     }


### PR DESCRIPTION
5chスレッドの過去ログ読み込みでresumeモードを有効にします。
DAT落ちした5chスレを再読み込みすると取得済のレスの後ろに先頭の>>1からスレの末尾まで追加されるバグが修正されます。

2023-07-12 に実装した5ch過去ログ読み込みでは過去ログURLから読み込んだDATデータを追加する処理でスレッドの途中から読み込むようにresumeモードが設定されていなかったのがバグの原因でした。

Closes #1203
