### PR TITLE
Add abone setting for consecutive posts to board preferences

### DIFF
--- a/src/article/preference.cpp
+++ b/src/article/preference.cpp
@@ -224,7 +224,12 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
         m_edit_regex.set_editable( false );
     }
 
-    m_label_abone_id.set_text( "ここでIDを削除してもレスが表示されない場合は板全体に対してIDがあぼーん指定されている可能性があります。\n板のプロパティのあぼーん設定も確認してください。" );
+    m_label_abone_id.set_text(
+        "ここでIDを削除してもレスが表示されない場合は板全体に対してIDがあぼーん指定されている可能性があります。\n"
+        "板のプロパティのあぼーん設定も確認してください。\n"
+        "連続投稿したIDをあぼーんする設定が優先されるためIDを削除しても再び登録されることがあります。"
+        );
+
     m_vbox_abone.set_spacing( 8 );
     m_vbox_abone_id.pack_start( m_label_abone_id, Gtk::PACK_SHRINK );
     m_vbox_abone_id.pack_start( m_edit_id );

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -405,6 +405,8 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     m_spin_abone_consecutive.set_increments( 1, 1 );
     m_spin_abone_consecutive.set_sensitive( true );
     m_spin_abone_consecutive.set_range( 0, 1000 );
+    const int abone_consecutive = DBTREE::board_get_abone_consecutive( get_url() );
+    m_spin_abone_consecutive.set_value( abone_consecutive );
 
     m_hbox_abone_consecutive.pack_start( m_label_abone_consecutive, Gtk::PACK_SHRINK );
     m_hbox_abone_consecutive.pack_start( m_spin_abone_consecutive, Gtk::PACK_SHRINK );
@@ -690,6 +692,10 @@ void Preferences::slot_ok_clicked()
     if( board_agent != DBTREE::board_get_board_agent( get_url() ) ) {
         DBTREE::board_set_board_agent( get_url(), board_agent );
     }
+
+    // 連続投稿したIDをスレのNG IDに追加 (回数)
+    const int abone_consecutive = m_spin_abone_consecutive.get_value_as_int();
+    DBTREE::board_set_abone_consecutive( get_url(), abone_consecutive );
 
     // あぼーん再設定
     std::list< std::string > list_id = MISC::get_lines( m_edit_id.get_text() );

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -63,6 +63,11 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     , m_label_samba( false, "書き込み規制秒数 (Samba24) ：" )
     , m_button_clearsamba( "秒数クリア" )
     , m_check_oldlog( "過去ログを表示する" )
+    , m_vbox_abone_general{ Gtk::ORIENTATION_VERTICAL, 0 }
+    , m_sep_general{ Gtk::ORIENTATION_HORIZONTAL }
+    , m_hbox_abone_consecutive{ Gtk::ORIENTATION_HORIZONTAL, 0 }
+    , m_label_abone_consecutive{ "(実験的な機能) 連続投稿したIDをスレのNG IDに追加する (0 : 未設定)：" }
+    , m_label_abone_consecutive_over_n_times{ " 回以上" }
     , m_hbox_low_number{ Gtk::ORIENTATION_HORIZONTAL, 4 }
     , m_hbox_high_number{ Gtk::ORIENTATION_HORIZONTAL, 4 }
     , m_button_remove_old_title( "dat落ちしたスレのタイトルを削除する" )
@@ -383,12 +388,38 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     std::list< std::string > list_regex = DBTREE::get_abone_list_regex_board( get_url() );
     m_edit_regex.set_text( MISC::concat_with_suffix( list_regex, '\n' ) );
 
+    // 一般
+    m_label_warning_subject.set_markup( R"(<span size="large" weight="bold">注意</span>)" );
+    m_label_warning_subject.set_margin_top( 20 );
+    m_label_warning_subject.set_margin_bottom( 20 );
+
     m_label_warning.set_text(
         "ここでのあぼーん設定は「" +  DBTREE::board_name( get_url() ) + "」板の全スレに適用されます。\n\n"
         "設定のし過ぎは板内の全スレの表示速度を低下させます。\n\n設定のし過ぎに気を付けてください。\n\n"
         "なおNG IDはJDimを再起動するとリセットされます。" );
 
-    m_notebook_abone.append_page( m_label_warning, "注意" );
+    m_sep_general.set_margin_top( 50 );
+    m_sep_general.set_margin_bottom( 40 );
+
+    // 連続投稿したIDをスレのNG IDに追加
+    m_spin_abone_consecutive.set_increments( 1, 1 );
+    m_spin_abone_consecutive.set_sensitive( true );
+    m_spin_abone_consecutive.set_range( 0, 1000 );
+
+    m_hbox_abone_consecutive.pack_start( m_label_abone_consecutive, Gtk::PACK_SHRINK );
+    m_hbox_abone_consecutive.pack_start( m_spin_abone_consecutive, Gtk::PACK_SHRINK );
+    m_hbox_abone_consecutive.pack_start( m_label_abone_consecutive_over_n_times, Gtk::PACK_SHRINK );
+    m_hbox_abone_consecutive.set_tooltip_text(
+        "このオプションは実験的なサポートのため変更または廃止の可能性があります。" );
+
+    m_vbox_abone_general.pack_start( m_label_warning_subject, Gtk::PACK_SHRINK );
+    m_vbox_abone_general.pack_start( m_label_warning, Gtk::PACK_SHRINK );
+    m_vbox_abone_general.pack_start( m_sep_general, Gtk::PACK_SHRINK );
+    m_vbox_abone_general.pack_start( m_hbox_abone_consecutive, Gtk::PACK_SHRINK );
+    m_vbox_abone_general.set_margin_start( 20 );
+    m_vbox_abone_general.set_margin_end( 20 );
+
+    m_notebook_abone.append_page( m_vbox_abone_general, "一般" );
     m_notebook_abone.append_page( m_edit_id, "NG ID" );
     m_notebook_abone.append_page( m_edit_name, "NG 名前" );
     m_notebook_abone.append_page( m_edit_word, "NG ワード" );

--- a/src/board/preference.h
+++ b/src/board/preference.h
@@ -146,8 +146,17 @@ namespace BOARD
 
         // あぼーん
         Gtk::Notebook m_notebook_abone;
-        Gtk::Label m_label_warning;
+        Gtk::Box m_vbox_abone_general; ///< "一般"タブの要素をパックする
+        Gtk::Label m_label_warning_subject; ///< "注意"ラベル
+        Gtk::Label m_label_warning; ///< あぼーん設定の注意書き
+        Gtk::Separator m_sep_general; ///< 注意書きと設定欄の境界線
         SKELETON::EditView m_edit_id, m_edit_name, m_edit_word, m_edit_regex;
+
+        // 連続投稿したIDをスレのNG IDに追加
+        Gtk::Box m_hbox_abone_consecutive; ///< ラベルと設定欄をパックする
+        Gtk::Label m_label_abone_consecutive; ///< 設定の項目ラベル
+        Gtk::Label m_label_abone_consecutive_over_n_times; ///< 数値の単位を明示するラベル
+        Gtk::SpinButton m_spin_abone_consecutive; ///< 回数の入力欄
 
         // スレッドあぼーん
         Gtk::Notebook m_notebook_abone_thread;

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -762,6 +762,28 @@ void ArticleBase::add_abone_id( const std::string& id )
 }
 
 
+/** @brief あぼーんIDを一度に複数追加する
+ *
+ * @details URLが未設定または渡されたIDが無いときは何もしない
+ * @param[in] id_span あぼーんするID
+ */
+void ArticleBase::add_abone_id_span( JDLIB::span<const char*> id_span )
+{
+    if( empty() ) return;
+    if( id_span.empty() ) return;
+
+#ifdef _DEBUG
+    std::cout << "ArticleBase::add_abone_id_span : " << id_span.size() << std::endl;
+#endif
+
+    std::copy( id_span.begin(), id_span.end(), std::back_inserter( m_list_abone_id ) );
+
+    update_abone();
+
+    m_save_info = true;
+}
+
+
 //
 // あぼーん名前追加
 //

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -11,6 +11,7 @@
 
 #include "jdencoding.h"
 
+#include "jdlib/span.h"
 #include "skeleton/lockable.h"
 
 #include <ctime>
@@ -374,6 +375,7 @@ namespace DBTREE
 
         // あぼ〜ん状態更新(reset_abone()と違って各項目ごと個別におこなう)
         void add_abone_id( const std::string& id );
+        void add_abone_id_span( JDLIB::span<const char*> id_span );
         void add_abone_name( const std::string& name );
         void add_abone_word( const std::string& word );
         void set_abone_res( const int num_from, const int num_to, const bool set );

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -2092,6 +2092,9 @@ void BoardBase::read_board_info()
     // テキストエンコーディングを判定する方法
     m_encoding_analysis_method = cf.get_option_int( "encoding_analysis_method", 0, 0, EncodingAnalysisMethod::max );
 
+    // 連続投稿したIDをスレのNG IDに追加 (回数)
+    m_abone_consecutive = cf.get_option_int( "abone_consecutive", 0, 0, 1000 );
+
 #ifdef _DEBUG
     std::cout << "modified = " << get_date_modified() << std::endl;
 #endif
@@ -2185,7 +2188,8 @@ void BoardBase::save_jdboard_info()
          << "status = " << m_status << std::endl
          << "max_res = " << m_number_max_res << std::endl
          << "user_agent = " << m_board_agent << std::endl
-         << "encoding_analysis_method = " << m_encoding_analysis_method << std::endl;
+         << "encoding_analysis_method = " << m_encoding_analysis_method << std::endl
+         << "abone_consecutive = " << m_abone_consecutive << std::endl;
     ;
 
     CACHE::save_rawdata( path_info, sstr.str() );

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -221,6 +221,9 @@ namespace DBTREE
         /// テキストエンコーディングを判定する方法
         int m_encoding_analysis_method{};
 
+        /// 連続投稿したIDをスレのNG IDに追加 (回数)
+        int m_abone_consecutive{};
+
       protected:
 
         ARTICLE_INFO_LIST& get_list_artinfo(){ return m_list_artinfo; }
@@ -601,6 +604,10 @@ namespace DBTREE
         // テキストエンコーディングを判定する方法
         int get_encoding_analysis_method() const noexcept { return m_encoding_analysis_method; }
         void set_encoding_analysis_method( int meth ) { m_encoding_analysis_method = meth; }
+
+        // 連続投稿したIDをスレのNG IDに追加 (回数)
+        int get_abone_consecutive() const noexcept { return m_abone_consecutive; }
+        void set_abone_consecutive( const int count ) { m_abone_consecutive = count; }
 
       private:
 

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -1345,6 +1345,13 @@ void DBTREE::add_abone_id( const std::string& url, const std::string& id )
 }
 
 
+/// @brief あぼーんIDを一度に複数追加する
+void DBTREE::add_abone_id_span( const std::string& url, JDLIB::span<const char*> id_span )
+{
+    DBTREE::get_article( url )->add_abone_id_span( id_span );
+}
+
+
 void DBTREE::add_abone_name( const std::string& url, const std::string& name )
 {
     DBTREE::get_article( url )->add_abone_name( name );

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -748,6 +748,17 @@ void DBTREE::board_set_encoding_analysis_method( const std::string& url, const i
     DBTREE::get_board( url )->set_encoding_analysis_method( meth );
 }
 
+// 連続投稿したIDをスレのNG IDに追加 (回数)
+int DBTREE::board_get_abone_consecutive( const std::string& url )
+{
+    return DBTREE::get_board( url )->get_abone_consecutive();
+}
+
+void DBTREE::board_set_abone_consecutive( const std::string& url, const int count )
+{
+    DBTREE::get_board( url )->set_abone_consecutive( count );
+}
+
 
 /////////////////////////////////////////////////
 

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -205,6 +205,10 @@ namespace DBTREE
     int board_encoding_analysis_method( const std::string& url );
     void board_set_encoding_analysis_method( const std::string& url, const int meth );
 
+    // 連続投稿したIDをスレのNG IDに追加 (回数)
+    int board_get_abone_consecutive( const std::string& url );
+    void board_set_abone_consecutive( const std::string& url, const int count );
+
     // 全スレの書き込み履歴のリセット
     void clear_all_post_history();
 

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -10,6 +10,8 @@
 #include "etcboardinfo.h"
 #include "jdencoding.h"
 
+#include "jdlib/span.h"
+
 #include <atomic>
 #include <ctime>
 #include <list>
@@ -419,6 +421,7 @@ namespace DBTREE
     // 個別のあぼーん情報のセットと更新
     void set_abone_res( const std::string& url, const int num_from, const int num_to, const bool set );
     void add_abone_id( const std::string& url, const std::string& id );
+    void add_abone_id_span( const std::string& url, JDLIB::span<const char*> id_span );
     void add_abone_name( const std::string& url, const std::string& name );
     void add_abone_word( const std::string& url, const std::string& word );
 

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -81,6 +81,12 @@ namespace DBTREE
         // 発言数で色を変える回数
         int m_num_id[ LINK_NUM ];
 
+        // 連続投稿したIDをスレのNG IDに追加 (回数)
+        int m_abone_consecutive{}; ///< あぼーんにする連続投稿回数
+        int m_consecutive_count{}; ///< 連続投稿した回数をカウントする
+        const char* m_prev_link_id{}; ///< 前のレスのIDを保持して比較する
+        std::vector<const char*> m_vec_abone_consecutive; ///< スレのNG IDに追加するIDを一時保存しておく
+
         // あぼーん情報
         // 実体は親のarticlebaseクラスが持っていてcopy_abone_info()でコピーする
         std::list< std::string > m_list_abone_id;   // あぼーんするID


### PR DESCRIPTION
### Add abone setting for consecutive posts to board preferences
板のプロパティにある「あぼ〜ん設定(スレビュー)」タブにある「注意」タブを「一般」タブに名称変更します。
その中に「連続投稿したIDをスレのNG IDに追加する」を追加してあぼ〜んにする連続投稿回数を設定できるようにします。
設定可能な値は 0(未設定) から 1000 までの範囲で初期設定は 0 です。

#### 注意
- 連続投稿したIDをあぼーんする設定が優先されるためスレのプロパティにあるNG IDからIDを削除しても再び登録されることがあります。
- このオプションは実験的なサポートのため変更または廃止の可能性があります。

### BoardBase: Implement abone_consecutive setting
板の設定「連続投稿したIDをスレのNG IDに追加」の設定値を保存する処理を追加します。また、板のプロパティの設定欄に値を反映するように実装します。

#### 設定の場所を板にした理由
全体設定は影響が大きく使い勝手の悪さが予測されるため実装しません。
スレ主(>>1)が作品を連続投稿していくスレなどあぼーんが不適切な状況があります。

スレ設定は使いどころがあるかもしれませんが需要が不明なため見送ります。

### Implement adding consecutive post IDs to thread's NG ID list
連続投稿したIDをスレのNG IDに追加する処理を実装します。
実験的な機能の影響範囲を小さくするためこの修正では板のNG IDに追加しません。

Closes #1278
