### PR TITLE
Admin: Add const qualifier to pointer parameter in member function

### DIFF
--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -955,7 +955,7 @@ void Admin::update_boardname( const std::string& url )
 //
 // URLやステータスを更新
 //
-void Admin::update_status( View* view, const bool force )
+void Admin::update_status( const View* view, const bool force )
 {
     if( view ){
         set_title( view->get_url(), view->get_title(), force );

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -164,7 +164,7 @@ namespace SKELETON
         void delete_jdwin();
 
         // URLやステータスを更新
-        void update_status( View* view, const bool force );
+        void update_status( const View* view, const bool force );
 
         DragableNoteBook* get_notebook(){ return m_notebook.get(); }
 


### PR DESCRIPTION
メンバー関数のポインター型引数にconstを付けられるとcppcheckに指摘されたため修正します。

cppcheck 2.11.1のレポート
```
src/skeleton/admin.cpp:958:34: style: Parameter 'view' can be declared as pointer to const [constParameterPointer]
void Admin::update_status( View* view, const bool force )
                                 ^
```
