### PR TITLE
Fix compiler warnings for -Wmissing-variable-declarations part1

### DIFF
--- a/src/aamanager.cpp
+++ b/src/aamanager.cpp
@@ -14,7 +14,9 @@
 #include "cache.h"
 #include "type.h"
 
-CORE::AAManager* instance_aamanager = nullptr;
+
+static CORE::AAManager* instance_aamanager = nullptr;
+
 
 CORE::AAManager* CORE::get_aamanager()
 {

--- a/src/article/articleadmin.cpp
+++ b/src/article/articleadmin.cpp
@@ -33,7 +33,9 @@
 #include "config/globalconf.h"
 #include "dndmanager.h"
 
-ARTICLE::ArticleAdmin *instance_articleadmin = nullptr;
+
+static ARTICLE::ArticleAdmin *instance_articleadmin = nullptr;
+
 
 ARTICLE::ArticleAdmin* ARTICLE::get_admin()
 {

--- a/src/bbslist/bbslistadmin.cpp
+++ b/src/bbslist/bbslistadmin.cpp
@@ -18,7 +18,8 @@
 
 
 // お気に入りの共通UNDOバッファ
-SKELETON::UNDO_BUFFER *instance_undo_buffer_favorite = nullptr;
+static SKELETON::UNDO_BUFFER *instance_undo_buffer_favorite = nullptr;
+
 
 SKELETON::UNDO_BUFFER* BBSLIST::get_undo_buffer_favorite()
 {
@@ -38,7 +39,8 @@ void BBSLIST::delete_undo_buffer_favorite()
 //////////////////////////////////////////////
 
 
-BBSLIST::BBSListAdmin *instance_bbslistadmin = nullptr;
+static BBSLIST::BBSListAdmin *instance_bbslistadmin = nullptr;
+
 
 BBSLIST::BBSListAdmin* BBSLIST::get_admin()
 {

--- a/src/board/boardadmin.cpp
+++ b/src/board/boardadmin.cpp
@@ -29,8 +29,8 @@
 #include "dndmanager.h"
 
 
+static BOARD::BoardAdmin *instance_boardadmin = nullptr;
 
-BOARD::BoardAdmin *instance_boardadmin = nullptr;
 
 BOARD::BoardAdmin* BOARD::get_admin()
 {

--- a/src/compmanager.cpp
+++ b/src/compmanager.cpp
@@ -15,7 +15,8 @@ enum
     MAX_COMPLETION = 50
 };
 
-CORE::Completion_Manager* instance_completion_manager = nullptr;
+
+static CORE::Completion_Manager* instance_completion_manager = nullptr;
 
 
 CORE::Completion_Manager* CORE::get_completion_manager()

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -13,8 +13,8 @@
 #include "jdlib/miscutil.h"
 
 
-CONFIG::ConfigItems* instance_confitem = nullptr;
-CONFIG::ConfigItems* instance_confitem_bkup = nullptr;
+static CONFIG::ConfigItems* instance_confitem = nullptr;
+static CONFIG::ConfigItems* instance_confitem_bkup = nullptr;
 
 
 CONFIG::ConfigItems* CONFIG::get_confitem()

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -64,7 +64,7 @@
 using namespace CORE;
 
 
-Core* instance_core;
+static Core* instance_core;
 
 
 Core* CORE::get_instance()

--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -22,7 +22,8 @@ enum
     SIZE_OF_HEAP = 16 * 1024
 };
 
-CORE::Css_Manager* instance_css_manager = nullptr;
+
+static CORE::Css_Manager* instance_css_manager = nullptr;
 
 
 CORE::Css_Manager* CORE::get_css_manager()

--- a/src/dbimg/imginterface.cpp
+++ b/src/dbimg/imginterface.cpp
@@ -12,7 +12,7 @@
 
 
 // インスタンスは Core でひとつだけ作って、Coreのデストラクタでdeleteする
-DBIMG::ImgRoot *instance_dbimg_root = nullptr;
+static DBIMG::ImgRoot *instance_dbimg_root = nullptr;
 
 
 void DBIMG::create_root()

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -12,8 +12,9 @@
 
 #include "global.h"
 
+
 // インスタンスは Core でひとつだけ作って、Coreのデストラクタでdeleteする
-DBTREE::Root *instance_dbtree_root = nullptr;
+static DBTREE::Root *instance_dbtree_root = nullptr;
 
 
 void DBTREE::create_root()

--- a/src/dispatchmanager.cpp
+++ b/src/dispatchmanager.cpp
@@ -12,7 +12,7 @@
 
 
 static std::mutex dispatch_mutex;
-CORE::DispatchManager* instance_dispmanager = nullptr;
+static CORE::DispatchManager* instance_dispmanager = nullptr;
 
 
 CORE::DispatchManager* CORE::get_dispmanager()

--- a/src/dndmanager.cpp
+++ b/src/dndmanager.cpp
@@ -5,7 +5,7 @@
 #include "dndmanager.h"
 
 
-CORE::DND_Manager* instance_dnd_manager = nullptr;
+static CORE::DND_Manager* instance_dnd_manager = nullptr;
 
 
 CORE::DND_Manager* CORE::get_dnd_manager()

--- a/src/history/historymanager.cpp
+++ b/src/history/historymanager.cpp
@@ -21,7 +21,7 @@
 #include "global.h"
 
 
-HISTORY::History_Manager* instance_history_manager = nullptr;
+static HISTORY::History_Manager* instance_history_manager = nullptr;
 
 
 HISTORY::History_Manager* HISTORY::get_history_manager()

--- a/src/icons/iconmanager.cpp
+++ b/src/icons/iconmanager.cpp
@@ -53,7 +53,7 @@
 #include "info.h"
 
 
-ICON::ICON_Manager* instance_icon_manager = nullptr;
+static ICON::ICON_Manager* instance_icon_manager = nullptr;
 
 
 ICON::ICON_Manager* ICON::get_icon_manager()

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -28,7 +28,8 @@
 #include <limits>
 
 
-IMAGE::ImageAdmin *instance_imageadmin = nullptr;
+static IMAGE::ImageAdmin *instance_imageadmin = nullptr;
+
 
 IMAGE::ImageAdmin* IMAGE::get_admin()
 {

--- a/src/linkfiltermanager.cpp
+++ b/src/linkfiltermanager.cpp
@@ -17,7 +17,9 @@
 
 #define ROOT_NODE_NAME_LINKFILTER "linkfilterlist"
 
-CORE::Linkfilter_Manager* instance_linkfilter_manager = nullptr;
+
+static CORE::Linkfilter_Manager* instance_linkfilter_manager = nullptr;
+
 
 CORE::Linkfilter_Manager* CORE::get_linkfilter_manager()
 {

--- a/src/login2ch.cpp
+++ b/src/login2ch.cpp
@@ -26,7 +26,8 @@ constexpr std::size_t kSizeOfRawData = 64 * 1024;
 #endif
 
 
-CORE::Login2ch* instance_login2ch = nullptr;
+static CORE::Login2ch* instance_login2ch = nullptr;
+
 
 CORE::Login2ch* CORE::get_login2ch()
 {

--- a/src/loginbe.cpp
+++ b/src/loginbe.cpp
@@ -23,7 +23,8 @@ constexpr std::size_t kSizeOfRawData = 64 * 1024;
 }
 
 
-CORE::LoginBe* instance_loginbe = nullptr;
+static CORE::LoginBe* instance_loginbe = nullptr;
+
 
 CORE::LoginBe* CORE::get_loginbe()
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,8 +38,7 @@ struct XSMPDATA
 #endif
 
 
-JDWinMain* Win_Main = nullptr;
-
+static JDWinMain* Win_Main = nullptr;
 
 
 // SIGINTのハンドラ

--- a/src/message/logmanager.cpp
+++ b/src/message/logmanager.cpp
@@ -29,7 +29,8 @@ enum
 };
 
 
-MESSAGE::Log_Manager* instance_log_manager = nullptr;
+static MESSAGE::Log_Manager* instance_log_manager = nullptr;
+
 
 MESSAGE::Log_Manager* MESSAGE::get_log_manager()
 {

--- a/src/message/messageadmin.cpp
+++ b/src/message/messageadmin.cpp
@@ -21,7 +21,9 @@
 #include "global.h"
 #include "session.h"
 
-MESSAGE::MessageAdmin* instance_messageadmin = nullptr;
+
+static MESSAGE::MessageAdmin* instance_messageadmin = nullptr;
+
 
 MESSAGE::MessageAdmin* MESSAGE::get_admin()
 {

--- a/src/searchmanager.cpp
+++ b/src/searchmanager.cpp
@@ -18,7 +18,8 @@
 #include <system_error>
 
 
-CORE::Search_Manager* instance_search_manager = nullptr;
+static CORE::Search_Manager* instance_search_manager = nullptr;
+
 
 CORE::Search_Manager* CORE::get_search_manager()
 {

--- a/src/sound/soundmanager.cpp
+++ b/src/sound/soundmanager.cpp
@@ -7,7 +7,9 @@
 
 #include "cache.h"
 
-SOUND::SOUND_Manager* instance_sound_manager = nullptr;
+
+static SOUND::SOUND_Manager* instance_sound_manager = nullptr;
+
 
 SOUND::SOUND_Manager* SOUND::get_sound_manager()
 {

--- a/src/updatemanager.cpp
+++ b/src/updatemanager.cpp
@@ -12,7 +12,8 @@
 
 #include <algorithm>
 
-CORE::CheckUpdate_Manager* instance_checkupdate_manager = nullptr;
+
+static CORE::CheckUpdate_Manager* instance_checkupdate_manager = nullptr;
 
 
 CORE::CheckUpdate_Manager* CORE::get_checkupdate_manager()

--- a/src/urlreplacemanager.cpp
+++ b/src/urlreplacemanager.cpp
@@ -13,7 +13,8 @@
 #include <list>
 
 
-CORE::Urlreplace_Manager* instance_urlreplace_manager = nullptr;
+static CORE::Urlreplace_Manager* instance_urlreplace_manager = nullptr;
+
 
 CORE::Urlreplace_Manager* CORE::get_urlreplace_manager()
 {

--- a/src/usrcmdmanager.cpp
+++ b/src/usrcmdmanager.cpp
@@ -23,7 +23,9 @@
 
 #include "config/globalconf.h"
 
-CORE::Usrcmd_Manager* instance_usrcmd_manager = nullptr;
+
+static CORE::Usrcmd_Manager* instance_usrcmd_manager = nullptr;
+
 
 CORE::Usrcmd_Manager* CORE::get_usrcmd_manager()
 {


### PR DESCRIPTION
静的でないグローバル変数に変数宣言がないとコンパイラーに指摘されたため静的変数に変更してコンパイラー警告を修正します。

clang-17のレポート (file pathを一部省略)
```
src/aamanager.cpp:17:18: warning: no previous extern declaration for non-static variable 'instance_aamanager' [-Wmissing-variable-declarations]
src/article/articleadmin.cpp:36:24: warning: no previous extern declaration for non-static variable 'instance_articleadmin' [-Wmissing-variable-declarations]
src/bbslist/bbslistadmin.cpp:21:24: warning: no previous extern declaration for non-static variable 'instance_undo_buffer_favorite' [-Wmissing-variable-declarations]
src/bbslist/bbslistadmin.cpp:41:24: warning: no previous extern declaration for non-static variable 'instance_bbslistadmin' [-Wmissing-variable-declarations]
src/board/boardadmin.cpp:33:20: warning: no previous extern declaration for non-static variable 'instance_boardadmin' [-Wmissing-variable-declarations]
src/compmanager.cpp:18:27: warning: no previous extern declaration for non-static variable 'instance_completion_manager' [-Wmissing-variable-declarations]
src/config/globalconf.cpp:16:22: warning: no previous extern declaration for non-static variable 'instance_confitem' [-Wmissing-variable-declarations]
src/config/globalconf.cpp:17:22: warning: no previous extern declaration for non-static variable 'instance_confitem_bkup' [-Wmissing-variable-declarations]
src/core.cpp:67:7: warning: no previous extern declaration for non-static variable 'instance_core' [-Wmissing-variable-declarations]
src/cssmanager.cpp:25:20: warning: no previous extern declaration for non-static variable 'instance_css_manager' [-Wmissing-variable-declarations]
src/dbimg/imginterface.cpp:15:17: warning: no previous extern declaration for non-static variable 'instance_dbimg_root' [-Wmissing-variable-declarations]
src/dbtree/interface.cpp:16:15: warning: no previous extern declaration for non-static variable 'instance_dbtree_root' [-Wmissing-variable-declarations]
src/dispatchmanager.cpp:15:24: warning: no previous extern declaration for non-static variable 'instance_dispmanager' [-Wmissing-variable-declarations]
src/dndmanager.cpp:8:20: warning: no previous extern declaration for non-static variable 'instance_dnd_manager' [-Wmissing-variable-declarations]
src/history/historymanager.cpp:24:27: warning: no previous extern declaration for non-static variable 'instance_history_manager' [-Wmissing-variable-declarations]
src/icons/iconmanager.cpp:56:21: warning: no previous extern declaration for non-static variable 'instance_icon_manager' [-Wmissing-variable-declarations]
src/image/imageadmin.cpp:31:20: warning: no previous extern declaration for non-static variable 'instance_imageadmin' [-Wmissing-variable-declarations]
src/linkfiltermanager.cpp:20:27: warning: no previous extern declaration for non-static variable 'instance_linkfilter_manager' [-Wmissing-variable-declarations]
src/login2ch.cpp:29:17: warning: no previous extern declaration for non-static variable 'instance_login2ch' [-Wmissing-variable-declarations]
src/loginbe.cpp:26:16: warning: no previous extern declaration for non-static variable 'instance_loginbe' [-Wmissing-variable-declarations]
src/main.cpp:41:12: warning: no previous extern declaration for non-static variable 'Win_Main' [-Wmissing-variable-declarations]
src/message/logmanager.cpp:32:23: warning: no previous extern declaration for non-static variable 'instance_log_manager' [-Wmissing-variable-declarations]
src/message/messageadmin.cpp:24:24: warning: no previous extern declaration for non-static variable 'instance_messageadmin' [-Wmissing-variable-declarations]
src/searchmanager.cpp:21:23: warning: no previous extern declaration for non-static variable 'instance_search_manager' [-Wmissing-variable-declarations]
src/sound/soundmanager.cpp:10:23: warning: no previous extern declaration for non-static variable 'instance_sound_manager' [-Wmissing-variable-declarations]
src/updatemanager.cpp:15:28: warning: no previous extern declaration for non-static variable 'instance_checkupdate_manager' [-Wmissing-variable-declarations]
src/urlreplacemanager.cpp:16:27: warning: no previous extern declaration for non-static variable 'instance_urlreplace_manager' [-Wmissing-variable-declarations]
src/usrcmdmanager.cpp:26:23: warning: no previous extern declaration for non-static variable 'instance_usrcmd_manager' [-Wmissing-variable-declarations]
```
