### PR TITLE
Fix compiler warnings for -Wdocumentation and related warnings

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -532,7 +532,7 @@ std::list<std::string> MISC::replace_str_list( const std::list<std::string>& lis
 }
 
 
-/** @brief str に含まれる改行文字(`\r\n`)を replace に置き換え
+/** @brief str に含まれる改行文字(\\r\\n)を replace に置き換え
  *
  * @param[in] str 処理する文字列
  * @param[in] replace マッチした改行文字と置き換える内容
@@ -1068,7 +1068,7 @@ std::string MISC::to_plain( const std::string& html )
 
 /** @brief HTMLをPango markupテキストに変換する
  *
- * @details `<mark>`と`<span>`タグの色を設定して文字参照をデコードして返す。
+ * @details @c @<mark@> と @c @<span@> タグの色を設定して文字参照をデコードして返す。
  * @param[in] html Pango markupテキストに変換する入力
  * @return 変換した結果
  */

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -102,7 +102,7 @@ namespace MISC
     std::list<std::string> replace_str_list( const std::list<std::string>& list_in,
                                              std::string_view pattern, std::string_view replacement );
 
-    /// str に含まれる改行文字(`\r\n`)を replace に置き換え
+    /// str に含まれる改行文字(\\r\\n)を replace に置き換え
     std::string replace_newlines_to_str( const std::string& str, std::string_view replace );
 
     // " を \" に置き換え

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -476,7 +476,6 @@ void App::slot_activate()
  *
  * URLを複数渡して起動しても最初の一つのみ開く
  * @param[in] files URLやDATファイルのリスト
- * @param[in] hint  未使用
  */
 void App::slot_open( const Gio::Application::type_vec_files& files, const Glib::ustring& )
 {


### PR DESCRIPTION
Doxygenのコメントに誤りがあるとコンパイラーに指摘されたため修正します。

clang-17のレポート (file pathを一部省略)
```
src/jdlib/miscutil.cpp:1071:26: warning: HTML tag 'span' requires an end tag [-Wdocumentation-html]
 1071 |  * @details `<mark>`と`<span>`タグの色を設定して文字参照をデコードして返す。
      |                        ~^~~~~
src/jdlib/miscutil.h:105:42: warning: unknown command tag name [-Wdocumentation-unknown-command]
  105 |     /// str に含まれる改行文字(`\r\n`)を replace に置き換え
      |                                 ^~
src/main.cpp:479:15: warning: parameter 'hint' not found in the function declaration [-Wdocumentation]
  479 |  * @param[in] hint  未使用
      |               ^~~~
```
