### PR TITLE
DrawAreaBase: Fix segfault

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -1850,7 +1850,14 @@ void DrawAreaBase::exec_draw_screen( const int y_redraw, const int height_redraw
     // 描画ループ
     CLIPINFO ci = { width_view, pos_y, upper, lower }; // 描画領域
     bool relayout = false;
-    while( header && header->rect->y < pos_y + height_view ){
+    while( header ) {
+        if( ! header->rect ) {
+            header = header->next_header;
+            continue;
+        }
+        if( header->rect->y >= pos_y + height_view ) {
+            break;
+        }
 
         // フォント設定
         set_node_font( header );


### PR DESCRIPTION
スレ一覧のタブをクリックしたときにクラッシュしたためgdbのバックトレースを参考にポインターのデリファレンスを修正します。

gdbのレポート
```
Thread 1 "jdim" received signal SIGSEGV, Segmentation fault.
0x0000555555b22f3c in ARTICLE::DrawAreaBase::exec_draw_screen (
    this=0x5555675008d0, y_redraw=0, height_redraw=723)
    at ../src/article/drawareabase.cpp:1853
1853        while( header && header->rect->y < pos_y + height_view ){
(gdb) p header
$1 = (ARTICLE::LAYOUT *) 0x555567911a68
(gdb) p header->rect
$2 = (ARTICLE::RECTANGLE *) 0x0
```
