### PR TITLE
Fix cancel operation on log search in the cache

### DIFF
--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1823,18 +1823,20 @@ void BoardBase::set_local_proxy_w( const std::string& proxy )
 }
 
 
-//
-// キャッシュ内のログ検索
-//
-// ArticleBase のアドレスをリスト(list_article)にセットして返す
-// query が空の時はキャッシュにあるログを全てヒットさせる
-// bm がtrueの時、しおりが付いている(スレ一覧でしおりを付けた or レスに一つでもしおりが付いている)スレのみを対象に検索する
-//
+/** @brief キャッシュ内のログ検索
+ *
+ * @param[out] list_article ArticleBase のアドレスをリスト(list_article)にセットして返す
+ * @param[in]  query        検索するテキスト, 空の時はキャッシュにあるログを全てヒットさせる
+ * @param[in]  mode_or      今のところ無視
+ * @param[in]  bm           trueの時、しおりが付いている(スレ一覧でしおりを付けた or レスに一つでもしおりが付いている)
+ *                          スレのみを対象に検索する
+ * @param[in]  stop         呼出元のスレッドで true にセットすると検索を停止する
+ */
 void BoardBase::search_cache( std::vector< DBTREE::ArticleBase* >& list_article,
                               const std::string& query,
                               const bool mode_or, // 今のところ無視
                               const bool bm,
-                              const bool stop // 呼出元のスレッドで true にセットすると検索を停止する
+                              const std::atomic<bool>& stop // 呼出元のスレッドで true にセットすると検索を停止する
     )
 {
 #ifdef _DEBUG
@@ -1855,7 +1857,7 @@ void BoardBase::search_cache( std::vector< DBTREE::ArticleBase* >& list_article,
 
     for( ArticleBase* article : m_hash_article ) {
 
-        if( stop ) break;
+        if( stop.load( std::memory_order_acquire ) ) break;
 
         if( ! article->is_cached() ) continue;
 

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -11,6 +11,7 @@
 #include "jdlib/jdregex.h"
 #include "skeleton/loadable.h"
 
+#include <atomic>
 #include <ctime>
 #include <list>
 #include <memory>
@@ -570,7 +571,7 @@ namespace DBTREE
                                    const std::string& query,
                                    const bool mode_or, // 今のところ無視
                                    const bool bm,
-                                   const bool stop // 呼出元のスレッドで true にセットすると検索を停止する
+                                   const std::atomic<bool>& stop // 呼出元のスレッドで true にセットすると検索を停止する
             );
 
         // datファイルのインポート

--- a/src/dbtree/boardlocal.h
+++ b/src/dbtree/boardlocal.h
@@ -31,9 +31,9 @@ namespace DBTREE
         void read_info() override {}
         void save_info() override {}
 
-        // キャッシュサーチをキャンセル
+        /// @brief キャッシュサーチをキャンセル
         void search_cache( std::vector< ArticleBase* >&, const std::string&, const bool, const bool,
-                           const bool ) override {}
+                           const std::atomic<bool>& ) override {}
 
         // datファイルのインポート
         std::string import_dat( const std::string& filename ) override;

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -616,13 +616,13 @@ void DBTREE::read_boardinfo_all()
 }
 
 void DBTREE::search_cache_all( std::vector< DBTREE::ArticleBase* >& list_article,
-                               const std::string& query, const bool mode_or, const bool bm, const bool stop )
+                               const std::string& query, const bool mode_or, const bool bm, const std::atomic<bool>& stop )
 {
     DBTREE::get_root()->search_cache( list_article, query, mode_or, bm, stop );
 }
 
 void DBTREE::search_cache( const std::string& url, std::vector< DBTREE::ArticleBase* >& list_article, const std::string& query,
-                           const bool mode_or, const bool bm, const bool stop )
+                           const bool mode_or, const bool bm, const std::atomic<bool>& stop )
 {
     DBTREE::get_board( url )->search_cache( list_article, query, mode_or, bm, stop );
 }

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -10,11 +10,12 @@
 #include "etcboardinfo.h"
 #include "jdencoding.h"
 
-#include <string>
-#include <list>
-#include <vector>
+#include <atomic>
 #include <ctime>
+#include <list>
+#include <string>
 #include <unordered_set>
+#include <vector>
 
 
 namespace XML
@@ -208,9 +209,9 @@ namespace DBTREE
     // query が空の時はキャッシュにあるログを全てヒットさせる
     // bm がtrueの時、しおりが付いている(スレ一覧でしおりを付けた or レスに一つでもしおりが付いている)スレのみを対象に検索する
     void search_cache_all( std::vector< DBTREE::ArticleBase* >& list_article,
-                           const std::string& query, const bool mode_or, const bool bm, const bool stop );
+                           const std::string& query, const bool mode_or, const bool bm, const std::atomic<bool>& stop );
     void search_cache( const std::string& url, std::vector< DBTREE::ArticleBase* >& list_article,
-                       const std::string& query, const bool mode_or, const bool bm, const bool stop );
+                       const std::string& query, const bool mode_or, const bool bm, const std::atomic<bool>& stop );
 
     // article 系
     bool article_is_cached( const std::string& url ); // キャッシュにあるかどうか

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -1508,11 +1508,11 @@ void Root::save_articleinfo_all()
 
 // 全ログ検索
 void Root::search_cache( std::vector< ArticleBase* >& list_article,
-                         const std::string& query, const bool mode_or, const bool bm, const bool stop )
+                         const std::string& query, const bool mode_or, const bool bm, const std::atomic<bool>& stop )
 {
     for( auto& b : m_list_board ) {
         b->search_cache( list_article, query, mode_or, bm, stop );
-        if( stop ) break;
+        if( stop.load( std::memory_order_acquire ) ) break;
     }
 }
 

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -13,6 +13,7 @@
 #include "skeleton/loadable.h"
 #include "xml/document.h"
 
+#include <atomic>
 #include <list>
 #include <memory>
 #include <set>
@@ -147,7 +148,8 @@ namespace DBTREE
         void save_articleinfo_all();
 
         // 全ログ検索
-        void search_cache( std::vector< ArticleBase* >& list_article, const std::string& query, const bool mode_or, const bool bm, const bool stop );
+        void search_cache( std::vector< ArticleBase* >& list_article, const std::string& query,
+                           const bool mode_or, const bool bm, const std::atomic<bool>& stop );
 
         // 全てのスレの書き込み履歴削除
         void clear_all_post_history();

--- a/src/searchmanager.cpp
+++ b/src/searchmanager.cpp
@@ -114,7 +114,7 @@ void Search_Manager::thread_search()
     std::cout << "Search_Manager::thread_search\n";
 #endif
 
-    m_stop = false;
+    m_stop.store( false, std::memory_order_release );
 
     if( m_searchmode == SEARCHMODE_LOG ) DBTREE::search_cache( m_url, m_list_article, m_query, m_mode_or, m_bm,  m_stop );
     else if( m_searchmode == SEARCHMODE_ALLLOG ) DBTREE::search_cache_all( m_list_article, m_query, m_mode_or, m_bm, m_stop );
@@ -182,7 +182,7 @@ void Search_Manager::stop( const std::string& id )
     std::cout << "Search_Manager::stop\n";
 #endif
 
-    m_stop = true;
+    m_stop.store( true, std::memory_order_release );
 
     // スレタイ検索停止
     if( m_searchmode == SEARCHMODE_TITLE && m_searchloader ) m_searchloader->stop_load();

--- a/src/searchmanager.h
+++ b/src/searchmanager.h
@@ -11,6 +11,7 @@
 
 #include <gtkmm.h>
 
+#include <atomic>
 #include <list>
 #include <memory>
 #include <string>
@@ -67,7 +68,7 @@ namespace CORE
         // 検索実行中
         bool m_searching{};
 
-        bool m_stop{};
+        std::atomic<bool> m_stop{}; ///< true にセットすると検索を停止する
 
         // スレタイ検索ローダ
         std::unique_ptr<SearchLoader> m_searchloader;


### PR DESCRIPTION
キャッシュ内のログ検索をキャンセルできない不具合を修正します。
前の修正でキャンセルを伝達するフラグ変数をconst参照渡しから値渡しに変更していたためキャンセルになったかチェック不能になっていました。

バグが入ったコミット
commit 9313fb246bd8612fd50c1d21dfaa1fd5d9f3d182

Closes #1249
