### PR TITLE
Socket: Define AI_V4MAPPED for OpenBSD

### DIFF
--- a/src/jdlib/jdsocket.cpp
+++ b/src/jdlib/jdsocket.cpp
@@ -24,6 +24,11 @@
 #include <iomanip>
 #endif
 
+// OpenBSD does not define the macro
+#ifndef AI_V4MAPPED
+#define AI_V4MAPPED 0
+#endif
+
 
 namespace {
 


### PR DESCRIPTION
OpenBSDで定義されないマクロをデフォルトの値(0)で定義します。
マクロの定義条件は汎用的にしたためOpenBSDであるかチェックはしません。

参考にしたコミット
https://github.com/nodejs/node/commit/75340f3c524cbe8602ba8f5a48b8bf8572bad8f1

修正にあたり不具合報告をしていただきありがとうございました。
https://mevius.5ch.net/test/read.cgi/unix/1568040383/850-851n
