### PR TITLE
Fix compiler waning for -Wmissing-noreturn

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,7 @@ static JDWinMain* Win_Main = nullptr;
 
 
 // SIGINTのハンドラ
+[[noreturn]]
 void sig_handler( int sig )
 {
     if( sig == SIGHUP || sig == SIGINT || sig == SIGQUIT ){


### PR DESCRIPTION
noreturn属性をつけることができる関数があるとコンパイラーに指摘されたため修正します。

clang-17のレポート (file pathを一部省略)
```
src/main.cpp:47:1: warning: function 'sig_handler' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
   47 | {
      | ^
```
