### PR TITLE
Control: Fix bitwise operations for bool value to ternary operator

### DIFF
--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -157,7 +157,9 @@ bool Control::get_eventbutton( const int id, GdkEventButton& event )
         if( dblclick ) event.type = GDK_2BUTTON_PRESS;
         if( trpclick ) event.type = GDK_3BUTTON_PRESS;
         event.button = button;
-        event.state = ( GDK_CONTROL_MASK & ctrl ) | ( GDK_SHIFT_MASK & shift ) | ( GDK_MOD1_MASK & alt );
+        event.state = ( ctrl ? GDK_CONTROL_MASK : 0 )
+                      | ( shift ? GDK_SHIFT_MASK : 0 )
+                      | ( alt ? GDK_MOD1_MASK : 0 );
         return true;
     }
 


### PR DESCRIPTION
bool変数をビット演算しているとcppcheckに指摘されたため修正します。

cppcheck 2.13.0のレポート (with inconclusive option)
```
src/control/control.cpp:160:42: style: inconclusive: Boolean expression 'ctrl' is used in bitwise operation. Did you mean '&&'? [bitwiseOnBoolean]
        event.state = ( GDK_CONTROL_MASK & ctrl ) | ( GDK_SHIFT_MASK & shift ) | ( GDK_MOD1_MASK & alt );
                                         ^
src/control/control.cpp:160:70: style: inconclusive: Boolean expression 'shift' is used in bitwise operation. Did you mean '&&'? [bitwiseOnBoolean]
        event.state = ( GDK_CONTROL_MASK & ctrl ) | ( GDK_SHIFT_MASK & shift ) | ( GDK_MOD1_MASK & alt );
                                                                     ^
src/control/control.cpp:160:98: style: inconclusive: Boolean expression 'alt' is used in bitwise operation. Did you mean '&&'? [bitwiseOnBoolean]
        event.state = ( GDK_CONTROL_MASK & ctrl ) | ( GDK_SHIFT_MASK & shift ) | ( GDK_MOD1_MASK & alt );
                                                                                                 ^
```
