### PR TITLE
BBSLIST::SelectListDialog: Fix getting name value

### DIFF
--- a/src/bbslist/selectdialog.cpp
+++ b/src/bbslist/selectdialog.cpp
@@ -118,9 +118,9 @@ void SelectListDialog::slot_ok_clicked()
 }
 
 
-std::string SelectListDialog::get_name()
+std::string SelectListDialog::get_name() const
 {
-    return m_label_name.get_text();
+    return m_entry_name.get_text();
 }
 
 std::string SelectListDialog::get_path() const

--- a/src/bbslist/selectdialog.h
+++ b/src/bbslist/selectdialog.h
@@ -38,7 +38,7 @@ namespace BBSLIST
         SelectListDialog( Gtk::Window* parent, const std::string& url, Glib::RefPtr< Gtk::TreeStore >& treestore );
         ~SelectListDialog() noexcept override;
 
-        std::string get_name();
+        std::string get_name() const;
         std::string get_path() const;
 
       protected:


### PR DESCRIPTION
お気に入り追加先選択のダイアログで名前の値を取得する処理が項目のラベル("名前:")を取得していたため修正します。

バグが入ったコミット: 9974da79dd6e553613bde9fe1e91ffe1d48ab165
