### PR TITLE
Root: Add board types for open2ch.net and next2ch.net and 2ch.sc

### DIFF
--- a/src/dbtree/boardfactory.cpp
+++ b/src/dbtree/boardfactory.cpp
@@ -20,6 +20,7 @@ std::unique_ptr<DBTREE::BoardBase> DBTREE::BoardFactory( int type, const std::st
 
         case TYPE_BOARD_2CH_COMPATI:
         case TYPE_BOARD_OPEN2CH:
+        case TYPE_BOARD_NEXT2CH:
             return std::make_unique<Board2chCompati>( root, path_board, name, basicauth );
 
         case TYPE_BOARD_LOCAL: return std::make_unique<BoardLocal>( root, path_board, name );

--- a/src/dbtree/boardfactory.cpp
+++ b/src/dbtree/boardfactory.cpp
@@ -18,7 +18,9 @@ std::unique_ptr<DBTREE::BoardBase> DBTREE::BoardFactory( int type, const std::st
     {
         case TYPE_BOARD_2CH: return std::make_unique<Board2ch>( root, path_board, name );
 
-        case TYPE_BOARD_2CH_COMPATI: return std::make_unique<Board2chCompati>( root, path_board, name, basicauth );
+        case TYPE_BOARD_2CH_COMPATI:
+        case TYPE_BOARD_OPEN2CH:
+            return std::make_unique<Board2chCompati>( root, path_board, name, basicauth );
 
         case TYPE_BOARD_LOCAL: return std::make_unique<BoardLocal>( root, path_board, name );
 

--- a/src/dbtree/boardfactory.cpp
+++ b/src/dbtree/boardfactory.cpp
@@ -21,6 +21,7 @@ std::unique_ptr<DBTREE::BoardBase> DBTREE::BoardFactory( int type, const std::st
         case TYPE_BOARD_2CH_COMPATI:
         case TYPE_BOARD_OPEN2CH:
         case TYPE_BOARD_NEXT2CH:
+        case TYPE_BOARD_2CHSC:
             return std::make_unique<Board2chCompati>( root, path_board, name, basicauth );
 
         case TYPE_BOARD_LOCAL: return std::make_unique<BoardLocal>( root, path_board, name );

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -490,6 +490,7 @@ void Root::bbsmenu2xml( const std::string& menu )
                        && ( is_2ch( url ) || is_machi( url ) ) )
                      || is_JBBS( url )
                      || is_vip2ch( url )
+                     || is_open2ch( url )
                 ) element_name = "board";
             else element_name = "link";
 
@@ -631,7 +632,8 @@ int Root::get_board_type( const std::string& url, std::string& root, std::string
             root = regex.str( 1 );
             path_board = regex.str( 2 );
 
-            type = TYPE_BOARD_2CH_COMPATI;
+            if( is_open2ch( url ) ) type = TYPE_BOARD_OPEN2CH;
+            else type = TYPE_BOARD_2CH_COMPATI;
         }
     }
 
@@ -660,6 +662,10 @@ int Root::get_board_type( const std::string& root ) const
     else if( is_machi( root ) )
         type = TYPE_BOARD_MACHI;
 
+    // おーぷん２ちゃんねる
+    else if( is_open2ch( root ) ) {
+        type = TYPE_BOARD_OPEN2CH;
+    }
     // ローカルファイル
     else if( is_local( root ) )
         type = TYPE_BOARD_LOCAL;
@@ -1613,6 +1619,20 @@ bool Root::is_vip2ch( const std::string& url )
     if( hostname.find( ".vip2ch.com" ) != std::string::npos ) return true;
 
     return false;
+}
+
+
+/** @brief おーぷん２ちゃんねるのURLかどうか
+ *
+ * @param[in] url チェック対象
+ * @return マッチしたらtrueを返す
+ */
+bool Root::is_open2ch( std::string_view url )
+{
+    constexpr bool protocol = false;
+    const std::string hostname = MISC::get_hostname( url, protocol );
+
+    return MISC::ends_with( hostname, "open2ch.net" );
 }
 
 

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -492,6 +492,7 @@ void Root::bbsmenu2xml( const std::string& menu )
                      || is_vip2ch( url )
                      || is_open2ch( url )
                      || is_next2ch( url )
+                     || is_2chsc( url )
                 ) element_name = "board";
             else element_name = "link";
 
@@ -635,6 +636,7 @@ int Root::get_board_type( const std::string& url, std::string& root, std::string
 
             if( is_open2ch( url ) ) type = TYPE_BOARD_OPEN2CH;
             else if( is_next2ch( url ) ) type = TYPE_BOARD_NEXT2CH;
+            else if( is_2chsc( url ) ) type = TYPE_BOARD_2CHSC;
             else type = TYPE_BOARD_2CH_COMPATI;
         }
     }
@@ -671,6 +673,10 @@ int Root::get_board_type( const std::string& root ) const
     // Next2ch
     else if( is_next2ch( root ) ) {
         type = TYPE_BOARD_NEXT2CH;
+    }
+    // 2ch.sc
+    else if( is_2chsc( root ) ) {
+        type = TYPE_BOARD_2CHSC;
     }
     // ローカルファイル
     else if( is_local( root ) )
@@ -1653,6 +1659,20 @@ bool Root::is_next2ch( std::string_view url )
     const std::string hostname = MISC::get_hostname( url, protocol );
 
     return hostname == "next2ch.net";
+}
+
+
+/** @brief 2ch.scのURLかどうか
+ *
+ * @param[in] url チェック対象
+ * @return マッチしたらtrueを返す
+ */
+bool Root::is_2chsc( std::string_view url )
+{
+    constexpr bool protocol = false;
+    const std::string hostname = MISC::get_hostname( url, protocol );
+
+    return ( MISC::ends_with( hostname, "2ch.sc" ) && hostname != "info.2ch.sc" );
 }
 
 

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -491,6 +491,7 @@ void Root::bbsmenu2xml( const std::string& menu )
                      || is_JBBS( url )
                      || is_vip2ch( url )
                      || is_open2ch( url )
+                     || is_next2ch( url )
                 ) element_name = "board";
             else element_name = "link";
 
@@ -633,6 +634,7 @@ int Root::get_board_type( const std::string& url, std::string& root, std::string
             path_board = regex.str( 2 );
 
             if( is_open2ch( url ) ) type = TYPE_BOARD_OPEN2CH;
+            else if( is_next2ch( url ) ) type = TYPE_BOARD_NEXT2CH;
             else type = TYPE_BOARD_2CH_COMPATI;
         }
     }
@@ -665,6 +667,10 @@ int Root::get_board_type( const std::string& root ) const
     // おーぷん２ちゃんねる
     else if( is_open2ch( root ) ) {
         type = TYPE_BOARD_OPEN2CH;
+    }
+    // Next2ch
+    else if( is_next2ch( root ) ) {
+        type = TYPE_BOARD_NEXT2CH;
     }
     // ローカルファイル
     else if( is_local( root ) )
@@ -1633,6 +1639,20 @@ bool Root::is_open2ch( std::string_view url )
     const std::string hostname = MISC::get_hostname( url, protocol );
 
     return MISC::ends_with( hostname, "open2ch.net" );
+}
+
+
+/** @brief Next2chのURLかどうか
+ *
+ * @param[in] url チェック対象
+ * @return マッチしたらtrueを返す
+ */
+bool Root::is_next2ch( std::string_view url )
+{
+    constexpr bool protocol = false;
+    const std::string hostname = MISC::get_hostname( url, protocol );
+
+    return hostname == "next2ch.net";
 }
 
 

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -206,6 +206,7 @@ namespace DBTREE
         static bool is_vip2ch( const std::string& url );
         static bool is_open2ch( std::string_view url );
         static bool is_next2ch( std::string_view url );
+        static bool is_2chsc( std::string_view url );
         static bool is_local( const std::string& url );
     };
 }

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -205,6 +205,7 @@ namespace DBTREE
         static bool is_machi( const std::string& url );
         static bool is_vip2ch( const std::string& url );
         static bool is_open2ch( std::string_view url );
+        static bool is_next2ch( std::string_view url );
         static bool is_local( const std::string& url );
     };
 }

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -204,6 +204,7 @@ namespace DBTREE
         static bool is_JBBS( const std::string& url );
         static bool is_machi( const std::string& url );
         static bool is_vip2ch( const std::string& url );
+        static bool is_open2ch( std::string_view url );
         static bool is_local( const std::string& url );
     };
 }

--- a/src/type.h
+++ b/src/type.h
@@ -11,6 +11,7 @@ enum
     TYPE_BOARD_LOCAL,        // ローカルファイル
     TYPE_BOARD_JBBS,         // したらば
     TYPE_BOARD_MACHI,        // まち
+    TYPE_BOARD_OPEN2CH,      // おーぷん２ちゃんねる
     TYPE_BOARD_UNKNOWN,
 
     // その他一般的なデータタイプ

--- a/src/type.h
+++ b/src/type.h
@@ -13,6 +13,7 @@ enum
     TYPE_BOARD_MACHI,        // まち
     TYPE_BOARD_OPEN2CH,      // おーぷん２ちゃんねる
     TYPE_BOARD_NEXT2CH,      // Next2ch
+    TYPE_BOARD_2CHSC,        // 2ch.sc
     TYPE_BOARD_UNKNOWN,
 
     // その他一般的なデータタイプ

--- a/src/type.h
+++ b/src/type.h
@@ -12,6 +12,7 @@ enum
     TYPE_BOARD_JBBS,         // したらば
     TYPE_BOARD_MACHI,        // まち
     TYPE_BOARD_OPEN2CH,      // おーぷん２ちゃんねる
+    TYPE_BOARD_NEXT2CH,      // Next2ch
     TYPE_BOARD_UNKNOWN,
 
     // その他一般的なデータタイプ

--- a/test/gtest_dbtree_root.cpp
+++ b/test/gtest_dbtree_root.cpp
@@ -190,6 +190,33 @@ TEST_F(DBTREE_Root_IsOpen2chTest, match_open2ch_net_with_subdomain)
 }
 
 
+class DBTREE_Root_IsNext2chTest : public ::testing::Test {};
+
+TEST_F(DBTREE_Root_IsNext2chTest, empty_string)
+{
+    EXPECT_FALSE( DBTREE::Root::is_open2ch( "" ) );
+}
+
+TEST_F(DBTREE_Root_IsNext2chTest, not_match_other_domains)
+{
+    EXPECT_FALSE( DBTREE::Root::is_next2ch( "https://subdomain.2ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_next2ch( "https://5ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_next2ch( "http://subdomain.bbspink.com/board" ) );
+}
+
+TEST_F(DBTREE_Root_IsNext2chTest, not_match_next2ch_net_without_subdomain)
+{
+    EXPECT_TRUE( DBTREE::Root::is_next2ch( "http://next2ch.net/board" ) );
+    EXPECT_TRUE( DBTREE::Root::is_next2ch( "https://next2ch.net/board" ) );
+}
+
+TEST_F(DBTREE_Root_IsNext2chTest, match_next2ch_net_with_subdomain)
+{
+    EXPECT_FALSE( DBTREE::Root::is_next2ch( "http://subdomain.next2ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_next2ch( "https://subdomain.next2ch.net/board" ) );
+}
+
+
 class DBTREE_Root_IsLocalTest : public ::testing::Test {};
 
 TEST_F(DBTREE_Root_IsLocalTest, empty_string)

--- a/test/gtest_dbtree_root.cpp
+++ b/test/gtest_dbtree_root.cpp
@@ -217,6 +217,40 @@ TEST_F(DBTREE_Root_IsNext2chTest, match_next2ch_net_with_subdomain)
 }
 
 
+class DBTREE_Root_Is2chscTest : public ::testing::Test {};
+
+TEST_F(DBTREE_Root_Is2chscTest, empty_string)
+{
+    EXPECT_FALSE( DBTREE::Root::is_2chsc( "" ) );
+}
+
+TEST_F(DBTREE_Root_Is2chscTest, not_match_other_domains)
+{
+    EXPECT_FALSE( DBTREE::Root::is_2chsc( "https://subdomain.open2ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_2chsc( "https://next2ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_2chsc( "http://subdomain.2ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_2chsc( "http://subdomain.5ch.net/board" ) );
+}
+
+TEST_F(DBTREE_Root_Is2chscTest, not_match_2chsc_without_subdomain)
+{
+    EXPECT_TRUE( DBTREE::Root::is_2chsc( "http://2ch.sc/board" ) );
+    EXPECT_TRUE( DBTREE::Root::is_2chsc( "https://2ch.sc/board" ) );
+}
+
+TEST_F(DBTREE_Root_Is2chscTest, match_2chsc_with_subdomain)
+{
+    EXPECT_TRUE( DBTREE::Root::is_2chsc( "http://subdomain.2ch.sc/board" ) );
+    EXPECT_TRUE( DBTREE::Root::is_2chsc( "https://subdomain.2ch.sc/board" ) );
+}
+
+TEST_F(DBTREE_Root_Is2chscTest, not_match_2chsc_with_info_subdomain)
+{
+    EXPECT_FALSE( DBTREE::Root::is_2chsc( "http://info.2ch.sc/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_2chsc( "https://info.2ch.sc/board" ) );
+}
+
+
 class DBTREE_Root_IsLocalTest : public ::testing::Test {};
 
 TEST_F(DBTREE_Root_IsLocalTest, empty_string)

--- a/test/gtest_dbtree_root.cpp
+++ b/test/gtest_dbtree_root.cpp
@@ -163,6 +163,33 @@ TEST_F(DBTREE_Root_IsVip2chTest, match_vip2ch_com_with_subdomain)
 }
 
 
+class DBTREE_Root_IsOpen2chTest : public ::testing::Test {};
+
+TEST_F(DBTREE_Root_IsOpen2chTest, empty_string)
+{
+    EXPECT_FALSE( DBTREE::Root::is_open2ch( "" ) );
+}
+
+TEST_F(DBTREE_Root_IsOpen2chTest, not_match_other_domains)
+{
+    EXPECT_FALSE( DBTREE::Root::is_open2ch( "https://subdomain.2ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_open2ch( "https://5ch.net/board" ) );
+    EXPECT_FALSE( DBTREE::Root::is_open2ch( "http://subdomain.bbspink.com/board" ) );
+}
+
+TEST_F(DBTREE_Root_IsOpen2chTest, not_match_open2ch_net_without_subdomain)
+{
+    EXPECT_TRUE( DBTREE::Root::is_open2ch( "http://open2ch.net/board" ) );
+    EXPECT_TRUE( DBTREE::Root::is_open2ch( "https://open2ch.net/board" ) );
+}
+
+TEST_F(DBTREE_Root_IsOpen2chTest, match_open2ch_net_with_subdomain)
+{
+    EXPECT_TRUE( DBTREE::Root::is_open2ch( "http://subdomain.open2ch.net/board" ) );
+    EXPECT_TRUE( DBTREE::Root::is_open2ch( "https://subdomain.open2ch.net/board" ) );
+}
+
+
 class DBTREE_Root_IsLocalTest : public ::testing::Test {};
 
 TEST_F(DBTREE_Root_IsLocalTest, empty_string)


### PR DESCRIPTION
### Root: Add board type for open2ch.net

掲示板のURLのうち板を表す部分が5ch.netと共通するおーぷん２ちゃんねる(open2ch.net)は掲示板の種類を別のタイプに分けて板移転の対象にならないようにします。

合わせて、引数のURLドメインがおーぷん２ちゃんねるの掲示板であるかチェックする関数のテストを追加します。
`is_open2ch()`は静的メンバー関数(static)として定義されてます。

### Root: Add board type for next2ch.net

掲示板のURLのうち板を表す部分が5ch.netと共通するNext2ch(next2ch.net)は掲示板の種類を別のタイプに分けて板移転の対象にならないようにします。

合わせて、引数のURLドメインがNext2chの掲示板であるかチェックする関数のテストを追加します。
`is_next2ch()`は静的メンバー関数(static)として定義されてます。

### Root: Add board type for 2ch.sc

掲示板のURLのうち板を表す部分が5ch.netと共通する2ちゃんねる(2ch.sc)は掲示板の種類を別のタイプに分けて板移転の対象にならないようにします。

合わせて、引数のURLドメインがの2ちゃんねる(2ch.sc)掲示板であるかチェックする関数のテストを追加します。
`is_2chsc()`は静的メンバー関数(static)として定義されてます。
