### PR TITLE
Fix compiler warnings for -Wsuggest-destructor-override part2

### DIFF
--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -275,7 +275,7 @@ namespace ARTICLE
         auto sig_view_map() { return m_view.signal_map(); }
 
         explicit DrawAreaBase( const std::string& url );
-        ~DrawAreaBase();
+        ~DrawAreaBase() override;
 
         const std::string& get_url() const { return m_url; }
         int width_client() const { return m_width_client; }

--- a/src/bbslist/addetcdialog.h
+++ b/src/bbslist/addetcdialog.h
@@ -24,7 +24,7 @@ namespace BBSLIST
       public:
 
         AddEtcDialog( const bool move, const std::string& url, const std::string& _name, const std::string& _id, const std::string& _passwd );
-        ~AddEtcDialog() noexcept;
+        ~AddEtcDialog() noexcept override;
 
         std::string get_name() const { return m_entry_name.get_text(); }
         std::string get_url() const { return m_entry_url.get_text(); }

--- a/src/bbslist/editlistwin.h
+++ b/src/bbslist/editlistwin.h
@@ -26,7 +26,7 @@ namespace BBSLIST
       public:
 
         EditListWin( const std::string& url, const Glib::RefPtr< Gtk::TreeStore >& treestore );
-        ~EditListWin() noexcept;
+        ~EditListWin() noexcept override;
 
         void clock_in();
         void append_item();

--- a/src/board/columns.h
+++ b/src/board/columns.h
@@ -66,7 +66,7 @@ namespace BOARD
             add( m_col_article );
         }
 
-        ~TreeColumns() noexcept = default;
+        ~TreeColumns() noexcept override = default;
     };
 }
 

--- a/src/replacestrpref.h
+++ b/src/replacestrpref.h
@@ -39,7 +39,7 @@ namespace CORE
 
         ReplaceStrDiag( Gtk::Window* parent, ReplaceStrCondition condition,
                         const Glib::ustring& pattern, const Glib::ustring& replace );
-        ~ReplaceStrDiag() noexcept = default;
+        ~ReplaceStrDiag() noexcept override = default;
 
         bool get_active() const { return m_check_active.get_active(); }
         bool get_icase() const { return m_check_icase.get_active(); }
@@ -77,7 +77,7 @@ namespace CORE
             add( m_col_pattern );
             add( m_col_replace );
         }
-        ~ReplaceRecord() noexcept = default;
+        ~ReplaceRecord() noexcept override = default;
     };
 
     class ReplaceStrPref : public SKELETON::PrefDiag
@@ -111,7 +111,7 @@ namespace CORE
       public:
 
         ReplaceStrPref( Gtk::Window* parent, const std::string& url );
-        ~ReplaceStrPref() noexcept = default;
+        ~ReplaceStrPref() noexcept override = default;
 
       private:
 

--- a/src/setupwizard.h
+++ b/src/setupwizard.h
@@ -152,7 +152,7 @@ namespace CORE
 
       public:
         SetupWizard();
-        ~SetupWizard();
+        ~SetupWizard() override;
 
       private:
         void slot_switch_page( Gtk::Widget* notebookpage, guint page );

--- a/src/skeleton/aboutdiag.h
+++ b/src/skeleton/aboutdiag.h
@@ -48,7 +48,7 @@ namespace SKELETON
       public:
 
         explicit AboutDiag( const Glib::ustring& title );
-        ~AboutDiag() noexcept;
+        ~AboutDiag() noexcept override;
 
         int run();
 

--- a/src/skeleton/compentry.h
+++ b/src/skeleton/compentry.h
@@ -43,7 +43,7 @@ namespace SKELETON
 
         // mode は補完モード ( compmanager.h 参照 )
         explicit CompletionEntry( const int mode );
-        ~CompletionEntry() noexcept;
+        ~CompletionEntry() noexcept override;
 
         SIG_OPERATE signal_operate(){ return m_sig_operate; }
         SIG_ACTIVATE signal_activate(){ return m_sig_activate; }

--- a/src/skeleton/editview.h
+++ b/src/skeleton/editview.h
@@ -63,7 +63,7 @@ namespace SKELETON
         SIG_BUTTON_PRESS sig_button_press() { return m_sig_button_press; }
 
         EditTextView();
-        ~EditTextView() noexcept;
+        ~EditTextView() noexcept override;
 
         void insert_str( const std::string& str, bool use_br );
 
@@ -129,7 +129,7 @@ namespace SKELETON
     public:
 
         EditView();
-        ~EditView() noexcept;
+        ~EditView() noexcept override;
 
         SIG_BUTTON_PRESS sig_button_press(){ return m_textview.sig_button_press(); }
         SIG_KEY_PRESS sig_key_press(){ return m_textview.sig_key_press(); }

--- a/src/skeleton/filediag.h
+++ b/src/skeleton/filediag.h
@@ -48,7 +48,7 @@ namespace SKELETON
             else set_transient_for( *CORE::get_mainwindow() );
         }
 
-        ~FileDiag() noexcept = default;
+        ~FileDiag() noexcept override = default;
 
         virtual int run(){
 

--- a/src/skeleton/imgtoolbutton.h
+++ b/src/skeleton/imgtoolbutton.h
@@ -32,7 +32,7 @@ namespace SKELETON
             : Base( *Gtk::manage( new Gtk::Image( ICON::get_icon( iconid ) ) ), label )
         {}
 
-        ~ToolButtonExtension() noexcept = default;
+        ~ToolButtonExtension() noexcept override = default;
     };
 
     using ImgToolButton = ToolButtonExtension<Gtk::ToolButton>;

--- a/src/skeleton/label_entry.h
+++ b/src/skeleton/label_entry.h
@@ -27,7 +27,7 @@ namespace SKELETON
       public:
 
         LabelEntry( const bool editable, const std::string& label, const std::string& text = std::string() );
-        ~LabelEntry() noexcept;
+        ~LabelEntry() noexcept override;
 
         SIG_ACTIVATE signal_activate(){ return m_sig_activate; }
 

--- a/src/skeleton/login.h
+++ b/src/skeleton/login.h
@@ -28,7 +28,7 @@ namespace SKELETON
       public:
 
         explicit Login( const std::string& url );
-        ~Login();
+        ~Login() override;
 
         bool login_now() const { return m_login_now; }
         void set_login_now( bool login_now ){ m_login_now = login_now; }

--- a/src/skeleton/notebook.h
+++ b/src/skeleton/notebook.h
@@ -15,7 +15,7 @@ namespace SKELETON
       public:
 
         using Gtk::Notebook::Notebook;
-        ~JDNotebook() noexcept;
+        ~JDNotebook() noexcept override;
 
         // unpack = true の時取り除く
         int append_remove_page( bool unpack, Widget& child, const Glib::ustring& tab_label, bool use_mnemonic = false );

--- a/src/skeleton/popupwin.h
+++ b/src/skeleton/popupwin.h
@@ -30,7 +30,7 @@ namespace SKELETON
     public:
 
         PopupWin( Gtk::Widget* parent, SKELETON::View* view, const int mrg_x, const int mrg_y );
-        ~PopupWin() noexcept = default;
+        ~PopupWin() noexcept override = default;
 
         // m_view　からの hide シグナルをブリッジする
         SIG_HIDE_POPUP& sig_hide_popup() { return m_sig_hide_popup; }

--- a/src/skeleton/tabnote.cpp
+++ b/src/skeleton/tabnote.cpp
@@ -27,7 +27,7 @@ public:
     {
         set_has_window( false );
     }
-    ~DummyWidget() noexcept = default;
+    ~DummyWidget() noexcept override = default;
 };
 
 

--- a/src/skeleton/tabswitchmenu.h
+++ b/src/skeleton/tabswitchmenu.h
@@ -30,7 +30,7 @@ namespace SKELETON
         static Glib::RefPtr<TabSwitchMenu> create( DragableNoteBook* notebook );
 
         explicit TabSwitchMenu( DragableNoteBook* notebook );
-        ~TabSwitchMenu() noexcept = default;
+        ~TabSwitchMenu() noexcept override = default;
 
         /// メニュー項目を作り直してラベルとアイコンを更新する
         void update_labels_and_icons();

--- a/src/skeleton/toolmenubutton.h
+++ b/src/skeleton/toolmenubutton.h
@@ -31,7 +31,7 @@ namespace SKELETON
                         const bool show_arrow ,
                         const int id );
 
-        ~ToolMenuButton() noexcept;
+        ~ToolMenuButton() noexcept override;
 
         SKELETON::MenuButton* get_button(){ return m_button; }
 


### PR DESCRIPTION
オーバーライドしたデストラクタにoverrideキーワードが付いていないとコンパイラーに指摘されたため修正します。

clang-17のレポート (file pathを一部省略)
```
src/article/drawareabase.h:278:9: warning: '~DrawAreaBase' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/bbslist/addetcdialog.h:27:9: warning: '~AddEtcDialog' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/bbslist/editlistwin.h:29:9: warning: '~EditListWin' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/board/columns.h:69:9: warning: '~TreeColumns' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/replacestrpref.h:114:9: warning: '~ReplaceStrPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/replacestrpref.h:42:9: warning: '~ReplaceStrDiag' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/replacestrpref.h:80:9: warning: '~ReplaceRecord' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/setupwizard.h:155:9: warning: '~SetupWizard' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/skeleton/aboutdiag.h:51:9: warning: '~AboutDiag' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/skeleton/compentry.h:46:9: warning: '~CompletionEntry' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/skeleton/editview.h:132:9: warning: '~EditView' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/skeleton/editview.h:66:9: warning: '~EditTextView' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/skeleton/filediag.h:51:9: warning: '~FileDiag' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/skeleton/imgtoolbutton.h:35:9: warning: '~ToolButtonExtension' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/skeleton/label_entry.h:30:9: warning: '~LabelEntry' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/skeleton/login.h:31:9: warning: '~Login' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/skeleton/notebook.h:18:9: warning: '~JDNotebook' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/skeleton/popupwin.h:33:9: warning: '~PopupWin' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/skeleton/tabnote.cpp:30:5: warning: '~DummyWidget' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/skeleton/tabswitchmenu.h:33:9: warning: '~TabSwitchMenu' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
src/skeleton/toolmenubutton.h:34:9: warning: '~ToolMenuButton' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
```
