### PR TITLE
Organize function parameter names part1,2,3

### DIFF
--- a/src/article/articleviewbase.h
+++ b/src/article/articleviewbase.h
@@ -269,7 +269,7 @@ namespace ARTICLE
         bool slot_motion_notify( GdkEventMotion* event );
         bool slot_key_release( GdkEventKey* event );
         bool slot_scroll_event( GdkEventScroll* event );
-        bool slot_leave_notify( GdkEventCrossing* ev );
+        bool slot_leave_notify( GdkEventCrossing* event );
 
         // レスポップアップ関係
 

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -425,7 +425,7 @@ namespace ARTICLE
                                   const bool init_popupwin, const int mrg_right, const int mrg_bottom );
 
         // 文字の幅などの情報
-        int get_width_of_one_char( const char* str, int& byte, char& pre_char, bool& wide_mode, const int mode );
+        int get_width_of_one_char( const char* utfstr, int& byte, char& pre_char, bool& wide_mode, const int mode );
         bool set_init_wide_mode( const char* str, const int pos_start, const int pos_to );
         bool is_wrapped( const int x, const int border, const char* str ) const;
 

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -420,8 +420,8 @@ namespace ARTICLE
         void set_align( LAYOUT* div, int id_end, int align );
         void set_align_line( LAYOUT* div, LAYOUT* layout_from, LAYOUT* layout_to, RECTANGLE* rect_from, RECTANGLE* rect_to,
                              int width_line, int align );
-        void layout_one_text_node( LAYOUT* node, int& node_x, int& node_y, int& br_size, const int width_view );
-        void layout_one_img_node( LAYOUT* node, int& node_x, int& node_y, int& brsize, const int width_view,
+        void layout_one_text_node( LAYOUT* layout, int& x, int& y, int& br_size, const int width_view );
+        void layout_one_img_node( LAYOUT* layout, int& x, int& y, int& br_size, const int width_view,
                                   const bool init_popupwin, const int mrg_right, const int mrg_bottom );
 
         // 文字の幅などの情報

--- a/src/bbslist/addetcdialog.h
+++ b/src/bbslist/addetcdialog.h
@@ -27,7 +27,8 @@ namespace BBSLIST
 
       public:
 
-        AddEtcDialog( const bool move, const std::string& url, const std::string& _name, const std::string& _id, const std::string& _passwd );
+        AddEtcDialog( const bool move, const std::string& url, const std::string& name,
+                      const std::string& id, const std::string& passwd );
         ~AddEtcDialog() noexcept override;
 
         std::string get_name() const { return m_entry_name.get_text(); }

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -407,7 +407,7 @@ bool CONFIG::get_instruct_tglart(){
     get_confitem()->instruct_tglart_end = true; // 一度表示したら表示しない
     return get_confitem()->instruct_tglart;
 }
-void CONFIG::set_instruct_tglart( const bool tgl ){ get_confitem()->instruct_tglart = tgl; }
+void CONFIG::set_instruct_tglart( const bool set ){ get_confitem()->instruct_tglart = set; }
 
 bool CONFIG::get_instruct_tglimg(){
 
@@ -417,7 +417,7 @@ bool CONFIG::get_instruct_tglimg(){
     return get_confitem()->instruct_tglimg;
 }
 
-void CONFIG::set_instruct_tglimg( bool tgl ){ get_confitem()->instruct_tglimg = tgl; }
+void CONFIG::set_instruct_tglimg( bool set ){ get_confitem()->instruct_tglimg = set; }
 
 
 // スレビューでdeleteを押したときに確認ダイアログを表示する

--- a/src/control/mouseconfig.cpp
+++ b/src/control/mouseconfig.cpp
@@ -100,22 +100,22 @@ void MouseConfig::set_one_motion_impl( const int id, const int mode, const std::
 
 
 // 操作文字列取得
-std::string MouseConfig::get_str_motions( const int id_ ) const
+std::string MouseConfig::get_str_motions( const int id ) const
 {
-    int id = id_;
+    int id_ = id;
 
     // (注) この行が無いと画像ビューのコンテキストメニューにマウスジェスチャが表示されない
-    if( id == CONTROL::CancelMosaic ) id = CONTROL::CancelMosaicButton;
+    if( id_ == CONTROL::CancelMosaic ) id_ = CONTROL::CancelMosaicButton;
 
-    return MouseKeyConf::get_str_motions( id );
+    return MouseKeyConf::get_str_motions( id_ );
 }
 
 
 // IDからデフォルトの操作文字列取得
-std::string MouseConfig::get_default_motions( const int id_ ) const
+std::string MouseConfig::get_default_motions( const int id ) const
 {
-    int id = id_;
-    if( id == CONTROL::CancelMosaic ) id = CONTROL::CancelMosaicButton;
+    int id_ = id;
+    if( id_ == CONTROL::CancelMosaic ) id_ = CONTROL::CancelMosaicButton;
 
-    return MouseKeyConf::get_default_motions( id );
+    return MouseKeyConf::get_default_motions( id_ );
 }

--- a/src/dbtree/article2chcompati.cpp
+++ b/src/dbtree/article2chcompati.cpp
@@ -16,9 +16,9 @@
 
 using namespace DBTREE;
 
-Article2chCompati::Article2chCompati( const std::string& datbase, const std::string& _id, bool cached,
+Article2chCompati::Article2chCompati( const std::string& datbase, const std::string& id, bool cached,
                                       const Encoding enc )
-    : ArticleBase( datbase, _id, cached, enc )
+    : ArticleBase( datbase, id, cached, enc )
 {
     assert( ! get_id().empty() );
 

--- a/src/dbtree/articlejbbs.cpp
+++ b/src/dbtree/articlejbbs.cpp
@@ -14,8 +14,8 @@
 
 using namespace DBTREE;
 
-ArticleJBBS::ArticleJBBS( const std::string& datbase, const std::string& _id, bool cached, const Encoding enc )
-    : ArticleBase( datbase, _id, cached, enc )
+ArticleJBBS::ArticleJBBS( const std::string& datbase, const std::string& id, bool cached, const Encoding enc )
+    : ArticleBase( datbase, id, cached, enc )
 {
     assert( ! get_id().empty() );
 

--- a/src/dbtree/articlemachi.cpp
+++ b/src/dbtree/articlemachi.cpp
@@ -17,8 +17,8 @@
 using namespace DBTREE;
 
 
-ArticleMachi::ArticleMachi( const std::string& datbase, const std::string& _id, bool cached, const Encoding enc )
-    : ArticleBase( datbase, _id, cached, enc )
+ArticleMachi::ArticleMachi( const std::string& datbase, const std::string& id, bool cached, const Encoding enc )
+    : ArticleBase( datbase, id, cached, enc )
 {
     assert( !get_id().empty() );
 

--- a/src/dbtree/frontloader.cpp
+++ b/src/dbtree/frontloader.cpp
@@ -16,9 +16,9 @@
 using namespace DBTREE;
 
 
-FrontLoader::FrontLoader( const std::string& url_boadbase )
+FrontLoader::FrontLoader( const std::string& url_boardbase )
     : SKELETON::TextLoader()
-    , m_url_boadbase( url_boadbase )
+    , m_url_boadbase( url_boardbase )
 {
 }
 

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -82,13 +82,13 @@ enum
 using namespace DBTREE;
 
 
-NodeTreeBase::NodeTreeBase( const std::string& url, const std::string& modified )
+NodeTreeBase::NodeTreeBase( const std::string& url, const std::string& date_modified )
     : SKELETON::Loadable()
     , m_url( url )
     , m_resume( RESUME_NO )
     , m_heap( SIZE_OF_HEAP )
 {
-    set_date_modified( modified );
+    set_date_modified( date_modified );
 
     // ルートヘッダ作成。中は空。
     m_id_header = -1; // ルートヘッダIDが 0 になるように -1
@@ -116,7 +116,7 @@ NodeTreeBase::NodeTreeBase( const std::string& url, const std::string& modified 
     }
 
 #ifdef _DEBUG
-    std::cout << "NodeTreeBase::NodeTreeBase url = " << m_url << " modified = " << get_date_modified()
+    std::cout << "NodeTreeBase::NodeTreeBase url = " << m_url << " date_modified = " << get_date_modified()
               << " noname = " << m_default_noname << std::endl;
 #endif
 }

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -356,7 +356,7 @@ namespace DBTREE
         // m_buffer_write に作成した文字列をセットする
         void parse_write( std::string_view str, const std::size_t max_lng_write );
 
-        bool check_anchor( const int mode, const char* str_in, int& n, std::string& str_out, std::string& str_link,
+        bool check_anchor( const int mode, const char* str_in, int& n_in, std::string& str_out, std::string& str_link,
                            ANCINFO* ancinfo ) const;
         /// リンクが現れたかチェックして文字列を取得する関数
         int check_link( const char* str_in, int& lng_in, std::string& str_text, std::string& str_link ) const;

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -1188,7 +1188,7 @@ void Root::load_etc()
 //
 // 外部板追加
 //
-bool Root::add_etc( const std::string& url, const std::string& name, const std::string& basicauth, const std::string& boardid )
+bool Root::add_etc( const std::string& url, const std::string& name, const std::string& basicauth, const std::string& id )
 {
 #ifdef _DEBUG
     std::cout << "Root::add_etc url = " << url << " name = " << name
@@ -1199,7 +1199,7 @@ bool Root::add_etc( const std::string& url, const std::string& name, const std::
     info.url = url;
     info.name = name;
     info.basicauth = basicauth;
-    info.boardid = boardid;
+    info.boardid = id;
 
     if( set_board( info.url, info.name, info.basicauth ) )
     {

--- a/src/dbtree/ruleloader.cpp
+++ b/src/dbtree/ruleloader.cpp
@@ -17,9 +17,9 @@
 
 using namespace DBTREE;
 
-RuleLoader::RuleLoader( const std::string& url_boadbase )
+RuleLoader::RuleLoader( const std::string& url_boardbase )
     : SKELETON::TextLoader()
-    , m_url_boadbase( url_boadbase )
+    , m_url_boadbase( url_boardbase )
 {
 #ifdef _DEBUG
     std::cout << "RuleLoader::RuleLoader : " << RuleLoader::get_url() << std::endl;

--- a/src/dbtree/settingloader.cpp
+++ b/src/dbtree/settingloader.cpp
@@ -16,9 +16,9 @@
 
 using namespace DBTREE;
 
-SettingLoader::SettingLoader( const std::string& url_boadbase )
+SettingLoader::SettingLoader( const std::string& url_boardbase )
     : SKELETON::TextLoader()
-    , m_url_boadbase( url_boadbase )
+    , m_url_boadbase( url_boardbase )
 {
 #ifdef _DEBUG
     std::cout << "SettingLoader::SettingLoader : " << m_url_boadbase << std::endl;

--- a/src/jdlib/jdsocket.h
+++ b/src/jdlib/jdsocket.h
@@ -69,7 +69,7 @@ namespace JDLIB
         /// @brief タイムアウト時間 (単位は秒) を設定する
         void set_timeout( long timeout ) { m_tout = timeout; }
 
-        bool connect( const std::string& host, const std::string& port, const bool use_ipv6 );
+        bool connect( const std::string& hostname, const std::string& port, const bool use_ipv6 );
         void close();
 
         int write( const char* buf, const std::size_t bufsize );

--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -194,25 +194,25 @@ bool MISC::is_eucjp( std::string_view input, std::size_t read_byte )
  *
  * エスケープシーケンス(ESC = \\x1B)の有無と該当しないバイトが含まれるかチェックする。
  * 呼び出し元の処理のため空文字列に対する返り値は他の`is_*`関数と逆(false)になっている。
- * @param[in] input 入力
- * @param[in,out] byte チェックを開始する位置、チェックを打ち切った位置を返す
+ * @param[in]     input     入力
+ * @param[in,out] read_byte チェックを開始する位置、チェックを打ち切った位置を返す
  * @return
  *   - ESCを見つけたらtrue
  *   - 0x80以上を見つけたらfalse
  *   - 空文字列またはASCIIのみならfalse
  */
-bool MISC::is_jis( std::string_view input, std::size_t& byte )
+bool MISC::is_jis( std::string_view input, std::size_t& read_byte )
 {
     if( input.empty() ) return false;
 
-    while( byte < input.size() && byte < CHECK_LIMIT )
+    while( read_byte < input.size() && read_byte < CHECK_LIMIT )
     {
         // ESCが出現したか否かだけで判断
-        if( JIS_ESC_SEQ_START( input[ byte ] ) ) return true;
+        if( JIS_ESC_SEQ_START( input[ read_byte ] ) ) return true;
         // JISに該当しないコード 0x80〜
-        else if( ! CTRL_AND_ASCII_RANGE( input[ byte ] ) ) return false;
+        else if( ! CTRL_AND_ASCII_RANGE( input[ read_byte ] ) ) return false;
 
-        ++byte;
+        ++read_byte;
     }
 
     // ループが終了していたら制御文字かアスキー

--- a/src/jdlib/miscgtk.cpp
+++ b/src/jdlib/miscgtk.cpp
@@ -213,9 +213,9 @@ std::string MISC::color_to_str( const Gdk::RGBA& rgba )
 //
 // 入力文字列は大文字小文字を区別しない
 // 未知のキーワードや不正な値は変換して返す
-std::string MISC::htmlcolor_to_str( const std::string& _htmlcolor )
+std::string MISC::htmlcolor_to_str( const std::string& htmlcolor_ )
 {
-    std::string htmlcolor = MISC::tolower_str( _htmlcolor );
+    std::string htmlcolor = MISC::tolower_str( htmlcolor_ );
 
     if( htmlcolor[0] != '#' ) {
         const color_map key{ htmlcolor.c_str(), nullptr };

--- a/src/jdlib/miscgtk.h
+++ b/src/jdlib/miscgtk.h
@@ -20,7 +20,7 @@ namespace MISC
     std::string color_to_str( const Gdk::RGBA& rgba );
 
     // htmlカラー (#ffffffなど) -> 16進数表記の文字列
-    std::string htmlcolor_to_str( const std::string& htmlcolor );
+    std::string htmlcolor_to_str( const std::string& htmlcolor_ );
 
     // Gdk::RGBA -> int 変換
     guint32 color_to_int( const Gdk::RGBA& color );

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -835,7 +835,7 @@ void SESSION::set_full_win_main( const bool set ){ full_win_main = set; }
 bool SESSION::is_dialog_shown(){ return dialog_shown; }
 void SESSION::set_dialog_shown( const bool set ){ dialog_shown = set; }
 
-void SESSION::set_show_sidebar( const bool showurl ){ win_show_sidebar = showurl; }
+void SESSION::set_show_sidebar( const bool showbar ){ win_show_sidebar = showbar; }
 
 
 // メインウィンドウのペインの敷居の位置

--- a/src/session.h
+++ b/src/session.h
@@ -196,13 +196,13 @@ namespace SESSION
 
     // 各window が最大化されているか
     bool is_maximized_win_main(); // メインウィンドウ
-    void set_maximized_win_main( const bool maximized );
+    void set_maximized_win_main( const bool set );
 
     bool is_maximized_win_img(); // 画像ウィンドウ
     void set_maximized_win_img( const bool set );
 
     bool is_maximized_win_mes(); // 書き込みウィンドウ
-    void set_maximized_win_mes( const bool maximized );
+    void set_maximized_win_mes( const bool set );
 
 
     // 各window が最小化されているか
@@ -308,7 +308,7 @@ namespace SESSION
     // サイドバーのツールバー項目
     const std::string& get_items_sidebar_toolbar_str();
     std::string get_items_sidebar_toolbar_default_str();
-    void set_items_sidebar_toolbar_str( const std::string& items );
+    void set_items_sidebar_toolbar_str( const std::string& items_str );
     int get_item_sidebar_toolbar( const int num );
 
     // メインツールバーの項目
@@ -332,19 +332,19 @@ namespace SESSION
     // スレ一覧のツールバー項目
     const std::string& get_items_board_toolbar_str();
     std::string get_items_board_toolbar_default_str();
-    void set_items_board_toolbar_str( const std::string& items );
+    void set_items_board_toolbar_str( const std::string& items_str );
     int get_item_board_toolbar( const int num );
 
     // 書き込みビューのツールバー項目
     const std::string& get_items_msg_toolbar_str();
     std::string get_items_msg_toolbar_default_str();
-    void set_items_msg_toolbar_str( const std::string& items );
+    void set_items_msg_toolbar_str( const std::string& items_str );
     int get_item_msg_toolbar( const int num );
 
     // スレ一覧の列項目
     const std::string& get_items_board_col_str();
     std::string get_items_board_col_default_str();
-    void set_items_board_col_str( const std::string& items );
+    void set_items_board_col_str( const std::string& items_str );
     int get_item_board_col( const int num );
 
     // スレ一覧のコンテキストメニュー項目

--- a/src/skeleton/dragnote.cpp
+++ b/src/skeleton/dragnote.cpp
@@ -344,10 +344,10 @@ int DragableNoteBook::get_tabicon( const int page )
 //
 // タブにアイコンをセットする
 //
-void DragableNoteBook::set_tabicon( const std::string& iconname, const int page, const int id )
+void DragableNoteBook::set_tabicon( const std::string& iconname, const int page, const int icon_id )
 {
     SKELETON::TabLabel* tablabel = m_notebook_tab.get_tablabel( page );
-    if( tablabel && id != ICON::NONE ) tablabel->set_id_icon( id );
+    if( tablabel && icon_id != ICON::NONE ) tablabel->set_id_icon( icon_id );
 }
 
 

--- a/src/skeleton/dragnote.h
+++ b/src/skeleton/dragnote.h
@@ -125,7 +125,7 @@ namespace SKELETON
 
         int append_page( const std::string& url, Gtk::Widget& child );
         int insert_page( const std::string& url, Gtk::Widget& child, int page );
-        void remove_page( const int page, const bool adust_tab );
+        void remove_page( const int page, const bool adjust_tab );
 
         // ツールバー関係
         // 各Adminクラスの virtual void show_toolbar()でツールバーを作成してappend_toolbar()で登録する
@@ -144,7 +144,7 @@ namespace SKELETON
 
         // タブのアイコン取得/セット
         int get_tabicon( const int page );
-        void set_tabicon( const std::string& iconname, const int page, const int icon );
+        void set_tabicon( const std::string& iconname, const int page, const int icon_id );
 
         // ドラッグ可/不可切り替え(デフォルト false );
         void set_dragable( bool dragable ){ m_dragable = dragable; }

--- a/src/xml/dom.h
+++ b/src/xml/dom.h
@@ -77,7 +77,7 @@ namespace XML
         void append_treestore( Glib::RefPtr< Gtk::TreeStore >& treestore,
                                SKELETON::EditColumns& columns,
                                std::list< Gtk::TreePath >& list_path_expand,
-                               const Gtk::TreeModel::Row& parnet = Gtk::TreeModel::Row() ) const;
+                               const Gtk::TreeModel::Row& parent = Gtk::TreeModel::Row() ) const;
 
       public:
 


### PR DESCRIPTION
### Organize function parameter names part1

関数の宣言と定義で仮引数の名前が異なっているとcppcheckに指摘されたため名前を整理して揃えます。

cppcheck 2.13.0のレポート (with inconclusive option)
```
src/article/articleviewbase.cpp:2014:60: style: inconclusive: Function 'slot_leave_notify' argument 1 names different: declaration 'ev' definition 'event'. [funcArgNamesDifferent]
src/bbslist/addetcdialog.cpp:15:114: style: inconclusive: Function 'AddEtcDialog' argument 4 names different: declaration '_id' definition 'id'. [funcArgNamesDifferent]
src/bbslist/addetcdialog.cpp:15:137: style: inconclusive: Function 'AddEtcDialog' argument 5 names different: declaration '_passwd' definition 'passwd'. [funcArgNamesDifferent]
src/bbslist/addetcdialog.cpp:15:89: style: inconclusive: Function 'AddEtcDialog' argument 3 names different: declaration '_name' definition 'name'. [funcArgNamesDifferent]
src/config/globalconf.cpp:410:46: style: inconclusive: Function 'set_instruct_tglart' argument 1 names different: declaration 'set' definition 'tgl'. [funcArgNamesDifferent]
src/config/globalconf.cpp:420:40: style: inconclusive: Function 'set_instruct_tglimg' argument 1 names different: declaration 'set' definition 'tgl'. [funcArgNamesDifferent]
src/control/mouseconfig.cpp:103:53: style: inconclusive: Function 'get_str_motions' argument 1 names different: declaration 'id' definition 'id_'. [funcArgNamesDifferent]
src/control/mouseconfig.cpp:115:57: style: inconclusive: Function 'get_default_motions' argument 1 names different: declaration 'id' definition 'id_'. [funcArgNamesDifferent]
src/dbtree/article2chcompati.cpp:19:86: style: inconclusive: Function 'Article2chCompati' argument 2 names different: declaration 'id' definition '_id'. [funcArgNamesDifferent]
src/dbtree/articlejbbs.cpp:17:74: style: inconclusive: Function 'ArticleJBBS' argument 2 names different: declaration 'id' definition '_id'. [funcArgNamesDifferent]
src/dbtree/articlemachi.cpp:20:76: style: inconclusive: Function 'ArticleMachi' argument 2 names different: declaration 'id' definition '_id'. [funcArgNamesDifferent]
src/dbtree/frontloader.cpp:19:46: style: inconclusive: Function 'FrontLoader' argument 1 names different: declaration 'url_boardbase' definition 'url_boadbase'. [funcArgNamesDifferent]
```

### Organize function parameter names part2

関数の宣言と定義で仮引数の名前が異なっているとcppcheckに指摘されたため名前を整理して揃えます。

cppcheck 2.13.0のレポート (with inconclusive option)
```
src/article/drawareabase.cpp:1358:50: style: inconclusive: Function 'layout_one_text_node' argument 1 names different: declaration 'node' definition 'layout'. [funcArgNamesDifferent]
src/article/drawareabase.cpp:1358:63: style: inconclusive: Function 'layout_one_text_node' argument 2 names different: declaration 'node_x' definition 'x'. [funcArgNamesDifferent]
src/article/drawareabase.cpp:1358:71: style: inconclusive: Function 'layout_one_text_node' argument 3 names different: declaration 'node_y' definition 'y'. [funcArgNamesDifferent]
src/article/drawareabase.cpp:1470:49: style: inconclusive: Function 'layout_one_img_node' argument 1 names different: declaration 'node' definition 'layout'. [funcArgNamesDifferent]
src/article/drawareabase.cpp:1470:62: style: inconclusive: Function 'layout_one_img_node' argument 2 names different: declaration 'node_x' definition 'x'. [funcArgNamesDifferent]
src/article/drawareabase.cpp:1470:70: style: inconclusive: Function 'layout_one_img_node' argument 3 names different: declaration 'node_y' definition 'y'. [funcArgNamesDifferent]
src/article/drawareabase.cpp:1470:78: style: inconclusive: Function 'layout_one_img_node' argument 4 names different: declaration 'brsize' definition 'br_size'. [funcArgNamesDifferent]
src/dbtree/root.cpp:1182:119: style: inconclusive: Function 'add_etc' argument 4 names different: declaration 'id' definition 'boardid'. [funcArgNamesDifferent]
src/dbtree/ruleloader.cpp:20:44: style: inconclusive: Function 'RuleLoader' argument 1 names different: declaration 'url_boardbase' definition 'url_boadbase'. [funcArgNamesDifferent]
src/dbtree/settingloader.cpp:19:50: style: inconclusive: Function 'SettingLoader' argument 1 names different: declaration 'url_boardbase' definition 'url_boadbase'. [funcArgNamesDifferent]
src/jdlib/jdsocket.cpp:101:42: style: inconclusive: Function 'connect' argument 1 names different: declaration 'host' definition 'hostname'. [funcArgNamesDifferent]
src/jdlib/misccharcode.cpp:204:57: style: inconclusive: Function 'is_jis' argument 2 names different: declaration 'read_byte' definition 'byte'. [funcArgNamesDifferent]
src/jdlib/miscgtk.cpp:216:56: style: inconclusive: Function 'htmlcolor_to_str' argument 1 names different: declaration 'htmlcolor' definition '_htmlcolor'. [funcArgNamesDifferent]
```

### Organize function parameter names part3

関数の宣言と定義で仮引数の名前が異なっているとcppcheckに指摘されたため名前を整理して揃えます。

cppcheck 2.13.0のレポート (with inconclusive option)
```
src/article/drawareabase.cpp:1567:54: style: inconclusive: Function 'get_width_of_one_char' argument 1 names different: declaration 'str' definition 'utfstr'. [funcArgNamesDifferent]
src/dbtree/nodetreebase.cpp:2974:39: style: inconclusive: Function 'check_anchor' argument 3 names different: declaration 'n' definition 'n_in'. [funcArgNamesDifferent]
src/dbtree/nodetreebase.cpp:85:72: style: inconclusive: Function 'NodeTreeBase' argument 2 names different: declaration 'date_modified' definition 'modified'. [funcArgNamesDifferent]
src/session.cpp:1012:61: style: inconclusive: Function 'set_items_msg_toolbar_str' argument 1 names different: declaration 'items' definition 'items_str'. [funcArgNamesDifferent]
src/session.cpp:1034:59: style: inconclusive: Function 'set_items_board_col_str' argument 1 names different: declaration 'items' definition 'items_str'. [funcArgNamesDifferent]
src/session.cpp:798:50: style: inconclusive: Function 'set_maximized_win_main' argument 1 names different: declaration 'maximized' definition 'set'. [funcArgNamesDifferent]
src/session.cpp:804:49: style: inconclusive: Function 'set_maximized_win_mes' argument 1 names different: declaration 'maximized' definition 'set'. [funcArgNamesDifferent]
src/session.cpp:838:44: style: inconclusive: Function 'set_show_sidebar' argument 1 names different: declaration 'showbar' definition 'showurl'. [funcArgNamesDifferent]
src/session.cpp:909:65: style: inconclusive: Function 'set_items_sidebar_toolbar_str' argument 1 names different: declaration 'items' definition 'items_str'. [funcArgNamesDifferent]
src/session.cpp:992:63: style: inconclusive: Function 'set_items_board_toolbar_str' argument 1 names different: declaration 'items' definition 'items_str'. [funcArgNamesDifferent]
src/skeleton/dragnote.cpp:188:64: style: inconclusive: Function 'remove_page' argument 2 names different: declaration 'adust_tab' definition 'adjust_tab'. [funcArgNamesDifferent]
src/skeleton/dragnote.cpp:347:92: style: inconclusive: Function 'set_tabicon' argument 3 names different: declaration 'icon' definition 'id'. [funcArgNamesDifferent]
src/xml/dom.cpp:474:56: style: inconclusive: Function 'append_treestore' argument 4 names different: declaration 'parnet' definition 'parent'. [funcArgNamesDifferent]
```
