### PR TITLE
Fix compiler warning for -Wdeprecated-copy-with-dtor

### DIFF
--- a/src/article/caret.h
+++ b/src/article/caret.h
@@ -18,8 +18,7 @@ namespace ARTICLE
         LAYOUT* layout{}; // キャレットの属するレイアウトノードへのポインタ
         long byte{}; // 何バイト目の文字の「前」か
 
-        CARET_POSITION() noexcept = default;
-        ~CARET_POSITION() noexcept = default;
+        // リソース管理は行わないのでコンストラクタ、デストラクタ、コピー演算子は暗黙に実装する
 
         // キャレット座標計算関数
         void set( LAYOUT* _layout, long _byte,


### PR DESCRIPTION
ユーザー定義のデストラクタを持つクラスはコピーコンストラクタを暗黙的に生成するのは非推奨とコンパイラーに指摘されたため修正します。

メンバー変数は[基本型(fundamental types)][1]のみのでリソース管理を行わないのでコンストラクタ、デストラクタを削除して暗黙の生成に変更します。

[1]: https://en.cppreference.com/w/cpp/language/types

clang-17のレポート (file pathを一部省略)
```
src/article/caret.h:22:9: warning: definition of implicit copy assignment operator for 'CARET_POSITION' is deprecated because it has a user-declared destructor [-Wdeprecated-copy-with-dtor]
   22 |         ~CARET_POSITION() noexcept = default;
      |         ^
```
