### PR TITLE
Board2ch: Get rid of useless override member functions

### DIFF
--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -262,29 +262,6 @@ std::string Board2ch::create_newarticle_message( const std::string& subject, con
 }
 
 
-//
-// 新スレ作成時のbbscgi のURL
-//
-// (例) "http://www.hoge2ch.net/test/bbs.cgi"
-//
-//
-std::string Board2ch::url_bbscgi_new() const
-{
-    return Board2chCompati::url_bbscgi_new();
-}
-
-
-//
-// 新スレ作成時のsubbbscgi のURL
-//
-// (例) "http://www.hoge2ch.net/test/subbbs.cgi"
-//
-std::string Board2ch::url_subbbscgi_new() const
-{
-    return Board2chCompati::url_subbbscgi_new();
-}
-
-
 /** @brief SETTING.TXT の項目 BBS_UNICODE の値を返す
  *
  * @remarks 2022-04-30 以降、5chでは BBS_UNICODE が無効になったため

--- a/src/dbtree/board2ch.h
+++ b/src/dbtree/board2ch.h
@@ -61,12 +61,6 @@ namespace DBTREE
                                                const std::string& mail, const std::string& msg,
                                                const bool utf8_post ) override;
 
-        // 新スレ作成用のbbscgi のURL
-        std::string url_bbscgi_new() const override;
-        
-        // 新スレ作成用のsubbbscgi のURL
-        std::string url_subbbscgi_new() const override;
-
         // datの最大サイズ(Kバイト)
         int get_max_dat_lng() const override { return DEFAULT_MAX_DAT_LNG; }
 


### PR DESCRIPTION
親クラスのメンバー関数を呼び出しているだけのメンバー関数があるとcppcheckに指摘されたため子クラスのメンバーを整理します。

cppcheck 2.12.1のレポート
```
src/dbtree/board2ch.h:64:21: style: The function 'url_bbscgi_new' overrides a function in a base class but just delegates back to the base class. [uselessOverride]
        std::string url_bbscgi_new() const override;
                    ^
src/dbtree/board2chcompati.h:45:21: note: Virtual function in base class
        std::string url_bbscgi_new() const override;
                    ^
src/dbtree/board2ch.h:64:21: note: Function in derived class
        std::string url_bbscgi_new() const override;
                    ^
src/dbtree/board2ch.h:67:21: style: The function 'url_subbbscgi_new' overrides a function in a base class but just delegates back to the base class. [uselessOverride]
        std::string url_subbbscgi_new() const override;
                    ^
src/dbtree/board2chcompati.h:48:21: note: Virtual function in base class
        std::string url_subbbscgi_new() const override;
                    ^
src/dbtree/board2ch.h:67:21: note: Function in derived class
        std::string url_subbbscgi_new() const override;
                    ^
```
