### PR TITLE
IMAGE::Preferences: Set ellipsis sign to end of the property value

### DIFF
--- a/src/image/preference.cpp
+++ b/src/image/preference.cpp
@@ -91,6 +91,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url )
         child->set_halign( Gtk::ALIGN_START );
         child->set_hexpand( true );
         static_cast<Gtk::Label*>( child )->set_selectable( true );
+        static_cast<Gtk::Label*>( child )->set_ellipsize( Pango::ELLIPSIZE_END );
     }
 
     set_title( "画像のプロパティ" );


### PR DESCRIPTION
画像のプロパティの値が長いときはウインドウに収まらない末尾の部分を省略記号(…)に置き換えます。
修正前はテキストの長さに合わせてウインドウの最小サイズが水平方向に大きくなっていました。

バグが入ったコミット: 388d7bdc726f9f5bf970936cf8b11b7647c58131

関連のissue: #1329 
