### PR TITLE
Fix compiler warnings for -Winconsistent-missing-destructor-override part4,5,6,7

### DIFF
--- a/src/article/articleview.h
+++ b/src/article/articleview.h
@@ -40,7 +40,7 @@ namespace ARTICLE
 
       public:
         explicit ArticleViewMain( const std::string& url );
-        ~ArticleViewMain();
+        ~ArticleViewMain() override;
 
         void clock_in() override;
         void clock_in_always() override;

--- a/src/article/articleviewbase.h
+++ b/src/article/articleviewbase.h
@@ -94,7 +94,7 @@ namespace ARTICLE
     public:
 
         ArticleViewBase( const std::string& url, const std::string& url_article );
-        ~ArticleViewBase();
+        ~ArticleViewBase() override;
 
         const std::string& url_article() const { return m_url_article; }
 

--- a/src/article/articleviewetc.h
+++ b/src/article/articleviewetc.h
@@ -19,7 +19,7 @@ namespace ARTICLE
 
       public:
         explicit ArticleViewRes( const std::string& url );
-        ~ArticleViewRes();
+        ~ArticleViewRes() override;
 
         // SKELETON::View の関数のオーバロード
         void relayout( const bool completely = false ) override;
@@ -43,7 +43,7 @@ namespace ARTICLE
 
       public:
         explicit ArticleViewName( const std::string& url );
-        ~ArticleViewName();
+        ~ArticleViewName() override;
 
         // SKELETON::View の関数のオーバロード
         void relayout( const bool completely = false ) override;
@@ -67,7 +67,7 @@ namespace ARTICLE
 
       public:
         explicit ArticleViewID( const std::string& url );
-        ~ArticleViewID();
+        ~ArticleViewID() override;
 
         // SKELETON::View の関数のオーバロード
         void relayout( const bool completely = false ) override;
@@ -91,7 +91,7 @@ namespace ARTICLE
 
       public:
         explicit ArticleViewBM( const std::string& url );
-        ~ArticleViewBM();
+        ~ArticleViewBM() override;
 
         // SKELETON::View の関数のオーバロード
         void relayout( const bool completely = false ) override;
@@ -116,7 +116,7 @@ namespace ARTICLE
 
       public:
         explicit ArticleViewPost( const std::string& url );
-        ~ArticleViewPost();
+        ~ArticleViewPost() override;
 
         // SKELETON::View の関数のオーバロード
         void relayout( const bool completely = false ) override;
@@ -141,7 +141,7 @@ namespace ARTICLE
 
       public:
         explicit ArticleViewHighRefRes( const std::string& url );
-        ~ArticleViewHighRefRes();
+        ~ArticleViewHighRefRes() override;
 
         // SKELETON::View の関数のオーバロード
         void relayout( const bool completely = false ) override;
@@ -164,7 +164,7 @@ namespace ARTICLE
     {
       public:
         explicit ArticleViewURL( const std::string& url );
-        ~ArticleViewURL();
+        ~ArticleViewURL() override;
 
         // SKELETON::View の関数のオーバロード
         void relayout( const bool completely = false ) override;
@@ -188,7 +188,7 @@ namespace ARTICLE
 
       public:
         explicit ArticleViewRefer( const std::string& url );
-        ~ArticleViewRefer();
+        ~ArticleViewRefer() override;
 
         // SKELETON::View の関数のオーバロード
         void relayout( const bool completely = false ) override;
@@ -214,7 +214,7 @@ namespace ARTICLE
 
       public:
         explicit ArticleViewDrawout( const std::string& url );
-        ~ArticleViewDrawout();
+        ~ArticleViewDrawout() override;
 
         // SKELETON::View の関数のオーバロード
         void relayout( const bool completely = false ) override;
@@ -237,7 +237,7 @@ namespace ARTICLE
 
       public:
         explicit ArticleViewPostlog( const std::string& url );
-        ~ArticleViewPostlog();
+        ~ArticleViewPostlog() override;
 
         // SKELETON::View の関数のオーバロード
         void relayout( const bool completely = false ) override;

--- a/src/article/articleviewinfo.h
+++ b/src/article/articleviewinfo.h
@@ -14,7 +14,7 @@ namespace ARTICLE
     {
       public:
         explicit ArticleViewInfo( const std::string& url );
-        ~ArticleViewInfo();
+        ~ArticleViewInfo() override;
 
         // viewの操作をキャンセル
         bool operate_view( const int control ) override { return false; }

--- a/src/article/articleviewpopup.h
+++ b/src/article/articleviewpopup.h
@@ -19,7 +19,7 @@ namespace ARTICLE
 
       public:
         ArticleViewPopup( const std::string& url, bool show_abone );
-        ~ArticleViewPopup();
+        ~ArticleViewPopup() override;
 
         void stop() override {}
 
@@ -41,7 +41,7 @@ namespace ARTICLE
 
       public:
         ArticleViewPopupHTML( const std::string& url, const std::string& html ): ArticleViewPopup( url, false ), m_html( html ){}
-        ~ArticleViewPopupHTML() noexcept = default;
+        ~ArticleViewPopupHTML() noexcept override = default;
 
         void show_view() override { append_html( m_html ); }
     };
@@ -59,7 +59,7 @@ namespace ARTICLE
       public:
         ArticleViewPopupRes( const std::string& url, const std::string& num, bool show_title, bool show_abone )
         : ArticleViewPopup( url, show_abone ), m_str_num( num ), m_show_title( show_title ){}
-        ~ArticleViewPopupRes() noexcept = default;
+        ~ArticleViewPopupRes() noexcept override = default;
 
         void show_view() override
         {
@@ -79,7 +79,7 @@ namespace ARTICLE
 
       public:
         ArticleViewPopupName( const std::string& url, const std::string& name ): ArticleViewPopup( url, false ), m_str_name( name ){}
-        ~ArticleViewPopupName() noexcept = default;
+        ~ArticleViewPopupName() noexcept override = default;
 
         void show_view() override
         {
@@ -99,7 +99,7 @@ namespace ARTICLE
 
       public:
         ArticleViewPopupID( const std::string& url, const std::string& id ): ArticleViewPopup( url, false ), m_str_id( id ) {}
-        ~ArticleViewPopupID() noexcept = default;
+        ~ArticleViewPopupID() noexcept override = default;
 
         void show_view() override
         {
@@ -119,7 +119,7 @@ namespace ARTICLE
 
       public:
         ArticleViewPopupRefer( const std::string& url, const std::string& num ): ArticleViewPopup( url, false ), m_str_num( num ){}
-        ~ArticleViewPopupRefer() noexcept = default;
+        ~ArticleViewPopupRefer() noexcept override = default;
 
         void show_view() override
         {
@@ -139,7 +139,7 @@ namespace ARTICLE
       public:
         ArticleViewPopupDrawout( const std::string& url, const std::string& query, bool mode_or )
         : ArticleViewPopup( url, false ), m_query( query ), m_mode_or( mode_or ){}
-        ~ArticleViewPopupDrawout() noexcept = default;
+        ~ArticleViewPopupDrawout() noexcept override = default;
 
         void show_view() override
         {
@@ -156,7 +156,7 @@ namespace ARTICLE
     {
       public:
         explicit ArticleViewPopupBM( const std::string& url ) : ArticleViewPopup( url, false ){}
-        ~ArticleViewPopupBM() noexcept = default;
+        ~ArticleViewPopupBM() noexcept override = default;
 
         void show_view() override
         {

--- a/src/article/articleviewpreview.h
+++ b/src/article/articleviewpreview.h
@@ -16,7 +16,7 @@ namespace ARTICLE
 
       public:
         explicit ArticleViewPreview( const std::string& url );
-        ~ArticleViewPreview();
+        ~ArticleViewPreview() override;
 
         bool operate_view( const int control ) override;
 

--- a/src/article/articleviewsearch.h
+++ b/src/article/articleviewsearch.h
@@ -31,7 +31,7 @@ namespace ARTICLE
 
         // exec_search == true ならviewを開いてすぐに検索開始
         ArticleViewSearch( const std::string& url, const bool exec_search );
-        ~ArticleViewSearch();
+        ~ArticleViewSearch() override;
 
         // SKELETON::View の関数のオーバロード
 

--- a/src/article/embeddedimage.h
+++ b/src/article/embeddedimage.h
@@ -34,7 +34,7 @@ namespace ARTICLE
       public:
 
         explicit EmbeddedImage( const std::string& url );
-        ~EmbeddedImage();
+        ~EmbeddedImage() override;
 
         Glib::RefPtr< Gdk::Pixbuf > get_pixbuf(){ return m_pixbuf; }
 

--- a/src/article/preference.h
+++ b/src/article/preference.h
@@ -81,7 +81,7 @@ namespace ARTICLE
       public:
 
         Preferences( Gtk::Window* parent, const std::string& url, const std::string& command );
-        ~Preferences() noexcept;
+        ~Preferences() noexcept override;
 
       private:
         void slot_ok_clicked() override;

--- a/src/article/toolbar.h
+++ b/src/article/toolbar.h
@@ -29,7 +29,7 @@ namespace ARTICLE
       public:
 
         ArticleToolBar(); 
-        ~ArticleToolBar() noexcept;
+        ~ArticleToolBar() noexcept override;
 
         // タブが切り替わった時に呼び出される( Viewの情報を取得する )
         void set_view( SKELETON::View * view ) override;

--- a/src/article/toolbarsearch.h
+++ b/src/article/toolbarsearch.h
@@ -26,7 +26,7 @@ namespace ARTICLE
       public:
 
         SearchToolBar();
-        ~SearchToolBar() noexcept;
+        ~SearchToolBar() noexcept override;
 
         // タブが切り替わった時に呼び出される( Viewの情報を取得する )
         void set_view( SKELETON::View * view ) override;

--- a/src/article/toolbarsimple.h
+++ b/src/article/toolbarsimple.h
@@ -14,7 +14,7 @@ namespace ARTICLE
       public:
 
         ArticleToolBarSimple();
-        ~ArticleToolBarSimple() noexcept;
+        ~ArticleToolBarSimple() noexcept override;
 
       protected:
 

--- a/src/articleitemmenupref.h
+++ b/src/articleitemmenupref.h
@@ -14,7 +14,7 @@ namespace CORE
       public:
 
         ArticleItemMenuPref( Gtk::Window* parent, const std::string& url );
-        ~ArticleItemMenuPref() noexcept = default;
+        ~ArticleItemMenuPref() noexcept override = default;
 
       private:
 

--- a/src/articleitempref.h
+++ b/src/articleitempref.h
@@ -14,7 +14,7 @@ namespace CORE
       public:
 
         ArticleItemPref( Gtk::Window* parent, const std::string& url );
-        ~ArticleItemPref() noexcept = default;
+        ~ArticleItemPref() noexcept override = default;
 
       private:
 

--- a/src/boarditemmenupref.h
+++ b/src/boarditemmenupref.h
@@ -14,7 +14,7 @@ namespace CORE
       public:
 
         BoardItemMenuPref( Gtk::Window* parent, const std::string& url );
-        ~BoardItemMenuPref() noexcept = default;
+        ~BoardItemMenuPref() noexcept override = default;
 
       private:
 

--- a/src/boarditempref.h
+++ b/src/boarditempref.h
@@ -14,7 +14,7 @@ namespace CORE
       public:
 
         BoardItemColumnPref( Gtk::Window* parent, const std::string& url );
-        ~BoardItemColumnPref() noexcept = default;
+        ~BoardItemColumnPref() noexcept override = default;
 
       private:
 
@@ -30,7 +30,7 @@ namespace CORE
       public:
 
         BoardItemPref( Gtk::Window* parent, const std::string& url );
-        ~BoardItemPref() noexcept = default;
+        ~BoardItemPref() noexcept override = default;
 
       private:
 

--- a/src/core.h
+++ b/src/core.h
@@ -121,7 +121,7 @@ namespace CORE
     public:
 
         explicit Core( JDWinMain& win_main );
-        ~Core();
+        ~Core() override;
 
         Gtk::Widget* get_toplevel();
 

--- a/src/dbimg/delimgdiag.h
+++ b/src/dbimg/delimgdiag.h
@@ -118,7 +118,7 @@ namespace DBIMG
             show_all_children();
         }
 
-        ~DelImgDiag() noexcept = default;
+        ~DelImgDiag() noexcept override = default;
     };
 
 }

--- a/src/dbtree/article2ch.h
+++ b/src/dbtree/article2ch.h
@@ -16,7 +16,7 @@ namespace DBTREE
       public:
 
         Article2ch( const std::string& datbase, const std::string& id, bool cached, const Encoding enc );
-        ~Article2ch() noexcept;
+        ~Article2ch() noexcept override;
 
         // 書き込みメッセージ作成
         std::string create_write_message( const std::string& name, const std::string& mail,

--- a/src/dbtree/article2chcompati.h
+++ b/src/dbtree/article2chcompati.h
@@ -16,7 +16,7 @@ namespace DBTREE
       public:
 
         Article2chCompati( const std::string& datbase, const std::string& id, bool cached, const Encoding enc );
-        ~Article2chCompati() noexcept;
+        ~Article2chCompati() noexcept override;
 
         // 書き込みメッセージ作成
         std::string create_write_message( const std::string& name, const std::string& mail,

--- a/src/dbtree/articlejbbs.h
+++ b/src/dbtree/articlejbbs.h
@@ -18,7 +18,7 @@ namespace DBTREE
       public:
 
         ArticleJBBS( const std::string& datbase, const std::string& id, bool cached, const Encoding enc );
-        ~ArticleJBBS() noexcept;
+        ~ArticleJBBS() noexcept override;
 
         // 書き込みメッセージ変換
         std::string create_write_message( const std::string& name, const std::string& mail,

--- a/src/dbtree/articlelocal.h
+++ b/src/dbtree/articlelocal.h
@@ -16,7 +16,7 @@ namespace DBTREE
       public:
 
         ArticleLocal( const std::string& datbase, const std::string& id, const Encoding enc );
-        ~ArticleLocal();
+        ~ArticleLocal() override;
 
         // ID がこのスレのものかどうか
         bool equal( const std::string& datbase, const std::string& id ) const override;

--- a/src/dbtree/articlemachi.h
+++ b/src/dbtree/articlemachi.h
@@ -18,7 +18,7 @@ namespace DBTREE
       public:
 
         ArticleMachi( const std::string& datbase, const std::string& id, bool cached, const Encoding enc );
-        ~ArticleMachi() noexcept;
+        ~ArticleMachi() noexcept override;
 
         // 書き込みメッセージ作成
         std::string create_write_message( const std::string& name, const std::string& mail,

--- a/src/dbtree/bbsmenu.h
+++ b/src/dbtree/bbsmenu.h
@@ -54,7 +54,7 @@ public:
     BBSMenu( BBSMenu&& ) = delete;
     BBSMenu( const BBSMenu& ) = delete;
 
-    ~BBSMenu() noexcept = default;
+    ~BBSMenu() noexcept override = default;
 
     BBSMenu& operator=( BBSMenu&& ) = delete;
     BBSMenu& operator=( const BBSMenu& ) = delete;

--- a/src/dbtree/board2ch.h
+++ b/src/dbtree/board2ch.h
@@ -29,7 +29,7 @@ namespace DBTREE
       public:
 
         Board2ch( const std::string& root, const std::string& path_board,const std::string& name );
-        ~Board2ch() noexcept;
+        ~Board2ch() noexcept override;
 
         // ユーザーエージェント
         const std::string& get_agent() const override; // ダウンロード用

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -25,7 +25,7 @@ namespace DBTREE
       public:
 
         Board2chCompati( const std::string& root, const std::string& path_board, const std::string& name, const std::string& basicauth );
-        ~Board2chCompati();
+        ~Board2chCompati() override;
 
         // 書き込み時に必要なキーワード( hana=mogera や suka=pontan など )を
         // 確認画面のhtmlから解析する      

--- a/src/dbtree/boardjbbs.h
+++ b/src/dbtree/boardjbbs.h
@@ -25,7 +25,7 @@ namespace DBTREE
       public:
 
         BoardJBBS( const std::string& root, const std::string& path_board,const std::string& name );
-        ~BoardJBBS() noexcept;
+        ~BoardJBBS() noexcept override;
 
         std::string url_datpath() const override;
 

--- a/src/dbtree/boardlocal.h
+++ b/src/dbtree/boardlocal.h
@@ -16,7 +16,7 @@ namespace DBTREE
       public:
 
         BoardLocal( const std::string& root, const std::string& path_board, const std::string& name );
-        ~BoardLocal() noexcept;
+        ~BoardLocal() noexcept override;
 
         // url がこの板のものかどうか
         bool equal( const std::string& url ) const override;

--- a/src/dbtree/boardmachi.h
+++ b/src/dbtree/boardmachi.h
@@ -16,7 +16,7 @@ namespace DBTREE
       public:
 
         BoardMachi( const std::string& root, const std::string& path_board,const std::string& name );
-        ~BoardMachi() noexcept = default;
+        ~BoardMachi() noexcept override = default;
 
         // url がこの板のものかどうか
         bool equal( const std::string& url ) const override;

--- a/src/dbtree/frontloader.h
+++ b/src/dbtree/frontloader.h
@@ -24,7 +24,7 @@ namespace DBTREE
       public:
 
         explicit FrontLoader( const std::string& url_boardbase );
-        ~FrontLoader() = default;
+        ~FrontLoader() override = default;
 
       protected:
 

--- a/src/dbtree/nodetree2ch.h
+++ b/src/dbtree/nodetree2ch.h
@@ -24,7 +24,7 @@ namespace DBTREE
 
         NodeTree2ch( const std::string& url, const std::string& org_url,
                      const std::string& date_modified, time_t since_time );
-        ~NodeTree2ch();
+        ~NodeTree2ch() override;
 
         int get_res_number_max() const noexcept override { return m_res_number_max; }
         std::size_t get_dat_volume_max() const noexcept override { return m_dat_volume_max; }

--- a/src/dbtree/nodetree2chcompati.h
+++ b/src/dbtree/nodetree2chcompati.h
@@ -26,7 +26,7 @@ namespace DBTREE
       public:
 
         NodeTree2chCompati( const std::string& url, const std::string& date_modified );
-        ~NodeTree2chCompati();
+        ~NodeTree2chCompati() override;
 
       protected:
 

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -158,7 +158,7 @@ namespace DBTREE
       public:
 
         NodeTreeBase( const std::string& url, const std::string& date_modified );
-        ~NodeTreeBase();
+        ~NodeTreeBase() override;
 
         bool empty() const noexcept { return m_url.empty(); }
         void update_url( const std::string& url );

--- a/src/dbtree/nodetreedummy.h
+++ b/src/dbtree/nodetreedummy.h
@@ -16,7 +16,7 @@ namespace DBTREE
       public:
 
         explicit NodeTreeDummy( const std::string& url );
-        ~NodeTreeDummy();
+        ~NodeTreeDummy() override;
 
         // ダウンロードしない
         void download_dat( const bool check_update ) override {}

--- a/src/dbtree/nodetreejbbs.h
+++ b/src/dbtree/nodetreejbbs.h
@@ -29,7 +29,7 @@ namespace DBTREE
       public:
 
         NodeTreeJBBS( const std::string& url, const std::string& date_modified );
-        ~NodeTreeJBBS();
+        ~NodeTreeJBBS() override;
 
       protected:
 

--- a/src/dbtree/nodetreelocal.h
+++ b/src/dbtree/nodetreelocal.h
@@ -16,7 +16,7 @@ namespace DBTREE
       public:
 
         explicit NodeTreeLocal( const std::string& url );
-        ~NodeTreeLocal();
+        ~NodeTreeLocal() override;
 
         // ダウンロードしない
         void download_dat( const bool check_update ) override {}

--- a/src/dbtree/nodetreemachi.h
+++ b/src/dbtree/nodetreemachi.h
@@ -37,7 +37,7 @@ namespace DBTREE
       public:
 
         NodeTreeMachi( const std::string& url, const std::string& date_modified );
-        ~NodeTreeMachi();
+        ~NodeTreeMachi() override;
 
       protected:
 

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -88,7 +88,7 @@ namespace DBTREE
       public:
 
         Root();
-        ~Root();
+        ~Root() override;
 
         // 板一覧のxml
         const XML::Document& xml_document() const { return m_xml_document; }

--- a/src/dbtree/ruleloader.h
+++ b/src/dbtree/ruleloader.h
@@ -24,7 +24,7 @@ namespace DBTREE
       public:
 
         explicit RuleLoader( const std::string& url_boardbase );
-        ~RuleLoader();
+        ~RuleLoader() override;
 
       protected:
 

--- a/src/dbtree/settingloader.h
+++ b/src/dbtree/settingloader.h
@@ -39,7 +39,7 @@ namespace DBTREE
       public:
 
         explicit SettingLoader( const std::string& url_boardbase );
-        ~SettingLoader();
+        ~SettingLoader() override;
 
         const std::string& default_noname() const { return m_default_noname; }
         int line_number() const noexcept { return m_line_number; }

--- a/src/fontcolorpref.h
+++ b/src/fontcolorpref.h
@@ -82,7 +82,7 @@ namespace CORE
       public:
 
         FontColorPref( Gtk::Window* parent, const std::string& url );
-        ~FontColorPref() noexcept;
+        ~FontColorPref() noexcept override;
 
       private:
 

--- a/src/globalabonepref.h
+++ b/src/globalabonepref.h
@@ -72,7 +72,7 @@ namespace CORE
             show_all_children();
         }
 
-        ~GlobalAbonePref() noexcept = default;
+        ~GlobalAbonePref() noexcept override = default;
     };
 
 }

--- a/src/globalabonethreadpref.h
+++ b/src/globalabonethreadpref.h
@@ -133,7 +133,7 @@ namespace CORE
             show_all_children();
         }
 
-        ~GlobalAboneThreadPref() noexcept = default;
+        ~GlobalAboneThreadPref() noexcept override = default;
     };
 
 }

--- a/src/livepref.h
+++ b/src/livepref.h
@@ -35,7 +35,7 @@ namespace CORE
       public:
 
         LivePref( Gtk::Window* parent, const std::string& url );
-        ~LivePref() noexcept = default;
+        ~LivePref() noexcept override = default;
 
       private:
 

--- a/src/login2ch.h
+++ b/src/login2ch.h
@@ -24,7 +24,7 @@ namespace CORE
       public:
 
         Login2ch();
-        ~Login2ch() = default;
+        ~Login2ch() override = default;
 
         void start_login() override;
         void logout() override;

--- a/src/loginbe.h
+++ b/src/loginbe.h
@@ -24,7 +24,7 @@ namespace CORE
       public:
 
         LoginBe();
-        ~LoginBe() = default;
+        ~LoginBe() override = default;
 
         void start_login() override;
         void logout() override;

--- a/src/mainitempref.h
+++ b/src/mainitempref.h
@@ -14,7 +14,7 @@ namespace CORE
       public:
 
         MainItemPref( Gtk::Window* parent, const std::string& url );
-        ~MainItemPref() noexcept = default;
+        ~MainItemPref() noexcept override = default;
 
       private:
 

--- a/src/maintoolbar.h
+++ b/src/maintoolbar.h
@@ -41,7 +41,7 @@ namespace CORE
       public:
 
         MainToolBar(); 
-        ~MainToolBar() noexcept;
+        ~MainToolBar() noexcept override;
 
       protected:
 

--- a/src/msgitempref.h
+++ b/src/msgitempref.h
@@ -14,7 +14,7 @@ namespace CORE
       public:
 
         MsgItemPref( Gtk::Window* parent, const std::string& url );
-        ~MsgItemPref() noexcept = default;
+        ~MsgItemPref() noexcept override = default;
 
       private:
 

--- a/src/openurldiag.h
+++ b/src/openurldiag.h
@@ -19,7 +19,7 @@ namespace CORE
       public:
 
         explicit OpenURLDialog( const std::string& url );
-        ~OpenURLDialog() noexcept = default;
+        ~OpenURLDialog() noexcept override = default;
 
       protected:
 

--- a/src/passwdpref.h
+++ b/src/passwdpref.h
@@ -134,7 +134,7 @@ namespace CORE
             show_all_children();
         }
 
-        ~PasswdPref() noexcept = default;
+        ~PasswdPref() noexcept override = default;
     };
 
 }

--- a/src/privacypref.h
+++ b/src/privacypref.h
@@ -78,7 +78,7 @@ namespace CORE
             show_all_children();
         }
 
-        ~PrivacyPref() noexcept = default;
+        ~PrivacyPref() noexcept override = default;
     };
 
 }

--- a/src/proxypref.h
+++ b/src/proxypref.h
@@ -256,7 +256,7 @@ namespace CORE
             show_all_children();
         }
 
-        ~ProxyPref() noexcept = default;
+        ~ProxyPref() noexcept override = default;
     };
 
 }

--- a/src/searchitempref.h
+++ b/src/searchitempref.h
@@ -14,7 +14,7 @@ namespace CORE
       public:
 
         SearchItemPref( Gtk::Window* parent, const std::string& url );
-        ~SearchItemPref() noexcept = default;
+        ~SearchItemPref() noexcept override = default;
 
       private:
 

--- a/src/searchloader.h
+++ b/src/searchloader.h
@@ -24,7 +24,7 @@ namespace CORE
       public:
 
         SearchLoader();
-        ~SearchLoader();
+        ~SearchLoader() override;
 
         SIG_SEARCH_FIN sig_search_fin(){ return m_sig_search_fin; }
 

--- a/src/sidebaritempref.h
+++ b/src/sidebaritempref.h
@@ -14,7 +14,7 @@ namespace CORE
       public:
 
         SidebarItemPref( Gtk::Window* parent, const std::string& url  );
-        ~SidebarItemPref() noexcept = default;
+        ~SidebarItemPref() noexcept override = default;
 
       private:
 

--- a/src/skeleton/aamenu.h
+++ b/src/skeleton/aamenu.h
@@ -31,7 +31,7 @@ namespace SKELETON
       public:
 
         explicit AAMenu( Gtk::Window& parent );
-        ~AAMenu();
+        ~AAMenu() override;
 
         // 選択されたらemitされる
         SIG_AAMENU_SELECTED sig_selected() { return m_sig_selected; }

--- a/src/skeleton/hpaned.h
+++ b/src/skeleton/hpaned.h
@@ -19,7 +19,7 @@ namespace SKELETON
       public:
 
         explicit JDHPaned( const int fixmode );
-        ~JDHPaned() noexcept;
+        ~JDHPaned() noexcept override;
 
         HPaneControl& get_ctrl(){ return m_pctrl; }
 

--- a/src/skeleton/panecontrol.h
+++ b/src/skeleton/panecontrol.h
@@ -100,7 +100,7 @@ namespace SKELETON
       public:
 
         using PaneControl::PaneControl;
-        ~HPaneControl() noexcept = default;
+        ~HPaneControl() noexcept override = default;
 
       protected:
 
@@ -122,7 +122,7 @@ namespace SKELETON
       public:
 
         using PaneControl::PaneControl;
-        ~VPaneControl() noexcept = default;
+        ~VPaneControl() noexcept override = default;
 
       protected:
 

--- a/src/skeleton/selectitempref.h
+++ b/src/skeleton/selectitempref.h
@@ -79,7 +79,7 @@ namespace SKELETON
       public:
 
         SelectItemPref( Gtk::Window* parent, const std::string& url );
-        ~SelectItemPref() noexcept = default;
+        ~SelectItemPref() noexcept override = default;
 
       private:
 

--- a/src/skeleton/tablabel.h
+++ b/src/skeleton/tablabel.h
@@ -49,7 +49,7 @@ namespace SKELETON
       public:
 
         explicit TabLabel( const std::string& url );
-        ~TabLabel() noexcept = default;
+        ~TabLabel() noexcept override = default;
 
         SIG_TAB_MOTION_EVENT sig_tab_motion_event(){ return  m_sig_tab_motion_event; }
         SIG_TAB_LEAVE_EVENT sig_tab_leave_event(){ return m_sig_tab_leave_event; }

--- a/src/skeleton/textloader.h
+++ b/src/skeleton/textloader.h
@@ -33,7 +33,7 @@ namespace SKELETON
       public:
 
         TextLoader();
-        ~TextLoader();
+        ~TextLoader() override;
 
         const std::string& get_data() const { return m_data; }
 

--- a/src/skeleton/vpaned.h
+++ b/src/skeleton/vpaned.h
@@ -19,7 +19,7 @@ namespace SKELETON
       public:
 
         explicit JDVPaned( const int fixmode );
-        ~JDVPaned() noexcept;
+        ~JDVPaned() noexcept override;
 
         VPaneControl& get_ctrl(){ return m_pctrl; }
 

--- a/src/winmain.h
+++ b/src/winmain.h
@@ -29,7 +29,7 @@ class JDWinMain : public SKELETON::JDWindow
   public:
 
     JDWinMain( const bool init, const bool skip_setupdiag, const int init_w, const int init_h, const int init_x, const int init_y );
-    ~JDWinMain();
+    ~JDWinMain() override;
 
     // 通常のセッション保存
     void save_session();


### PR DESCRIPTION
### Fix compiler warnings for -Winconsistent-missing-destructor-override part4

オーバーライドしたデストラクタにoverrideキーワードが付いていないとコンパイラーに指摘されたため修正します。

<details>
<summary>clang-17のレポート (file pathを一部省略)</summary>

```
src/article/articleview.h:43:9: warning: '~ArticleViewMain' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewbase.h:97:9: warning: '~ArticleViewBase' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewetc.h:119:9: warning: '~ArticleViewPost' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewetc.h:144:9: warning: '~ArticleViewHighRefRes' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewetc.h:167:9: warning: '~ArticleViewURL' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewetc.h:191:9: warning: '~ArticleViewRefer' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewetc.h:217:9: warning: '~ArticleViewDrawout' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewetc.h:22:9: warning: '~ArticleViewRes' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewetc.h:240:9: warning: '~ArticleViewPostlog' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewetc.h:46:9: warning: '~ArticleViewName' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewetc.h:70:9: warning: '~ArticleViewID' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewetc.h:94:9: warning: '~ArticleViewBM' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewpopup.h:102:9: warning: '~ArticleViewPopupID' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewpopup.h:122:9: warning: '~ArticleViewPopupRefer' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewpopup.h:142:9: warning: '~ArticleViewPopupDrawout' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewpopup.h:159:9: warning: '~ArticleViewPopupBM' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewpopup.h:22:9: warning: '~ArticleViewPopup' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewpopup.h:44:9: warning: '~ArticleViewPopupHTML' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewpopup.h:62:9: warning: '~ArticleViewPopupRes' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewpopup.h:82:9: warning: '~ArticleViewPopupName' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
```

</details>

### Fix compiler warnings for -Winconsistent-missing-destructor-override part5

オーバーライドしたデストラクタにoverrideキーワードが付いていないとコンパイラーに指摘されたため修正します。

<details>
<summary>clang-17のレポート (file pathを一部省略)</summary>

```
src/article/articleviewinfo.h:17:9: warning: '~ArticleViewInfo' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewpreview.h:19:9: warning: '~ArticleViewPreview' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/articleviewsearch.h:34:9: warning: '~ArticleViewSearch' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/embeddedimage.h:37:9: warning: '~EmbeddedImage' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/preference.h:84:9: warning: '~Preferences' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/toolbar.h:32:9: warning: '~ArticleToolBar' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/toolbarsearch.h:29:9: warning: '~SearchToolBar' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/article/toolbarsimple.h:17:9: warning: '~ArticleToolBarSimple' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/article2ch.h:19:9: warning: '~Article2ch' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/article2chcompati.h:19:9: warning: '~Article2chCompati' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/articlejbbs.h:21:9: warning: '~ArticleJBBS' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/articlelocal.h:19:9: warning: '~ArticleLocal' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/articlemachi.h:21:9: warning: '~ArticleMachi' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/nodetree2ch.h:27:9: warning: '~NodeTree2ch' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/nodetree2chcompati.h:29:9: warning: '~NodeTree2chCompati' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/nodetreebase.h:161:9: warning: '~NodeTreeBase' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/nodetreedummy.h:19:9: warning: '~NodeTreeDummy' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/nodetreejbbs.h:32:9: warning: '~NodeTreeJBBS' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/nodetreelocal.h:19:9: warning: '~NodeTreeLocal' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/nodetreemachi.h:40:9: warning: '~NodeTreeMachi' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
```

</details>

### Fix compiler warnings for -Winconsistent-missing-destructor-override part6

オーバーライドしたデストラクタにoverrideキーワードが付いていないとコンパイラーに指摘されたため修正します。

<details>
<summary>clang-17のレポート (file pathを一部省略)</summary>

```
src/articleitemmenupref.h:17:9: warning: '~ArticleItemMenuPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/board2ch.h:32:9: warning: '~Board2ch' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/board2chcompati.h:28:9: warning: '~Board2chCompati' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/boardjbbs.h:28:9: warning: '~BoardJBBS' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/boardlocal.h:19:9: warning: '~BoardLocal' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/boardmachi.h:19:9: warning: '~BoardMachi' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/frontloader.h:27:9: warning: '~FrontLoader' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/root.h:84:9: warning: '~Root' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/ruleloader.h:27:9: warning: '~RuleLoader' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/settingloader.h:42:9: warning: '~SettingLoader' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/login2ch.h:27:9: warning: '~Login2ch' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/loginbe.h:27:9: warning: '~LoginBe' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/skeleton/aamenu.h:34:9: warning: '~AAMenu' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/skeleton/hpaned.h:22:9: warning: '~JDHPaned' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/skeleton/panecontrol.h:103:9: warning: '~HPaneControl' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/skeleton/panecontrol.h:125:9: warning: '~VPaneControl' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/skeleton/selectitempref.h:82:9: warning: '~SelectItemPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/skeleton/tablabel.h:52:9: warning: '~TabLabel' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/skeleton/textloader.h:36:9: warning: '~TextLoader' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/skeleton/vpaned.h:22:9: warning: '~JDVPaned' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
```

</details>

### Fix compiler warnings for -Winconsistent-missing-destructor-override part7

オーバーライドしたデストラクタにoverrideキーワードが付いていないとコンパイラーに指摘されたため修正します。

<details>
<summary>clang-17のレポート (file pathを一部省略)</summary>

```
src/articleitempref.h:17:9: warning: '~ArticleItemPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/boarditemmenupref.h:17:9: warning: '~BoardItemMenuPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/boarditempref.h:17:9: warning: '~BoardItemColumnPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/boarditempref.h:33:9: warning: '~BoardItemPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/core.h:124:9: warning: '~Core' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbimg/delimgdiag.h:121:9: warning: '~DelImgDiag' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/dbtree/bbsmenu.h:57:5: warning: '~BBSMenu' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/fontcolorpref.h:85:9: warning: '~FontColorPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/globalabonepref.h:75:9: warning: '~GlobalAbonePref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/globalabonethreadpref.h:136:9: warning: '~GlobalAboneThreadPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/livepref.h:38:9: warning: '~LivePref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/mainitempref.h:17:9: warning: '~MainItemPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/maintoolbar.h:44:9: warning: '~MainToolBar' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/msgitempref.h:17:9: warning: '~MsgItemPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/openurldiag.h:22:9: warning: '~OpenURLDialog' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/passwdpref.h:137:9: warning: '~PasswdPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/privacypref.h:81:9: warning: '~PrivacyPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/proxypref.h:259:9: warning: '~ProxyPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/searchitempref.h:17:9: warning: '~SearchItemPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/searchloader.h:27:9: warning: '~SearchLoader' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/sidebaritempref.h:17:9: warning: '~SidebarItemPref' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
src/winmain.h:32:5: warning: '~JDWinMain' overrides a destructor but is not marked 'override' [-Winconsistent-missing-destructor-override]
```

</details>

関連のpull request: #1305
