### PR TITLE
Root: Add test cases for is_xxx()

### DIFF
--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -198,7 +198,6 @@ namespace DBTREE
         void load_movetable();
 
         // urlのタイプ判定
-        static bool is_JBBS( const std::string& url );
         static bool is_machi( const std::string& url );
         static bool is_vip2ch( const std::string& url );
         static bool is_local( const std::string& url );
@@ -206,6 +205,7 @@ namespace DBTREE
       public:
 
         static bool is_2ch( const std::string& url );
+        static bool is_JBBS( const std::string& url );
     };
 }
 

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -198,7 +198,6 @@ namespace DBTREE
         void load_movetable();
 
         // urlのタイプ判定
-        static bool is_vip2ch( const std::string& url );
         static bool is_local( const std::string& url );
 
       public:
@@ -206,6 +205,7 @@ namespace DBTREE
         static bool is_2ch( const std::string& url );
         static bool is_JBBS( const std::string& url );
         static bool is_machi( const std::string& url );
+        static bool is_vip2ch( const std::string& url );
     };
 }
 

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -198,11 +198,14 @@ namespace DBTREE
         void load_movetable();
 
         // urlのタイプ判定
-        static bool is_2ch( const std::string& url );
         static bool is_JBBS( const std::string& url );
         static bool is_machi( const std::string& url );
         static bool is_vip2ch( const std::string& url );
         static bool is_local( const std::string& url );
+
+      public:
+
+        static bool is_2ch( const std::string& url );
     };
 }
 

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -197,15 +197,14 @@ namespace DBTREE
         void load_etc();
         void load_movetable();
 
-        // urlのタイプ判定
-        static bool is_local( const std::string& url );
-
       public:
 
+        // urlのタイプ判定
         static bool is_2ch( const std::string& url );
         static bool is_JBBS( const std::string& url );
         static bool is_machi( const std::string& url );
         static bool is_vip2ch( const std::string& url );
+        static bool is_local( const std::string& url );
     };
 }
 

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -198,7 +198,6 @@ namespace DBTREE
         void load_movetable();
 
         // urlのタイプ判定
-        static bool is_machi( const std::string& url );
         static bool is_vip2ch( const std::string& url );
         static bool is_local( const std::string& url );
 
@@ -206,6 +205,7 @@ namespace DBTREE
 
         static bool is_2ch( const std::string& url );
         static bool is_JBBS( const std::string& url );
+        static bool is_machi( const std::string& url );
     };
 }
 

--- a/test/gtest_dbtree_root.cpp
+++ b/test/gtest_dbtree_root.cpp
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "dbtree/root.h"
+
+#include "gtest/gtest.h"
+
+
+namespace {
+
+class DBTREE_Root_Is2chTest : public ::testing::Test {};
+
+TEST_F(DBTREE_Root_Is2chTest, empty_string)
+{
+    EXPECT_FALSE( DBTREE::Root::is_2ch( "" ) );
+}
+
+TEST_F(DBTREE_Root_Is2chTest, not_match_other_domains)
+{
+    EXPECT_FALSE( DBTREE::Root::is_2ch( "https://subdomain.open2ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_2ch( "https://next2ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_2ch( "http://subdomain.2ch.sc/board" ) );
+}
+
+TEST_F(DBTREE_Root_Is2chTest, not_match_2ch_without_subdomain)
+{
+    EXPECT_FALSE( DBTREE::Root::is_2ch( "http://2ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_2ch( "https://2ch.net/board" ) );
+}
+
+TEST_F(DBTREE_Root_Is2chTest, match_2ch_with_subdomain)
+{
+    EXPECT_TRUE( DBTREE::Root::is_2ch( "http://subdomain.2ch.net/board" ) );
+    EXPECT_TRUE( DBTREE::Root::is_2ch( "https://subdomain.2ch.net/board" ) );
+}
+
+TEST_F(DBTREE_Root_Is2chTest, not_match_2ch_with_info_subdomain)
+{
+    EXPECT_FALSE( DBTREE::Root::is_2ch( "http://info.2ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_2ch( "https://info.2ch.net/board" ) );
+}
+
+TEST_F(DBTREE_Root_Is2chTest, match_5ch_without_subdomain)
+{
+    EXPECT_TRUE( DBTREE::Root::is_2ch( "http://5ch.net/board" ) );
+    EXPECT_TRUE( DBTREE::Root::is_2ch( "https://5ch.net/board" ) );
+}
+
+TEST_F(DBTREE_Root_Is2chTest, match_5ch_with_subdomain)
+{
+    EXPECT_TRUE( DBTREE::Root::is_2ch( "http://subdomain.5ch.net/board" ) );
+    EXPECT_TRUE( DBTREE::Root::is_2ch( "https://subdomain.5ch.net/board" ) );
+}
+
+TEST_F(DBTREE_Root_Is2chTest, not_match_5ch_with_info_subdomain)
+{
+    EXPECT_FALSE( DBTREE::Root::is_2ch( "http://info.5ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_2ch( "https://info.5ch.net/board" ) );
+}
+
+TEST_F(DBTREE_Root_Is2chTest, not_match_bbspink_without_subdomain)
+{
+    EXPECT_FALSE( DBTREE::Root::is_2ch( "http://bbspink.com/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_2ch( "https://bbspink.com/board" ) );
+}
+
+TEST_F(DBTREE_Root_Is2chTest, match_bbspink_with_subdomain)
+{
+    EXPECT_TRUE( DBTREE::Root::is_2ch( "http://subdomain.bbspink.com/board" ) );
+    EXPECT_TRUE( DBTREE::Root::is_2ch( "https://subdomain.bbspink.com/board" ) );
+}
+
+TEST_F(DBTREE_Root_Is2chTest, match_bbspink_with_info_subdomain)
+{
+    EXPECT_TRUE( DBTREE::Root::is_2ch( "http://info.bbspink.com/board" ) );
+    EXPECT_TRUE( DBTREE::Root::is_2ch( "https://info.bbspink.com/board" ) );
+}
+
+} // namespace

--- a/test/gtest_dbtree_root.cpp
+++ b/test/gtest_dbtree_root.cpp
@@ -75,4 +75,37 @@ TEST_F(DBTREE_Root_Is2chTest, match_bbspink_with_info_subdomain)
     EXPECT_TRUE( DBTREE::Root::is_2ch( "https://info.bbspink.com/board" ) );
 }
 
+
+class DBTREE_Root_IsJBBSTest : public ::testing::Test {};
+
+TEST_F(DBTREE_Root_IsJBBSTest, empty_string)
+{
+    EXPECT_FALSE( DBTREE::Root::is_JBBS( "" ) );
+}
+
+TEST_F(DBTREE_Root_IsJBBSTest, not_match_other_domains)
+{
+    EXPECT_FALSE( DBTREE::Root::is_JBBS( "https://subdomain.2ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_JBBS( "https://5ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_JBBS( "http://subdomain.bbspink.com/board" ) );
+}
+
+TEST_F(DBTREE_Root_IsJBBSTest, match_jbbs_livedoor_jp)
+{
+    EXPECT_TRUE( DBTREE::Root::is_JBBS( "http://jbbs.livedoor.jp/board/12345" ) );
+    EXPECT_TRUE( DBTREE::Root::is_JBBS( "https://jbbs.livedoor.jp/board/67890" ) );
+}
+
+TEST_F(DBTREE_Root_IsJBBSTest, match_jbbs_shitaraba_com)
+{
+    EXPECT_TRUE( DBTREE::Root::is_JBBS( "http://jbbs.shitaraba.com/board/98765" ) );
+    EXPECT_TRUE( DBTREE::Root::is_JBBS( "https://jbbs.shitaraba.com/board/43210" ) );
+}
+
+TEST_F(DBTREE_Root_IsJBBSTest, match_jbbs_shitaraba_net)
+{
+    EXPECT_TRUE( DBTREE::Root::is_JBBS( "http://jbbs.shitaraba.net/board/13579" ) );
+    EXPECT_TRUE( DBTREE::Root::is_JBBS( "https://jbbs.shitaraba.net/board/24680" ) );
+}
+
 } // namespace

--- a/test/gtest_dbtree_root.cpp
+++ b/test/gtest_dbtree_root.cpp
@@ -162,4 +162,32 @@ TEST_F(DBTREE_Root_IsVip2chTest, match_vip2ch_com_with_subdomain)
     EXPECT_TRUE( DBTREE::Root::is_vip2ch( "https://subdomain.vip2ch.com/board" ) );
 }
 
+
+class DBTREE_Root_IsLocalTest : public ::testing::Test {};
+
+TEST_F(DBTREE_Root_IsLocalTest, empty_string)
+{
+    EXPECT_FALSE( DBTREE::Root::is_local( "" ) );
+}
+
+TEST_F(DBTREE_Root_IsLocalTest, not_match_other_domains)
+{
+    EXPECT_FALSE( DBTREE::Root::is_local( "https://subdomain.2ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_local( "https://5ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_local( "http://subdomain.bbspink.com/board" ) );
+}
+
+TEST_F(DBTREE_Root_IsLocalTest, match_file_scheme_at_head)
+{
+    EXPECT_TRUE( DBTREE::Root::is_local( "file://2ch.net/board" ) );
+    EXPECT_TRUE( DBTREE::Root::is_local( "file:///home/user/foobar" ) );
+}
+
+TEST_F(DBTREE_Root_IsLocalTest, match_file_scheme_at_middle_or_tail)
+{
+    // file:// の位置が先頭にあるかチェックしていない
+    EXPECT_TRUE( DBTREE::Root::is_local( "http://2ch.net/file://board" ) );
+    EXPECT_TRUE( DBTREE::Root::is_local( "https:://5ch.net/board/file://" ) );
+}
+
 } // namespace

--- a/test/gtest_dbtree_root.cpp
+++ b/test/gtest_dbtree_root.cpp
@@ -108,4 +108,31 @@ TEST_F(DBTREE_Root_IsJBBSTest, match_jbbs_shitaraba_net)
     EXPECT_TRUE( DBTREE::Root::is_JBBS( "https://jbbs.shitaraba.net/board/24680" ) );
 }
 
+
+class DBTREE_Root_IsMachiTest : public ::testing::Test {};
+
+TEST_F(DBTREE_Root_IsMachiTest, empty_string)
+{
+    EXPECT_FALSE( DBTREE::Root::is_machi( "" ) );
+}
+
+TEST_F(DBTREE_Root_IsMachiTest, not_match_other_domains)
+{
+    EXPECT_FALSE( DBTREE::Root::is_machi( "https://subdomain.2ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_machi( "https://5ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_machi( "http://subdomain.bbspink.com/board" ) );
+}
+
+TEST_F(DBTREE_Root_IsMachiTest, match_machi_to_without_subdomain)
+{
+    EXPECT_TRUE( DBTREE::Root::is_machi( "http://machi.to/board" ) );
+    EXPECT_TRUE( DBTREE::Root::is_machi( "https://machi.to/board" ) );
+}
+
+TEST_F(DBTREE_Root_IsMachiTest, match_machi_to_with_subdomain)
+{
+    EXPECT_TRUE( DBTREE::Root::is_machi( "http://subdomain.machi.to/board" ) );
+    EXPECT_TRUE( DBTREE::Root::is_machi( "https://subdomain.machi.to/board" ) );
+}
+
 } // namespace

--- a/test/gtest_dbtree_root.cpp
+++ b/test/gtest_dbtree_root.cpp
@@ -135,4 +135,31 @@ TEST_F(DBTREE_Root_IsMachiTest, match_machi_to_with_subdomain)
     EXPECT_TRUE( DBTREE::Root::is_machi( "https://subdomain.machi.to/board" ) );
 }
 
+
+class DBTREE_Root_IsVip2chTest : public ::testing::Test {};
+
+TEST_F(DBTREE_Root_IsVip2chTest, empty_string)
+{
+    EXPECT_FALSE( DBTREE::Root::is_vip2ch( "" ) );
+}
+
+TEST_F(DBTREE_Root_IsVip2chTest, not_match_other_domains)
+{
+    EXPECT_FALSE( DBTREE::Root::is_vip2ch( "https://subdomain.2ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_vip2ch( "https://5ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_vip2ch( "http://subdomain.bbspink.com/board" ) );
+}
+
+TEST_F(DBTREE_Root_IsVip2chTest, not_match_vip2ch_com_without_subdomain)
+{
+    EXPECT_FALSE( DBTREE::Root::is_vip2ch( "http://vip2ch.com/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_vip2ch( "https://vip2ch.com/board" ) );
+}
+
+TEST_F(DBTREE_Root_IsVip2chTest, match_vip2ch_com_with_subdomain)
+{
+    EXPECT_TRUE( DBTREE::Root::is_vip2ch( "http://subdomain.vip2ch.com/board" ) );
+    EXPECT_TRUE( DBTREE::Root::is_vip2ch( "https://subdomain.vip2ch.com/board" ) );
+}
+
 } // namespace

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,6 +1,7 @@
 # Add test code source files to following list.
 sources = [
   'gtest_dbtree_nodetreebase.cpp',
+  'gtest_dbtree_root.cpp',
   'gtest_dbtree_spchar_decoder.cpp',
   'gtest_jdlib_cookiemanager.cpp',
   'gtest_jdlib_jdiconv.cpp',


### PR DESCRIPTION
#### Add test cases for `DBTREE::Root::is_2ch()`

引数のURLドメインが2ch.net, 5ch.net, bbspink.comの掲示板であるかチェックする関数のテストを追加します。
関数はRootクラスのprivateメンバーですがテストのためpublicに変更します。
`is_2ch()`は静的メンバー関数(static)として定義されています。

#### Add test cases for `DBTREE::Root::is_JBBS()`

引数のURLドメインがしたらば掲示板であるかチェックする関数のテストを追加します。
関数はRootクラスのprivateメンバーですがテストのためpublicに変更します。
`is_JBBS()`は静的メンバー関数(static)として定義されています。

#### Add test cases for `DBTREE::Root::is_machi()`

引数のURLドメインがまちBBSの掲示板であるかチェックする関数のテストを追加します。
関数はRootクラスのprivateメンバーですがテストのためpublicに変更します。
`is_machi()`は静的メンバー関数(static)として定義されています。

#### Add test cases for `DBTREE::Root::is_vip2ch()`

引数のURLドメインがVIPサービスの掲示板であるかチェックする関数のテストを追加します。
関数はRootクラスのprivateメンバーですがテストのためpublicに変更します。
`is_vip2ch()`は静的メンバー関数(static)として定義されてます。

#### Add test cases for `DBTREE::Root::is_local()`

引数のURLスキーマがfile:スキームであるかチェックする関数のテストを追加します。
関数はRootクラスのprivateメンバーですがテストのためpublicに変更します。
`is_local()`は静的メンバー関数(static)として定義されています。
