### PR TITLE
Add const qualifier to pointer variables in local scope part6

### DIFF
--- a/src/bbslist/bbslistadmin.cpp
+++ b/src/bbslist/bbslistadmin.cpp
@@ -259,7 +259,7 @@ void BBSListAdmin::get_history( const std::string& url, CORE::DATA_INFO_LIST& in
 {
     info_list.clear();
 
-    BBSListViewBase* view = dynamic_cast< BBSListViewBase* >( get_view( url ) );
+    const BBSListViewBase* view = dynamic_cast<BBSListViewBase*>( get_view( url ) );
     if( view ) return view->get_history( info_list );
 }
 

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -1885,7 +1885,7 @@ void BoardViewBase::update_item_all()
     for( Gtk::TreeModel::Row row : child ) {
         if( ! row ) continue;
 
-        DBTREE::ArticleBase* art = row[ m_columns.m_col_article ];
+        const DBTREE::ArticleBase* art = row[ m_columns.m_col_article ];
         if( ! art ) continue;
 
         update_row_common( row );

--- a/src/dndmanager.cpp
+++ b/src/dndmanager.cpp
@@ -40,7 +40,7 @@ void CORE::DND_End()
 
 bool CORE::DND_Now_dnd()
 {
-    CORE::DND_Manager* manager = CORE::get_dnd_manager();
+    const CORE::DND_Manager* manager = CORE::get_dnd_manager();
     if( manager ) return manager->now_dnd();
 
     return false;


### PR DESCRIPTION
ローカルのポインター変数にconstを付けられるとcppcheckに指摘されたため修正します。

cppcheck 2.11.1のレポート
```
src/bbslist/bbslistadmin.cpp:262:22: style: Variable 'view' can be declared as pointer to const [constVariablePointer]
    BBSListViewBase* view = dynamic_cast< BBSListViewBase* >( get_view( url ) );
                     ^
src/board/boardviewbase.cpp:1888:30: style: Variable 'art' can be declared as pointer to const [constVariablePointer]
        DBTREE::ArticleBase* art = row[ m_columns.m_col_article ];
                             ^
src/dndmanager.cpp:43:24: style: Variable 'manager' can be declared as pointer to const [constVariablePointer]
    CORE::DND_Manager* manager = CORE::get_dnd_manager();
                       ^
```
