### PR TITLE
Adjust window size for small display

### DIFF
--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -398,10 +398,17 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     m_edit_settingtxt.set_editable( false );
     m_edit_settingtxt.set_text( DBTREE::settingtxt( get_url() ) );
 
-    m_notebook.append_page( m_vbox, "一般" );
+    // ディスプレイ解像度が小さい環境で表示できるようにスクロール可能にする
+    m_scroll_vbox.add( m_vbox );
+    m_scroll_vbox.set_policy( Gtk::POLICY_NEVER, Gtk::POLICY_AUTOMATIC );
+    m_scroll_network.add( m_vbox_network );
+    m_scroll_network.set_policy( Gtk::POLICY_NEVER, Gtk::POLICY_AUTOMATIC );
+    m_notebook.set_scrollable( true );
+
+    m_notebook.append_page( m_scroll_vbox, "一般" );
     const int page_localrule = 1;
     m_notebook.append_page( *m_localrule, "ローカルルール" );
-    m_notebook.append_page( m_vbox_network, "ネットワーク設定" );
+    m_notebook.append_page( m_scroll_network, "ネットワーク設定" );
     const int page_abone_article = 3;
     m_notebook.append_page( m_notebook_abone, "あぼ〜ん設定(スレビュー)" );
     m_notebook.append_page( m_notebook_abone_thread, "あぼ〜ん設定(スレ一覧)" );
@@ -410,7 +417,8 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
 
     get_content_area()->pack_start( m_notebook );
     set_title( "「" + DBTREE::board_name( get_url() ) + "」のプロパティ" );
-    resize( 600, 400 );
+    // ウインドウの自然なサイズを設定するがディスプレイに合わせて調整される
+    set_default_size( 850, 750 );
     show_all_children();
 
     if( command == "show_localrule" ) m_notebook.set_current_page( page_localrule );

--- a/src/board/preference.h
+++ b/src/board/preference.h
@@ -56,6 +56,8 @@ namespace BOARD
     {
         Gtk::Notebook m_notebook;
         Gtk::VBox m_vbox;
+        Gtk::ScrolledWindow m_scroll_vbox; ///< "一般"タブをスクロール可能にする
+        Gtk::ScrolledWindow m_scroll_network; ///< "ネットワーク設定"タブをスクロール可能にする
 
         // 書き込み時のデフォルト名とメール
         Gtk::Frame m_frame_write;

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -103,6 +103,8 @@ FontColorPref::FontColorPref( Gtk::Window* parent, const std::string& url )
     m_fontbutton.set_tooltip_text( m_tooltips_font[ 0 ] );
 
     set_title( "フォントと色の詳細設定" );
+    // ウインドウの自然なサイズを設定するがディスプレイに合わせて調整される
+    set_default_size( 670, 590 );
     show_all_children();
 }
 
@@ -239,7 +241,11 @@ void FontColorPref::pack_widget()
     m_bt_reset_all_colors.signal_clicked().connect( sigc::mem_fun( *this, &FontColorPref::slot_reset_all_colors ) );
     m_vbox_color.pack_end( m_bt_reset_all_colors, Gtk::PACK_SHRINK );
 
-    m_notebook.append_page( m_vbox_color, "色の設定" );    
+    // ディスプレイ解像度が小さい環境で表示できるようにスクロール可能にする
+    m_scroll_color.add( m_vbox_color );
+    m_scroll_color.set_policy( Gtk::POLICY_NEVER, Gtk::POLICY_AUTOMATIC );
+
+    m_notebook.append_page( m_scroll_color, "色の設定" );
 
     // 全体
     get_content_area()->pack_start( m_notebook );

--- a/src/fontcolorpref.h
+++ b/src/fontcolorpref.h
@@ -63,6 +63,7 @@ namespace CORE
         // 色の設定
         Gtk::Label m_label_warning_color;
         Gtk::VBox m_vbox_color;
+        Gtk::ScrolledWindow m_scroll_color; ///< "色の設定"タブをスクロール可能にする
 
         Gtk::CheckButton m_chk_use_gtktheme_message;
         Gtk::CheckButton m_chk_use_gtkrc_tree;

--- a/src/proxypref.h
+++ b/src/proxypref.h
@@ -27,27 +27,39 @@ namespace CORE
         Gtk::VBox m_vbox;
         Gtk::HBox m_hbox;
 
+        Gtk::Box m_hbox_port; ///< "ポート番号"のラベルと入力欄を一つにまとめる
+        Gtk::Label m_label_port; ///< "ポート番号"のラベル
+
       public:
 
         Gtk::CheckButton ckbt;
         Gtk::CheckButton send_cookie_check;
         SKELETON::LabelEntry entry_host;
-        SKELETON::LabelEntry entry_port;
+        Gtk::Entry entry_port; ///< "ポート番号"の入力欄
 
         ProxyFrame( const std::string& title, const Glib::ustring& ckbt_label, const Glib::ustring& send_label,
                     const Glib::ustring& host_label, const Glib::ustring& port_label )
-            : ckbt( ckbt_label, true )
+            : m_hbox_port{ Gtk::ORIENTATION_HORIZONTAL, 0 }
+            , m_label_port{ port_label, true }
+            , ckbt( ckbt_label, true )
             , send_cookie_check( send_label, true )
             , entry_host( true, host_label)
-            , entry_port( true, port_label )
         {
             send_cookie_check.set_tooltip_text( kSendCookieTooltip );
+            // ポート番号の最大値が収まる幅に調整する
+            entry_port.set_width_chars( 5 );
+            entry_port.set_max_length( 5 );
+            entry_port.set_hexpand( false );
+            m_label_port.set_mnemonic_widget( entry_port );
+
+            m_hbox_port.pack_start( m_label_port, 0, 0, false );
+            m_hbox_port.pack_start( entry_port, 0, 0, false );
 
             m_hbox.set_spacing( 8 );
             m_hbox.pack_start( ckbt, Gtk::PACK_SHRINK );
             m_hbox.pack_start( send_cookie_check, Gtk::PACK_SHRINK );
             m_hbox.pack_start( entry_host );
-            m_hbox.pack_start( entry_port, Gtk::PACK_SHRINK );
+            m_hbox.pack_start( m_hbox_port, Gtk::PACK_SHRINK );
 
             m_hbox.set_border_width( 8 );
             m_vbox.set_spacing( 8 );
@@ -64,6 +76,9 @@ namespace CORE
         Gtk::Box m_vbox;
         Gtk::Box m_hbox;
 
+        Gtk::Box m_hbox_port; ///< "ポート番号"のラベルと入力欄を一つにまとめる
+        Gtk::Label m_label_port; ///< "ポート番号"のラベル
+
         Gtk::Box m_vbox_exp_option;
         Gtk::Box m_hbox_fallback_proxy;
         Glib::RefPtr<Glib::Binding> m_binding_notice;
@@ -79,13 +94,15 @@ namespace CORE
         Gtk::Label notice_label;
 
         SKELETON::LabelEntry entry_host;
-        SKELETON::LabelEntry entry_port;
+        Gtk::Entry entry_port; ///< "ポート番号"の入力欄
 
         ProxyFrameFallbackOption( const std::string& title, const Glib::ustring& ckbt_label,
                                   const Glib::ustring& send_label, const Glib::ustring& fallback_label,
                                   const Glib::ustring& host_label, const Glib::ustring& port_label )
             : m_vbox( Gtk::ORIENTATION_VERTICAL, 0 )
             , m_hbox( Gtk::ORIENTATION_HORIZONTAL, 8 )
+            , m_hbox_port{ Gtk::ORIENTATION_HORIZONTAL, 0 }
+            , m_label_port{ port_label, true }
             , m_vbox_exp_option( Gtk::ORIENTATION_VERTICAL, 0 )
             , m_hbox_fallback_proxy( Gtk::ORIENTATION_HORIZONTAL, 0 )
             , m_toggle_notice( "注意事項" )
@@ -94,9 +111,16 @@ namespace CORE
             , fallback_proxy_check( fallback_label, true )
             , notice_label( kFallbackProxyNotice, false )
             , entry_host( true, host_label)
-            , entry_port( true, port_label )
         {
             send_cookie_check.set_tooltip_text( kSendCookieTooltip );
+            // ポート番号の最大値が収まる幅に調整する
+            entry_port.set_width_chars( 5 );
+            entry_port.set_max_length( 5 );
+            entry_port.set_hexpand( false );
+            m_label_port.set_mnemonic_widget( entry_port );
+
+            m_hbox_port.pack_start( m_label_port, 0, 0, false );
+            m_hbox_port.pack_start( entry_port, 0, 0, false );
 
             fallback_proxy_check.set_halign( Gtk::ALIGN_START );
             m_toggle_notice.set_halign( Gtk::ALIGN_END );
@@ -113,7 +137,7 @@ namespace CORE
             m_hbox.pack_start( ckbt, Gtk::PACK_SHRINK );
             m_hbox.pack_start( send_cookie_check, Gtk::PACK_SHRINK );
             m_hbox.pack_start( entry_host );
-            m_hbox.pack_start( entry_port, Gtk::PACK_SHRINK );
+            m_hbox.pack_start( m_hbox_port, Gtk::PACK_SHRINK );
 
             m_hbox_fallback_proxy.set_hexpand( true );
             m_hbox_fallback_proxy.set_margin_start( 8 );


### PR DESCRIPTION
### BOARD::Preferences: Adjust window size to display size
ディスプレイ解像度が小さい環境で板のプロパティを開いたときウインドウがデスクトップ画面からはみ出さないようにスクロールバーを追加します。

修正前はディスプレイ解像度が小さい場合ウインドウの一部が画面外にはみ出して見たり操作したりすることが困難になっていました。

### FontColorPref: Adjust window size to display size
ディスプレイ解像度が小さい環境でフォントと色の詳細設定を開いたときウインドウがデスクトップ画面からはみ出さないようにスクロールバーを追加します。

修正前はディスプレイ解像度が小さい場合ウインドウの一部が画面外にはみ出して見たり操作したりすることが困難になっていました。

### ProxyPref: Adjust window size to display size
ディスプレイ解像度が小さい環境でプロキシ設定を開いたときウインドウがデスクトップ画面からはみ出さないように"ポート番号"の入力欄のサイズを変更します。

修正前はディスプレイ解像度が小さい場合ウインドウの一部が画面外にはみ出して見たり操作したりすることが困難になっていました。

Closes #1255
