### PR TITLE
Add logic to identify `<a>` elements as reply anchors in HTML parsing

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -2197,8 +2197,14 @@ create_multispace:
 
                 if( ! a_link.empty() && ! a_str.empty() ) {
 
+                    // res anchor linked by <a> element
+                    if( a_str.size() > 8 && a_str.compare( 0, 8, "&gt;&gt;" ) == 0 && g_ascii_isdigit( a_str[8] ) ) {
+                        // アンカーは後で処理するのでここは抜ける
+                        pos = pos_str_start;
+                    }
+
                     // BE link
-                    if( a_link.rfind( "javascript:be(", 0 ) == 0 ) {
+                    else if( a_link.rfind( "javascript:be(", 0 ) == 0 ) {
                         m_buf_link.assign( PROTO_BE ); // 確保したメモリを再利用するため = は使わない
                         a_link.remove_prefix( 14 );
                         a_link.remove_suffix( 2 );


### PR DESCRIPTION
DATに含まれるHTMLの解析処理を修正して`<a>`要素がレスアンカーであるか判定する処理を追加します。

板URLとスレURLのドメインやパスが一致しないスレ、例えば2chスレ過去ログ板にあるスレはレスアンカー部分の`<a>`にあるhref属性とスレURLが異なるためアンカーのリンクが正常に動作しませんでした。

Closes #1219
