### PR TITLE
NodeTreeMachi: Fix subject encoding

### DIFF
--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -192,7 +192,8 @@ char* NodeTreeMachi::process_raw_lines( std::string& rawlines )
                 std::string reg_subject( "<title>([^<]*)</title>" );
                 if( m_regex->exec( reg_subject, line, offset, icase, newline, usemigemo, wchar ) ){
 
-                    m_subject_machi = MISC::Iconv( m_regex->str( 1 ), Encoding::utf8, get_encoding() );
+                    const Encoding enc = DBTREE::board_encoding( get_url() );
+                    m_subject_machi = MISC::Iconv( m_regex->str( 1 ), Encoding::utf8, enc );
 #ifdef _DEBUG
                     std::cout << "NodeTreeMachi::process_raw_lines" << std::endl;
                     std::cout << "subject = " << m_subject_machi << std::endl;


### PR DESCRIPTION
まちBBSのスレ一覧から未読スレを開くとスレタイトルが文字化けする不具合を修正します。

以前の修正でスレタイトルのエンコーディング変換に間違いがありBoardMachiのエンコーディングを使うところがNodeTreeMachiが管理するエンコーディングになっていました。

commit 93749e7cb271636373b63c0084ef7cfa998e09f3

修正にあたり不具合報告をしていただきありがとうございました。
https://next2ch.net/test/read.cgi/linux/1654053581/172

Closes #1273 