### PR TITLE
Fix compiler warning for -Wsuggest-destructor-override part3

### DIFF
--- a/src/bbslist/addetcdialog.h
+++ b/src/bbslist/addetcdialog.h
@@ -51,7 +51,7 @@ namespace BBSLIST
       public:
 
         AddEtcBBSMenuDialog( Gtk::Window* parent, const bool edit, const Glib::ustring& url, const Glib::ustring& name );
-        ~AddEtcBBSMenuDialog() noexcept = default;
+        ~AddEtcBBSMenuDialog() noexcept override = default;
 
         std::string get_name() const { return m_entry_name.get_text(); }
         std::string get_url() const { return m_entry_url.get_text(); }


### PR DESCRIPTION
オーバーライドしたデストラクタにoverrideキーワードが付いていないとコンパイラーに指摘されたため修正します。

clang-17のレポート (file pathを一部省略)
```
src/bbslist/addetcdialog.h:54:9: warning: '~AddEtcBBSMenuDialog' overrides a destructor but is not marked 'override' [-Wsuggest-destructor-override]
   54 |         ~AddEtcBBSMenuDialog() noexcept = default;
      |         ^
```

関連のpull request: #1305
