### PR TITLE
Fix code that accesses the moved variable

### DIFF
--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -213,10 +213,10 @@ void LinkFilterPref::slot_ok_clicked()
             LinkFilterItem item;
             item.url = row[ m_columns.m_col_url ];
             item.cmd = row[ m_columns.m_col_cmd ];
-            list_item.push_back( std::move( item ) );
 #ifdef _DEBUG
             std::cout << item.url << " " << item.cmd << std::endl;
 #endif
+            list_item.push_back( std::move( item ) );
         }
     }
 


### PR DESCRIPTION
moveしたあとの変数にアクセスしているとcppcheckに指摘されたため修正します。

cppcheck 2.13.0のレポート (with inconclusive option)
```
src/linkfilterpref.cpp:218:26: warning: inconclusive: Access of moved variable 'item'. [accessMoved]
            std::cout << item.url << " " << item.cmd << std::endl;
                         ^
src/linkfilterpref.cpp:216:34: note: Calling std::move(item)
            list_item.push_back( std::move( item ) );
                                 ^
src/linkfilterpref.cpp:218:26: note: Access of moved variable 'item'.
            std::cout << item.url << " " << item.cmd << std::endl;
                         ^
```
