### PR TITLE
Fix compiler warning for -Wdeprecated-redundant-constexpr-static-def

### DIFF
--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -32,8 +32,6 @@
 using namespace SKELETON;
 
 
-constexpr const char* DragTreeView::s_css_classname;
-
 DragTreeView::DragTreeView( const std::string& url, const std::string& dndtarget,
     const bool use_usr_fontcolor, const std::string& fontname, const int colorid_text, const int colorid_bg, const int colorid_bg_even )
     : JDTreeViewBase()

--- a/src/skeleton/editview.cpp
+++ b/src/skeleton/editview.cpp
@@ -780,8 +780,6 @@ EditView::EditView()
 EditView::~EditView() noexcept = default;
 
 
-constexpr const char* EditView::s_css_classname;
-
 //
 // EditTextViewのスタイルを更新する
 //

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -30,8 +30,6 @@
 using namespace SKELETON;
 
 
-constexpr const char* ToolBar::s_css_label;
-
 ToolBar::ToolBar( Admin* admin )
     : m_admin( admin )
     , m_enable_slot{ true }

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -46,7 +46,6 @@ enum
 
 using namespace SKELETON;
 
-constexpr const char* JDWindow::s_css_stat_label;
 
 // メッセージウィンドウでは m_mginfo が不要なので need_mginfo = false になる
 JDWindow::JDWindow( const bool fold_when_focusout, const bool need_mginfo )


### PR DESCRIPTION
C++17からinline変数が導入されたことによりクラスのconstepxr staticメンバー変数のout-of-line定義が重複になり廃止予定になったとコンパイラーに指摘されたため取り除きます。

clang-17のレポート
```
src/skeleton/dragtreeview.cpp:35:37: warning: out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated [-Wdeprecated-redundant-constexpr-static-def]
   35 | constexpr const char* DragTreeView::s_css_classname;
      |                                     ^
src/skeleton/editview.cpp:783:33: warning: out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated [-Wdeprecated-redundant-constexpr-static-def]
  783 | constexpr const char* EditView::s_css_classname;
      |                                 ^
src/skeleton/toolbar.cpp:33:32: warning: out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated [-Wdeprecated-redundant-constexpr-static-def]
   33 | constexpr const char* ToolBar::s_css_label;
      |                                ^
src/skeleton/window.cpp:49:33: warning: out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated [-Wdeprecated-redundant-constexpr-static-def]
   49 | constexpr const char* JDWindow::s_css_stat_label;
      |                                 ^
```
