### PR TITLE
Fix codes that are reported by cppcheck 2.13.0

### DIFF
--- a/src/article/preference.cpp
+++ b/src/article/preference.cpp
@@ -271,7 +271,7 @@ void Preferences::slot_ok_clicked()
     std::vector< char > vec_abone_res;
     vec_abone_res.resize( DBTREE::article_number_load( get_url() ) + 1 );
     std::list< std::string > list_res = MISC::get_lines( m_edit_res.get_text() );
-    for( std::string& num_str : list_res ) {
+    for( const std::string& num_str : list_res ) {
 
         int number = atoi( num_str.c_str() );
         if( number >= 1 ){

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -1119,7 +1119,7 @@ guint64 CACHE::get_dirsize( const std::string& dir )
     DIR *dirp = opendir( to_locale_cstr( dir ) );
     if( !dirp ) return 0;
 
-    struct dirent *direntry;
+    const struct dirent *direntry;
     while( ( direntry = readdir( dirp ) ) ){
         std::string filename = dir + direntry->d_name;
         total_size += CACHE::get_filesize( filename );

--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -291,7 +291,7 @@ size = atof( sizestr.c_str() ); \
 type = SIZETYPE_PX; \
 if( sizestr.find( "em" ) != std::string::npos ) type = SIZETYPE_EM; \
 }while(0)
-CSS_PROPERTY Css_Manager::create_property( std::map< std::string, std::string >& css_pair )
+CSS_PROPERTY Css_Manager::create_property( const std::map<std::string, std::string>& css_pair )
 {
     CSS_PROPERTY css;
     clear_property( &css );

--- a/src/cssmanager.h
+++ b/src/cssmanager.h
@@ -175,7 +175,7 @@ namespace CORE
         int register_class( const std::string& classname );
 
         // cssプロパティ関係
-        CSS_PROPERTY create_property( std::map< std::string, std::string >& css_pair );
+        CSS_PROPERTY create_property( const std::map<std::string, std::string>& css_pair );
         void set_property( const std::string& classname, const CSS_PROPERTY& css );
         void clear_property( CSS_PROPERTY* css );
         void set_default_css();

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -3701,7 +3701,7 @@ bool NodeTreeBase::check_abone_chain( const int number )
                     // ひとつでもあぼーんされていないレスが見付かったらあぼーんしない
                     while( anc_from <= anc_to ){
 
-                        NODE* tmphead = res_header( anc_from++ );
+                        const NODE* tmphead = res_header( anc_from++ );
                         if( tmphead && ! tmphead->headinfo->abone ) return false;
                     }
 
@@ -3782,7 +3782,7 @@ void NodeTreeBase::check_reference( const int number )
 #ifdef _DEBUG
                     std::cout << "from " << from << std::endl;
 #endif
-                    NODE* tmphead = res_header( from );
+                    const NODE* tmphead = res_header( from );
                     if( tmphead && ! tmphead->headinfo->abone ){
                         m_refer_posts.insert( from );
                     }

--- a/src/jdlib/jdiconv.cpp
+++ b/src/jdlib/jdiconv.cpp
@@ -135,7 +135,7 @@ std::string& Iconv::convert( char* str_in, std::size_t size_in, std::string& out
     const char* buf_in_end = str_in + size_in;
 
     char* buf_out_tmp = out_buf.data();
-    char* buf_out_end = out_buf.data() + out_buf.size();
+    const char* buf_out_end = out_buf.data() + out_buf.size();
 
     const char* pre_check = nullptr; // 前回チェックしたUTF-8の先頭
 

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1843,9 +1843,9 @@ std::string MISC::recover_path( const std::string& str )
     return str;
 }
 
-std::vector< std::string > MISC::recover_path( std::vector< std::string > list_str )
+std::vector<std::string> MISC::recover_path( const std::vector<std::string>& list_path )
 {
-    return list_str;
+    return list_path;
 }
 
 

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -245,7 +245,7 @@ namespace MISC
 
     // pathセパレータを / に置き換える
     std::string recover_path( const std::string& str );
-    std::vector< std::string > recover_path( std::vector< std::string > list_str );
+    std::vector<std::string> recover_path( const std::vector<std::string>& list_path );
 
     // 文字列(utf-8)に全角英数字が含まれるか判定する
     bool has_widechar( const char* str );

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -1153,15 +1153,11 @@ void SESSION::set_col_diff( const int width ){ board_col_diff = width; }
 // 現在開いているarticle の ARTICLE::DrawAreaBase
 ARTICLE::DrawAreaBase* SESSION::get_base_drawarea()
 {
-    ARTICLE::ArticleViewBase* base_view = nullptr;
-    base_view = dynamic_cast< ARTICLE::ArticleViewBase* >( ARTICLE::get_admin()->get_current_view() );
+    auto base_view = dynamic_cast<const ARTICLE::ArticleViewBase*>( ARTICLE::get_admin()->get_current_view() );
 
     if( base_view == nullptr ) return nullptr;
 
-    ARTICLE::DrawAreaBase* base_drawarea = nullptr;
-    base_drawarea = base_view->drawarea();
-
-    return base_drawarea;
+    return base_view->drawarea();
 }
 
 

--- a/src/viewfactory.cpp
+++ b/src/viewfactory.cpp
@@ -26,7 +26,7 @@
 
 #include "message/messageview.h"
 
-SKELETON::View* CORE::ViewFactory( int type, const std::string& url, VIEWFACTORY_ARGS view_args )
+SKELETON::View* CORE::ViewFactory( int type, const std::string& url, const VIEWFACTORY_ARGS& view_args )
 {
     switch( type )
     {

--- a/src/viewfactory.h
+++ b/src/viewfactory.h
@@ -76,7 +76,7 @@ namespace CORE
         std::string arg4;
     };
     
-    SKELETON::View* ViewFactory( int type, const std::string& url, VIEWFACTORY_ARGS view_args = VIEWFACTORY_ARGS() );
+    SKELETON::View* ViewFactory( int type, const std::string& url, const VIEWFACTORY_ARGS& view_args = {} );
 }
 
 #endif


### PR DESCRIPTION
### Add const qualifier to pointer for local variable

ローカル変数のポインターにconstを付けられるとcppcheckに指摘されたため修正します。

cppcheck 2.13のレポート
```
src/cache.cpp:1122:20: style: Variable 'direntry' can be declared as pointer to const [constVariablePointer]
    struct dirent *direntry;
                   ^
src/jdlib/jdiconv.cpp:138:11: style: Variable 'buf_out_end' can be declared as pointer to const [constVariablePointer]
    char* buf_out_end = out_buf.data() + out_buf.size();
          ^
src/session.cpp:1156:31: style: Variable 'base_view' can be declared as pointer to const [constVariablePointer]
    ARTICLE::ArticleViewBase* base_view = nullptr;
                              ^
src/dbtree/nodetreebase.cpp:3704:31: style: Variable 'tmphead' can be declared as pointer to const [constVariablePointer]
                        NODE* tmphead = res_header( anc_from++ );
                              ^
src/dbtree/nodetreebase.cpp:3785:27: style: Variable 'tmphead' can be declared as pointer to const [constVariablePointer]
                    NODE* tmphead = res_header( from );
                          ^
```

### Add const qualifier to reference for local variable and parameter

ローカル変数や関数パラメーターの参照にconstを付けられるとcppcheckに指摘されたため修正します。

cppcheck 2.13のレポート
```
src/article/preference.cpp:274:23: style: Variable 'num_str' can be declared as reference to const [constVariableReference]
    for( std::string& num_str : list_res ) {
                      ^
src/cssmanager.cpp:294:82: style: Parameter 'css_pair' can be declared as reference to const [constParameterReference]
CSS_PROPERTY Css_Manager::create_property( std::map< std::string, std::string >& css_pair )
                                                                                 ^
```

### Change function argument type to const reference

関数の値渡しをするパラメーターをconst referenceにできるとcppcheckに指摘されたため修正します。

cppcheck 2.13のレポート
```
src/jdlib/miscutil.cpp:1846:75: performance: Parameter 'list_str' is passed by value. It could be passed as a const reference which is usually faster and recommended in C++. [passedByValue]
std::vector< std::string > MISC::recover_path( std::vector< std::string > list_str )
                                                                          ^
src/viewfactory.cpp:29:87: performance: Parameter 'view_args' is passed by value. It could be passed as a const reference which is usually faster and recommended in C++. [passedByValue]
SKELETON::View* CORE::ViewFactory( int type, const std::string& url, VIEWFACTORY_ARGS view_args )
                                                                                      ^
```
