### PR TITLE
config: Add include "config.h" to src/config/globalconf.h

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -48,6 +48,26 @@ jobs:
       - name: ./builddir/src/jdim -V
         run: ./builddir/src/jdim -V
 
+  Unity-build-gcc12-with-options-Werror:
+    runs-on: ubuntu-22.04
+    env:
+      CC: gcc-12
+      CXX: g++-12
+    steps:
+      - uses: actions/checkout@v3
+      - name: dependencies installation
+        run: |
+          sudo apt update
+          sudo apt install g++-12 libasound2-dev libgtest-dev libgtkmm-3.0-dev libmigemo-dev libssl-dev meson zlib1g-dev
+      - name: meson setup builddir -Dunity=on -Dunity_size=1000 -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dalsa=enabled -Dmigemo=enabled -Dtls=openssl -Dcompat_cache_dir=disabled -Dsessionlib=no -Dwerror=true
+      - run: meson setup builddir -Dunity=on -Dunity_size=1000 -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dalsa=enabled -Dmigemo=enabled -Dtls=openssl -Dcompat_cache_dir=disabled -Dsessionlib=no -Dwerror=true
+      - name: ninja -C builddir -k0
+        run: ninja -C builddir -k0
+      - name: meson test -v -C builddir
+        run: meson test -v -C builddir
+      - name: ./builddir/src/jdim -V
+        run: ./builddir/src/jdim -V
+
   muon-master:
     runs-on: ubuntu-22.04
     env:

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -6,6 +6,10 @@
 #ifndef _GLOBALCONF_H
 #define _GLOBALCONF_H
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <string>
 #include <list>
 


### PR DESCRIPTION
### config: Add include "config.h" to src/config/globalconf.h

migemoとUnity buildを組み合わせてビルドするとコンパイルエラーになる場合があったためヘッダーファイルに#includeを追加して修正します。

ninjaのエラーログ
```
In file included from src/jdim.p/jdim-unity0.cpp:42:
/home/(snip)/errdir/../src/winmain.cpp:89:29: error: ‘get_migemodict_path’ is not a member of ‘CONFIG’
  89 |     jdmigemo::init( CONFIG::get_migemodict_path() );
     |                             ^~~~~~~~~~~~~~~~~~~
In file included from test/gtest_jdim.p/gtest_jdim-unity0.cpp:42:
/home/(snip)/errdir/../src/winmain.cpp:89:29: error: ‘get_migemodict_path’ is not a member of ‘CONFIG’
  89 |     jdmigemo::init( CONFIG::get_migemodict_path() );
     |                             ^~~~~~~~~~~~~~~~~~~
```

#### 背景
`CONFIG::get_migemodict_path()`は src/config/globalconf.h の中で`HAVE_MIGEMO_H`マクロが定義されているときに宣言されます。
`HAVE_MIGEMO_H`マクロは config.h で定義されますが globalconf.h はconfig.h を含まない状態でした。
このため config.h をincludeしていない状態で globalconf.h をincludeすると`CONFIG::get_migemodict_path()`が宣言されません。

Unity buildはソースコードを結合するため、初回のinclude globalconf.hで`CONFIG::get_migemodict_path()`が宣言されないとインクルードガードの仕組みによって関数の宣言が妨げられます。

### CI: Add weekly jobs which use Unity build with build options

GitHub Actionsのworkflowにビルドオプションを切り替えて Unity buildを有効にしてビルドするjobを追加して定期的に実行します。
追加するjobはパッチをマージする要件にはしないのでPull requestを開いたときやmasterブランチにpushしたときには実行しません。

追加するjobの構成

- スケジュール: 毎週月曜日 00:00 UTC
- OS: Ubuntu 22.04
- Compiler: gcc 12
- Unity size: 1000
- Meson options:
  * -Dalsa=enabled
  * -Dmigemo=enabled
  * -Dtls=openssl
  * -Dcompat_cache_dir=disabled
  * -Dsessionlib=no
  * -Dwerror=true

Closes #1302
