### PR TITLE
NodeTreeMachi: Add abone check on offlaw.cgi mode

### DIFF
--- a/src/dbtree/nodetreemachi.cpp
+++ b/src/dbtree/nodetreemachi.cpp
@@ -272,6 +272,9 @@ const char* NodeTreeMachi::raw2dat( char* rawlines, int& byte )
             name = m_regex->str( 2 );
             mail = m_regex->str( 3 );
             date = m_regex->str( 4 );
+            // ID: が見つからなければあぼ〜ん
+            const auto i = date.rfind( "ID:" );
+            if( i == std::string::npos ) continue;
             body = m_regex->str( 5 );
             if( num == 1 ) m_subject_machi = m_regex->str( 6 );
         }


### PR DESCRIPTION
まちBBSでofflaw.cgiを使ってdatを読み込むとき"あぼーん"されたレスであるかチェックする処理を追加します。

あぼーんされたレスはレス番号以外のデータが定形のワードに置換されているため、日付とIDのセクションに"ID:"が含まれていない場合はあぼーんされたレスと判定します。

ウェブアーカイブに保存されている[offlaw.cgiの仕様][1]では2008-03-15の時点でログフォーマットにIDが含まれています。

[1]: http://web.archive.org/web/20100923093314/http://machi.to/offlaw.txt
