### PR TITLE
Fix compiler warning for -Wshadow-uncaptured-local

### DIFF
--- a/test/gtest_xml_dom.cpp
+++ b/test/gtest_xml_dom.cpp
@@ -250,7 +250,7 @@ TEST_F(XML_DomChildren, remove_if)
     child->setAttribute( "pet", "hamster" );
 
     const std::size_t removed = dom.remove_if(
-        []( const XML::Dom* child ) { return child->getAttribute( "pet" ) == "dog"; } );
+        []( const XML::Dom* c ) { return c->getAttribute( "pet" ) == "dog"; } );
 
     EXPECT_EQ( removed, 2 );
     EXPECT_EQ( dom.firstChild()->nodeName(), "Bob" );


### PR DESCRIPTION
ラムダ式の引数がローカル変数の名前をシャドーイングしているとコンパイラーに指摘されたため修正します。

clang-17のレポート (file pathを一部省略)
```
test/gtest_xml_dom.cpp:253:29: warning: declaration shadows a local variable [-Wshadow-uncaptured-local]
  253 |         []( const XML::Dom* child ) { return child->getAttribute( "pet" ) == "dog"; } );
      |                             ^
```
