### PR TITLE
NodeTree2chCompati: Handle URL redirect to support reading kako log

### DIFF
--- a/src/dbtree/nodetree2chcompati.cpp
+++ b/src/dbtree/nodetree2chcompati.cpp
@@ -12,14 +12,26 @@
 
 #include "config/globalconf.h"
 
+#include "httpcode.h"
+#include "session.h"
+
 #include <cstring>
 
 
 using namespace DBTREE;
 
 
+/// @brief 読み込みの状態
+enum class NodeTree2chCompati::Mode
+{
+    normal, ///< 普通の読み込み
+    kako,   ///< URLリダイレクトで過去ログのURLを読み込み
+};
+
+
 NodeTree2chCompati::NodeTree2chCompati( const std::string& url, const std::string& date_modified )
     : NodeTreeBase( url, date_modified )
+    , m_mode{ Mode::normal }
 {
 #ifdef _DEBUG
     std::cout << "NodeTree2chCompati::NodeTree2chCompati url = " << url << " modified = " << date_modified << std::endl;
@@ -53,13 +65,15 @@ void NodeTree2chCompati::clear()
 
     // iconv 削除
     m_iconv.reset();
+    m_mode = Mode::normal;
 }
 
 
 
-//
-// ロード実行前に呼ぶ初期化関数
-//
+/** @brief ロード実行前に呼ぶ初期化関数
+ *
+ * @details URLリダイレクトの処理を続行するため m_mode はリセットしない
+ */
 void NodeTree2chCompati::init_loading()
 {
 #ifdef _DEBUG    
@@ -96,17 +110,34 @@ const char* NodeTree2chCompati::raw2dat( char* rawlines, int& byte )
 //
 void NodeTree2chCompati::create_loaderdata( JDLIB::LOADERDATA& data )
 {
-    data.url = get_url();
     data.agent = DBTREE::get_agent( get_url() );
+    data.byte_readfrom = 0;
 
-    // 1byte前からレジュームして '\n' が返ってこなかったらあぼーんがあったってこと
-    if( get_lng_dat() ) {
-        data.byte_readfrom = get_lng_dat() -1;
-        // 更新チェックのときは未取得の範囲を指定する
-        if( is_checking_update() ) data.byte_readfrom += 1;
-        set_resume( true );
+    // サーバーから過去ログのURLを通知された
+    if( m_mode == Mode::kako ) {
+
+        // レジューム設定
+        // DATを読み込んでいた場合はレジュームを有りにして、DATの未取得部分を追加するように処理する
+        set_resume( get_lng_dat() > 0 );
+
+        data.url = location();
     }
-    else set_resume( false );
+
+    // 普通の読み込み
+    else {
+
+        // レジューム設定
+        // 1byte前からレジュームして '\n' が返ってこなかったらあぼーんがあったってこと
+        if( get_lng_dat() ) {
+            data.byte_readfrom = get_lng_dat() -1;
+            // 更新チェックのときは未取得の範囲を指定する
+            if( is_checking_update() ) data.byte_readfrom += 1;
+            set_resume( true );
+        }
+        else set_resume( false );
+
+        data.url = get_url();
+    }
 
     data.host_proxy = DBTREE::get_proxy_host( get_url() );
     data.port_proxy = DBTREE::get_proxy_port( get_url() );
@@ -118,4 +149,48 @@ void NodeTree2chCompati::create_loaderdata( JDLIB::LOADERDATA& data )
     data.encoding_analysis_method = DBTREE::board_encoding_analysis_method( get_url() );
 
     if( ! get_date_modified().empty() ) data.modified = get_date_modified();
+}
+
+
+/**
+ * @brief ロード完了
+ */
+void NodeTree2chCompati::receive_finish()
+{
+#ifdef _DEBUG
+    std::cout << "NodeTree2chCompati::receive_finish : " << get_url()
+              << " , mode = " << ( m_mode == Mode::normal ? "normal" : "kako" )
+              << ", code = " << get_code() << std::endl;
+#endif
+
+    // 更新チェックではない、オンラインの場合はURLリダイレクトを処理する
+    if( ! is_checking_update()
+        && SESSION::is_online()
+        && ( get_code() == HTTP_REDIRECT || get_code() == HTTP_MOVED_PERM )
+        ){
+
+        // サーバーから過去ログのURLを通知された
+        if( m_mode == Mode::normal ) {
+
+            m_mode = Mode::kako;
+
+#ifdef _DEBUG
+            std::cout << "NodeTree2chCompati::receive_finish : switch mode to kako, location = "
+                      << location() << std::endl;
+#endif
+            download_dat( false );
+            return;
+        }
+
+        // 失敗
+        m_mode = Mode::normal;
+    }
+
+    // 過去ログから読み込んだ場合は DAT 落ちにする
+    if( m_mode != Mode::normal ) {
+        m_mode = Mode::normal;
+        set_code( HTTP_OLD );
+    }
+
+    NodeTreeBase::receive_finish();
 }

--- a/src/dbtree/nodetree2chcompati.h
+++ b/src/dbtree/nodetree2chcompati.h
@@ -21,7 +21,10 @@ namespace DBTREE
 {
     class NodeTree2chCompati : public NodeTreeBase
     {
+        enum class Mode;
+
         std::unique_ptr<JDLIB::Iconv> m_iconv;
+        Mode m_mode;
 
       public:
 
@@ -35,6 +38,7 @@ namespace DBTREE
         const char* raw2dat( char* rawlines, int& byte ) override;
 
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;
+        void receive_finish() override;
     };
 }
 


### PR DESCRIPTION
2ch互換板のdat落ちしたスレにアクセスしたとき別のURLへ移転通知されたときはURLリダイレクトの処理を行うように変更します。

この修正によりリダイレクトをサポートする掲示板では過去ログを読み込むようになります。

Closes #1334
