### PR TITLE
Add license to pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: FSFAP -->
 <!--
 Pull request(PR)の作成ありがとうございます！
 このコメントやテンプレートは変形・削除しても問題ありません。


### PR DESCRIPTION
ファイル作成したときにライセンス表示が抜けていたため FSFAP を追記します。

関連のpull request: #1299
