### PR TITLE
jdlib/miscutil: fix return value of ascii_trim for whitespace-only string (#1213)

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -364,7 +364,7 @@ std::string MISC::ascii_trim( const std::string& str )
 
     constexpr std::string_view space_chars = " \n\t\r";
     const auto start = str.find_first_not_of( space_chars );
-    if( start == std::string::npos ) return str;
+    if( start == std::string::npos ) return std::string();
 
     const auto end = str.find_last_not_of( space_chars ) + 1;
     return str.substr( start, end - start );

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -137,6 +137,11 @@ TEST_F(AsciiTrimTest, empty_data)
     EXPECT_EQ( "", MISC::ascii_trim( "" ) );
 }
 
+TEST_F(AsciiTrimTest, multiple_whitespace_only_data)
+{
+	EXPECT_EQ( "", MISC::ascii_trim("  ") );
+}
+
 TEST_F(AsciiTrimTest, no_space_chars_at_start_and_end)
 {
     EXPECT_EQ( "Hello \n \r \t World", MISC::ascii_trim( "Hello \n \r \t World" ) );


### PR DESCRIPTION
whitespace だけの文字列の入力に対して、その whitespace を全て
正しく除去したものを返すよう修正する。
修正前は、そのような文字列の入力に対しては変更前の文字列を返していたが、
これを空白の文字列を新たに作成し、それを返すよう変更する。

従って、以下の変更を一部修正する。
https://github.com/JDimproved/JDim/commit/62abdbfc55c9e1df8d92d862cfb33c33b8a01b90

これに応じて、対応するテストをAsciiTrimTestの中に追加する。

[1] https://mao.5ch.net/test/read.cgi/linux/1689151433/302

Fixes #1213