### PR TITLE
Introduce encoding detection option when encoding choose is disabled

### DIFF
--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -38,7 +38,9 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
 
     , m_check_live( "実況する" )
 
+    , m_vbox_encoding{ Gtk::ORIENTATION_VERTICAL, 0 }
     , m_hbox_encoding{ Gtk::ORIENTATION_HORIZONTAL, 4 }
+    , m_vbox_encoding_analysis_method{ Gtk::ORIENTATION_VERTICAL, 2 }
 
     , m_vbox_network{ Gtk::ORIENTATION_VERTICAL, 8 }
     , m_hbox_agent{ Gtk::ORIENTATION_HORIZONTAL, 2 }
@@ -183,12 +185,44 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
 
         m_hbox_encoding.pack_start( m_label_charset, Gtk::PACK_SHRINK );
         m_hbox_encoding.pack_start( m_combo_charset, Gtk::PACK_SHRINK );
+
+        m_vbox_encoding.pack_start( m_hbox_encoding, Gtk::PACK_SHRINK );
     }
     else {
         // エンコーディング設定は安全でないので無効のときは設定欄(コンボボックス)を表示しない
         m_label_charset.set_text( Glib::ustring::compose( "テキストエンコーディング :  %1", tmpcharset ) );
 
         m_hbox_encoding.pack_start( m_label_charset, Gtk::PACK_SHRINK );
+
+        m_binding_encoding = Glib::Binding::bind_property( m_toggle_encoding.property_active(),
+                                                           m_revealer_encoding.property_reveal_child() );
+        m_toggle_encoding.set_label( "(実験的な機能) エンコーディングの判定" );
+        m_toggle_encoding.set_tooltip_text(
+            "このオプションは実験的なサポートのため変更または廃止の可能性があります。" );
+        m_toggle_encoding.set_halign( Gtk::ALIGN_END );
+        m_hbox_encoding.pack_end( m_toggle_encoding, Gtk::PACK_SHRINK );
+
+        m_label_encoding_analysis_method.set_markup( "<b>テキストエンコーディングを判定する方法</b>" );
+        m_label_encoding_analysis_method.set_halign( Gtk::ALIGN_START );
+
+        m_radio_encoding_default.set_group( m_group_encoding );
+        m_radio_encoding_default.set_label( "デフォルト設定を使う" );
+
+        m_radio_encoding_http_header.set_group( m_group_encoding );
+        m_radio_encoding_http_header.set_label( "HTTPヘッダーのエンコーディング情報を使う" );
+
+        m_vbox_encoding_analysis_method.set_margin_start( 30 );
+        m_vbox_encoding_analysis_method.set_margin_end( 30 );
+        m_vbox_encoding_analysis_method.set_margin_top( 10 );
+        m_vbox_encoding_analysis_method.set_margin_bottom( 10 );
+        m_vbox_encoding_analysis_method.pack_start( m_label_encoding_analysis_method, Gtk::PACK_SHRINK );
+        m_vbox_encoding_analysis_method.pack_start( m_radio_encoding_default, Gtk::PACK_SHRINK );
+        m_vbox_encoding_analysis_method.pack_start( m_radio_encoding_http_header, Gtk::PACK_SHRINK );
+
+        m_revealer_encoding.add( m_vbox_encoding_analysis_method );
+
+        m_vbox_encoding.pack_start( m_hbox_encoding, Gtk::PACK_SHRINK );
+        m_vbox_encoding.pack_start( m_revealer_encoding, Gtk::PACK_SHRINK );
     }
 
     // 一般ページのパッキング
@@ -245,7 +279,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     m_vbox.pack_start( m_label_last_access, Gtk::PACK_SHRINK );
     m_vbox.pack_start( m_hbox_modified, Gtk::PACK_SHRINK );
     m_vbox.pack_start( m_hbox_live, Gtk::PACK_SHRINK );
-    m_vbox.pack_start( m_hbox_encoding, Gtk::PACK_SHRINK );
+    m_vbox.pack_start( m_vbox_encoding, Gtk::PACK_SHRINK );
     m_vbox.pack_start( m_check_oldlog, Gtk::PACK_SHRINK );
     m_vbox.pack_start( m_frame_write, Gtk::PACK_SHRINK );
     m_vbox.pack_start( m_frame_cookie, Gtk::PACK_SHRINK );

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -223,6 +223,14 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
 
         m_vbox_encoding.pack_start( m_hbox_encoding, Gtk::PACK_SHRINK );
         m_vbox_encoding.pack_start( m_revealer_encoding, Gtk::PACK_SHRINK );
+
+        if( const int method = DBTREE::board_encoding_analysis_method( get_url() );
+                method == EncodingAnalysisMethod::http_header ) {
+            m_radio_encoding_http_header.set_active( true );
+        }
+        else {
+            m_radio_encoding_default.set_active( true );
+        }
     }
 
     // 一般ページのパッキング
@@ -611,6 +619,14 @@ void Preferences::slot_ok_clicked()
     if( m_check_live.get_active() ) live_sec = m_spin_live.get_value_as_int();
     DBTREE::board_set_live_sec( get_url(), live_sec );
     CORE::core_set_command( "redraw_article_toolbar" );
+
+    // テキストエンコーディングを判定する方法
+    if( m_radio_encoding_http_header.get_active() ) {
+        DBTREE::board_set_encoding_analysis_method( get_url(), EncodingAnalysisMethod::http_header );
+    }
+    else {
+        DBTREE::board_set_encoding_analysis_method( get_url(), EncodingAnalysisMethod::use_default );
+    }
 
     // 最大レス数
     const int number_max_res = m_spin_maxres.get_value_as_int();

--- a/src/board/preference.h
+++ b/src/board/preference.h
@@ -84,9 +84,20 @@ namespace BOARD
         Gtk::SpinButton m_spin_live;
 
         // テキストエンコーディング
+        Gtk::Box m_vbox_encoding; ///< テキストエンコーディングの設定をパックする
         Gtk::Box m_hbox_encoding;
         Gtk::Label m_label_charset;
         Gtk::ComboBoxText m_combo_charset;
+
+        Glib::RefPtr<Glib::Binding> m_binding_encoding; ///< ToggleButtonとRevealerをバインドする
+        Gtk::ToggleButton m_toggle_encoding;
+        Gtk::Revealer m_revealer_encoding;
+
+        Gtk::Box m_vbox_encoding_analysis_method; ///< テキストエンコーディングを判定する方法をパックする
+        Gtk::Label m_label_encoding_analysis_method; ///< "エンコーディングの判定"のラベル
+        Gtk::RadioButtonGroup m_group_encoding;
+        Gtk::RadioButton m_radio_encoding_default;
+        Gtk::RadioButton m_radio_encoding_http_header;
 
         // ネットワーク設定
         Gtk::Box m_vbox_network;

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -128,6 +128,21 @@ const std::string& ArticleBase::get_since_date()
 }
 
 
+/** @brief テキストエンコーディングを表す列挙型を返す
+ *
+ * @details 板やスレのテキストエンコーディング設定が無効のときは
+ * 板のプロパティにある「テキストエンコーディングを判定する方法」を参照して返す値を決定する。
+ */
+Encoding ArticleBase::get_encoding() const
+{
+    if( ! CONFIG::get_choose_character_encoding()
+            && DBTREE::board_encoding_analysis_method( m_url ) == EncodingAnalysisMethod::use_default ) {
+        return DBTREE::board_default_encoding( m_url );
+    }
+    return m_encoding;
+}
+
+
 // スレ速度
 int ArticleBase::get_speed() const
 {

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -157,7 +157,7 @@ namespace DBTREE
         int get_number_max() const noexcept { return m_number_max; }
 
         // 文字エンコーディング
-        Encoding get_encoding() const noexcept { return m_encoding; }
+        Encoding get_encoding() const;
         void set_encoding( const Encoding encoding ){ m_encoding = encoding; }
 
         // スレ速度

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -49,6 +49,7 @@ Board2chCompati::Board2chCompati( const std::string& root, const std::string& pa
     set_ext( ".dat" );
     set_id( path_board.substr( 1 ) ); // 先頭の '/' を除く
     set_encoding( Encoding::sjis );
+    set_default_encoding( Encoding::sjis );
 
     BoardBase::set_basicauth( basicauth );
 }

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1050,6 +1050,7 @@ void BoardBase::create_loaderdata( JDLIB::LOADERDATA& data )
     data.basicauth = get_basicauth();
     data.modified = get_date_modified();
     data.cookie_for_request = cookie_for_request();
+    data.encoding_analysis_method = get_encoding_analysis_method();
 }
 
 
@@ -1427,6 +1428,7 @@ bool BoardBase::start_checkking_if_board_moved()
     data.init_for_data();
     data.url = url_boardbase();
     data.cookie_for_request = cookie_for_request();
+    data.encoding_analysis_method = get_encoding_analysis_method();
 
     if( start_load( data ) ){
         m_read_url_boardbase = true;
@@ -2087,6 +2089,9 @@ void BoardBase::read_board_info()
     // 板のユーザーエージェント設定
     m_board_agent = cf.get_option_str( "user_agent", std::string{} );
 
+    // テキストエンコーディングを判定する方法
+    m_encoding_analysis_method = cf.get_option_int( "encoding_analysis_method", 0, 0, EncodingAnalysisMethod::max );
+
 #ifdef _DEBUG
     std::cout << "modified = " << get_date_modified() << std::endl;
 #endif
@@ -2180,6 +2185,7 @@ void BoardBase::save_jdboard_info()
          << "status = " << m_status << std::endl
          << "max_res = " << m_number_max_res << std::endl
          << "user_agent = " << m_board_agent << std::endl
+         << "encoding_analysis_method = " << m_encoding_analysis_method << std::endl;
     ;
 
     CACHE::save_rawdata( path_info, sstr.str() );

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -218,6 +218,9 @@ namespace DBTREE
         /// 板のユーザーエージェント設定 (空のときは全体設定を使う)
         std::string m_board_agent;
 
+        /// テキストエンコーディングを判定する方法
+        int m_encoding_analysis_method{};
+
       protected:
 
         ARTICLE_INFO_LIST& get_list_artinfo(){ return m_list_artinfo; }
@@ -594,6 +597,10 @@ namespace DBTREE
         // 板の更新チェック時に、更新チェックを行うスレのアドレスのリスト
         // キャッシュが存在し、かつdat落ちしていないで新着数が0のスレを速度の順でソートして返す
         std::list< std::string > get_check_update_articles();
+
+        // テキストエンコーディングを判定する方法
+        int get_encoding_analysis_method() const noexcept { return m_encoding_analysis_method; }
+        void set_encoding_analysis_method( int meth ) { m_encoding_analysis_method = meth; }
 
       private:
 

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -38,6 +38,7 @@ BoardJBBS::BoardJBBS( const std::string& root, const std::string& path_board, co
     set_ext( "" );
     set_id( path_board.substr( 1 ) ); // 先頭の '/' を除く  
     set_encoding( Encoding::eucjp );
+    set_default_encoding( Encoding::eucjp );
 }
 
 

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -35,6 +35,7 @@ BoardMachi::BoardMachi( const std::string& root, const std::string& path_board, 
     set_ext( "" );
     set_id( path_board.substr( 1 ) ); // 先頭の '/' を除く  
     set_encoding( Encoding::sjis );
+    set_default_encoding( Encoding::sjis );
 }
 
 

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -305,6 +305,12 @@ void DBTREE::board_set_encoding( const std::string& url, const Encoding enc )
 }
 
 
+Encoding DBTREE::board_default_encoding( const std::string& url )
+{
+    return DBTREE::get_board( url )->get_default_encoding();
+}
+
+
 std::string DBTREE::board_cookie_by_host( const std::string& url )
 {
     return DBTREE::get_board( url )->cookie_by_host();
@@ -729,6 +735,17 @@ const std::string& DBTREE::board_get_board_agent( const std::string& url )
 void DBTREE::board_set_board_agent( const std::string& url, const std::string& user_agent )
 {
     DBTREE::get_board( url )->set_board_agent( user_agent );
+}
+
+// テキストエンコーディングを判定する方法
+int DBTREE::board_encoding_analysis_method( const std::string& url )
+{
+    return DBTREE::get_board( url )->get_encoding_analysis_method();
+}
+
+void DBTREE::board_set_encoding_analysis_method( const std::string& url, const int meth )
+{
+    DBTREE::get_board( url )->set_encoding_analysis_method( meth );
 }
 
 

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -108,6 +108,7 @@ namespace DBTREE
     const std::string& board_subjecttxt( const std::string& url );
     Encoding board_encoding( const std::string& url );
     void board_set_encoding( const std::string& url, const Encoding enc );
+    Encoding board_default_encoding( const std::string& url );
     std::string board_cookie_by_host( const std::string& url );
     std::string board_cookie_for_request( const std::string& url );
     std::string board_cookie_for_post( const std::string& url );
@@ -199,6 +200,10 @@ namespace DBTREE
     // 板のユーザーエージェント設定
     const std::string& board_get_board_agent( const std::string& url );
     void board_set_board_agent( const std::string& url, const std::string& user_agent );
+
+    // テキストエンコーディングを判定する方法
+    int board_encoding_analysis_method( const std::string& url );
+    void board_set_encoding_analysis_method( const std::string& url, const int meth );
 
     // 全スレの書き込み履歴のリセット
     void clear_all_post_history();

--- a/src/dbtree/nodetree2ch.cpp
+++ b/src/dbtree/nodetree2ch.cpp
@@ -192,6 +192,7 @@ void NodeTree2ch::create_loaderdata( JDLIB::LOADERDATA& data )
 
     data.size_buf = CONFIG::get_loader_bufsize();
     data.timeout = CONFIG::get_loader_timeout();
+    data.encoding_analysis_method = DBTREE::board_encoding_analysis_method( get_url() );
 
     if( ! get_date_modified().empty() ) data.modified = get_date_modified();
 }

--- a/src/dbtree/nodetree2chcompati.cpp
+++ b/src/dbtree/nodetree2chcompati.cpp
@@ -115,6 +115,7 @@ void NodeTree2chCompati::create_loaderdata( JDLIB::LOADERDATA& data )
     data.timeout = CONFIG::get_loader_timeout();
     data.basicauth = DBTREE::board_basicauth( get_url() );
     data.cookie_for_request = DBTREE::board_cookie_for_request( get_url() );
+    data.encoding_analysis_method = DBTREE::board_encoding_analysis_method( get_url() );
 
     if( ! get_date_modified().empty() ) data.modified = get_date_modified();
 }

--- a/src/dbtree/nodetreejbbs.cpp
+++ b/src/dbtree/nodetreejbbs.cpp
@@ -111,6 +111,7 @@ void NodeTreeJBBS::create_loaderdata( JDLIB::LOADERDATA& data )
     data.size_buf = CONFIG::get_loader_bufsize();
     data.timeout = CONFIG::get_loader_timeout();
     data.cookie_for_request = DBTREE::board_cookie_for_request( get_url() );
+    data.encoding_analysis_method = DBTREE::board_encoding_analysis_method( get_url() );
 
     if( ! get_date_modified().empty() ) data.modified = get_date_modified();
 

--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -134,6 +134,7 @@ void NodeTreeMachi::create_loaderdata( JDLIB::LOADERDATA& data )
     data.size_buf = CONFIG::get_loader_bufsize();
     data.timeout = CONFIG::get_loader_timeout();
     data.cookie_for_request = DBTREE::board_cookie_for_request( get_url() );
+    data.encoding_analysis_method = DBTREE::board_encoding_analysis_method( get_url() );
 
     if( ! get_date_modified().empty() ) data.modified = get_date_modified();
 

--- a/src/jdencoding.h
+++ b/src/jdencoding.h
@@ -21,4 +21,16 @@ enum class Encoding
     utf8,  ///< UTF-8
 };
 
+
+/** @brief テキストエンコーディングを判定する方法を表す定数をまとめた構造体
+ *
+ * @details 0 より小さい値は無効な値にするため定義しない
+ */
+struct EncodingAnalysisMethod
+{
+    static constexpr const int use_default = 0; ///< デフォルト設定を使う
+    static constexpr const int http_header = 1; ///< HTTPヘッダーのエンコーディング情報を使う
+    static constexpr const int max = http_header;
+};
+
 #endif

--- a/src/jdlib/loaderdata.cpp
+++ b/src/jdlib/loaderdata.cpp
@@ -56,6 +56,7 @@ void LOADERDATA::init()
     basicauth.clear();
     size_buf = 0;
     timeout = 0;
+    encoding_analysis_method = -1;
 }
 
 

--- a/src/jdlib/loaderdata.h
+++ b/src/jdlib/loaderdata.h
@@ -55,6 +55,8 @@ namespace JDLIB
         size_t size_buf;
         int timeout;
 
+        int encoding_analysis_method; ///< テキストエンコーディングを判定する方法
+
         LOADERDATA();
 
         void init();

--- a/src/skeleton/loadable.cpp
+++ b/src/skeleton/loadable.cpp
@@ -21,12 +21,14 @@ enum class Loadable::CharsetDetection
     parse_header, ///< HTTP header を解析する
     parse_meta,   ///< HTML meta 要素を解析する
     finished,     ///< 検出を終えた
+    use_default,  ///< デフォルト設定を使う
 };
 
 
 Loadable::Loadable()
     : m_charset_det{ CharsetDetection::parse_header }
     , m_encoding{ Encoding::unknown }
+    , m_default_encoding{ Encoding::unknown }
 {
     clear_load_data();
 }
@@ -111,7 +113,13 @@ bool Loadable::start_load( const JDLIB::LOADERDATA& data )
 
     // 情報初期化
     // m_date_modified, m_cookie は初期化しない
-    m_charset_det = CharsetDetection::parse_header;
+    if( data.encoding_analysis_method == EncodingAnalysisMethod::http_header ) {
+        m_charset_det = CharsetDetection::parse_header;
+    }
+    else {
+        m_charset_det = CharsetDetection::use_default;
+        set_encoding( m_default_encoding );
+    }
     m_code = HTTP_INIT;
     m_str_code = std::string();
     m_location = std::string();

--- a/src/skeleton/loadable.h
+++ b/src/skeleton/loadable.h
@@ -74,6 +74,7 @@ namespace SKELETON
 
         CharsetDetection m_charset_det; ///< HTTPやHTMLからテキストの文字エンコーディングを検出する処理の状態
         Encoding m_encoding;
+        Encoding m_default_encoding; ///< デフォルト設定
 
         // ローダからコピーしたデータ
         int m_code;
@@ -98,6 +99,9 @@ namespace SKELETON
 
         Encoding get_encoding() const { return m_encoding; }
         void set_encoding( const Encoding encoding ){ m_encoding = encoding; }
+
+        Encoding get_default_encoding() const noexcept { return m_default_encoding; }
+        void set_default_encoding( const Encoding encoding ) { m_default_encoding = encoding; }
 
         int get_code() const { return m_code; }
         void set_code( int code ) { m_code = code; }


### PR DESCRIPTION
### Introduce encoding detection option when encoding choose is disabled
    
板のプロパティにエンコーディングを判定する方法を選択するオプションを実装します。
この設定はユーザーがテキストエンコーディングを選択するオプションが有効のときは利用できません。

このオプションは実験的なサポートのため変更または廃止の可能性があります。

#### エンコーディングを判定する方法
* デフォルト設定を使う (初期設定)
* HTTPヘッダーのエンコーディング情報を使う

#### 互換性の注意
修正前の動作は「HTTPヘッダーのエンコーディング情報を使う」ですが、修正後は「デフォルト設定を使う」が初期設定になり動作が変更されます。

### dbtree: Implement 'Use default encoding' behavior mode
    
板やスレの読み込むときに行うテキストエンコーディング変換にデフォルト設定のエンコーディングを使うモードを実装します。

このモードは板のプロパティのエンコーディングを判定する方法にある「デフォルト設定を使う」設定を選択しているときに使用されます。

関連のissue: #1265
