### PR TITLE
Fix compiler warnings for -Wswitch-enum

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -2429,6 +2429,7 @@ void ArticleViewBase::slot_on_url( const std::string& url, const std::string& im
                     status_url = tmp;
                     break;
 
+                case Encoding::unknown: // suppress -Wswitch-enum
                 default:
 
                     status_url = url;

--- a/src/jdlib/jdsocket.cpp
+++ b/src/jdlib/jdsocket.cpp
@@ -277,6 +277,8 @@ bool Socket::socks_handshake( const std::string& hostname, const std::string& po
         *p++ = 0;
         break;
 
+    case Proxy::none: // suppress -Wswitch-enum
+    case Proxy::http:
     default:
         // XXX SOCK5未対応
         return ret;


### PR DESCRIPTION
switch文で明示的に処理されていない列挙型の値があるとコンパイラーに指摘されたため追加します。

clang-17のレポート (file pathを一部省略)
```
src/jdlib/jdsocket.cpp:252:13: warning: enumeration values 'none' and 'http' not explicitly handled in switch [-Wswitch-enum]
  252 |     switch( protocol ) {
      |             ^~~~~~~~
src/article/articleviewbase.cpp:2417:21: warning: enumeration value 'unknown' not explicitly handled in switch [-Wswitch-enum]
 2417 |             switch( enc )
      |                     ^~~
```
