### PR TITLE
Root: Move analyze_board_xml() definition to cpp file

### DIFF
--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -565,6 +565,15 @@ void Root::slot_analyze_board_xml( T& bbsmenu )
 }
 
 
+/**
+ * @brief XML に含まれる板情報を取り出してデータベースを更新
+ */
+void Root::analyze_board_xml()
+{
+    slot_analyze_board_xml( *this );
+}
+
+
 //
 // 板のタイプを判定
 //

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -182,8 +182,8 @@ namespace DBTREE
         void receive_finish() override;
         void bbsmenu2xml( const std::string& menu );
 
-        /// @brief XML に含まれる板情報を取り出してデータベースを更新
-        void analyze_board_xml() { slot_analyze_board_xml( *this ); }
+        // XML に含まれる板情報を取り出してデータベースを更新
+        void analyze_board_xml();
 
         // 板のタイプを判定
         int get_board_type( const std::string& url, std::string& root, std::string& path_board ) const;


### PR DESCRIPTION
メンバー関数の中で呼び出しているテンプレート関数はインスタンス化が必要だが利用可能な定義がないとclangに警告されたためメンバー関数をclass定義の外に移動します。

clang 17のレポート
```
../src/dbtree/root.h:186:36: warning: instantiation of function 'DBTREE::Root::slot_analyze_board_xml<DBTREE::Root>' required here, but no definition is available [-Wundefined-func-template]
  186 |         void analyze_board_xml() { slot_analyze_board_xml( *this ); }
      |                                    ^
../src/dbtree/root.h:175:14: note: forward declaration of template entity is here
  175 |         void slot_analyze_board_xml( T& bbsmenu );
      |              ^
../src/dbtree/root.h:186:36: note: add an explicit instantiation declaration to suppress this warning if 'DBTREE::Root::slot_analyze_board_xml<DBTREE::Root>' is explicitly instantiated in another translation unit
  186 |         void analyze_board_xml() { slot_analyze_board_xml( *this ); }
      |                                    ^
```

関連のpull request: #1307
