### PR TITLE
Reset errno to zero before calling functions

### DIFF
--- a/src/iomonitor.cpp
+++ b/src/iomonitor.cpp
@@ -64,6 +64,7 @@ void IOMonitor::init_connection()
     int mkfifo_status = -1;
 
     do_makefifo:
+    errno = 0;
     mkfifo_status = mkfifo( m_fifo_file.c_str(), O_RDWR | S_IRUSR | S_IWUSR );
 
     // FIFO作成でエラーになった( 基本的に既にメインプロセスがある )
@@ -73,6 +74,7 @@ void IOMonitor::init_connection()
         if( errno == EEXIST )
         {
             // FIFOを書き込み専用モードでオープン( ノンブロック )
+            errno = 0;
             if( ( m_fifo_fd = open( m_fifo_file.c_str(), O_WRONLY | O_NONBLOCK ) ) == -1 )
             {
                 // 反対側が既にオープンされていない( 異常終了などでメインプロセスがない )

--- a/src/jdlib/jdiconv.cpp
+++ b/src/jdlib/jdiconv.cpp
@@ -58,6 +58,7 @@ Iconv::Iconv( const Encoding to, const Encoding from, const bool broken_sjis_be_
 void Iconv::open_by_alternative_names( const char* to_str, const char* from_str )
 {
     // "MS932"で失敗したら"CP932"で試してみる
+    errno = 0;
     if( m_enc_to == Encoding::sjis ) m_cd = g_iconv_open( "CP932", from_str );
     else if( m_enc_from == Encoding::sjis ) m_cd = g_iconv_open( to_str, "CP932" );
 
@@ -150,6 +151,7 @@ std::string& Iconv::convert( char* str_in, std::size_t size_in, std::string& out
         std::size_t byte_left_in = buf_in_end - buf_in_tmp;
         std::size_t byte_left_out = buf_out_end - buf_out_tmp;
 
+        errno = 0;
         const int ret = g_iconv( m_cd, &buf_in_tmp, &byte_left_in, &buf_out_tmp, &byte_left_out );
 
 #ifdef _DEBUG

--- a/src/jdlib/jdsocketopenssl.h
+++ b/src/jdlib/jdsocketopenssl.h
@@ -149,6 +149,7 @@ void Socket::tls_close()
 {
     int ret;
 
+    errno = 0;
     while( ( ret = SSL_shutdown( m_tls ) ) != 1 ) {
         WaitFor want_read = WaitFor::recv;
 


### PR DESCRIPTION
関数を呼び出した後にerrnoの値をチェックする箇所では関数を呼び出す前に errno を 0 にリセットします。

参考文献
- <https://linuxjm.osdn.jp/html/LDP_man-pages/man3/errno.3.html>
- <https://www.jpcert.or.jp/sc-rules/c-err30-c.html>
