### PR TITLE
article: Add const qualifier to pointer variables in local scope

### DIFF
--- a/src/article/articleadmin.cpp
+++ b/src/article/articleadmin.cpp
@@ -640,7 +640,7 @@ void ArticleAdmin::open_searchbar()
 {
     if( ! m_toolbar ) return;
 
-    SKELETON::View* view = get_current_view();
+    const SKELETON::View* view = get_current_view();
     if( ! view ) return;
 
     m_toolbar->open_searchbar();

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -600,8 +600,8 @@ void DrawAreaBase::append_res( const int from_num, const int to_num )
 
     if( scroll ){
 
-        CORE::CSS_PROPERTY* css = m_layout_tree->get_separator()->css;
-        RECTANGLE* rect = m_layout_tree->get_separator()->rect;
+        const CORE::CSS_PROPERTY* css = m_layout_tree->get_separator()->css;
+        const RECTANGLE* rect = m_layout_tree->get_separator()->rect;
 
         m_scrollinfo.reset();
         m_scrollinfo.dy = 0;
@@ -4293,8 +4293,8 @@ bool DrawAreaBase::set_selection( const CARET_POSITION& caret_pos, RECTANGLE* re
         layout = layout_tmp;
     }
 
-    RECTANGLE* rect_from = layout->rect;
-    RECTANGLE* rect_to = layout_to->rect;
+    const RECTANGLE* rect_from = layout->rect;
+    const RECTANGLE* rect_to = layout_to->rect;
     if( ! rect_from || ! rect_to ) return false;
     while( rect_to->next_rect ) rect_to = rect_to->next_rect;
 
@@ -4439,7 +4439,7 @@ bool DrawAreaBase::set_selection_str()
 //
 bool DrawAreaBase::is_caret_on_selection( const CARET_POSITION& caret_pos ) const
 {
-    LAYOUT* layout = caret_pos.layout;
+    const LAYOUT* layout = caret_pos.layout;
 
     if( !layout || ! m_selection.select || m_selection.str.empty() ) return false;
     if( layout->id_header != m_selection.caret_from.layout->id_header ) return false;

--- a/src/article/toolbar.cpp
+++ b/src/article/toolbar.cpp
@@ -59,7 +59,7 @@ void ArticleToolBar::set_view( SKELETON::View * view )
     m_enable_slot = false;
 
     // ArticleViewBase固有の情報をコピー
-    ArticleViewBase* articleview = dynamic_cast< ArticleViewBase* >( view );
+    const ArticleViewBase* articleview = dynamic_cast<ArticleViewBase*>( view );
     if( articleview ){
 
         m_url_article = articleview->url_article();


### PR DESCRIPTION
ローカルのポインター変数にconstを付けられるとcppcheckに指摘されたため修正します。

cppcheck 2.11.1のレポート
```
src/article/toolbar.cpp:62:22: style: Variable 'articleview' can be declared as pointer to const [constVariablePointer]
    ArticleViewBase* articleview = dynamic_cast< ArticleViewBase* >( view );
                     ^
src/article/drawareabase.cpp:603:29: style: Variable 'css' can be declared as pointer to const [constVariablePointer]
        CORE::CSS_PROPERTY* css = m_layout_tree->get_separator()->css;
                            ^
src/article/drawareabase.cpp:604:20: style: Variable 'rect' can be declared as pointer to const [constVariablePointer]
        RECTANGLE* rect = m_layout_tree->get_separator()->rect;
                   ^
src/article/drawareabase.cpp:4296:16: style: Variable 'rect_from' can be declared as pointer to const [constVariablePointer]
    RECTANGLE* rect_from = layout->rect;
               ^
src/article/drawareabase.cpp:4442:13: style: Variable 'layout' can be declared as pointer to const [constVariablePointer]
    LAYOUT* layout = caret_pos.layout;
            ^
src/article/articleadmin.cpp:643:21: style: Variable 'view' can be declared as pointer to const [constVariablePointer]
    SKELETON::View* view = get_current_view();
                    ^
```
