### PR TITLE
Fix compiler warnings for -Wenum-float-conversion

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -54,10 +54,11 @@
 
 using namespace ARTICLE;
 
+
+static constexpr int AUTOSCR_CIRCLE = 24; ///< オートスクロールの時のサークルの大きさ
+
 enum
 {
-    AUTOSCR_CIRCLE = 24, // オートスクロールの時のサークルの大きさ
-
     BIG_HEIGHT = 100000000,
 
     LAYOUT_MIN_HEIGHT = 2, // viewの高さがこの値よりも小さい時はリサイズしていないと考える

--- a/src/global.h
+++ b/src/global.h
@@ -12,9 +12,9 @@ enum{
     TIMER_TIMEOUT_SMOOTH_SCROLL = 33, // msec  スレビューのスムーススクロール描画用クロック周期
 
     MAX_MG_LNG = 5,  // マウスジェスチャの最大ストローク
-
-    ICON_SIZE = 32 // 画像アイコンの大きさ
 };
+
+static constexpr const int ICON_SIZE = 32; // 画像アイコンの大きさ
 
 
 // 書き込みビューの名前欄の空白


### PR DESCRIPTION
無名列挙型の値がdobule型の変数と算術演算しているとコンパイラーの警告で指摘されたためconstexpr定数に変更して修正します。

clang-17のレポート
```
src/image/imageadmin.cpp:978:41: warning: compound assignment of floating-point type 'double' from enumeration type '(unnamed enum at ../src/global.h:10:1)' [-Wenum-float-conversion]
  978 |         if( scroll == SCROLL_LEFT ) pos -= ICON_SIZE;
      |                                     ~~~ ^  ~~~~~~~~~
src/image/imageadmin.cpp:979:18: warning: compound assignment of floating-point type 'double' from enumeration type '(unnamed enum at ../src/global.h:10:1)' [-Wenum-float-conversion]
  979 |         else pos += ICON_SIZE;
      |              ~~~ ^  ~~~~~~~~~
src/article/drawareabase.cpp:2305:47: warning: arithmetic between enumeration type '(unnamed enum at /home/ma8ma/var/repos/JDim/weverythingclang17-unity/../src/article/drawareabase.cpp:57:1)' and floating-point type 'double' [-Wenum-float-conversion]
 2305 |     constexpr const double r = AUTOSCR_CIRCLE / 2.0;
      |                                ~~~~~~~~~~~~~~ ^ ~~~
```
