### PR TITLE
Root: Support machi.to URL without subdomain

### DIFF
--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -1593,11 +1593,10 @@ bool Root::is_JBBS( const std::string& url )
 //
 bool Root::is_machi( const std::string& url )
 {
-    const std::string hostname = MISC::get_hostname( url );
+    constexpr bool protocol = false;
+    const std::string hostname = MISC::get_hostname( url, protocol );
 
-    if( hostname.find( ".machi.to" ) != std::string::npos ) return true;
-
-    return false;
+    return MISC::ends_with( hostname, "machi.to" );
 }
 
 


### PR DESCRIPTION
まちBBSのURLのうち地方名サブドメインが付いてないURLをまちBBSとして扱うように修正します。
まちBBSのURLは地方名サブドメインが付いてるタイプとサブドメインが無いタイプの2種類あります。

修正前は地方名サブドメインが付いてないURLを登録して開くとHTTPリダイレクトが発生して読み込みに失敗していました。

例
- `https://tokyo.machi.to/tokyo/`
- `https://machi.to/tokyo/`

参考文献
https://www.machi.to/bbs/read.cgi/tawara/1416672649/65

Closes #1242
