### PR TITLE
environment: Use std::find_if() instead of range-based for loops

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -251,17 +251,15 @@ std::string ENVIRONMENT::get_distname()
     else if( CACHE::load_rawdata( "/etc/release", text_data ) )
     {
         std::list< std::string > lines = MISC::get_lines( text_data );
-        for( std::string& line : lines )
-        {
-            // 名前が含まれている行を取得
-            if( line.find( "BeleniX" ) != std::string::npos
-                || line.find( "Nexenta" ) != std::string::npos
-                || line.find( "SchilliX" ) != std::string::npos
-                || line.find( "Solaris" ) != std::string::npos )
-            {
-                tmp = std::move( line );
-                break;
-            }
+        auto it = std::find_if( lines.begin(), lines.end(),
+                                // 名前が含まれている行を取得
+                                []( const std::string& line )
+                                { return line.find( "BeleniX" ) != std::string::npos
+                                      || line.find( "Nexenta" ) != std::string::npos
+                                      || line.find( "SchilliX" ) != std::string::npos
+                                      || line.find( "Solaris" ) != std::string::npos; } );
+        if( it != lines.end() ) {
+            tmp = std::move( *it );
         }
     }
     // ファイルの中身がそのままディストリ名として扱える物


### PR DESCRIPTION
`std::find_if()`が使えるとcppcheckに指摘されたためforループ文を修正します。

cppcheck 2.11.1のレポート
```
src/environment.cpp:261:13: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
            {
            ^
```
