### PR TITLE
Migrate GitHub workflow actions/checkout to v4

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,7 +20,7 @@ jobs:
       # https://github.com/JDimproved/JDim/issues/943
       AVOID_CRASH: -Wl,--push-state,--no-as-needed -lcrypt -Wl,--pop-state
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dependencies installation
         run: |
           sudo apt update
@@ -63,7 +63,7 @@ jobs:
             cxx: clang++-10
             package: clang-10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dependencies installation
         run: |
           sudo apt update
@@ -104,7 +104,7 @@ jobs:
             cxx: clang++-15
             package: clang-15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dependencies installation
         run: |
           sudo apt update
@@ -134,7 +134,7 @@ jobs:
           - config_args: -Dtls=openssl -Dsessionlib=xsmp -Dalsa=enabled -Dpangolayout=enabled
             packages: libssl-dev libasound2-dev
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dependencies installation (${{ matrix.deps.packages }})
         run: |
           sudo apt update
@@ -164,7 +164,7 @@ jobs:
           - config_args: -Dtls=openssl -Dsessionlib=xsmp -Dalsa=enabled -Dpangolayout=enabled
             packages: libssl-dev libasound2-dev
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dependencies installation (${{ matrix.deps.packages }})
         run: |
           sudo apt update
@@ -182,7 +182,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/jekyll-build-pages@v1
         with:
           source: ./docs

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -14,7 +14,7 @@ jobs:
       CC: gcc-12
       CXX: g++-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dependencies installation
         run: |
           sudo apt update
@@ -34,7 +34,7 @@ jobs:
       CC: clang-15
       CXX: clang++-15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dependencies installation
         run: |
           sudo apt update
@@ -54,7 +54,7 @@ jobs:
       CC: gcc-12
       CXX: g++-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dependencies installation
         run: |
           sudo apt update
@@ -74,7 +74,7 @@ jobs:
       CC: gcc-11
       CXX: g++-11
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: dependencies installation
         run: |
           sudo apt update


### PR DESCRIPTION
Node.js 16 を使う actions が非推奨になったと警告が表示されたため [actions/checkout@v4][ac4] に移行します。

ジョブのログ
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3.
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

[ac4]: https://github.com/actions/checkout/tree/v4
