### PR TITLE
Bump version to 0.11.0-beta

### DIFF
--- a/docs/manual/2023.md
+++ b/docs/manual/2023.md
@@ -11,6 +11,74 @@ layout: default
 
 <a name="0.11.0-unreleased"></a>
 ### [0.11.0-unreleased](https://github.com/JDimproved/JDim/compare/63816063253...master) (unreleased)
+- ([#1308](https://github.com/JDimproved/JDim/pull/1308))
+  Bump version to 0.11.0-beta
+- ([#1307](https://github.com/JDimproved/JDim/pull/1307))
+  Implement external BBSMENU
+- ([#1306](https://github.com/JDimproved/JDim/pull/1306))
+  Fix GitHub Actions workflows weeky CI
+- ([#1305](https://github.com/JDimproved/JDim/pull/1305))
+  Fix compiler warnings for `-Winconsistent-missing-destructor-override` part1,2,3
+- ([#1304](https://github.com/JDimproved/JDim/pull/1304))
+  Fix compiler warnings for `-Wsuggest-destructor-override` part2
+- ([#1303](https://github.com/JDimproved/JDim/pull/1303))
+  config: Add include "config.h" to src/config/globalconf.h
+- ([#1300](https://github.com/JDimproved/JDim/pull/1300))
+  `BBSListViewBase`: Update save function to be able to exclude multi dirs
+- ([#1299](https://github.com/JDimproved/JDim/pull/1299))
+  Update documents for introducing GPL-2.0-or-later
+- ([#1298](https://github.com/JDimproved/JDim/pull/1298))
+  Update license of the files that are confirmed by contributors
+- ([#1296](https://github.com/JDimproved/JDim/pull/1296))
+  `Loadable`: Add const qualifier to member function
+- ([#1295](https://github.com/JDimproved/JDim/pull/1295))
+  `Root`: Refactor BBS URL check functions
+- ([#1294](https://github.com/JDimproved/JDim/pull/1294))
+  `Root`: Add board types for open2ch.net and next2ch.net and 2ch.sc
+- ([#1293](https://github.com/JDimproved/JDim/pull/1293))
+  Change function argument type for `MISC::get_hostname()`
+- ([#1292](https://github.com/JDimproved/JDim/pull/1292))
+  Add test cases for `MISC::get_hostname()`
+- ([#1291](https://github.com/JDimproved/JDim/pull/1291))
+  `Root`: Add test cases for is\_xxx()
+- ([#1290](https://github.com/JDimproved/JDim/pull/1290))
+  Fix compiler warnings for `-Wsuggest-destructor-override` part1
+- ([#1289](https://github.com/JDimproved/JDim/pull/1289))
+  Fix compiler waning for `-Wmissing-noreturn`
+- ([#1288](https://github.com/JDimproved/JDim/pull/1288))
+  Fix compiler warnings for `-Wswitch-enum`
+- ([#1287](https://github.com/JDimproved/JDim/pull/1287))
+  Fix compiler warning for `-Wdeprecated-copy-with-dtor`
+- ([#1286](https://github.com/JDimproved/JDim/pull/1286))
+  Fix compiler warnings for `-Wmissing-variable-declarations` part1
+- ([#1285](https://github.com/JDimproved/JDim/pull/1285))
+  Fix compiler warning for `-Wdeprecated-redundant-constexpr-static-def`
+- ([#1284](https://github.com/JDimproved/JDim/pull/1284))
+  Fix compiler warnings for `-Wenum-float-conversion`
+- ([#1283](https://github.com/JDimproved/JDim/pull/1283))
+  Fix compiler warnings for `-Wanon-enum-enum-conversion`
+- ([#1282](https://github.com/JDimproved/JDim/pull/1282))
+  `Socket`: Fix stop check for IO event notify
+- ([#1280](https://github.com/JDimproved/JDim/pull/1280))
+  `Socket`: Use `poll(2)` instead of `select(2)` for IO event notify
+- ([#1279](https://github.com/JDimproved/JDim/pull/1279))
+  Add abone setting for consecutive posts to board preferences
+- ([#1277](https://github.com/JDimproved/JDim/pull/1277))
+  add guess encoding from text option
+- ([#1276](https://github.com/JDimproved/JDim/pull/1276))
+  `DrawAreaBase`: Fix segfault
+- ([#1275](https://github.com/JDimproved/JDim/pull/1275))
+  `NodeTreeMachi`: Fix subject encoding
+- ([#1274](https://github.com/JDimproved/JDim/pull/1274))
+  `TextLoader`: Add default encoding to fix Mojibake
+- ([#1272](https://github.com/JDimproved/JDim/pull/1272))
+  Introduce encoding detection option when encoding choose is disabled
+- ([#1271](https://github.com/JDimproved/JDim/pull/1271))
+  Modify board preferences to adjust text encoding setting position
+- ([#1270](https://github.com/JDimproved/JDim/pull/1270))
+  `Board2ch`: Get rid of useless override member functions
+- ([#1268](https://github.com/JDimproved/JDim/pull/1268))
+  Update histories
 
 
 <a name="0.10.1-20231007"></a>

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 
 project('jdim', 'cpp',
-        version : '0.10.1',
+        version : '0.11.0-beta',
         license : 'GPL2',
         meson_version : '>= 0.53.0',
         default_options : ['warning_level=3', 'cpp_std=c++17'])

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -15,10 +15,10 @@
 // SEE ALSO: ENVIRONMENT::get_jdversion()
 
 #define MAJORVERSION 0
-#define MINORVERSION 10
-#define MICROVERSION 1
-#define JDDATE_FALLBACK    "20231007"
-#define JDTAG     ""
+#define MINORVERSION 11
+#define MICROVERSION 0
+#define JDDATE_FALLBACK    "20231224"
+#define JDTAG     "beta"
 
 //---------------------------------
 


### PR DESCRIPTION
### Update histories

### Bump version to 0.11.0-beta
機能フリーズ期間に入るためバージョン番号をベータ版に更新します。

関連のissue: #1269
