### PR TITLE
Fix GitHub Actions workflows weeky CI

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -60,7 +60,7 @@ jobs:
           sudo apt update
           sudo apt install g++-12 libasound2-dev libgtest-dev libgtkmm-3.0-dev libmigemo-dev libssl-dev meson zlib1g-dev
       - name: meson setup builddir -Dunity=on -Dunity_size=1000 -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dalsa=enabled -Dmigemo=enabled -Dtls=openssl -Dcompat_cache_dir=disabled -Dsessionlib=no -Dwerror=true
-      - run: meson setup builddir -Dunity=on -Dunity_size=1000 -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dalsa=enabled -Dmigemo=enabled -Dtls=openssl -Dcompat_cache_dir=disabled -Dsessionlib=no -Dwerror=true
+        run: meson setup builddir -Dunity=on -Dunity_size=1000 -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dalsa=enabled -Dmigemo=enabled -Dtls=openssl -Dcompat_cache_dir=disabled -Dsessionlib=no -Dwerror=true
       - name: ninja -C builddir -k0
         run: ninja -C builddir -k0
       - name: meson test -v -C builddir


### PR DESCRIPTION
GitHub Actions にstep構文の間違いがあると指摘されたため修正します。

```
Annotations
1 error
Error: .github#L1
every step must define a `uses` or `run` key
```

https://github.com/JDimproved/JDim/actions/runs/7232497358
