### PR TITLE
BBSMenu: Fix compiler warning for -Wdefaulted-function-deleted

### DIFF
--- a/src/dbtree/bbsmenu.h
+++ b/src/dbtree/bbsmenu.h
@@ -15,16 +15,6 @@
 
 namespace DBTREE
 {
-// clang 8以下ではnoexceptがついたdefault constructorがコンパイルできない
-// 参考文献: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86583
-namespace {
-#if defined(__clang__) && __clang_major__ < 9
-constexpr bool kSupportNoexceptDefaultCtor = false;
-#else
-constexpr bool kSupportNoexceptDefaultCtor = true;
-#endif
-}
-
 
 /** @brief BBSMENUの取得と板一覧のデータを構築するクラス
  *
@@ -60,12 +50,13 @@ public:
     {
     }
 
-    BBSMenu( BBSMenu&& ) noexcept(kSupportNoexceptDefaultCtor)= default;
+    // copyとmoveは SKELETON::Loadable と XML::Document の対応が必要
+    BBSMenu( BBSMenu&& ) = delete;
     BBSMenu( const BBSMenu& ) = delete;
 
     ~BBSMenu() noexcept = default;
 
-    BBSMenu& operator=( BBSMenu&& ) noexcept(kSupportNoexceptDefaultCtor) = default;
+    BBSMenu& operator=( BBSMenu&& ) = delete;
     BBSMenu& operator=( const BBSMenu& ) = delete;
 
     /// @brief 外部BBSMENUは name の重複を許すため url のみで検索するときに使う


### PR DESCRIPTION
親クラス Loadable のmove constructorは暗黙的に削除されているため
子クラス BBSMenu のmove constructorに対してclangが警告を出しました。

BBSMenu のコピーやムーブは今のところ行っていないためmove constructorをdeleteに変更して修正します。

clang-16のレポート
```
In file included from ../src/bbslist/bbslistview.cpp:11:
../src/dbtree/bbsmenu.h:63:5: error: explicitly defaulted move constructor is implicitly deleted [-Werror,-Wdefaulted-function-deleted]
    BBSMenu( BBSMenu&& ) noexcept(kSupportNoexceptDefaultCtor)= default;
    ^
../src/dbtree/bbsmenu.h:35:17: note: move constructor of 'BBSMenu' is implicitly deleted because base class 'SKELETON::Loadable' has a deleted move constructor
class BBSMenu : public SKELETON::Loadable
                ^
../src/skeleton/loadable.h:71:40: note: copy constructor of 'Loadable' is implicitly deleted because field 'm_loader' has a deleted copy constructor
        std::unique_ptr<JDLIB::Loader> m_loader;
                                       ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/unique_ptr.h:522:7: note: 'unique_ptr' has been explicitly marked deleted here
      unique_ptr(const unique_ptr&) = delete;
      ^
../src/dbtree/bbsmenu.h:63:65: note: replace 'default' with 'delete'
    BBSMenu( BBSMenu&& ) noexcept(kSupportNoexceptDefaultCtor)= default;
                                                                ^~~~~~~
                                                                delete
../src/dbtree/bbsmenu.h:68:14: error: explicitly defaulted move assignment operator is implicitly deleted [-Werror,-Wdefaulted-function-deleted]
    BBSMenu& operator=( BBSMenu&& ) noexcept(kSupportNoexceptDefaultCtor) = default;
             ^
```

#### 背景
Pull requestやmasterブランチのCIでは警告ありでコンパイルが通っていましたが
Weekly CIはコンパイラー警告をエラーにするオプションなのでjobが失敗して通知が届きました。
https://github.com/JDimproved/JDim/actions/runs/7317856697
