### PR TITLE
NodeTreeBase: Fix HTML href attribute parsing

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -2160,8 +2160,13 @@ create_multispace:
                 create_node_ntext( m_parsed_text.data(), m_parsed_text.size(), fgcolor, bgcolor, in_bold, fontid );
                 m_parsed_text.clear();
 
-                while( pos < pos_end && *pos != '=' ) ++pos;
-                ++pos;
+                for( bool found = false; ! found; ) {
+                    while( pos < pos_end && *pos != '=' ) ++pos;
+                    // NOTE: 速度を重視するためhrefの判定は最後のfだけチェック
+                    // `<a>`タグに含まれる'='、global属性、data属性で誤判定する可能性がある
+                    found = ( pos[-1] == 'f' || pos[-1] == 'F' || pos >= pos_end );
+                    ++pos;
+                }
 
                 if( *pos == ' ' ) ++pos;
                 if( pos >= pos_end ) continue;


### PR DESCRIPTION
datデータからHTML要素を解析する処理のうち`<a>`要素のhref属性を探す処理を修正します。
修正前は`<a>`タグの中で最初に現れる属性がhrefであると決め打ちしていたためhrefの前に別の属性があるリンクではURLが間違って設定される問題がありました。

#### 注意
href属性の判定は速度を重視するため不完全なチェックです。`<a>`タグに含まれる'='、global属性、data属性で誤判定する可能性があります。

修正にあたり不具合報告をしていただきありがとうございました。
https://next2ch.net/test/read.cgi/linux/1654053581/127

Closes #1236
