### PR TITLE
Decode character reference in thread subject to fix postlog saving

### DIFF
--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -1068,7 +1068,12 @@ void MessageViewBase::save_postlog()
     if( ! m_text_message ) return;
 
     std::string subject = MESSAGE::get_admin()->get_new_subject();
-    if( subject.empty() ) subject = DBTREE::article_subject( get_url() );
+    if( subject.empty() ) {
+        // article_subject() の戻り値はスレの文字エンコーディングで扱えない文字を文字参照に変換している。
+        // そのまま Log_Manager::save() に渡すと & が二重にエスケープされるため
+        // 文字参照をUTF-8テキストにデコードしておく。
+        subject = MISC::chref_decode( DBTREE::article_subject( get_url() ) );
+    }
     const std::string msg = m_text_message->get_text();
     const std::string name = get_entry_name().get_text();
     const std::string mail = get_entry_mail().get_text();


### PR DESCRIPTION
書き込みログをファイルに保存する前にスレタイに含まれる文字参照をデコードするように修正します。
修正前はスレタイに含まれている文字参照のアンパサンド(&)が二重にエスケープされて保存される状態だったのでログを見たとき文字参照の状態で表示される問題がありました。

#### 注意
これまでに保存されたログは文字参照のまま変わらず表示されるため過去のログを直すにはログファイル(log/postlog)を手動で編集する必要があります。

Closes #1319
