### PR TITLE
LinkFilterDiag: Rename member function to avoid conflict with parent member

### DIFF
--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -235,7 +235,7 @@ void LinkFilterPref::slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::
 
     LinkFilterDiag diag( this, row[ m_columns.m_col_url ], row[ m_columns.m_col_cmd ] );
     if( diag.run() == Gtk::RESPONSE_OK ){
-        row[ m_columns.m_col_url ] = diag.get_url();
+        row[ m_columns.m_col_url ] = diag.get_entry_url();
         row[ m_columns.m_col_cmd ] = diag.get_cmd();
         static_cast<void>( row ); // cppcheck: unreadVariable
     }
@@ -352,5 +352,5 @@ void LinkFilterPref::slot_delete()
 void LinkFilterPref::slot_add()
 {
     LinkFilterDiag diag( this, "", "" );
-    if( diag.run() == Gtk::RESPONSE_OK ) append_row( diag.get_url(), diag.get_cmd() );
+    if( diag.run() == Gtk::RESPONSE_OK ) append_row( diag.get_entry_url(), diag.get_cmd() );
 }

--- a/src/linkfilterpref.h
+++ b/src/linkfilterpref.h
@@ -26,7 +26,7 @@ namespace CORE
 
         LinkFilterDiag( Gtk::Window* parent, const std::string& url, const std::string& cmd );
 
-        Glib::ustring get_url() const { return m_entry_url.get_text(); }
+        Glib::ustring get_entry_url() const { return m_entry_url.get_text(); }
         Glib::ustring get_cmd() const { return m_entry_cmd.get_text(); }
 
       private:


### PR DESCRIPTION
親クラスのメンバー関数と名前が重複しているとcppcheckに指摘されたため子クラスのメンバー関数の名前を変更します。

cppcheck 2.12.1のレポート
```
src/linkfilterpref.h:29:23: warning: The class 'LinkFilterDiag' defines member function with name 'get_url' also defined in its parent class 'PrefDiag'. [duplInheritedMember]
        Glib::ustring get_url() const { return m_entry_url.get_text(); }
                      ^
src/skeleton/prefdiag.h:32:28: note: Parent function 'PrefDiag::get_url'
        const std::string& get_url() const { return m_url; }
                           ^
src/linkfilterpref.h:29:23: note: Derived function 'LinkFilterDiag::get_url'
        Glib::ustring get_url() const { return m_entry_url.get_text(); }
                      ^
```
