### PR TITLE
IMAGE::Preferences: Use Gtk::Grid to adjust UI layout

### DIFF
--- a/src/image/preference.cpp
+++ b/src/image/preference.cpp
@@ -16,14 +16,16 @@ using namespace IMAGE;
 
 Preferences::Preferences( Gtk::Window* parent, const std::string& url )
     : SKELETON::PrefDiag( parent, url, true )
-    ,m_label_url( false, "URL：", get_url() )
-    ,m_label_cache( false, "ローカルキャッシュパス：", DBIMG::get_cache_path( url ) )
-    ,m_label_ref( false, "参照元スレ名：" )
-    ,m_label_url_ref( false, "参照元レス：" )
-    ,m_open_ref( "開く" )
-    ,m_label_wh( false, "大きさ : ", std::string() )
-    ,m_label_size( false, "サイズ( byte / Kbyte ) : ", std::string() )
-    ,m_label_type( false, "種類 : ", std::string() )
+    , m_label_url{ "URL:" }
+    , m_label_url_value{ get_url() }
+    , m_label_cache{ "ローカルキャッシュパス:" }
+    , m_label_cache_value{ DBIMG::get_cache_path( url ) }
+    , m_label_ref{ "参照元スレ名:" }
+    , m_label_url_ref{ "参照元レス:" }
+    , m_open_ref{ "開く" }
+    , m_label_wh{ "大きさ:" }
+    , m_label_size{ "サイズ( byte / Kbyte ):" }
+    , m_label_type{ "種類:" }
     ,m_check_protect( "キャッシュを保護する" )
 {
     // 一般
@@ -33,19 +35,17 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url )
     const std::string daturl = DBTREE::url_dat( refurl, num_from, num_to, num_str );
     const std::string readcgi = DBTREE::url_readcgi( daturl, num_from, 0 );
 
-    m_label_ref.set_text( MISC::to_plain( DBTREE::article_modified_subject( daturl ) ) );
-    m_label_url_ref.set_text( readcgi );
+    m_label_ref_value.set_text( MISC::to_plain( DBTREE::article_modified_subject( daturl ) ) );
+    m_label_url_ref_value.set_text( readcgi );
 
     m_open_ref.signal_clicked().connect( sigc::mem_fun(*this, &Preferences::slot_open_ref ) );
-    m_hbox_ref.pack_start( m_label_url_ref );
-    m_hbox_ref.pack_start( m_open_ref, Gtk::PACK_SHRINK );
 
-    m_label_wh.set_text( std::to_string( DBIMG::get_width( get_url() ) )
+    m_label_wh_value.set_text( std::to_string( DBIMG::get_width( get_url() ) )
                                          + " x "
                                          + std::to_string( DBIMG::get_height( get_url() ) ) );
 
     int size = DBIMG::get_filesize( get_url() );
-    m_label_size.set_text( std::to_string( size ) + " / " + std::to_string( size/1024 ) );
+    m_label_size_value.set_text( std::to_string( size ) + " / " + std::to_string( size/1024 ) );
 
     std::string type;
     switch( DBIMG::get_type_real( get_url() ) ){
@@ -58,25 +58,46 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url )
     }
 
     if( DBIMG::is_fake( get_url() ) ) type += " ※拡張子が偽装されています※";
-    m_label_type.set_text( type );
+    m_label_type_value.set_text( type );
 
     m_check_protect.set_active( DBIMG::is_protected( get_url() ) );
 
-    m_vbox_info.set_border_width( 16 );
-    m_vbox_info.set_spacing( 8 );
-    m_vbox_info.pack_start( m_label_url, Gtk::PACK_SHRINK );
-    m_vbox_info.pack_start( m_label_cache, Gtk::PACK_SHRINK );
-    m_vbox_info.pack_start( m_label_ref, Gtk::PACK_SHRINK );
-    m_vbox_info.pack_start( m_hbox_ref, Gtk::PACK_SHRINK );
-    m_vbox_info.pack_start( m_label_wh, Gtk::PACK_SHRINK );
-    m_vbox_info.pack_start( m_label_size, Gtk::PACK_SHRINK );
-    m_vbox_info.pack_start( m_label_type, Gtk::PACK_SHRINK );
+    m_grid_info.set_column_spacing( 10 );
+    m_grid_info.set_row_spacing( 8 );
 
-    m_vbox_info.pack_end( m_check_protect, Gtk::PACK_SHRINK );
+    m_grid_info.attach( m_label_url, 0, 0, 1, 1 );
+    m_grid_info.attach( m_label_url_value, 1, 0, 2, 1 );
+    m_grid_info.attach( m_label_cache, 0, 1, 1, 1 );
+    m_grid_info.attach( m_label_cache_value, 1, 1, 2, 1 );
+    m_grid_info.attach( m_label_ref, 0, 2, 1, 1 );
+    m_grid_info.attach( m_label_ref_value, 1, 2, 2, 1 );
+    m_grid_info.attach( m_label_url_ref, 0, 3, 1, 1 );
+    m_grid_info.attach( m_label_url_ref_value, 1, 3, 1, 1 );
+    m_grid_info.attach( m_open_ref, 2, 3, 1, 1 );
+    m_grid_info.attach( m_label_wh, 0, 4, 1, 1 );
+    m_grid_info.attach( m_label_wh_value, 1, 4, 2, 1 );
+    m_grid_info.attach( m_label_size, 0, 5, 1, 1 );
+    m_grid_info.attach( m_label_size_value, 1, 5, 2, 1 );
+    m_grid_info.attach( m_label_type, 0, 6, 1, 1 );
+    m_grid_info.attach( m_label_type_value, 1, 6, 2, 1 );
+
+    for( int y = 0; y < 7; ++y ) {
+        // label column
+        Gtk::Widget* child = m_grid_info.get_child_at( 0, y );
+        child->set_halign( Gtk::ALIGN_START );
+
+        // value column
+        child = m_grid_info.get_child_at( 1, y );
+        child->set_halign( Gtk::ALIGN_START );
+        child->set_hexpand( true );
+        static_cast<Gtk::Label*>( child )->set_selectable( true );
+    }
 
     set_title( "画像のプロパティ" );
-    get_content_area()->pack_start( m_vbox_info );
-    resize( 600, 400 );
+    get_content_area()->property_margin() = 16;
+    get_content_area()->pack_start( m_grid_info );
+    get_content_area()->pack_end( m_check_protect, Gtk::PACK_SHRINK );
+    set_default_size( 700, 400 );
     show_all_children();
 }
 

--- a/src/image/preference.h
+++ b/src/image/preference.h
@@ -5,26 +5,31 @@
 
 #include "skeleton/prefdiag.h"
 #include "skeleton/editview.h"
-#include "skeleton/label_entry.h"
 
 namespace IMAGE
 {
     class Preferences : public SKELETON::PrefDiag
     {
         // 情報
-        Gtk::VBox m_vbox_info;
+        Gtk::Grid m_grid_info;
 
-        SKELETON::LabelEntry m_label_url;
-        SKELETON::LabelEntry m_label_cache;
-        SKELETON::LabelEntry m_label_ref;
+        Gtk::Label m_label_url;
+        Gtk::Label m_label_url_value;
+        Gtk::Label m_label_cache;
+        Gtk::Label m_label_cache_value;
+        Gtk::Label m_label_ref;
+        Gtk::Label m_label_ref_value;
 
-        Gtk::HBox m_hbox_ref;
-        SKELETON::LabelEntry m_label_url_ref;
+        Gtk::Label m_label_url_ref;
+        Gtk::Label m_label_url_ref_value;
         Gtk::Button m_open_ref;
 
-        SKELETON::LabelEntry m_label_wh;
-        SKELETON::LabelEntry m_label_size;
-        SKELETON::LabelEntry m_label_type;
+        Gtk::Label m_label_wh;
+        Gtk::Label m_label_wh_value;
+        Gtk::Label m_label_size;
+        Gtk::Label m_label_size_value;
+        Gtk::Label m_label_type;
+        Gtk::Label m_label_type_value;
 
         Gtk::CheckButton m_check_protect;
 


### PR DESCRIPTION
画像のプロパティにある項目の名称と値をグリッドレイアウトに変更してレイアウト調整します。

関連のissue: #1329
