### PR TITLE
BoardBase: Ignore encoding analysis when encoding setting is enabled

### DIFF
--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1075,7 +1075,10 @@ void BoardBase::receive_data( std::string_view buf )
     if( m_rawdata_left.capacity() < bb::kSizeOfRawData ) {
         m_rawdata_left.reserve( bb::kSizeOfRawData );
     }
-    if( get_code() != HTTP_OK ) set_encoding( m_encoding_bak );
+    if( get_code() != HTTP_OK
+        // about:config の「スレ一覧とスレビューのプロパティにあるエンコーディング設定を有効にする」
+        // が"はい"のときはHTTP通信のエンコーディング情報は無視して設定された値を優先する
+        || CONFIG::get_choose_character_encoding() ) set_encoding( m_encoding_bak );
     if( ! m_iconv ) m_iconv = std::make_unique<JDLIB::Iconv>( Encoding::utf8, get_encoding() );
 
     m_rawdata_left.append( buf );


### PR DESCRIPTION
掲示板のsubject.txtを取得して解析する部分を修正して板のテキストエンコーディングを設定する処理を変更します。

about:config の「(安全でない) スレ一覧とスレビューのプロパティにあるエンコーディング設定を有効にする」が"はい"のときはHTTPヘッダーやHTMLデータに含まれるエンコーディング情報を無視して板のプロパティで設定されたエンコーディングを優先します。

#### 背景事情
2023-10-01 時点では、5chのagreeやkesサーバーにある板からsubject.txtを取得するとHTTPのContent-Typeにはcharset=utf-8が指定されています。
しかし、送られてきたテキストデータはshift_jisで符号化されているため文字化けが発生します。

修正前は板のプロパティでテキストエンコーディングを変更して文字化けを直しても再びsubject.txtを取得したときにエンコーディングが再判定されて文字化けが再発する問題がありました。

関連のissue: #1265
