### PR TITLE
Iconv: Fix incorrect reset for errno value

### DIFF
--- a/src/jdlib/jdiconv.cpp
+++ b/src/jdlib/jdiconv.cpp
@@ -49,6 +49,7 @@ Iconv::Iconv( const Encoding to, const Encoding from, const bool broken_sjis_be_
     std::cout << "Iconv::Iconv coding = " << from_str << " to " << to_str << std::endl;
 #endif
 
+    errno = 0;
     m_cd = g_iconv_open( to_str, from_str );
 
     if( m_cd == ( GIConv) -1 ) open_by_alternative_names( to_str, from_str );
@@ -58,11 +59,10 @@ Iconv::Iconv( const Encoding to, const Encoding from, const bool broken_sjis_be_
 void Iconv::open_by_alternative_names( const char* to_str, const char* from_str )
 {
     // "MS932"で失敗したら"CP932"で試してみる
-    errno = 0;
     if( m_enc_to == Encoding::sjis ) m_cd = g_iconv_open( "CP932", from_str );
     else if( m_enc_from == Encoding::sjis ) m_cd = g_iconv_open( to_str, "CP932" );
 
-    // "EUCJP-*"で失敗したら"EUCJP"で試してみる
+    // "EUCJP-MS"で失敗したら"EUCJP"で試してみる
     if( m_cd == ( GIConv ) - 1 && ( errno & EINVAL ) != 0 )
     {
         if( m_enc_to == Encoding::eucjp ) m_cd = g_iconv_open( "EUCJP//TRANSLIT", from_str );


### PR DESCRIPTION
iconvを初期化する処理でエラーを正しく判定していなかった不具合を修正します。
errnoの値をチェックする前に値を0にリセットしていたためエラーの検知ができなくなっていました。

#### バグ発覚の経緯
FreeBSD のiconvはエンコーディング EUCJP-MS をサポートしていない
場合があるようです。JDimでは EUCJP-MS が使えないとき EUCJP に
フォールバックして処理を続行しますが上記の不具合によって
機能していませんでした。

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1640504277/328-333n
