### PR TITLE
DrawAreaBase: Add null check to fix segfault

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -1808,6 +1808,12 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
         header = m_layout_tree->get_header_of_res( pivot );
         if( ! header ) break;
 
+        if( ! header->rect ) {
+            top = pivot + 1;
+            header = nullptr;
+            continue;
+        }
+
 /*
         std::cout << "top = " << top << " back = " << back << " pivot = " << pivot
                   << " pos_y = " << pos_y << " y = " << header->rect->y


### PR DESCRIPTION
スレを更新したときに異常終了したためgdbで調べたところLAYOUT構造体のメンバーにアクセスしたときnullptrを参照していました。
そのためメンバーにアクセスする処理の前にnullチェックを追加して修正します。

gdb のバックトレース
```
Thread 1 "jdim" received signal SIGSEGV, Segmentation fault.
ARTICLE::DrawAreaBase::exec_draw_screen (this=0x55555cd359c0,
    y_redraw=0, height_redraw=723)
    at ../src/article/drawareabase.cpp:1820
1820                if( header->rect->y <= pos_y && header->next_header->rect->y >= pos_y )  break;
(gdb) p header
$1 = (ARTICLE::LAYOUT *) 0x55555d4969a8
(gdb) p header->rect
$2 = (ARTICLE::RECTANGLE *) 0x0
```
