### PR TITLE
add guess encoding from text option

### DIFF
--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -211,6 +211,9 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
         m_radio_encoding_http_header.set_group( m_group_encoding );
         m_radio_encoding_http_header.set_label( "HTTPヘッダーのエンコーディング情報を使う" );
 
+        m_radio_encoding_guess.set_group( m_group_encoding );
+        m_radio_encoding_guess.set_label( "テキストからエンコーディングを推測する" );
+
         m_vbox_encoding_analysis_method.set_margin_start( 30 );
         m_vbox_encoding_analysis_method.set_margin_end( 30 );
         m_vbox_encoding_analysis_method.set_margin_top( 10 );
@@ -218,18 +221,23 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
         m_vbox_encoding_analysis_method.pack_start( m_label_encoding_analysis_method, Gtk::PACK_SHRINK );
         m_vbox_encoding_analysis_method.pack_start( m_radio_encoding_default, Gtk::PACK_SHRINK );
         m_vbox_encoding_analysis_method.pack_start( m_radio_encoding_http_header, Gtk::PACK_SHRINK );
+        m_vbox_encoding_analysis_method.pack_start( m_radio_encoding_guess, Gtk::PACK_SHRINK );
 
         m_revealer_encoding.add( m_vbox_encoding_analysis_method );
 
         m_vbox_encoding.pack_start( m_hbox_encoding, Gtk::PACK_SHRINK );
         m_vbox_encoding.pack_start( m_revealer_encoding, Gtk::PACK_SHRINK );
 
-        if( const int method = DBTREE::board_encoding_analysis_method( get_url() );
-                method == EncodingAnalysisMethod::http_header ) {
-            m_radio_encoding_http_header.set_active( true );
-        }
-        else {
-            m_radio_encoding_default.set_active( true );
+        switch( DBTREE::board_encoding_analysis_method( get_url() ) ) {
+            case EncodingAnalysisMethod::http_header:
+                m_radio_encoding_http_header.set_active( true );
+                break;
+            case EncodingAnalysisMethod::guess:
+                m_radio_encoding_guess.set_active( true );
+                break;
+            default:
+                m_radio_encoding_default.set_active( true );
+                break;
         }
     }
 
@@ -623,6 +631,9 @@ void Preferences::slot_ok_clicked()
     // テキストエンコーディングを判定する方法
     if( m_radio_encoding_http_header.get_active() ) {
         DBTREE::board_set_encoding_analysis_method( get_url(), EncodingAnalysisMethod::http_header );
+    }
+    else if( m_radio_encoding_guess.get_active() ) {
+        DBTREE::board_set_encoding_analysis_method( get_url(), EncodingAnalysisMethod::guess );
     }
     else {
         DBTREE::board_set_encoding_analysis_method( get_url(), EncodingAnalysisMethod::use_default );

--- a/src/board/preference.h
+++ b/src/board/preference.h
@@ -98,6 +98,7 @@ namespace BOARD
         Gtk::RadioButtonGroup m_group_encoding;
         Gtk::RadioButton m_radio_encoding_default;
         Gtk::RadioButton m_radio_encoding_http_header;
+        Gtk::RadioButton m_radio_encoding_guess;
 
         // ネットワーク設定
         Gtk::Box m_vbox_network;

--- a/src/jdencoding.h
+++ b/src/jdencoding.h
@@ -30,7 +30,8 @@ struct EncodingAnalysisMethod
 {
     static constexpr const int use_default = 0; ///< デフォルト設定を使う
     static constexpr const int http_header = 1; ///< HTTPヘッダーのエンコーディング情報を使う
-    static constexpr const int max = http_header;
+    static constexpr const int guess = 2; ///< テキストからエンコーディングを推測する
+    static constexpr const int max = guess;
 };
 
 #endif


### PR DESCRIPTION
### Add 'Guess encoding from text' option to board properties
板のプロパティにあるエンコーディングを判定する方法に「テキストからエンコーディングを推測する」オプションを追加します。
このオプションはユーザーがテキストエンコーディングを選択する設定が有効のときは利用できません。
    
このオプションは実験的なサポートのため変更または廃止の可能性があります。

### Loadable: Implement 'Guess encoding from text' behavior mode
板やスレを読み込むときに行うテキストエンコーディング変換に「テキストからエンコーディングを推測する」モードを実装します。
    
このモードは板のプロパティのエンコーディングを判定する方法にある「テキストからエンコーディングを推測する」オプションを選択しているときに使用されます。
エンコーディングを推測した結果が正しいとは限らないため利用の際は注意してください。

関連のissue: #1265
