### PR TITLE
Add thread view text drawing method choice to about:config

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -73,6 +73,9 @@
        描画にPangoLayoutを使う。デフォルトでは PangoGlyphString を使用する。
        スレビューのテキスト表示に問題があるときはこのオプションを試してみてください。
 
+       about:config 「スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )」で変更が可能。
+       変更後に開いたスレから適用される。 (v0.10.1-20230930から追加)
+
     -Dmigemo=enabled
 
        migemoによる検索が有効になる。migemoがUTF-8の辞書でインストールされている必要がある。

--- a/docs/manual/make.md
+++ b/docs/manual/make.md
@@ -85,7 +85,9 @@ OSやディストリビューション別の解説は [#592][dis592] を参照�
   <dt>-Dpangolayout=enabled</dt>
   <dd>
     描画に PangoLayout を使う。デフォルトでは PangoGlyphString を使用する。
-    スレビューのテキスト表示に問題があるときはこのオプションを試してみてください。
+    スレビューのテキスト表示に問題があるときはこのオプションを試してみてください。<br>
+    about:config 「スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )」で変更が可能。
+    変更後に開いたスレから適用される。 <small>(v0.10.1-20230930から追加)</small>
   </dd>
   <dt>-Dmigemo=enabled</dt>
   <dd>

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -87,6 +87,22 @@ namespace ARTICLE
         int lower; // 画面下、大きい値
     };
 
+    /// @brief 文字を描写する関数は変数が多いため構造体を使って参照を渡す
+    struct RenderTextArguments
+    {
+        cairo_t* text_cr;
+        struct RECTANGLE* rect; // NOTE: rect->width は更新されることがある
+        const char* text;
+        int n_ustr;
+        int x;
+        int y;
+        int color;
+        int color_back;
+        int width_line;
+        int byte_to;
+        bool bold;
+    };
+
     ///////////////////////////////////
 
 
@@ -241,6 +257,9 @@ namespace ARTICLE
             gint64 last_time; // 前回コールバックが呼び出された時間(frame)
             guint id; // コールバックのID
         } m_deceleration{};
+
+        /// @brief 文字を描画するメンバー関数の関数ポインター
+        void (DrawAreaBase::*m_render_text)( RenderTextArguments& args );
 
       public:
 
@@ -423,6 +442,8 @@ namespace ARTICLE
         void draw_one_text_node( LAYOUT* layout, const CLIPINFO& ci );
         void draw_string( LAYOUT* node, const CLIPINFO& ci,
                           const int color, const int color_back, const int byte_from, const int byte_to );
+        void render_text_glyphstring( RenderTextArguments& args );
+        void render_text_pangolayout( RenderTextArguments& args );
         bool draw_one_img_node( LAYOUT* layout, const CLIPINFO& ci );
         char get_layout_fontid(LAYOUT *layout ) const;
         void set_node_font( LAYOUT* layout );

--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -221,6 +221,7 @@ void AboutConfig::append_rows()
     append_row( "書き込み履歴のあるスレを削除する時にダイアログを表示", get_confitem()->show_del_written_thread_diag, CONF_SHOW_DEL_WRITTEN_THREAD_DIAG );
     append_row( "スレを削除する時に画像キャッシュも削除する ( 0: ダイアログ表示 1: 削除 2: 削除しない )", get_confitem()->delete_img_in_thread, CONF_DELETE_IMG_IN_THREAD );
     append_row( "最大表示可能レス数", get_confitem()->max_resnumber, CONF_MAX_RESNUMBER );
+    append_row( "スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )", get_confitem()->text_rendering_method, CONF_TEXT_RENDERING_METHOD );
 
     // 書き込みウィンドウ
     append_row( "" );

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -593,6 +593,9 @@ bool ConfigItems::load( const bool restore )
     //最大表示可能レス数
     max_resnumber = cf.get_option_int( "max_resnumber", CONF_MAX_RESNUMBER, 1, std::numeric_limits< int >::max() - 1 );
 
+    // スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )
+    text_rendering_method = cf.get_option_int( "text_rendering_method", CONF_TEXT_RENDERING_METHOD, 0, 1 );
+
     // FIFOの作成などにエラーがあったらダイアログを表示する
     show_diag_fifo_error = cf.get_option_bool( "show_diag_fifo_error", CONF_SHOW_DIAG_FIFO_ERROR );
 
@@ -954,6 +957,7 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "show_del_written_thread_diag", show_del_written_thread_diag );
     cf.update( "delete_img_in_thread", delete_img_in_thread );
     cf.update( "max_resnumber", max_resnumber );
+    cf.update( "text_rendering_method", text_rendering_method );
     cf.update( "show_diag_fifo_error", show_diag_fifo_error );
     cf.update( "save_session", save_session );
 

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -538,6 +538,9 @@ namespace CONFIG
         //最大表示可能レス数
         int max_resnumber{};
 
+        /// @brief スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )
+        int text_rendering_method{};
+
         // FIFOの作成などにエラーがあったらダイアログを表示する
         bool show_diag_fifo_error{};
 

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -166,6 +166,11 @@ namespace CONFIG
         CONF_SHOW_DEL_WRITTEN_THREAD_DIAG = 1, // 書き込み履歴のあるスレを削除する時にダイアログを表示
         CONF_DELETE_IMG_IN_THREAD = 0, // スレを削除する時に画像キャッシュも削除する ( 0: ダイアログ表示 1: 削除 2: 削除しない )
         CONF_MAX_RESNUMBER = 65536, //最大表示可能レス数
+#ifdef USE_PANGOLAYOUT
+        CONF_TEXT_RENDERING_METHOD = 1, ///< スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )
+#else
+        CONF_TEXT_RENDERING_METHOD = 0, ///< スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )
+#endif
         CONF_SHOW_DIAG_FIFO_ERROR = 1, // FIFOの作成などにエラーがあったらダイアログを表示する
         CONF_SAVE_SESSION = 0, // 指定した分ごとにセッションを自動保存 (0: 保存しない)
         CONF_BROKEN_SJIS_BE_UTF8 = 0, ///< 不正なMS932文字列をUTF-8と見なす

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -620,6 +620,8 @@ void CONFIG::set_delete_img_in_thread( const int set ){ get_confitem()->delete_i
 int CONFIG::get_max_resnumber(){ return get_confitem()->max_resnumber; }
 void CONFIG::set_max_resnumber( const int set ){ get_confitem()->max_resnumber = set; }
 
+/// @brief スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )
+int CONFIG::get_text_rendering_method() { return get_confitem()->text_rendering_method; }
 
 // FIFOの作成などにエラーがあったらダイアログを表示する
 bool CONFIG::get_show_diag_fifo_error(){ return get_confitem()->show_diag_fifo_error; }

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -620,6 +620,9 @@ namespace CONFIG
     int get_max_resnumber();
     void set_max_resnumber( const int set );
 
+    // スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )
+    int get_text_rendering_method();
+
     // FIFOの作成などにエラーがあったらダイアログを表示する
     bool get_show_diag_fifo_error();
     void set_show_diag_fifo_error( const bool set );


### PR DESCRIPTION
about:config に「スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )」を追加します。
ビルドオプション(`-Dpangolayout=enabled`)は削除せず残しデフォルト設定の方法を指定します。

修正前は描画方法をビルドオプションで指定していました。
2つの方法(PangoLayoutとPangoGlyphString)はpangoライブラリで実装できるため設定で変更できる仕組みを導入して利便性を向上させます。

Closes #1258
