### PR TITLE
Log_Manager::check_write: skip heading continuous newlines for early-check

### DIFF
--- a/src/message/logmanager.cpp
+++ b/src/message/logmanager.cpp
@@ -184,6 +184,20 @@ bool Log_Manager::check_write( const std::string& url, const bool newthread, con
 
             bool flag = true;
             size_t i = 0, i2 = 0;
+
+            // 簡易チェックの場合、とにかく改行でも空白でもない所まで読み飛ばす
+            while (1) {
+                if ( item.head[ i ] == '\n' ) { ++i; continue; }
+                if ( item.head[ i ] == ' ' ) { ++i; continue; }
+                break;
+            }
+
+            while ( i2 < headsize ) {
+                if ( msg[ i2 ] == '\n' ) { ++i2; continue; }
+                if ( msg[ i2 ] == ' ' ) { ++i2; continue; }
+                break;
+            }
+
             while( item.head[ i ] != '\0' && i2 < headsize ){
 
                 // 空白は除く


### PR DESCRIPTION
先頭に空白行が連続する書き込みをすると、5chの仕様ではそれらを
削除したものが帰ってくるので、Log_Manager::check_write で
簡易チェックをするとき、先頭の連続する改行は読み飛ばす

不具合報告:
https://next2ch.net/test/read.cgi/linux/1654053581/112-113

Closes #1220