### PR TITLE
Add handling to use 2ch proxy if past logs not available without proxy

### DIFF
--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -110,6 +110,7 @@ bool ConfigItems::load( const bool restore )
     str_tmp = cf.get_option_str( "proxy_for2ch", "" );
     set_proxy_for2ch( str_tmp );
     proxy_port_for2ch = cf.get_option_int( "proxy_port_for2ch", CONF_PROXY_PORT_FOR2CH, 1, 65535 );
+    use_fallback_proxy_for2ch = cf.get_option_bool( "use_fallback_proxy_for2ch", CONF_USE_FALLBACK_PROXY_FOR2CH );
 
     // 書き込み用プロクシとポート番号
     use_proxy_for2ch_w = cf.get_option_bool( "use_proxy_for2ch_w", CONF_USE_PROXY_FOR2CH_W );
@@ -700,6 +701,7 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "send_cookie_to_proxy_for2ch", send_cookie_to_proxy_for2ch );
     cf.update( "proxy_for2ch", tmp_proxy );
     cf.update( "proxy_port_for2ch", proxy_port_for2ch );
+    cf.update( "use_fallback_proxy_for2ch", use_fallback_proxy_for2ch );
 
     if( proxy_basicauth_for2ch_w.empty() ) tmp_proxy = proxy_for2ch_w;
     else tmp_proxy = proxy_basicauth_for2ch_w + "@" + proxy_for2ch_w;

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -53,6 +53,7 @@ namespace CONFIG
         std::string proxy_for2ch;
         int proxy_port_for2ch{};
         std::string proxy_basicauth_for2ch;
+        bool use_fallback_proxy_for2ch{};
 
         // 書き込み用プロクシとポート番号
         bool use_proxy_for2ch_w{};

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -21,6 +21,7 @@ namespace CONFIG
         CONF_USE_PROXY_FOR2CH = 0, // 2ch 読み込み用プロクシを使用するか
         CONF_SEND_COOKIE_TO_PROXY_FOR2CH = 0, // 2ch 読み込み用プロクシにクッキーを送信するか
         CONF_PROXY_PORT_FOR2CH = 8080, // 2ch 読み込み用プロクシポート番号
+        CONF_USE_FALLBACK_PROXY_FOR2CH = 0, ///< プロキシを使わない接続で過去ログが見つからなかったときは2ch読み込み用プロキシを使う
         CONF_USE_PROXY_FOR2CH_W = 0, // 2ch 書き込み用プロクシを使用するか
         CONF_SEND_COOKIE_TO_PROXY_FOR2CH_W = 0, // 2ch 書き込み用プロクシにクッキーを送信するか
         CONF_PROXY_PORT_FOR2CH_W = 8080, // 2ch 書き込み用プロクシポート番号

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -189,11 +189,13 @@ bool CONFIG::get_send_cookie_to_proxy_for2ch() { return get_confitem()->send_coo
 const std::string& CONFIG::get_proxy_for2ch() { return get_confitem()->proxy_for2ch; }
 int CONFIG::get_proxy_port_for2ch() { return get_confitem()->proxy_port_for2ch; }
 const std::string& CONFIG::get_proxy_basicauth_for2ch() { return get_confitem()->proxy_basicauth_for2ch; }
+bool CONFIG::get_use_fallback_proxy_for2ch() { return get_confitem()->use_fallback_proxy_for2ch; }
 
 void CONFIG::set_use_proxy_for2ch( bool set ){ get_confitem()->use_proxy_for2ch = set; }
 void CONFIG::set_send_cookie_to_proxy_for2ch( bool set ){ get_confitem()->send_cookie_to_proxy_for2ch = set; }
 void CONFIG::set_proxy_for2ch( const std::string& proxy ){ get_confitem()->set_proxy_for2ch( proxy ); }
 void CONFIG::set_proxy_port_for2ch( int port ){ get_confitem()->proxy_port_for2ch = port; }
+void CONFIG::set_use_fallback_proxy_for2ch( bool set ) { get_confitem()->use_fallback_proxy_for2ch = set; }
 
 bool CONFIG::get_use_proxy_for2ch_w() { return get_confitem()->use_proxy_for2ch_w; }
 bool CONFIG::get_send_cookie_to_proxy_for2ch_w() { return get_confitem()->send_cookie_to_proxy_for2ch_w; }

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -152,11 +152,13 @@ namespace CONFIG
     const std::string& get_proxy_for2ch();
     int get_proxy_port_for2ch();
     const std::string& get_proxy_basicauth_for2ch();
+    bool get_use_fallback_proxy_for2ch();
 
     void set_use_proxy_for2ch( const bool set );
     void set_send_cookie_to_proxy_for2ch( bool set );
     void set_proxy_for2ch( const std::string& proxy );
     void set_proxy_port_for2ch( const int port );
+    void set_use_fallback_proxy_for2ch( const bool set );
 
     // 2ch 書き込み用プロクシとポート番号
     bool get_use_proxy_for2ch_w();


### PR DESCRIPTION
### Add 2ch proxy setting for cases where past logs not found in direct connection
プロキシを使わない接続で過去ログが見つからなかったときは2ch読み込み用プロキシを使う設定を実装します。
この設定は実験的なサポートのため変更または廃止の可能性があります。

### Implement user interface for using 2ch proxy when past logs not found without proxy
プロキシを使わない接続で過去ログが見つからなかったときは2ch読み込み用プロキシを使う設定のオプションを実装します。
このオプションは実験的なサポートのため変更または廃止の可能性があります。

### Add handling to use 2ch proxy if past logs not available without proxy]
プロキシを使わない接続で過去ログが見つからなかったときは2ch読み込み用プロキシを使う処理を実装します。
この機能は実験的なサポートのため変更または廃止の可能性があります。

Closes #1202
Closes ma8ma/JDim#80