### PR TITLE
Update histories

### DIFF
--- a/docs/manual/2023.md
+++ b/docs/manual/2023.md
@@ -9,7 +9,89 @@ layout: default
 
 
 <a name="0.11.0-unreleased"></a>
-### [0.11.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.10.1...master) (unreleased)
+### [0.11.0-unreleased](https://github.com/JDimproved/JDim/compare/63816063253...master) (unreleased)
+
+
+<a name="0.10.1-20231007"></a>
+### [0.10.1-20231007](https://github.com/JDimproved/JDim/compare/JDim-v0.10.1...63816063253) (2023-10-07)
+- ([#1267](https://github.com/JDimproved/JDim/pull/1267))
+  Add experimental 'Write in UTF-8' option to board preferences
+- ([#1266](https://github.com/JDimproved/JDim/pull/1266))
+  `BoardBase`: Ignore encoding analysis when encoding setting is enabled
+- ([#1263](https://github.com/JDimproved/JDim/pull/1263))
+  `LinkFilterDiag`: Rename member function to avoid conflict with parent member
+- ([#1262](https://github.com/JDimproved/JDim/pull/1262))
+  `Admin`: Add const qualifier to pointer parameter in member function
+- ([#1261](https://github.com/JDimproved/JDim/pull/1261))
+  `Root`: Use `std::find_if()` instead of range-based for loops
+- ([#1260](https://github.com/JDimproved/JDim/pull/1260))
+  environment: Use `std::find_if()` instead of range-based for loops
+- ([#1259](https://github.com/JDimproved/JDim/pull/1259))
+  Add thread view text drawing method choice to about:config
+- ([#1257](https://github.com/JDimproved/JDim/pull/1257))
+  Adjust window size for small display
+- ([#1256](https://github.com/JDimproved/JDim/pull/1256))
+  Reset errno to zero before calling functions
+- ([#1254](https://github.com/JDimproved/JDim/pull/1254))
+  `NodeTreeBase`: Use `std::any_of()` instead of range-based for loops
+- ([#1253](https://github.com/JDimproved/JDim/pull/1253))
+  `BoardBase`: Use `std::any_of()` instead of range-based for loops
+- ([#1252](https://github.com/JDimproved/JDim/pull/1252))
+  `Search_Manager`: Sort log search results by since time
+- ([#1251](https://github.com/JDimproved/JDim/pull/1251))
+  Fix cancel operation on log search in the cache
+- ([#1248](https://github.com/JDimproved/JDim/pull/1248))
+  Add const qualifier to pointer variables in local scope part6
+- ([#1247](https://github.com/JDimproved/JDim/pull/1247))
+  `Root`: Support 5ch.net URL without subdomain
+- ([#1246](https://github.com/JDimproved/JDim/pull/1246))
+  Remove link confirmation page for URLs in machi.to threads
+- ([#1245](https://github.com/JDimproved/JDim/pull/1245))
+  `Root`: Support machi.to URL without subdomain
+- ([#1244](https://github.com/JDimproved/JDim/pull/1244))
+  Implement `MISC::ends_with(haystack, needle)`
+- ([#1240](https://github.com/JDimproved/JDim/pull/1240))
+  Set upper limitation to 99999 for displaying post count
+- ([#1239](https://github.com/JDimproved/JDim/pull/1239))
+  Improve performance for `NodeTreeBase::set_num_id_name()`
+- ([#1238](https://github.com/JDimproved/JDim/pull/1238))
+  Enhance post count display with posting order
+- ([#1237](https://github.com/JDimproved/JDim/pull/1237))
+  `NodeTreeBase`: Fix HTML href attribute parsing
+- ([#1235](https://github.com/JDimproved/JDim/pull/1235))
+  skeleton: Add const qualifier to pointer variables in local scope
+- ([#1234](https://github.com/JDimproved/JDim/pull/1234))
+  `BoardBase`: Add const qualifier to pointer variables in local scope
+- ([#1232](https://github.com/JDimproved/JDim/pull/1232))
+  `History_Manager`: Add const qualifier to pointer variables in local scope
+- ([#1231](https://github.com/JDimproved/JDim/pull/1231))
+  Deprecate platforms where gcc version less than 9
+- ([#1230](https://github.com/JDimproved/JDim/pull/1230))
+  Extend proxy support for accessing kako log server in fallback
+- ([#1228](https://github.com/JDimproved/JDim/pull/1228))
+  article: Add const qualifier to pointer variables in local scope
+- ([#1227](https://github.com/JDimproved/JDim/pull/1227))
+  dbimg: Add const qualifier to pointer variables in local scope
+- ([#1226](https://github.com/JDimproved/JDim/pull/1226))
+  `NodeTreeBase`: Fix schema-less URL parsing
+- ([#1224](https://github.com/JDimproved/JDim/pull/1224))
+  `DrawAreaBase`: Use `cairo_t` instead of `std::unique_ptr<cairo_t>`
+- ([#1223](https://github.com/JDimproved/JDim/pull/1223))
+  `DrawAreaBase`: Add null check to fix segfault
+- ([#1222](https://github.com/JDimproved/JDim/pull/1222))
+  Add logic to identify `<a>` elements as reply anchors in HTML parsing
+- ([#1221](https://github.com/JDimproved/JDim/pull/1221))
+  `Log_Manager::check_write`: skip heading continuous newlines for early-check
+- ([#1217](https://github.com/JDimproved/JDim/pull/1217))
+  `Socket`: Define `AI_V4MAPPED` for OpenBSD
+- ([#1216](https://github.com/JDimproved/JDim/pull/1216))
+  Add handling to use 2ch proxy if past logs not available without proxy
+- ([#1215](https://github.com/JDimproved/JDim/pull/1215))
+  Implement shortcut key and mouse gesture for moving to updatable tab
+- ([#1214](https://github.com/JDimproved/JDim/pull/1214))
+  jdlib/miscutil: fix return value of ascii_trim for whitespace-only string (#1213)
+- ([#1209](https://github.com/JDimproved/JDim/pull/1209))
+  Remove Autotools support
 
 
 <a name="JDim-v0.10.1"></a>

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -17,7 +17,7 @@
 #define MAJORVERSION 0
 #define MINORVERSION 10
 #define MICROVERSION 1
-#define JDDATE_FALLBACK    "20230723"
+#define JDDATE_FALLBACK    "20231007"
 #define JDTAG     ""
 
 //---------------------------------


### PR DESCRIPTION
### Update histories
更新履歴の項目が長くなったため分割します。

### Update `JDDATE_FALLBACK` macro to 20231007

関連のissue: https://github.com/JDimproved/JDim/issues/1269