### PR TITLE
Implement external BBSMENU

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ layout: default
 - [マウスジェスチャについて]({{ site.baseurl }}/mouse/)
 
 - [お気に入りについて]({{ site.baseurl }}/favorite/)
-- [外部板について]({{ site.baseurl }}/external/)
+- [外部板と外部BBSMENUについて]({{ site.baseurl }}/external/)
 - [実況モードについて]({{ site.baseurl }}/live/)
 - [ユーザーコマンド、リンクフィルタについて]({{ site.baseurl }}/usrcmd/)
 - [アスキーアート(AA)の入力について]({{ site.baseurl }}/asciiart/)

--- a/docs/manual/external.md
+++ b/docs/manual/external.md
@@ -1,5 +1,5 @@
 ---
-title: 外部板について
+title: 外部板と外部BBSMENUについて
 layout: default
 ---
 
@@ -10,6 +10,7 @@ layout: default
 - [現在の対応板](#support)
 - [外部板の登録方法](#register)
 - [まちBBSのofflaw形式対応について](#machi_offlaw)
+- [外部BBSMENUの登録方法](#register_bbsmenu)
 
 
 <a name="support"></a>
@@ -43,3 +44,18 @@ offlaw形式での読み込みには以下のような長短がある。
 
 × リモートホストが取得できなくなった<br>
 × offlaw形式で読み込んだログは過去のバージョンのJDimでは読めない
+
+
+<a name="register_bbsmenu"></a>
+### 外部BBSMENUの登録方法
+<small>v0.10.1-20231223 から追加</small>
+
+外部BBSMENUを登録するには、サイドバーの板一覧の一番上にある「`外部BBSMENU`」フォルダを右クリックして
+「`外部BBSMENU追加`」を選択し、BBSMENU名とアドレスを入力してOKボタンを押す。
+BBSMENUが読み込まれると板一覧の下部に読み込んだ板が追加される。
+後からBBSMENUのアドレスや名前を変更する場合は対象のBBSMENUの上で右クリックすると出てくる「`編集`」メニューからおこなう。
+
+設定ファイルのフォーマットは予告なく変更する場合がある。
+そのためファイルの編集による登録はサポートしていない。
+
+注意: 実験的なサポートのため変更または廃止の可能性があります。

--- a/src/bbslist/addetcdialog.cpp
+++ b/src/bbslist/addetcdialog.cpp
@@ -52,3 +52,52 @@ AddEtcDialog::AddEtcDialog( const bool move, const std::string& url, const std::
 
 
 AddEtcDialog::~AddEtcDialog() noexcept = default;
+
+
+/** @brief コンストラクタ
+ *
+ * @param[in] parent 親ウインドウ (nullable)
+ * @param[in] edit   true なら編集モード
+ * @param[in] url    BBSMENUのURLの初期値
+ * @param[in] name   BBSMENU名前の初期値
+ */
+AddEtcBBSMenuDialog::AddEtcBBSMenuDialog( Gtk::Window* parent, const bool edit,
+                                          const Glib::ustring& url, const Glib::ustring& name )
+    : SKELETON::PrefDiag{ parent, url, true }
+    , m_label_supplement{ Glib::ustring{ edit ? "「OK」を押すとBBSMENUをダウンロードして更新します。"
+                                              : "「OK」を押すとBBSMENUをダウンロードして板一覧の下部に追加します。" }
+                          + "\nこの機能は実験的なサポートのため変更または廃止の可能性があります。" }
+    , m_label_name{ "板名(_N)", true }
+    , m_label_url{ "アドレス(_U)", true }
+{
+    set_default_size( 600, -1 );
+
+    m_label_name.set_alignment( Gtk::ALIGN_START );
+    m_label_url.set_alignment( Gtk::ALIGN_START );
+    m_label_name.set_mnemonic_widget( m_entry_name );
+    m_label_url.set_mnemonic_widget( m_entry_url );
+
+    m_entry_name.set_hexpand( true );
+    m_entry_url.set_hexpand( true );
+    m_entry_name.set_text( name );
+    m_entry_url.set_text( url );
+
+    m_grid.set_column_spacing( 8 );
+    m_grid.set_row_spacing( 8 );
+    m_grid.attach( m_label_name, 0, 0, 1, 1 );
+    m_grid.attach( m_entry_name, 1, 0, 1, 1 );
+    m_grid.attach( m_label_url, 0, 1, 1, 1 );
+    m_grid.attach( m_entry_url, 1, 1, 1, 1 );
+
+    get_content_area()->set_spacing( 8 );
+    get_content_area()->property_margin() = 8;
+    get_content_area()->pack_start( m_label_supplement );
+    get_content_area()->pack_start( m_grid );
+
+    set_activate_entry( m_entry_name );
+    set_activate_entry( m_entry_url );
+
+    set_title( edit ? "外部BBSMENU編集" : "外部BBSMENU追加" );
+
+    show_all_children();
+}

--- a/src/bbslist/addetcdialog.h
+++ b/src/bbslist/addetcdialog.h
@@ -30,8 +30,32 @@ namespace BBSLIST
         std::string get_url() const { return m_entry_url.get_text(); }
         std::string get_id() const { return m_entry_id.get_text(); }
         std::string get_passwd() const { return m_entry_pw.get_text(); }
-    };   
+    };
 
+
+    /**
+     * @brief 外部BBSMENUを追加/編集するダイアログ
+     */
+    class AddEtcBBSMenuDialog : public SKELETON::PrefDiag
+    {
+        /// @brief タイトルと入力欄だけでは分かりにくいため補足説明をつける
+        Gtk::Label m_label_supplement;
+
+        Gtk::Label m_label_name;
+        Gtk::Label m_label_url;
+        Gtk::Entry m_entry_name;
+        Gtk::Entry m_entry_url;
+
+        Gtk::Grid m_grid;
+
+      public:
+
+        AddEtcBBSMenuDialog( Gtk::Window* parent, const bool edit, const Glib::ustring& url, const Glib::ustring& name );
+        ~AddEtcBBSMenuDialog() noexcept = default;
+
+        std::string get_name() const { return m_entry_name.get_text(); }
+        std::string get_url() const { return m_entry_url.get_text(); }
+    };
 }
 
 #endif

--- a/src/bbslist/bbslistview.cpp
+++ b/src/bbslist/bbslistview.cpp
@@ -8,6 +8,7 @@
 
 #include "skeleton/msgdiag.h"
 
+#include "dbtree/bbsmenu.h"
 #include "dbtree/interface.h"
 
 #include "config/globalconf.h"
@@ -48,7 +49,7 @@ BBSListViewMain::~BBSListViewMain()
 void BBSListViewMain::save_xml()
 {
     const std::string file = CACHE::path_xml_listmain();
-    constexpr std::string_view remove_dirs[] = { SUBDIR_ETCLIST };
+    constexpr std::string_view remove_dirs[] = { SUBDIR_ETCLIST, SUBDIR_BBSMENU };
     save_xml_impl( file, ROOT_NODE_NAME, remove_dirs );
 }
 
@@ -112,6 +113,62 @@ void BBSListViewMain::update_view()
 
     // 外部板追加ここまで
     //----------------------------------
+    // 外部BBSMENU追加
+
+    // <subdir>を挿入
+    // ルート要素の有無で処理を分ける( 旧様式=無, 新様式=有 )
+    if( root ) subdir = root->emplace_front( XML::NODE_TYPE_ELEMENT, "subdir" );
+    else subdir = get_document().emplace_front( XML::NODE_TYPE_ELEMENT, "subdir" );
+    subdir->setAttribute( "name", SUBDIR_BBSMENU );
+
+    // 子要素( <bbsmenu> )を追加
+    if( const auto& vec_bbsmenu = DBTREE::get_bbsmenus(); // 外部BBSMENU情報( dbtree/bbsmenu.h )
+        ! vec_bbsmenu.empty() ) {
+        for( const DBTREE::BBSMenu& info : vec_bbsmenu ) {
+            const std::string& info_name = info.get_name();
+            const std::string& info_url = info.get_url();
+
+            // 外部BBSMENUに追加
+            XML::Dom* bbsmenu = subdir->appendChild( XML::NODE_TYPE_ELEMENT, "bbsmenu" );
+            bbsmenu->setAttribute( "name", info_name );
+            bbsmenu->setAttribute( "url", info_url );
+
+            // <subdir>を板一覧の末尾に追加
+            // ルート要素の有無で処理を分ける( 旧様式=無, 新様式=有 )
+            XML::Dom* bbsmenu_subdir = root ? root->appendChild( XML::NODE_TYPE_ELEMENT, "subdir" )
+                                            : get_document().appendChild( XML::NODE_TYPE_ELEMENT, "subdir" );
+            bbsmenu_subdir->setAttribute( "name", info_name );
+            bbsmenu_subdir->setAttribute( "url", info_url );
+            bbsmenu_subdir->setAttribute( "data", "nosave" ); // 外部BBSMENUの板は個別に保存する
+
+            std::list<XML::Dom*> boardlist = info.xml_document().getElementsByTagName( "boardlist" );
+            if( boardlist.empty() ) continue;
+            const XML::Dom* categories = boardlist.front();
+
+            // カテゴリのサブディレクトリを作成してその中に板を追加していく
+            for( const XML::Dom* category_in : *categories ) {
+                const std::string category_name = category_in->getAttribute( "name" );
+                if( category_name.empty() ) continue;
+
+                XML::Dom* category_subdir = bbsmenu_subdir->appendChild( XML::NODE_TYPE_ELEMENT, "subdir" );
+                category_subdir->setAttribute( "name", category_name );
+                category_subdir->setAttribute( "url", category_in->getAttribute( "url" ) );
+                category_subdir->setAttribute( "dirid", category_in->getAttribute( "dirid" ) );
+
+                for( const XML::Dom* board_in : *category_in ) {
+                    const std::string board_name = board_in->getAttribute( "name" );
+                    if( board_name.empty() ) continue;
+
+                    XML::Dom* node_board = category_subdir->appendChild( XML::NODE_TYPE_ELEMENT, "board" );
+                    node_board->setAttribute( "name", board_name );
+                    node_board->setAttribute( "url", board_in->getAttribute( "url" ) );
+                }
+            }
+        }
+    }
+
+    // 外部BBSMENU追加ここまで
+    //----------------------------------
 
     // BBSListViewBase::xml2tree() m_document -> tree
     xml2tree( std::string( ROOT_NODE_NAME ) );
@@ -149,7 +206,13 @@ void BBSListViewMain::delete_view_impl()
     std::cout << "BBSListViewMain::delete_view_impl\n";
 #endif
 
-    // データベースから外部板削除
+    constexpr const int kDeleteTargetBoard = 0b01;
+    constexpr const int kDeleteTargetBBSMenu = 0b10;
+    int delete_target = 0;
+
+    std::vector<Gtk::TreeIter> delete_bbsmenu_iterators;
+
+    // データベースから外部板または外部BBSMENUを削除
     std::list< Gtk::TreeModel::iterator > list_it = get_treeview().get_selected_iterators();
     for( Gtk::TreeModel::iterator& iter : list_it ) {
         if( is_etcboard( iter ) ) {
@@ -163,14 +226,50 @@ void BBSListViewMain::delete_view_impl()
                       << "name = " << name << std::endl;
 #endif
             DBTREE::remove_etc( url , name );
+            delete_target |= kDeleteTargetBoard;
+        }
+        else if( is_bbsmenu( iter ) ) {
+            const std::string url = row2url( *iter );
+            const std::string name = row2name( *iter );
+
+            DBTREE::remove_bbsmenu( url, name );
+            delete_target |= kDeleteTargetBBSMenu;
+
+            // 板一覧の下部に追加した外部BBSMENUの板一覧を削除するためにイテレーターを記憶する
+            auto it = get_treestore()->get_iter( "0" );
+            while( it ) {
+                auto row_url = row2url( *it );
+                auto row_name = row2name( *it );
+                auto row_type = row2type( *it );
+                if( row_type == TYPE_DIR && row_url == url && row_name == name ) {
+                    delete_bbsmenu_iterators.push_back( std::move( *it ) );
+                    break;
+                }
+                ++it;
+            }
         }
     }
 
     const bool force = true; // 強制的に削除
     get_treeview().delete_selected_rows( force );
 
-    // etc.txt保存
-    DBTREE::save_etc();
+    // 板一覧の下部に追加した外部BBSMENUの板一覧を削除する
+    if( ! delete_bbsmenu_iterators.empty() ) {
+        // 取得したTreeStoreのイテレーターが壊れないように後ろから削除していく
+        auto rend = delete_bbsmenu_iterators.rend();
+        for( auto rit = delete_bbsmenu_iterators.rbegin(); rit != rend; ++rit ) {
+            get_treestore()->erase( *rit );
+        }
+    }
+
+    if( delete_target & kDeleteTargetBoard ) {
+        // etc.txt保存
+        DBTREE::save_etc();
+    }
+    if( delete_target & kDeleteTargetBBSMenu ) {
+        // bbsmenu.txt保存
+        DBTREE::save_bbsmenu();
+    }
 }
 
 
@@ -217,20 +316,30 @@ Gtk::Menu* BBSListViewMain::get_popupmenu( const std::string& url )
 
         if( type == TYPE_DIR ){
             if( is_etcdir( path ) ) popupmenu = id2popupmenu(  "popup_menu_etcdir" );
+            else if( is_bbsmenudir( path ) ) popupmenu = id2popupmenu( "popup_menu_bbsmenudir" );
             else popupmenu = id2popupmenu(  "popup_menu_dir" );
         }
         else if( type == TYPE_BOARD || type == TYPE_BOARD_UPDATE ){
             if( is_etcboard( path ) ) popupmenu = id2popupmenu(  "popup_menu_etc" );
             else popupmenu = id2popupmenu(  "popup_menu" );
         }
+        else if( type == TYPE_BBSMENU ) {
+            if( is_bbsmenu( path ) ) popupmenu = id2popupmenu( "popup_menu_bbsmenu" );
+            else popupmenu = id2popupmenu( "popup_menu" );
+        }
     }
     else{
+        bool have_bbsmenu = true;
+        bool have_etc = true;
+        for( const Gtk::TreeIter& iter : list_it ) {
+            if( ! is_bbsmenu( iter ) ) have_bbsmenu = false;
+            if( ! is_etcboard( iter ) ) have_etc = false;
 
-        const bool have_etc = std::all_of( list_it.cbegin(), list_it.cend(),
-                                           [this]( const Gtk::TreeIter& iter ) { return is_etcboard( iter ); } );
-
-        if( have_etc ) popupmenu = id2popupmenu(  "popup_menu_mul_etc" );
-        else popupmenu = id2popupmenu(  "popup_menu_mul" );
+            if( ! have_bbsmenu && ! have_etc ) break;
+        }
+        if( have_bbsmenu ) popupmenu = id2popupmenu( "popup_menu_mul_bbsmenu" );
+        else if( have_etc ) popupmenu = id2popupmenu( "popup_menu_mul_etc" );
+        else popupmenu = id2popupmenu( "popup_menu_mul" );
     }
 
     return popupmenu;

--- a/src/bbslist/bbslistviewbase.h
+++ b/src/bbslist/bbslistviewbase.h
@@ -31,6 +31,7 @@ namespace SKELETON
 
 
 #define SUBDIR_ETCLIST "外部板"
+#define SUBDIR_BBSMENU "外部BBSMENU"
 
 
 namespace BBSLIST
@@ -125,9 +126,16 @@ namespace BBSLIST
         // 外部板のディレクトリか
         bool is_etcdir( Gtk::TreePath path );
 
+        // 外部BBSMENUのディレクトリか
+        bool is_bbsmenudir( Gtk::TreePath path );
+
         // 外部板か
         bool is_etcboard( const Gtk::TreeModel::iterator& it );
         bool is_etcboard( Gtk::TreePath path );
+
+        // 外部BBSMENUか
+        bool is_bbsmenu( const Gtk::TreeModel::iterator& it );
+        bool is_bbsmenu( Gtk::TreePath path );
 
         // 起動時や移転があったときなどに行に含まれるURlを変更する
         void update_urls();
@@ -293,7 +301,9 @@ namespace BBSLIST
         void slot_append_favorite();
         void slot_newdir();
         void slot_newcomment();
+        void slot_newbbsmenu();
         void slot_newetcboard();
+        void slot_movebbsmenu();
         void slot_moveetcboard();
         void slot_rename();
         void slot_copy_url();
@@ -306,6 +316,7 @@ namespace BBSLIST
         void slot_create_vboard();
         void slot_search_cache_board();
         void slot_import_dat();
+        void slot_preferences_bbsmenu();
         void slot_preferences_board();
         void slot_preferences_article();
         void slot_preferences_image();
@@ -316,6 +327,9 @@ namespace BBSLIST
         void slot_sort( const int mode );
 
         virtual void delete_view_impl();
+
+        // 外部BBSMENU追加/編集
+        void add_newbbsmenu( const bool move, const std::string& _url, const std::string& _name );
 
         // 外部板追加/編集
         void add_newetcboard( const bool move, const std::string& _url, const std::string& _name, const std::string& _id, const std::string& _passwd );

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -129,6 +129,20 @@ std::string CACHE::path_etcboard()
 }
 
 
+/// @brief 外部BBSMENUのディレクトリ
+std::string CACHE::path_bbsmenu_root()
+{
+    return CACHE::path_root() + "bbsmenu/";
+}
+
+
+/// @brief 外部BBSMENUの設定ファイル
+std::string CACHE::path_bbsmenu()
+{
+    return CACHE::path_bbsmenu_root() + "bbsmenu.txt";
+}
+
+
 // ユーザーコマンド設定ファイル
 std::string CACHE::path_usrcmd()
 {

--- a/src/cache.h
+++ b/src/cache.h
@@ -60,6 +60,10 @@ namespace CACHE
     // 外部板設定ファイル( navi2ch 互換 )
     std::string path_etcboard();
 
+    // 外部BBSMENUのディレクトリと設定ファイル
+    std::string path_bbsmenu_root();
+    std::string path_bbsmenu();
+
     // ユーザーコマンド設定ファイル
     std::string path_usrcmd();
 

--- a/src/dbtree/bbsmenu.cpp
+++ b/src/dbtree/bbsmenu.cpp
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/** @file bbsmenu.cpp
+ *
+ * @remark DBTREE::Root クラスを元にして実装した関数があるため
+ * このファイルのライセンスは GPL-2.0-only になる。
+ */
+
+//#define _DEBUG
+#include "jddebug.h"
+
+#include "bbsmenu.h"
+
+#include "config/globalconf.h"
+#include "jdlib/cookiemanager.h"
+#include "jdlib/jdiconv.h"
+#include "jdlib/loaderdata.h"
+#include "jdlib/miscmsg.h"
+#include "jdlib/miscutil.h"
+#include "skeleton/msgdiag.h"
+
+#include "cache.h"
+#include "command.h"
+#include "httpcode.h"
+
+
+namespace DBTREE::bm {
+constexpr const std::size_t kSizeOfRawdata = 2 * 1024 * 1024; ///< bbsmenu.html の最大サイズ
+constexpr const char* kRootNodeName = "boardlist"; ///< ルート要素名( boards.xml )
+}
+
+
+using namespace DBTREE;
+
+
+std::string BBSMenu::path_bbsmenu_boards_xml() const
+{
+    constexpr const bool protocol = false;
+    std::string path = CACHE::path_bbsmenu_root();
+    path.append( MISC::get_hostname( m_url, protocol ) );
+    path.append( "-boards.xml" );
+    return path;
+}
+
+
+/** @brief ローカルキャッシュからBBSMENUのXML読み込み
+ *
+ * @see Root::load_cache()
+ */
+void BBSMenu::load_cache()
+{
+    const std::string path = path_bbsmenu_boards_xml();
+
+#ifdef _DEBUG
+    std::cout << "BBSMenu::load_cache xml = " << path << std::endl;
+#endif
+
+    std::string xml_bbsmenu;
+    if( CACHE::load_rawdata( path, xml_bbsmenu ) ) {
+
+        // Domノードを初期化
+        m_xml_document.init( xml_bbsmenu );
+
+        // Domノードの内容からDBに板を登録
+        analyze_board_xml();
+    }
+}
+
+
+/** @brief サーバから bbsmenu.html を読み込んで XML に変換開始
+ *
+ * @details 読み終わったらreceive_finish()でXMLに変換して"update_bbslist"コマンド発行
+ * @see Root::download_bbsmenu()
+ */
+void BBSMenu::download_bbsmenu()
+{
+    if( is_loading() ) return;
+
+    clear();
+    m_rawdata.reserve( bm::kSizeOfRawdata );
+
+    JDLIB::LOADERDATA data;
+    data.init_for_data();
+    data.url = m_url;
+    data.modified = get_date_modified();
+
+    bool send_cookie = true;
+
+    constexpr bool protocol = false;
+    const std::string host = MISC::get_hostname( data.url, protocol );
+    if( MISC::ends_with( host, ".5ch.net ") || MISC::ends_with( host, ".2ch.net" ) ) {
+        data.agent = CONFIG::get_agent_for2ch();
+        if( CONFIG::get_use_proxy_for2ch() ) {
+            data.host_proxy = CONFIG::get_proxy_for2ch();
+            data.port_proxy = CONFIG::get_proxy_port_for2ch();
+            data.basicauth_proxy = CONFIG::get_proxy_basicauth_for2ch();
+            data.basicauth = CONFIG::get_proxy_basicauth_for2ch();
+            send_cookie = CONFIG::get_send_cookie_to_proxy_for2ch();
+        }
+    }
+    else {
+        data.agent = CONFIG::get_agent_for_data();
+        if( CONFIG::get_use_proxy_for_data() ) {
+            data.host_proxy = CONFIG::get_proxy_for_data();
+            data.port_proxy = CONFIG::get_proxy_port_for_data();
+            data.basicauth_proxy = CONFIG::get_proxy_basicauth_for_data();
+            data.basicauth = CONFIG::get_proxy_basicauth_for_data();
+            send_cookie = CONFIG::get_send_cookie_to_proxy_for_data();
+        }
+    }
+
+    if( send_cookie ) {
+        const JDLIB::CookieManager* cookie_manager = JDLIB::get_cookie_manager();
+        data.cookie_for_request = cookie_manager->get_cookie_by_host( data.url );
+    }
+
+    start_load( data );
+}
+
+
+/** @brief BBSMENUを受信した後の処理
+ *
+ * @details 受信に失敗したときはローカルキャッシュから読み込む
+ * @see Root::receive_finish()
+ */
+void BBSMenu::receive_finish()
+{
+#ifdef _DEBUG
+    std::cout << "BBSMenu::receive_finish code = " << get_code() << std::endl;
+#endif
+
+    if( get_code() == HTTP_NOT_MODIFIED ) {
+
+        auto msg = Glib::ustring::compose(
+            "%1\n\nサーバー上のBBSMENUは更新されていません。強制的に再読み込みをしますか？", get_str_code() );
+        SKELETON::MsgDiag mdiag( nullptr, msg, false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
+        mdiag.set_default_response( Gtk::RESPONSE_YES );
+        if( mdiag.run() == Gtk::RESPONSE_YES ){
+            set_date_modified( std::string() );
+            download_bbsmenu();
+        }
+        else {
+            // 再読み込しない場合はローカルキャッシュからXMLを読み込む
+            load_cache();
+        }
+        return;
+    }
+
+    if( ( get_code() == HTTP_MOVED_PERM || get_code() == HTTP_REDIRECT ) && ! location().empty() ) {
+
+        auto msg = Glib::ustring::compose( "%1\n\nBBSMENUが %2 に移転しました。更新しますか？",
+                                           get_str_code(), location() );
+        SKELETON::MsgDiag mdiag( nullptr, msg, false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
+        mdiag.set_default_response( Gtk::RESPONSE_YES );
+        if( mdiag.run() == Gtk::RESPONSE_YES ){
+            set_date_modified( std::string() );
+            m_url = location();
+            download_bbsmenu();
+        }
+        else {
+            // 更新しない場合はローカルキャッシュからXMLを読み込む
+            load_cache();
+        }
+        return;
+    }
+
+    if( get_code() != HTTP_OK ) {
+
+        auto msg = Glib::ustring::compose( "%1\n\nBBSMENUの読み込みに失敗したためBBSMENUは更新されませんでした。\n\n"
+                                           "プロキシ設定やBBSMENUを取得するサーバのアドレスを確認して、"
+                                           "再読み込みをして下さい。", get_str_code() );
+        SKELETON::MsgDiag mdiag( nullptr, msg, false, Gtk::MESSAGE_ERROR );
+        mdiag.run();
+        MISC::ERRMSG( "bbsmenu load failed : " + get_str_code() );
+
+        // 通信に失敗したときはローカルキャッシュからXMLを読み込む
+        load_cache();
+
+        CORE::core_set_command( "update_bbslist" );
+        return;
+    }
+
+    // 文字コードを変換してXML作成
+    JDLIB::Iconv libiconv{ Encoding::utf8, Encoding::sjis };
+    const std::string& rawdata_utf8 = libiconv.convert( m_rawdata.data(), m_rawdata.size() );
+
+    bbsmenu2xml( rawdata_utf8 );
+
+    if( m_xml_document.hasChildNodes() ) {
+
+        // データベース更新
+        analyze_board_xml();
+
+        // bbslistview更新
+        CORE::core_set_command( "update_bbslist" );
+    }
+
+    clear();
+}
+
+
+/** @brief HTMLの解析を行いカテゴリと板を持つDOMを構築しXMLファイルに保存する
+ *
+ * @param[in] menu BBSMENUのHTMLデータ
+ * @see Root::bbsmenu2xml()
+ */
+void BBSMenu::bbsmenu2xml( const std::string& menu )
+{
+    if( menu.empty() ) return;
+
+    // menu のノードツリーを取得( menu がHTMLなので第二引数は true )
+    const XML::Document html( menu, true );
+
+    // XML用のノードツリーにルートノードを追加
+    m_xml_document.clear();
+    XML::Dom* root = m_xml_document.appendChild( XML::NODE_TYPE_ELEMENT, bm::kRootNodeName );
+
+    // カテゴリの要素 <subdir></subdir>
+    XML::Dom* subdir = nullptr;
+
+    // カテゴリの有効/無効
+    bool enabled = true;
+
+    // 現在の仕様では HTML > BODY > font[size="2"] の子要素が対象
+    // 特定のサイト(2ch.sc、next2ch.net)のbbsmenu.htmlにはfontタグがないため別のタグを使う
+    std::list<XML::Dom*> targets = html.getElementsByTagName( "font" );
+    if( targets.empty() ) targets = html.getElementsByTagName( "small" );
+    if( targets.empty() ) targets = html.getElementsByTagName( "body" );
+    if( targets.empty() ) {
+        MISC::ERRMSG( "parse error for bbsmenu" );
+        return;
+    }
+    for( const XML::Dom* child : *targets.front() ) {
+
+        // 要素b( カテゴリ名 )
+        if( child->nodeName() == "b" ) {
+
+            const std::string category = MISC::chref_decode( child->firstChild()->nodeValue() );
+
+            // 追加しないカテゴリ
+            if( category == "チャット"
+                || category == "ツール類"
+                || category == "他のサイト" ) {
+
+                enabled = false;
+                continue;
+            }
+            else enabled = true;
+
+            // <subdir>
+            subdir = root->appendChild( XML::NODE_TYPE_ELEMENT, "subdir" );
+            subdir->setAttribute( "name", category );
+        }
+        // 要素bに続く要素a( 板URL )
+        else if( subdir && enabled && child->nodeName() == "a" ) {
+
+            const std::string board_name = MISC::chref_decode( child->firstChild()->nodeValue() );
+            std::string url = child->getAttribute( "href" );
+
+            // Schema-less URL (net_path) ならBBSMENUのURLから http[s]: をコピーして追加する
+            if( url.compare( 0, 2, "//" ) == 0 ) {
+                const auto scheme = std::string_view{ m_url }.substr( 0, m_url.find( ':' ) + 1 );
+                url.insert( 0, scheme );
+            }
+
+            // 外部BBSMENUにある <a> 要素はすべて板として扱う
+            std::string element_name = "board";
+
+            XML::Dom* board = subdir->appendChild( XML::NODE_TYPE_ELEMENT, element_name );
+            board->setAttribute( "name", board_name );
+            board->setAttribute( "url", url );
+        }
+    }
+
+    root->setAttribute( "date_modified", get_date_modified() );
+
+#ifdef _DEBUG
+    std::cout << "modified = " << get_date_modified() << std::endl;
+#endif
+
+    // キャッシュディレクトリの bbsmenu/ は Root::save_bbsmenu() で作成するため呼び出す順序に注意すること
+    const std::string path = path_bbsmenu_boards_xml();
+    CACHE::save_rawdata( path, m_xml_document.get_xml() );
+
+#ifdef _DEBUG
+    std::cout << "BBSMenu::bbsmenu2xml : save " << path << std::endl;;
+#endif
+}

--- a/src/dbtree/bbsmenu.h
+++ b/src/dbtree/bbsmenu.h
@@ -15,6 +15,16 @@
 
 namespace DBTREE
 {
+// clang 8以下ではnoexceptがついたdefault constructorがコンパイルできない
+// 参考文献: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86583
+namespace {
+#if defined(__clang__) && __clang_major__ < 9
+constexpr bool kSupportNoexceptDefaultCtor = false;
+#else
+constexpr bool kSupportNoexceptDefaultCtor = true;
+#endif
+}
+
 
 /** @brief BBSMENUの取得と板一覧のデータを構築するクラス
  *
@@ -50,12 +60,12 @@ public:
     {
     }
 
-    BBSMenu( BBSMenu&& ) noexcept = default;
+    BBSMenu( BBSMenu&& ) noexcept(kSupportNoexceptDefaultCtor)= default;
     BBSMenu( const BBSMenu& ) = delete;
 
     ~BBSMenu() noexcept = default;
 
-    BBSMenu& operator=( BBSMenu&& ) noexcept = default;
+    BBSMenu& operator=( BBSMenu&& ) noexcept(kSupportNoexceptDefaultCtor) = default;
     BBSMenu& operator=( const BBSMenu& ) = delete;
 
     /// @brief 外部BBSMENUは name の重複を許すため url のみで検索するときに使う

--- a/src/dbtree/bbsmenu.h
+++ b/src/dbtree/bbsmenu.h
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/**
+ * @file bbsmenu.h
+ * @brief BBSMENUの取得と板一覧のデータを構築する
+ */
+#ifndef JDIM_DBTREE_BBSMENU_H
+#define JDIM_DBTREE_BBSMENU_H
+
+#include "skeleton/loadable.h"
+#include "xml/document.h"
+
+#include <string>
+#include <string_view>
+
+
+namespace DBTREE
+{
+
+/** @brief BBSMENUの取得と板一覧のデータを構築するクラス
+ *
+ * @details BBSMENUのURLにアクセスしてHTMLを取得して解析を行いカテゴリと板を持つDOMを構築する。
+ * DOMの内容は板一覧に追加されて管理・反映される。
+ * また、DOMからXMLを生成してキャッシュディレクトリに保存・読み込みを行う。
+ */
+class BBSMenu : public SKELETON::Loadable
+{
+    std::string m_url;
+    std::string m_name;
+    std::string m_rawdata;
+
+    XML::Document m_xml_document;
+
+    /** @brief 読み込んだDOMをRootクラスから参照するためのシグナル
+     *
+     * @note Root は sigc::trackable を継承していないためsignalの接続解除が動作しない。
+     * Root の寿命が尽きるとこのシグナルに接続された関数オブジェクトはdangling参照になるので注意。
+     */
+    sigc::signal<void, BBSMenu&> m_sig_analyze_board_xml;
+
+public:
+
+    /** @brief コンストラクタ
+     *
+     * @param[in] url  BBSMENUのURL
+     * @param[in] name BBSMENUの名称
+     */
+    BBSMenu( std::string_view url, std::string_view name )
+        : m_url{ url }
+        , m_name{ name }
+    {
+    }
+
+    BBSMenu( BBSMenu&& ) noexcept = default;
+    BBSMenu( const BBSMenu& ) = delete;
+
+    ~BBSMenu() noexcept = default;
+
+    BBSMenu& operator=( BBSMenu&& ) noexcept = default;
+    BBSMenu& operator=( const BBSMenu& ) = delete;
+
+    /// @brief 外部BBSMENUは name の重複を許すため url のみで検索するときに使う
+    bool equals( std::string_view url ) const noexcept { return m_url == url; }
+
+    /// @brief url と name の両方で検索するときに使う
+    bool equals( std::string_view url, std::string_view name ) const noexcept
+    {
+        return m_url == url && m_name == name;
+    }
+
+    /// @brief BBSMENUのURLを返す
+    const std::string& get_url() const { return m_url; }
+    /// @brief BBSMENUの名前を返す
+    const std::string& get_name() const { return m_name; }
+    /// @brief BBSMENUのXMLを保存するファイルパスを返す
+    std::string path_bbsmenu_boards_xml() const;
+
+    void reset( std::string_view url, std::string_view name )
+    {
+        m_url = url;
+        m_name = name;
+
+        m_rawdata.clear();
+        m_xml_document.clear();
+    }
+
+    void load_cache();
+    void download_bbsmenu();
+
+    /// @brief 構築したDOMを返す
+    const XML::Document& xml_document() const { return m_xml_document; }
+
+    auto& sig_analyze_board_xml() { return m_sig_analyze_board_xml; }
+
+private:
+
+    // BBSMENUのダウンロード用関数
+    void clear() { m_rawdata.clear(); }
+    /** @brief BBSMENU のデータを受信したときのコールバック
+     *
+     * @param[in] buf 受信したデータ
+     */
+    void receive_data( std::string_view buf ) override { m_rawdata.append( buf ); }
+    void receive_finish() override;
+
+    /// @brief XML に含まれる板情報を取り出してデータベースを更新する
+    void analyze_board_xml() { m_sig_analyze_board_xml.emit( *this ); }
+
+    void bbsmenu2xml( const std::string& menu );
+};
+
+} // namespace DBTREE
+
+#endif // JDIM_DBTREE_BBSMENU_H

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -4,9 +4,11 @@
 #include "jddebug.h"
 
 #include "interface.h"
-#include "root.h"
-#include "boardbase.h"
+
 #include "articlebase.h"
+#include "bbsmenu.h"
+#include "boardbase.h"
+#include "root.h"
 
 #include "jdlib/miscutil.h"
 
@@ -43,6 +45,13 @@ DBTREE::Root* DBTREE::get_root()
 {
     assert( instance_dbtree_root != nullptr );
     return instance_dbtree_root;
+}
+
+DBTREE::BBSMenu* DBTREE::get_bbsmenu( std::string_view url )
+{
+    auto bbsmenu = DBTREE::get_root()->get_bbsmenu( url );
+    assert( bbsmenu != nullptr );
+    return bbsmenu;
 }
 
 DBTREE::BoardBase* DBTREE::get_board( const std::string& url )
@@ -229,6 +238,63 @@ const std::string& DBTREE::get_date_modified()
 time_t DBTREE::get_time_modified()
 {
     return get_root()->get_time_modified();
+}
+
+
+const std::list<DBTREE::BBSMenu>& DBTREE::get_bbsmenus()
+{
+    return DBTREE::get_root()->get_bbsmenus();
+}
+
+
+std::string DBTREE::bbsmenu_name( std::string_view url )
+{
+    return DBTREE::get_bbsmenu( url )->get_name();
+}
+
+
+bool DBTREE::add_bbsmenu( const std::string& url, const std::string& name )
+{
+    return DBTREE::get_root()->add_bbsmenu( url, name );
+}
+
+
+bool DBTREE::move_bbsmenu( const std::string& url_old, const std::string& url_new,
+                           const std::string& name_old, const std::string& name_new )
+{
+    return DBTREE::get_root()->move_bbsmenu( url_old, url_new, name_old, name_new );
+}
+
+
+bool DBTREE::remove_bbsmenu( const std::string& url, const std::string& name )
+{
+    return DBTREE::get_root()->remove_bbsmenu( url, name );
+}
+
+
+void DBTREE::save_bbsmenu()
+{
+    DBTREE::get_root()->save_bbsmenu();
+}
+
+
+void DBTREE::download_bbsmenu( const std::string& url )
+{
+    DBTREE::get_bbsmenu( url )->download_bbsmenu();
+}
+
+
+// 外部BBSMENUの更新時間( std::time_t )
+std::time_t DBTREE::bbsmenu_get_time_modified( const std::string& url )
+{
+    return DBTREE::get_bbsmenu( url )->get_time_modified();
+}
+
+
+// 外部BBSMENUの更新時間( 文字列 )
+const std::string& DBTREE::bbsmenu_get_date_modified( const std::string& url )
+{
+    return DBTREE::get_bbsmenu( url )->get_date_modified();
 }
 
 

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -28,6 +28,7 @@ namespace XML
 namespace DBTREE
 {
     class Root;
+    class BBSMenu;
     class BoardBase;
     class NodeTreeBase;
     class ArticleBase;
@@ -37,6 +38,7 @@ namespace DBTREE
 
     // 各クラスのポインタ取得
     Root* get_root();
+    BBSMenu* get_bbsmenu( std::string_view url );
     BoardBase* get_board( const std::string& url );
     ArticleBase* get_article( const std::string& url );
 
@@ -95,6 +97,18 @@ namespace DBTREE
     void download_bbsmenu();
     const std::string& get_date_modified(); // bbsmenuの更新時間( 文字列 )
     time_t get_time_modified(); // bbsmenuの更新時間( time_t )
+
+    // 外部BBSMENU系
+    const std::list<DBTREE::BBSMenu>& get_bbsmenus();
+    std::string bbsmenu_name( std::string_view url );
+    bool add_bbsmenu( const std::string& url, const std::string& name );
+    bool move_bbsmenu( const std::string& url_old, const std::string& url_new,
+                       const std::string& name_old, const std::string& name_new );
+    bool remove_bbsmenu( const std::string& url, const std::string& name );
+    void save_bbsmenu();
+    void download_bbsmenu( const std::string& url );
+    const std::string& bbsmenu_get_date_modified( const std::string& url ); ///< 外部BBSMENUの更新時間( 文字列 )
+    std::time_t bbsmenu_get_time_modified( const std::string& url ); ///< 外部BBSMENUの更新時間( time_t )
 
     // board 系
     const std::string& board_path( const std::string& url );

--- a/src/dbtree/meson.build
+++ b/src/dbtree/meson.build
@@ -8,6 +8,7 @@ sources = [
   'articlejbbs.cpp',
   'articlelocal.cpp',
   'articlemachi.cpp',
+  'bbsmenu.cpp',
   'board2ch.cpp',
   'board2chcompati.cpp',
   'boardbase.cpp',

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -23,8 +23,9 @@
 
 namespace DBTREE
 {
-    class BoardBase;
     class ArticleBase;
+    class BBSMenu;
+    class BoardBase;
 
     // サーバ移転テーブル
     //
@@ -59,6 +60,9 @@ namespace DBTREE
         // 鯖移転テーブル
         std::list< MOVETABLE > m_movetable;
 
+        /// @brief 外部BBSMENU情報を保持するリスト
+        std::list<BBSMenu> m_list_bbsmenu;
+
         XML::Document m_xml_document;
         std::string m_rawdata;
         std::list< DBTREE::ETCBOARDINFO > m_etcboards; // 外部板情報
@@ -70,6 +74,9 @@ namespace DBTREE
 
         // Null board クラス
         std::unique_ptr<BoardBase> m_board_null;
+
+        /// @brief Null BBSMenu クラス
+        std::unique_ptr<BBSMenu> m_bbsmenu_null;
 
         // get_board()のキャッシュ
         // get_article_fromURL()のキャッシュ
@@ -154,6 +161,19 @@ namespace DBTREE
         // 全てのスレの書き込み履歴削除
         void clear_all_post_history();
 
+        /// @brief 外部BBSMENU情報を取得
+        const std::list<BBSMenu>& get_bbsmenus() const { return m_list_bbsmenu; }
+
+        // 外部BBSMENU
+        BBSMenu* get_bbsmenu( std::string_view url );
+        bool add_bbsmenu( const std::string& url, const std::string& name );
+        bool move_bbsmenu( const std::string& url_old, const std::string& url_new,
+                           const std::string& name_old, const std::string& name_new );
+        bool remove_bbsmenu( const std::string& url, const std::string& name );
+        void save_bbsmenu();
+        template<typename T>
+        void slot_analyze_board_xml( T& bbsmenu );
+
       private:
 
         // bbsmenuのダウンロード用関数
@@ -162,8 +182,8 @@ namespace DBTREE
         void receive_finish() override;
         void bbsmenu2xml( const std::string& menu );
 
-        // XML に含まれる板情報を取り出してデータベースを更新
-        void analyze_board_xml();
+        /// @brief XML に含まれる板情報を取り出してデータベースを更新
+        void analyze_board_xml() { slot_analyze_board_xml( *this ); }
 
         // 板のタイプを判定
         int get_board_type( const std::string& url, std::string& root, std::string& path_board ) const;
@@ -193,6 +213,7 @@ namespace DBTREE
                        const std::string& name,
                        BoardBase** board_old );
 
+        void load_bbsmenu();
         void load_cache();
         void load_etc();
         void load_movetable();

--- a/src/global.h
+++ b/src/global.h
@@ -108,6 +108,7 @@ static constexpr const int ICON_SIZE = 32; // 画像アイコンの大きさ
 #define ITEM_NAME_SELECTABONEIMG "選択範囲の画像をあぼ〜ん"
 
 #define ITEM_NAME_PREFERENCEVIEW "プロパティ"
+#define ITEM_NAME_PREF_BBSMENU   "BBSMENUのプロパティ"
 #define ITEM_NAME_PREF_BOARD     "板のプロパティ"
 #define ITEM_NAME_PREF_THREAD    "スレのプロパティ"
 #define ITEM_NAME_PREF_IMAGE     "画像のプロパティ"

--- a/src/icons/iconfiles.h
+++ b/src/icons/iconfiles.h
@@ -25,6 +25,7 @@ namespace ICON
         "link",
 
         // サイドバーやタブで使用するアイコン
+        "bbsmenu",
         "board",
         "board_update",
         "thread",

--- a/src/icons/iconid.h
+++ b/src/icons/iconid.h
@@ -25,6 +25,7 @@ namespace ICON
         LINK,
 
         // サイドバーやタブで使用するアイコン
+        BBSMENU,
         BOARD,
         BOARD_UPDATE,
         THREAD,

--- a/src/icons/iconmanager.cpp
+++ b/src/icons/iconmanager.cpp
@@ -240,6 +240,9 @@ ICON_Manager::ICON_Manager()
     const NamedIconLoader icon_loader{ size_menu };
     std::vector<Glib::ustring> icon_names;
 
+    // サイドバーやタブで使用するアイコン
+    m_list_icons[ ICON::BBSMENU ] = icon_loader.load_icon( "emblem-documents", size_menu );
+
     // 共通
     m_list_icons[ ICON::SEARCH_PREV ] = icon_loader.load_icon( "go-up", size_menu );
     m_list_icons[ ICON::SEARCH_NEXT ] = icon_loader.load_icon( "go-down", size_menu );

--- a/src/type.h
+++ b/src/type.h
@@ -17,6 +17,7 @@ enum
     TYPE_BOARD_UNKNOWN,
 
     // その他一般的なデータタイプ
+    TYPE_BBSMENU,
     TYPE_BOARD,
     TYPE_BOARD_UPDATE,
     TYPE_THREAD,

--- a/src/xml/dom.h
+++ b/src/xml/dom.h
@@ -117,6 +117,8 @@ namespace XML
         Dom* appendChild( const int node_type, const std::string& node_name );
         bool removeChild( Dom* node );
         Dom* emplace_front( int node_type, const std::string& node_name );
+        template<class Predicate>
+        std::size_t remove_if( Predicate pred );
 
         // 属性
         std::string getAttribute( const std::string& name ) const;
@@ -128,6 +130,29 @@ namespace XML
         auto begin() const noexcept { return m_childNodes.cbegin(); }
         auto end() const noexcept { return m_childNodes.cend(); }
     };
+
+    /** @brief 子ノードのうちpred(child)がtrueを返すものをすべて削除する
+     *
+     * @details このメンバー関数はchild自体もdeleteして開放する
+     * @tparam Predicate bool(const Dom*), trueなら削除する
+     * @param[in] pred 削除するかどうかチェックする関数呼び出し可能なオブジェクト
+     * @return 削除したノード数
+     */
+    template<typename Predicate>
+    std::size_t Dom::remove_if( Predicate pred )
+    {
+        std::size_t count = 0;
+        for( auto it = m_childNodes.begin(), end = m_childNodes.end(); it != end; ) {
+            it = std::find_if( it, end, pred );
+            if( it == end ) break;
+
+            Dom* child = *it;
+            it = m_childNodes.erase( it );
+            delete child;
+            ++count;
+        }
+        return count;
+    }
 }
 
 #endif

--- a/src/xml/tools.cpp
+++ b/src/xml/tools.cpp
@@ -19,6 +19,10 @@ std::string XML::get_name( const int type_id )
             name = "subdir";
             break;
 
+        case TYPE_BBSMENU: // 外部BBSMENU
+            name = "bbsmenu";
+            break;
+
         case TYPE_BOARD: // 板
             name = "board";
             break;
@@ -91,7 +95,11 @@ int XML::get_type( const std::string& node_name )
 {
     int type = TYPE_UNKNOWN;
 
-    if( node_name == "board" )
+    if( node_name == "bbsmenu" )
+    {
+        type = TYPE_BBSMENU;
+    }
+    else if( node_name == "board" )
     {
         type = TYPE_BOARD;
     }
@@ -171,6 +179,10 @@ Glib::RefPtr< Gdk::Pixbuf > XML::get_icon( const int type_id )
     {
         case TYPE_DIR:
             icon = ICON::get_icon( ICON::DIR );
+            break;
+
+        case TYPE_BBSMENU:
+            icon = ICON::get_icon( ICON::BBSMENU );
             break;
 
         case TYPE_BOARD:

--- a/test/gtest_xml_dom.cpp
+++ b/test/gtest_xml_dom.cpp
@@ -235,6 +235,29 @@ TEST_F(XML_DomChildren, emplace_front)
     EXPECT_EQ( dom.firstChild(), third_child );
 }
 
+TEST_F(XML_DomChildren, remove_if)
+{
+    XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "friends" };
+    XML::Dom* child;
+
+    child = dom.appendChild( XML::NODE_TYPE_ELEMENT, "Alice" );
+    child->setAttribute( "pet", "dog" );
+    child = dom.appendChild( XML::NODE_TYPE_ELEMENT, "Bob" );
+    child->setAttribute( "pet", "cat" );
+    child = dom.appendChild( XML::NODE_TYPE_ELEMENT, "Carol" );
+    child->setAttribute( "pet", "dog" );
+    child = dom.appendChild( XML::NODE_TYPE_ELEMENT, "Dave" );
+    child->setAttribute( "pet", "hamster" );
+
+    const std::size_t removed = dom.remove_if(
+        []( const XML::Dom* child ) { return child->getAttribute( "pet" ) == "dog"; } );
+
+    EXPECT_EQ( removed, 2 );
+    EXPECT_EQ( dom.firstChild()->nodeName(), "Bob" );
+    EXPECT_EQ( dom.firstChild()->getAttribute( "pet" ), "cat" );
+    EXPECT_EQ( dom.size(), 2 );
+}
+
 TEST_F(XML_DomChildren, children_clear)
 {
     XML::Dom dom{ XML::NODE_TYPE_UNKNOWN, "test" };


### PR DESCRIPTION
### Implement `CACHE::path_bbsmenu()` and `CACHE::path_bbsmenu_root()`

外部BBSMENUのディレクトリと設定ファイルのファイルパスを表す文字列を返す関数を実装します。

### Implement `XML::Dom::remove_if()`

`Dom`オブジェクトが持つchildノードのうち`pred(child)`がtrueを返すものをすべて削除するメンバー関数を実装します。
`remove_if()`はchild自体もdeleteして開放します。また、削除したchildの数を返します。

* Add test case for `XML::Dom::remove_if()`

### Implement `DBTREE::BBSMenu` class

BBSMENUの取得と板一覧のデータを構築するクラスを実装します。

`DBTREE::Root`クラスを元にして実装した関数があるため src/dbtree/bbsmenu.cpp のライセンスは GPL-2.0-only になります。
メンバー関数のうち`BBSMenu::path_bbsmenu_boards_xml()`は新規に書かれたコードなので抽出して GPL-2.0-or-later でライセンスすることが可能です。

### `Root`: Implement member functions for external BBSMENU

`Root`クラスに外部BBSMENUを取り扱うためのメンバーとメンバー関数を実装します。
外部BBSMENUの登録条件はURLの重複を許可しませんがBBSMENU名は重複できます。

### Implement DBTREE interface functions for external BBSMENU

`Root`クラスに実装された外部BBSMENUの機能にアクセスするインターフェース関数を実装します。

### Implement `AddEtcBBSMenuDialog` class

外部BBSMENUを追加/編集するダイアログボックスを実装します。

`AddEtcBBSMenuDialog`クラスは新規に書かれたコードなので抽出して GPL-2.0-or-later でライセンスすることが可能です。

### bbslist: Implement GUI for external BBSMENU

外部BBSMENUを追加するためのGUIを実装します。

#### 動作
- 板一覧の一番上に「外部BBSMENU」サブディレクトリを追加します。
- 「外部BBSMENU」を右クリックして「外部BBSMENUを追加する」を選択するとBBSMENU名とURLを入力するダイアログが表示されます。
- 入力してOKボタンを押すとBBSMENUがダウンロードされ板一覧の末尾に板が追加されます。
- 追加した外部BBSMENUの名前やURLを変更したいときは板一覧の「外部BBSMENU」をクリックしてサブディレクトリを開き変更したい項目を右クリックしてメニューの「編集」を選択して行います。
- 追加した外部BBSMENUを削除するときは同じくメニューの「外部BBSMENUを削除する」を選択します。確認ダイアログは表示しません。

設定ファイルのフォーマットは予告なく変更する場合があります。
そのためファイルの編集による登録はサポートしていません。

**この機能は実験的なサポートのため変更または廃止の可能性があります。**

#### 背景
修正前のJDimはBBSMENUの登録が一つに限られておりBBSMENUに含まれてない板は外部板に一つずつ追加していく必要がありました。
BBSMENUの登録数を増やして複数のBBSMENUから板を読み込めると便利になります。

### manual: Add description for external BBSMENU

外部BBSMENUの説明をオンラインマニュアルに追加します。

関連のissue: #1301
