### PR TITLE
Add experimental 'Write in UTF-8' option to board preferences

### DIFF
--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -82,6 +82,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
         "掲示板がUTF-8の書き込みに対応してるか確認して使用してください。\n"
         "このオプションは実験的なサポートのため変更または廃止の可能性があります。" );
 
+    m_check_utf8_post.set_active( DBTREE::board_check_utf8_post( get_url() ) );
     m_check_noname.set_active( DBTREE::board_check_noname( get_url() ) );
 
     m_entry_writename.set_text( DBTREE::board_get_write_name( get_url() ) ); 
@@ -549,6 +550,7 @@ void Preferences::slot_ok_clicked()
     DBTREE::board_set_local_proxy_port_w( get_url(), atoi( m_proxy_frame_w.entry_port.get_text().c_str() ) );
 
     // 書き込み設定
+    DBTREE::board_set_check_utf8_post( get_url(), m_check_utf8_post.get_active() );
     DBTREE::board_set_check_noname( get_url(), m_check_noname.get_active() );
 
     std::string tmpname = m_entry_writename.get_text();

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -28,6 +28,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     , m_frame_write( "書き込み設定" )
     , m_entry_writename( true, "名前：" )
     , m_entry_writemail( true, "メール：" )
+    , m_check_utf8_post( "(実験的な機能) UTF-8で書き込む" )
     , m_check_noname( "名前欄が空白の時は書き込まない" )
     , m_bt_clear_post_history( "この板にある全スレの書き込み履歴クリア" )
     , m_bt_set_default_namemail( "デフォルト" )
@@ -54,6 +55,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     , m_label_last_access( false, "最終アクセス日時 ：" )
     , m_label_modified( false, "最終更新日時 ：" )
     , m_button_clearmodified( "日時クリア" )
+    , m_sep_samba{ Gtk::ORIENTATION_VERTICAL }
     , m_label_samba( false, "書き込み規制秒数 (Samba24) ：" )
     , m_button_clearsamba( "秒数クリア" )
     , m_check_oldlog( "過去ログを表示する" )
@@ -69,8 +71,16 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     else m_label_samba.set_text( std::to_string( samba_sec ) );
 
     m_button_clearsamba.signal_clicked().connect( sigc::mem_fun(*this, &Preferences::slot_clear_samba ) );
+    m_hbox_samba.pack_start( m_check_utf8_post, Gtk::PACK_SHRINK );
+    m_hbox_samba.pack_start( m_sep_samba, Gtk::PACK_SHRINK );
     m_hbox_samba.pack_start( m_label_samba );
     m_hbox_samba.pack_start( m_button_clearsamba, Gtk::PACK_SHRINK );    
+    m_check_utf8_post.set_margin_end( 15 );
+    m_label_samba.set_margin_start( 15 );
+    m_sep_samba.set_hexpand( false );
+    m_check_utf8_post.set_tooltip_text(
+        "掲示板がUTF-8の書き込みに対応してるか確認して使用してください。\n"
+        "このオプションは実験的なサポートのため変更または廃止の可能性があります。" );
 
     m_check_noname.set_active( DBTREE::board_check_noname( get_url() ) );
 

--- a/src/board/preference.h
+++ b/src/board/preference.h
@@ -66,6 +66,7 @@ namespace BOARD
         Gtk::HBox m_hbox_write2;
         SKELETON::LabelEntry m_entry_writename;
         SKELETON::LabelEntry m_entry_writemail;
+        Gtk::CheckButton m_check_utf8_post; ///< UTF-8で書き込む
         Gtk::CheckButton m_check_noname; // 名無し書き込みチェック
         Gtk::Button m_bt_clear_post_history;
         Gtk::Button m_bt_set_default_namemail;
@@ -123,6 +124,7 @@ namespace BOARD
 
         // samba24
         Gtk::HBox m_hbox_samba;
+        Gtk::Separator m_sep_samba;
         SKELETON::LabelEntry m_label_samba;
         Gtk::Button m_button_clearsamba;
 

--- a/src/dbtree/article2ch.cpp
+++ b/src/dbtree/article2ch.cpp
@@ -28,7 +28,14 @@ Article2ch::Article2ch( const std::string& datbase, const std::string& id, bool 
 Article2ch::~Article2ch() noexcept = default;
 
 
-// 書き込みメッセージ変換
+/** @brief 書き込みメッセージ作成
+ *
+ * @param[in] name      名前、トリップ
+ * @param[in] mail      メールアドレス、sage
+ * @param[in] msg       書き込むメッセージ
+ * @param[in] utf8_post trueならUTF-8のままURLエンコードする
+ * @return URLエンコードしたフォームデータ (application/x-www-form-urlencoded)
+ */
 std::string Article2ch::create_write_message( const std::string& name, const std::string& mail,
                                               const std::string& msg, const bool utf8_post )
 {

--- a/src/dbtree/article2ch.cpp
+++ b/src/dbtree/article2ch.cpp
@@ -29,18 +29,21 @@ Article2ch::~Article2ch() noexcept = default;
 
 
 // 書き込みメッセージ変換
-std::string Article2ch::create_write_message( const std::string& name, const std::string& mail, const std::string& msg )
+std::string Article2ch::create_write_message( const std::string& name, const std::string& mail,
+                                              const std::string& msg, const bool utf8_post )
 {
     if( msg.empty() ) return std::string();
 
+    const Encoding enc{ utf8_post ? Encoding::utf8 : get_encoding() };
+
     std::stringstream ss_post;
-    ss_post << "FROM=" << MISC::url_encode_plus( name, get_encoding() )
-            << "&mail=" << MISC::url_encode_plus( mail, get_encoding() )
-            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_encoding() )
+    ss_post << "FROM=" << MISC::url_encode_plus( name, enc )
+            << "&mail=" << MISC::url_encode_plus( mail, enc )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, enc )
             << "&bbs=" << DBTREE::board_id( get_url() )
             << "&key=" << get_key()
             << "&time=" << get_time_modified()
-            << "&submit=" << MISC::url_encode_plus( "書き込む", get_encoding() )
+            << "&submit=" << MISC::url_encode_plus( "書き込む", enc )
             // XXX: ブラウザの種類に関係なく含めて問題ないか？
             << "&oekaki_thread1=";
 

--- a/src/dbtree/article2ch.h
+++ b/src/dbtree/article2ch.h
@@ -20,7 +20,7 @@ namespace DBTREE
 
         // 書き込みメッセージ変換
         std::string create_write_message( const std::string& name, const std::string& mail,
-                                          const std::string& msg ) override;
+                                          const std::string& msg, const bool utf8_post ) override;
 
       protected:
 

--- a/src/dbtree/article2ch.h
+++ b/src/dbtree/article2ch.h
@@ -18,7 +18,7 @@ namespace DBTREE
         Article2ch( const std::string& datbase, const std::string& id, bool cached, const Encoding enc );
         ~Article2ch() noexcept;
 
-        // 書き込みメッセージ変換
+        // 書き込みメッセージ作成
         std::string create_write_message( const std::string& name, const std::string& mail,
                                           const std::string& msg, const bool utf8_post ) override;
 

--- a/src/dbtree/article2chcompati.cpp
+++ b/src/dbtree/article2chcompati.cpp
@@ -38,7 +38,14 @@ Article2chCompati::Article2chCompati( const std::string& datbase, const std::str
 Article2chCompati::~Article2chCompati() noexcept = default;
 
 
-// 書き込みメッセージ変換
+/** @brief 書き込みメッセージ作成
+ *
+ * @param[in] name      名前、トリップ
+ * @param[in] mail      メールアドレス、sage
+ * @param[in] msg       書き込むメッセージ
+ * @param[in] utf8_post trueならUTF-8のままURLエンコードする
+ * @return URLエンコードしたフォームデータ (application/x-www-form-urlencoded)
+ */
 std::string Article2chCompati::create_write_message( const std::string& name, const std::string& mail,
                                                      const std::string& msg, const bool utf8_post )
 {

--- a/src/dbtree/article2chcompati.cpp
+++ b/src/dbtree/article2chcompati.cpp
@@ -39,19 +39,22 @@ Article2chCompati::~Article2chCompati() noexcept = default;
 
 
 // 書き込みメッセージ変換
-std::string Article2chCompati::create_write_message( const std::string& name, const std::string& mail, const std::string& msg )
+std::string Article2chCompati::create_write_message( const std::string& name, const std::string& mail,
+                                                     const std::string& msg, const bool utf8_post )
 {
     if( msg.empty() ) return std::string();
+
+    const Encoding enc{ utf8_post ? Encoding::utf8 : get_encoding() };
 
     std::stringstream ss_post;
     ss_post.clear();
     ss_post << "bbs="      << DBTREE::board_id( get_url() )
             << "&key="     << get_key()
             << "&time="    << get_time_modified()
-            << "&submit="  << MISC::url_encode_plus( "書き込む", get_encoding() )
-            << "&FROM="    << MISC::url_encode_plus( name, get_encoding() )
-            << "&mail="    << MISC::url_encode_plus( mail, get_encoding() )
-            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_encoding() );
+            << "&submit="  << MISC::url_encode_plus( "書き込む", enc )
+            << "&FROM="    << MISC::url_encode_plus( name, enc )
+            << "&mail="    << MISC::url_encode_plus( mail, enc )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, enc );
 
 #ifdef _DEBUG
     std::cout << "Article2chCompati::create_write_message " << ss_post.str() << std::endl;

--- a/src/dbtree/article2chcompati.h
+++ b/src/dbtree/article2chcompati.h
@@ -20,7 +20,7 @@ namespace DBTREE
 
         // 書き込みメッセージ変換
         std::string create_write_message( const std::string& name, const std::string& mail,
-                                          const std::string& msg ) override;
+                                          const std::string& msg, const bool utf8_post ) override;
 
         // bbscgi のURL
         std::string url_bbscgi() const override;

--- a/src/dbtree/article2chcompati.h
+++ b/src/dbtree/article2chcompati.h
@@ -18,7 +18,7 @@ namespace DBTREE
         Article2chCompati( const std::string& datbase, const std::string& id, bool cached, const Encoding enc );
         ~Article2chCompati() noexcept;
 
-        // 書き込みメッセージ変換
+        // 書き込みメッセージ作成
         std::string create_write_message( const std::string& name, const std::string& mail,
                                           const std::string& msg, const bool utf8_post ) override;
 

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -242,7 +242,7 @@ namespace DBTREE
 
         // 書き込みメッセージ作成
         virtual std::string create_write_message( const std::string& name, const std::string& mail,
-                                                  const std::string& msg ) { return {}; }
+                                                  const std::string& msg, const bool utf8_post ) { return {}; }
 
         // bbscgi のURL
         virtual std::string url_bbscgi() const { return {}; }

--- a/src/dbtree/articlejbbs.cpp
+++ b/src/dbtree/articlejbbs.cpp
@@ -30,6 +30,14 @@ ArticleJBBS::ArticleJBBS( const std::string& datbase, const std::string& _id, bo
 ArticleJBBS::~ArticleJBBS() noexcept = default;
 
 
+/** @brief 書き込みメッセージ作成
+ *
+ * @param[in] name      名前、トリップ
+ * @param[in] mail      メールアドレス、sage
+ * @param[in] msg       書き込むメッセージ
+ * @param[in] utf8_post trueならUTF-8のままURLエンコードする
+ * @return URLエンコードしたフォームデータ (application/x-www-form-urlencoded)
+ */
 std::string ArticleJBBS::create_write_message( const std::string& name, const std::string& mail,
                                                const std::string& msg, const bool utf8_post )
 {

--- a/src/dbtree/articlejbbs.cpp
+++ b/src/dbtree/articlejbbs.cpp
@@ -30,7 +30,8 @@ ArticleJBBS::ArticleJBBS( const std::string& datbase, const std::string& _id, bo
 ArticleJBBS::~ArticleJBBS() noexcept = default;
 
 
-std::string ArticleJBBS::create_write_message( const std::string& name, const std::string& mail, const std::string& msg )
+std::string ArticleJBBS::create_write_message( const std::string& name, const std::string& mail,
+                                               const std::string& msg, const bool utf8_post )
 {
     if( msg.empty() ) return std::string();
 
@@ -40,16 +41,18 @@ std::string ArticleJBBS::create_write_message( const std::string& name, const st
     std::string_view dir = std::string_view{ boardid }.substr( 0, i );
     std::string_view bbs = std::string_view{ boardid }.substr( i + 1 );
 
+    const Encoding enc{ utf8_post ? Encoding::utf8 : get_encoding() };
+
     std::stringstream ss_post;
     ss_post.clear();
     ss_post << "BBS="      << bbs
             << "&KEY="     << get_key()
             << "&DIR="     << dir
             << "&TIME="    << get_time_modified()
-            << "&submit="  << MISC::url_encode_plus( "書き込む", get_encoding() )
-            << "&NAME="    << MISC::url_encode_plus( name, get_encoding() )
-            << "&MAIL="    << MISC::url_encode_plus( mail, get_encoding() )
-            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_encoding() );
+            << "&submit="  << MISC::url_encode_plus( "書き込む", enc )
+            << "&NAME="    << MISC::url_encode_plus( name, enc )
+            << "&MAIL="    << MISC::url_encode_plus( mail, enc )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, enc );
 
 #ifdef _DEBUG
     std::cout << "Articlejbbs::create_write_message " << ss_post.str() << std::endl;

--- a/src/dbtree/articlejbbs.h
+++ b/src/dbtree/articlejbbs.h
@@ -22,7 +22,7 @@ namespace DBTREE
 
         // 書き込みメッセージ変換
         std::string create_write_message( const std::string& name, const std::string& mail,
-                                          const std::string& msg ) override;
+                                          const std::string& msg, const bool utf8_post ) override;
 
         // bbscgi のURL
         std::string url_bbscgi() const override;

--- a/src/dbtree/articlemachi.cpp
+++ b/src/dbtree/articlemachi.cpp
@@ -33,6 +33,14 @@ ArticleMachi::ArticleMachi( const std::string& datbase, const std::string& _id, 
 ArticleMachi::~ArticleMachi() noexcept = default;
 
 
+/** @brief 書き込みメッセージ作成
+ *
+ * @param[in] name      名前、トリップ
+ * @param[in] mail      メールアドレス、sage
+ * @param[in] msg       書き込むメッセージ
+ * @param[in] utf8_post trueならUTF-8のままURLエンコードする
+ * @return URLエンコードしたフォームデータ (application/x-www-form-urlencoded)
+ */
 std::string ArticleMachi::create_write_message( const std::string& name, const std::string& mail,
                                                 const std::string& msg, const bool utf8_post )
 {

--- a/src/dbtree/articlemachi.cpp
+++ b/src/dbtree/articlemachi.cpp
@@ -33,19 +33,22 @@ ArticleMachi::ArticleMachi( const std::string& datbase, const std::string& _id, 
 ArticleMachi::~ArticleMachi() noexcept = default;
 
 
-std::string ArticleMachi::create_write_message( const std::string& name, const std::string& mail, const std::string& msg )
+std::string ArticleMachi::create_write_message( const std::string& name, const std::string& mail,
+                                                const std::string& msg, const bool utf8_post )
 {
     if( msg.empty() ) return std::string();
+
+    const Encoding enc{ utf8_post ? Encoding::utf8 : get_encoding() };
 
     std::stringstream ss_post;
     ss_post.clear();
     ss_post << "BBS="      << DBTREE::board_id( get_url() )
             << "&KEY="     << get_key()
             << "&TIME="    << get_time_modified()
-            << "&submit="  << MISC::url_encode_plus( "書き込む", get_encoding() )
-            << "&NAME="    << MISC::url_encode_plus( name, get_encoding() )
-            << "&MAIL="    << MISC::url_encode_plus( mail, get_encoding() )
-            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_encoding() );
+            << "&submit="  << MISC::url_encode_plus( "書き込む", enc )
+            << "&NAME="    << MISC::url_encode_plus( name, enc )
+            << "&MAIL="    << MISC::url_encode_plus( mail, enc )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, enc );
 
 #ifdef _DEBUG
     std::cout << "ArticleMachi::create_write_message " << ss_post.str() << std::endl;

--- a/src/dbtree/articlemachi.h
+++ b/src/dbtree/articlemachi.h
@@ -22,7 +22,7 @@ namespace DBTREE
 
         // 書き込みメッセージ変換
         std::string create_write_message( const std::string& name, const std::string& mail,
-                                          const std::string& msg ) override;
+                                          const std::string& msg, const bool utf8_post ) override;
 
         // bbscgi のURL
         std::string url_bbscgi() const override;

--- a/src/dbtree/articlemachi.h
+++ b/src/dbtree/articlemachi.h
@@ -20,7 +20,7 @@ namespace DBTREE
         ArticleMachi( const std::string& datbase, const std::string& id, bool cached, const Encoding enc );
         ~ArticleMachi() noexcept;
 
-        // 書き込みメッセージ変換
+        // 書き込みメッセージ作成
         std::string create_write_message( const std::string& name, const std::string& mail,
                                           const std::string& msg, const bool utf8_post ) override;
 

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -208,7 +208,8 @@ void Board2ch::download_front()
 
 // 新スレ作成時の書き込みメッセージ作成
 std::string Board2ch::create_newarticle_message( const std::string& subject, const std::string& name,
-                                                 const std::string& mail, const std::string& msg )
+                                                 const std::string& mail, const std::string& msg,
+                                                 const bool utf8_post )
 {
     if( subject.empty() ) return std::string();
     if( msg.empty() ) return std::string();
@@ -219,12 +220,14 @@ std::string Board2ch::create_newarticle_message( const std::string& subject, con
         return {};
     }
 
+    const Encoding enc{ utf8_post ? Encoding::utf8 : get_encoding() };
+
     std::stringstream ss_post;
-    ss_post << "submit="   << MISC::url_encode_plus( "新規スレッド作成", get_encoding() )
-            << "&subject=" << MISC::url_encode_plus( subject, get_encoding() )
-            << "&FROM="    << MISC::url_encode_plus( name, get_encoding() )
-            << "&mail="    << MISC::url_encode_plus( mail, get_encoding() )
-            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_encoding() )
+    ss_post << "submit="   << MISC::url_encode_plus( "新規スレッド作成", enc )
+            << "&subject=" << MISC::url_encode_plus( subject, enc )
+            << "&FROM="    << MISC::url_encode_plus( name, enc )
+            << "&mail="    << MISC::url_encode_plus( mail, enc )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, enc )
             << "&bbs="     << get_id()
             << "&time="    << m_frontloader->get_time_modified();
 

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -206,7 +206,15 @@ void Board2ch::download_front()
 }
 
 
-// 新スレ作成時の書き込みメッセージ作成
+/** @brief 新スレ作成時の書き込みメッセージ作成
+ *
+ * @param[in] subject   スレタイトル
+ * @param[in] name      名前、トリップ
+ * @param[in] mail      メールアドレス、sage
+ * @param[in] msg       書き込むメッセージ
+ * @param[in] utf8_post trueならUTF-8のままURLエンコードする
+ * @return URLエンコードしたフォームデータ (application/x-www-form-urlencoded)
+ */
 std::string Board2ch::create_newarticle_message( const std::string& subject, const std::string& name,
                                                  const std::string& mail, const std::string& msg,
                                                  const bool utf8_post )

--- a/src/dbtree/board2ch.h
+++ b/src/dbtree/board2ch.h
@@ -56,7 +56,7 @@ namespace DBTREE
         // フロントページのダウンロード
         void download_front() override;
 
-        // 新スレ作成用のメッセージ変換
+        // 新スレ作成時の書き込みメッセージ作成
         std::string create_newarticle_message( const std::string& subject, const std::string& name,
                                                const std::string& mail, const std::string& msg,
                                                const bool utf8_post ) override;

--- a/src/dbtree/board2ch.h
+++ b/src/dbtree/board2ch.h
@@ -58,7 +58,8 @@ namespace DBTREE
 
         // 新スレ作成用のメッセージ変換
         std::string create_newarticle_message( const std::string& subject, const std::string& name,
-                                               const std::string& mail, const std::string& msg ) override;
+                                               const std::string& mail, const std::string& msg,
+                                               const bool utf8_post ) override;
 
         // 新スレ作成用のbbscgi のURL
         std::string url_bbscgi_new() const override;

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -176,7 +176,15 @@ std::string Board2chCompati::parse_form_data( const std::string& html )
 }
 
 
-// 新スレ作成時の書き込みメッセージ作成
+/** @brief 新スレ作成時の書き込みメッセージ作成
+ *
+ * @param[in] subject   スレタイトル
+ * @param[in] name      名前、トリップ
+ * @param[in] mail      メールアドレス、sage
+ * @param[in] msg       書き込むメッセージ
+ * @param[in] utf8_post trueならUTF-8のままURLエンコードする
+ * @return URLエンコードしたフォームデータ (application/x-www-form-urlencoded)
+ */
 std::string Board2chCompati::create_newarticle_message( const std::string& subject, const std::string& name,
                                                         const std::string& mail, const std::string& msg,
                                                         const bool utf8_post )

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -177,21 +177,24 @@ std::string Board2chCompati::parse_form_data( const std::string& html )
 
 
 // 新スレ作成時の書き込みメッセージ作成
-std::string Board2chCompati::create_newarticle_message( const std::string& subject,
-                                                       const std::string& name, const std::string& mail, const std::string& msg )
+std::string Board2chCompati::create_newarticle_message( const std::string& subject, const std::string& name,
+                                                        const std::string& mail, const std::string& msg,
+                                                        const bool utf8_post )
 {
     if( subject.empty() ) return std::string();
     if( msg.empty() ) return std::string();
 
+    const Encoding enc{ utf8_post ? Encoding::utf8 : get_encoding() };
+
     std::stringstream ss_post;
     ss_post.clear();
     ss_post << "bbs="      << get_id()
-            << "&subject=" << MISC::url_encode_plus( subject, get_encoding() )
+            << "&subject=" << MISC::url_encode_plus( subject, enc )
             << "&time="    << get_time_modified()
-            << "&submit="  << MISC::url_encode_plus( "新規スレッド作成", get_encoding() )
-            << "&FROM="    << MISC::url_encode_plus( name, get_encoding() )
-            << "&mail="    << MISC::url_encode_plus( mail, get_encoding() )
-            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_encoding() );
+            << "&submit="  << MISC::url_encode_plus( "新規スレッド作成", enc )
+            << "&FROM="    << MISC::url_encode_plus( name, enc )
+            << "&mail="    << MISC::url_encode_plus( mail, enc )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, enc );
 
 #ifdef _DEBUG
     std::cout << "Board2chCompati::create_newarticle_message " << ss_post.str() << std::endl;

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -37,7 +37,7 @@ namespace DBTREE
         // 確認画面のHTMLから書き込み、スレ立て時に使うフォームデータを取得する
         std::string parse_form_data( const std::string& html ) override;
 
-        // 新スレ作成用のメッセージ変換
+        // 新スレ作成時の書き込みメッセージ作成
         std::string create_newarticle_message( const std::string& subject, const std::string& name,
                                                const std::string& mail, const std::string& msg,
                                                const bool utf8_post ) override;

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -39,7 +39,8 @@ namespace DBTREE
 
         // 新スレ作成用のメッセージ変換
         std::string create_newarticle_message( const std::string& subject, const std::string& name,
-                                               const std::string& mail, const std::string& msg ) override;
+                                               const std::string& mail, const std::string& msg,
+                                               const bool utf8_post ) override;
 
         // 新スレ作成用のbbscgi のURL
         std::string url_bbscgi_new() const override;

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1986,6 +1986,7 @@ void BoardBase::read_board_info()
     m_view_sort_pre_column = cf.get_option_int( "view_sort_pre_column", -1, -1, COL_VISIBLE_END-1 );
     m_view_sort_pre_mode = cf.get_option_int( "view_sort_pre_mode", SORTMODE_ASCEND, 0, SORTMODE_NUM -1 );
 
+    m_check_utf8_post = cf.get_option_bool( "check_utf8_post", false );
     m_check_noname = cf.get_option_bool( "check_noname", false );
 
     m_show_oldlog = cf.get_option_bool( "show_oldlog", false );
@@ -2147,6 +2148,7 @@ void BoardBase::save_jdboard_info()
          << "view_sort_mode = " << m_view_sort_mode << std::endl
          << "view_sort_pre_column = " << m_view_sort_pre_column << std::endl
          << "view_sort_pre_mode = " << m_view_sort_pre_mode << std::endl
+         << "check_utf8_post = " << m_check_utf8_post << std::endl
          << "check_noname = " << m_check_noname << std::endl
          << "show_oldlog = " << m_show_oldlog << std::endl
          << "charset = " << MISC::encoding_to_cstr( get_encoding() ) << std::endl

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -443,7 +443,8 @@ namespace DBTREE
 
         // 新スレ作成用のメッセージ変換
         virtual std::string create_newarticle_message( const std::string& subject, const std::string& name,
-                                                       const std::string& mail, const std::string& msg )
+                                                       const std::string& mail, const std::string& msg,
+                                                       bool utf8_post )
         {
             return {};
         }

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -89,11 +89,15 @@ namespace DBTREE
         int m_view_sort_pre_column;
         int m_view_sort_pre_mode;
 
+        /// @brief trueならUTF-8で書き込む
+        bool m_check_utf8_post{};
+
         // 名無し書き込み不可
         bool m_check_noname{};
 
         // 過去ログも表示する
         bool m_show_oldlog{};
+
 
         //
         // subjectファイルのURLが "http://www.hoge2ch.net/hogeboard/subject.txt"
@@ -281,6 +285,10 @@ namespace DBTREE
         void set_view_sort_pre_column( int column ) { m_view_sort_pre_column = column; }
         int get_view_sort_pre_mode() const { return m_view_sort_pre_mode; }
         void set_view_sort_pre_mode( int mode ){ m_view_sort_pre_mode = mode; }
+
+        // trueならUTF-8で書き込む
+        bool get_check_utf8_post() const noexcept { return m_check_utf8_post; }
+        void set_check_utf8_post( const bool check ){ m_check_utf8_post = check; }
 
         // 名無し書き込み不可
         bool get_check_noname() const { return m_check_noname; }

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -441,7 +441,7 @@ namespace DBTREE
         // read_from_cache : まだスレ一覧を開いていないときにキャッシュのsubject.txtを読み込む
         virtual void download_subject( const std::string& url_update_view, const bool read_from_cache );
 
-        // 新スレ作成用のメッセージ変換
+        // 新スレ作成時の書き込みメッセージ作成
         virtual std::string create_newarticle_message( const std::string& subject, const std::string& name,
                                                        const std::string& mail, const std::string& msg,
                                                        bool utf8_post )

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -98,7 +98,7 @@ std::string BoardJBBS::url_datpath() const
 
 
 std::string BoardJBBS::create_newarticle_message( const std::string& subject, const std::string& name,
-                                                  const std::string& mail, const std::string& msg )
+                                                  const std::string& mail, const std::string& msg, bool utf8_post )
 {
     if( subject.empty() ) return std::string();
     if( msg.empty() ) return std::string();
@@ -109,13 +109,15 @@ std::string BoardJBBS::create_newarticle_message( const std::string& subject, co
     std::string dir = boardid.substr( 0, i );
     std::string bbs = boardid.substr( i + 1 );
 
+    const Encoding enc{ utf8_post ? Encoding::utf8 : get_encoding() };
+
     std::stringstream ss_post;
     ss_post.clear();
-    ss_post << "SUBJECT="  << MISC::url_encode_plus( subject, get_encoding() )
-            << "&submit="  << MISC::url_encode_plus( "新規書き込み", get_encoding() )
-            << "&NAME="    << MISC::url_encode_plus( name, get_encoding() )
-            << "&MAIL="    << MISC::url_encode_plus( mail, get_encoding() )
-            << "&MESSAGE=" << MISC::url_encode_plus( msg, get_encoding() )
+    ss_post << "SUBJECT="  << MISC::url_encode_plus( subject, enc )
+            << "&submit="  << MISC::url_encode_plus( "新規書き込み", enc )
+            << "&NAME="    << MISC::url_encode_plus( name, enc )
+            << "&MAIL="    << MISC::url_encode_plus( mail, enc )
+            << "&MESSAGE=" << MISC::url_encode_plus( msg, enc )
             << "&DIR="     << dir
             << "&BBS="     << bbs
             << "&TIME="    << get_time_modified();

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -97,6 +97,15 @@ std::string BoardJBBS::url_datpath() const
 
 
 
+/** @brief 新スレ作成時の書き込みメッセージ作成
+ *
+ * @param[in] subject   スレタイトル
+ * @param[in] name      名前、トリップ
+ * @param[in] mail      メールアドレス、sage
+ * @param[in] msg       書き込むメッセージ
+ * @param[in] utf8_post trueならUTF-8のままURLエンコードする
+ * @return URLエンコードしたフォームデータ (application/x-www-form-urlencoded)
+ */
 std::string BoardJBBS::create_newarticle_message( const std::string& subject, const std::string& name,
                                                   const std::string& mail, const std::string& msg, bool utf8_post )
 {

--- a/src/dbtree/boardjbbs.h
+++ b/src/dbtree/boardjbbs.h
@@ -31,7 +31,8 @@ namespace DBTREE
 
         // 新スレ作成用のメッセージ変換
         std::string create_newarticle_message( const std::string& subject, const std::string& name,
-                                               const std::string& mail, const std::string& msg ) override;
+                                               const std::string& mail, const std::string& msg,
+                                               const bool utf8_post ) override;
 
         // 新スレ作成用のbbscgi のURL
         std::string url_bbscgi_new() const override;

--- a/src/dbtree/boardjbbs.h
+++ b/src/dbtree/boardjbbs.h
@@ -29,7 +29,7 @@ namespace DBTREE
 
         std::string url_datpath() const override;
 
-        // 新スレ作成用のメッセージ変換
+        // 新スレ作成時の書き込みメッセージ作成
         std::string create_newarticle_message( const std::string& subject, const std::string& name,
                                                const std::string& mail, const std::string& msg,
                                                const bool utf8_post ) override;

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -169,7 +169,7 @@ std::string BoardMachi::url_datpath() const
 
 
 std::string BoardMachi::create_newarticle_message( const std::string& subject, const std::string& name,
-                                                   const std::string& mail, const std::string& msg )
+                                                   const std::string& mail, const std::string& msg, const bool )
 {
     if( subject.empty() ) return std::string();
     if( msg.empty() ) return std::string();

--- a/src/dbtree/boardmachi.h
+++ b/src/dbtree/boardmachi.h
@@ -28,7 +28,7 @@ namespace DBTREE
 
         std::string url_datpath() const override;
 
-        // 新スレ作成用のメッセージ変換
+        // 新スレ作成時の書き込みメッセージ作成
         std::string create_newarticle_message( const std::string& subject, const std::string& name,
                                                const std::string& mail, const std::string& msg,
                                                const bool utf8_post ) override;

--- a/src/dbtree/boardmachi.h
+++ b/src/dbtree/boardmachi.h
@@ -30,7 +30,8 @@ namespace DBTREE
 
         // 新スレ作成用のメッセージ変換
         std::string create_newarticle_message( const std::string& subject, const std::string& name,
-                                               const std::string& mail, const std::string& msg ) override;
+                                               const std::string& mail, const std::string& msg,
+                                               const bool utf8_post ) override;
 
         // 新スレ作成用のbbscgi のURL
         std::string url_bbscgi_new() const override;

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -491,6 +491,16 @@ void DBTREE::board_set_view_sort_pre_mode( const std::string& url, int mode )
     DBTREE::get_board( url )->set_view_sort_pre_mode( mode );
 }
 
+bool DBTREE::board_check_utf8_post( const std::string& url )
+{
+    return DBTREE::get_board( url )->get_check_utf8_post();
+}
+
+void DBTREE::board_set_check_utf8_post( const std::string& url, const bool check )
+{
+    DBTREE::get_board( url )->set_check_utf8_post( check );
+}
+
 bool DBTREE::board_check_noname( const std::string& url )
 {
     return DBTREE::get_board( url )->get_check_noname();

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -1178,17 +1178,17 @@ void DBTREE::set_write_fixmail( const std::string& url, bool set )
 
 
 std::string DBTREE::create_write_message( const std::string& url, const std::string& name, const std::string& mail,
-                                          const std::string& msg )
+                                          const std::string& msg, const bool utf8_post )
 {
-    return DBTREE::get_article( url )->create_write_message( name, mail, msg );
+    return DBTREE::get_article( url )->create_write_message( name, mail, msg, utf8_post );
 }
 
 
 std::string DBTREE::create_newarticle_message( const std::string& url, const std::string& subject,
                                                const std::string& name, const std::string& mail,
-                                               const std::string& msg )
+                                               const std::string& msg, const bool utf8_post )
 {
-    return DBTREE::get_board( url )->create_newarticle_message( subject, name, mail, msg );
+    return DBTREE::get_board( url )->create_newarticle_message( subject, name, mail, msg, utf8_post );
 }
 
 

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -140,6 +140,8 @@ namespace DBTREE
     void board_set_view_sort_pre_column( const std::string& url, int column );
     int board_view_sort_pre_mode( const std::string& url );
     void board_set_view_sort_pre_mode( const std::string& url, int mode );
+    bool board_check_utf8_post( const std::string& url );
+    void board_set_check_utf8_post( const std::string& url, const bool check );
     bool board_check_noname( const std::string& url );
     void board_set_check_noname( const std::string& url, const bool check );
     bool board_show_oldlog( const std::string& url );

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -318,10 +318,10 @@ namespace DBTREE
 
     // ポストするメッセージの作成
     std::string create_write_message( const std::string& url, const std::string& name, const std::string& mail,
-                                      const std::string& msg );
+                                      const std::string& msg, const bool utf8_post );
     std::string create_newarticle_message( const std::string& url, const std::string& subject,
                                            const std::string& name, const std::string& mail,
-                                           const std::string& msg );
+                                           const std::string& msg, const bool utf8_post );
 
     // 書き込み時のリファラ
     std::string get_write_referer( const std::string& url );

--- a/src/message/messageview.cpp
+++ b/src/message/messageview.cpp
@@ -52,7 +52,7 @@ MessageViewMain::~MessageViewMain()
 //
 // ポストするメッセージ作成
 //
-std::string MessageViewMain::create_message()
+std::string MessageViewMain::create_message( const bool utf8_post )
 {
     if( ! get_text_message() ) return std::string();
 
@@ -122,7 +122,7 @@ std::string MessageViewMain::create_message()
         }
     }
 
-    return DBTREE::create_write_message( get_url(), name, mail, msg );
+    return DBTREE::create_write_message( get_url(), name, mail, msg, utf8_post );
 }
 
 
@@ -170,7 +170,7 @@ void MessageViewMain::reload()
 //
 // ポストするメッセージ作成
 //
-std::string MessageViewNew::create_message()
+std::string MessageViewNew::create_message( const bool utf8_post )
 {
     if( ! get_text_message() ) return std::string();
 
@@ -193,7 +193,9 @@ std::string MessageViewNew::create_message()
 
     SKELETON::MsgDiag mdiag( get_parent_win(),
                              "新スレを作成しますか？", false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
-    if( mdiag.run() == Gtk::RESPONSE_YES ) return DBTREE::create_newarticle_message( get_url(), subject, name, mail, msg );
+    if( mdiag.run() == Gtk::RESPONSE_YES ) {
+        return DBTREE::create_newarticle_message( get_url(), subject, name, mail, msg, utf8_post );
+    }
 
     return std::string();
 }

--- a/src/message/messageview.cpp
+++ b/src/message/messageview.cpp
@@ -49,9 +49,11 @@ MessageViewMain::~MessageViewMain()
 }
 
 
-//
-// ポストするメッセージ作成
-//
+/** @brief ポストするメッセージ作成
+ *
+ * @param[in] utf8_post trueならUTF-8のままURLエンコードする
+ * @return URLエンコードしたフォームデータ (application/x-www-form-urlencoded)
+ */
 std::string MessageViewMain::create_message( const bool utf8_post )
 {
     if( ! get_text_message() ) return std::string();
@@ -165,11 +167,11 @@ void MessageViewMain::reload()
 }
 
 
-
-
-//
-// ポストするメッセージ作成
-//
+/** @brief ポストするメッセージ作成
+ *
+ * @param[in] utf8_post trueならUTF-8のままURLエンコードする
+ * @return URLエンコードしたフォームデータ (application/x-www-form-urlencoded)
+ */
 std::string MessageViewNew::create_message( const bool utf8_post )
 {
     if( ! get_text_message() ) return std::string();

--- a/src/message/messageview.h
+++ b/src/message/messageview.h
@@ -18,7 +18,7 @@ namespace MESSAGE
 
       private:
         void write_impl( const std::string& msg ) override;
-        std::string create_message() override;
+        std::string create_message( const bool utf8_post ) override;
     };
 
 
@@ -33,7 +33,7 @@ namespace MESSAGE
 
       private:
         void write_impl( const std::string& msg ) override;
-        std::string create_message() override;
+        std::string create_message( const bool utf8_post ) override;
     };
 
 }

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -633,7 +633,10 @@ void MessageViewBase::write()
         return;
     }
 
-    const std::string msg = create_message();
+    // trueならUTF-8で書き込む
+    const bool utf8_post = DBTREE::board_check_utf8_post( get_url() );
+
+    const std::string msg = create_message( utf8_post );
     if( msg.empty() ) return;
 
     // 数値文字参照(&#????;)書き込み可能か

--- a/src/message/messageviewbase.h
+++ b/src/message/messageviewbase.h
@@ -150,7 +150,7 @@ namespace MESSAGE
         void slot_switch_page( Gtk::Widget*, guint page );
         void slot_text_changed();
 
-        virtual std::string create_message() = 0;
+        virtual std::string create_message( const bool utf8_post ) = 0;
 
         void show_status();
 

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -180,6 +180,10 @@ void Post::post_msg()
     // http://www.asahi-net.or.jp/~sd5a-ucd/rec-html401j/interact/forms.html#h-17.13.4.1
     // http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1
     data.contenttype = "application/x-www-form-urlencoded";
+    // trueならUTF-8で書き込む
+    if( DBTREE::board_check_utf8_post( m_url ) ) {
+        data.contenttype.append( "; charset=utf-8" );
+    }
 
     data.agent = DBTREE::get_agent_w( m_url );
     data.referer = m_count < 1 ? m_post_strategy->get_referer( m_url ) : m_post_strategy->url_bbscgi( m_url );


### PR DESCRIPTION
### Add experimental 'Write in UTF-8' option to board preferences
板のプロパティに「UTF-8で書き込む」実験的なオプションを追加します。
掲示板がUTF-8の書き込みに対応してるか確認して使用してください。
このオプションは実験的なサポートのため変更または廃止の可能性があります。

#### 背景事情
名前欄に絵文字を入力して5ch.netに書き込むと名前に含まれる絵文字が文字参照の形で表示されます。
絵文字などShift_JISで表現できない文字はHTML文字参照に変換して送信しますが`&`が`&amp;`に変換されて文字参照がエスケープされるため元の文字にデコードできません。
UTF-8でURLエンコードすると文字参照を使わず送信することが可能です。

### BoardBase: Implement flag option to enable UTF-8 writing on boards
板に「UTF-8で書き込む」フラグ設定を実装します。

### Implement URL encode and HTTP Content-Type charset for UTF-8 mode
板の「UTF-8で書き込む」フラグ設定がtrueなら書き込みメッセージのURLエンコードをUTF-8に変更し、HTTP POSTリクエストのContent-Typeにcharset=utf-8を追加します。

### dbtree: Add source code documentation to the functions

Closes #1264
