### PR TITLE
Fix compiler warnings for -Wanon-enum-enum-conversion

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -6,9 +6,9 @@
 #include <string>
 
 
+static constexpr const int TIMER_TIMEOUT = 50; ///< msec  内部クロックの周期
 enum{
 
-    TIMER_TIMEOUT = 50, // msec  内部クロックの周期
     TIMER_TIMEOUT_SMOOTH_SCROLL = 33, // msec  スレビューのスムーススクロール描画用クロック周期
 
     MAX_MG_LNG = 5,  // マウスジェスチャの最大ストローク


### PR DESCRIPTION
異なる列挙型の値で算術演算しているとコンパイラーの警告で指摘されたためconstexpr定数に変更して修正します。

clang-16のレポート
```
/home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/image/imageview.cpp:181:55: warning: arithmetic between different enumeration types ('(unnamed enum at /home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/image/imageview.cpp:38:1)' and '(unnamed enum at ../src/global.h:9:1)') [-Wanon-enum-enum-conversion]
            if( m_redraw_count >= ( IMGWIN_REDRAWTIME / TIMER_TIMEOUT ) ) {
                                    ~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~
/home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/message/messageviewbase.cpp:145:36: warning: arithmetic between different enumeration types ('(unnamed enum at /home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/message/messageviewbase.cpp:48:1)' and '(unnamed enum at ../src/global.h:9:1)') [-Wanon-enum-enum-conversion]
    if( m_counter % ( PASS_TIMEOUT / TIMER_TIMEOUT ) == 0 ){
                      ~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~
/home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/board/boardviewbase.cpp:2557:47: warning: arithmetic between different enumeration types ('(unnamed enum at /home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/board/boardviewbase.cpp:50:1)' and '(unnamed enum at ../src/global.h:9:1)') [-Wanon-enum-enum-conversion]
    m_cancel_openrow_counter = CANCEL_OPENROW / TIMER_TIMEOUT;
                               ~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~
/home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/article/articleview.cpp:400:49: warning: arithmetic between different enumeration types ('(unnamed enum at /home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/article/articleview.cpp:39:1)' and '(unnamed enum at ../src/global.h:9:1)') [-Wanon-enum-enum-conversion]
        m_cancel_reload_counter = CANCEL_RELOAD / TIMER_TIMEOUT;
                                  ~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~
/home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/skeleton/edittreeview.cpp:220:45: warning: arithmetic between different enumeration types ('(unnamed enum at /home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/skeleton/edittreeview.cpp:31:1)' and '(unnamed enum at ../src/global.h:9:1)') [-Wanon-enum-enum-conversion]
        if( m_dnd_counter >= DNDSCROLLSPEED / TIMER_TIMEOUT ){
                             ~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~
/home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/skeleton/window.cpp:186:50: warning: arithmetic between different enumeration types ('(unnamed enum at /home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/skeleton/window.cpp:18:1)' and '(unnamed enum at ../src/global.h:9:1)') [-Wanon-enum-enum-conversion]
            constexpr int waitcount = FOCUS_TIME / TIMER_TIMEOUT;
                                      ~~~~~~~~~~ ^ ~~~~~~~~~~~~~
/home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/skeleton/window.cpp:206:41: warning: arithmetic between different enumeration types ('(unnamed enum at /home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/skeleton/window.cpp:18:1)' and '(unnamed enum at ../src/global.h:9:1)') [-Wanon-enum-enum-conversion]
            if( m_counter > UNGRAB_TIME / TIMER_TIMEOUT ){
                            ~~~~~~~~~~~ ^ ~~~~~~~~~~~~~
/home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/skeleton/window.cpp:232:56: warning: arithmetic between different enumeration types ('(unnamed enum at /home/ma8ma/var/repos/worktree/jdim-charlie/weverythingclang16-unity1k/../src/skeleton/window.cpp:18:1)' and '(unnamed enum at ../src/global.h:9:1)') [-Wanon-enum-enum-conversion]
            constexpr int waitcount = FOCUSOUT_TIMEOUT / TIMER_TIMEOUT;
                                      ~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~
```
