### PR TITLE
Add "Share thread view search query among tabs" to about:config

### DIFF
--- a/src/article/toolbar.cpp
+++ b/src/article/toolbar.cpp
@@ -7,9 +7,9 @@
 #include "articleadmin.h"
 #include "articleviewbase.h"
 
-#include "control/controlutil.h"
+#include "config/globalconf.h"
 #include "control/controlid.h"
-
+#include "control/controlutil.h"
 #include "icons/iconmanager.h"
 
 #include "command.h"
@@ -54,7 +54,7 @@ ArticleToolBar::~ArticleToolBar() noexcept = default;
 // virtual
 void ArticleToolBar::set_view( SKELETON::View * view )
 {
-    SKELETON::ToolBar::set_view( view );
+    SKELETON::ToolBar::set_view( view, CONFIG::get_share_query_among_tabs() );
 
     m_enable_slot = false;
 

--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -222,6 +222,7 @@ void AboutConfig::append_rows()
     append_row( "スレを削除する時に画像キャッシュも削除する ( 0: ダイアログ表示 1: 削除 2: 削除しない )", get_confitem()->delete_img_in_thread, CONF_DELETE_IMG_IN_THREAD );
     append_row( "最大表示可能レス数", get_confitem()->max_resnumber, CONF_MAX_RESNUMBER );
     append_row( "スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )", get_confitem()->text_rendering_method, CONF_TEXT_RENDERING_METHOD );
+    append_row( "(実験的な機能) スレビューの検索クエリをタブ間で共有する", get_confitem()->share_query_among_tabs, CONF_SHARE_QUERY_AMONG_TABS );
 
     // 書き込みウィンドウ
     append_row( "" );

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -599,6 +599,9 @@ bool ConfigItems::load( const bool restore )
     // スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )
     text_rendering_method = cf.get_option_int( "text_rendering_method", CONF_TEXT_RENDERING_METHOD, 0, 1 );
 
+    // (実験的な機能) スレビューの検索クエリをタブ間で共有する
+    share_query_among_tabs = cf.get_option_bool( "share_query_among_tabs", CONF_SHARE_QUERY_AMONG_TABS );
+
     // FIFOの作成などにエラーがあったらダイアログを表示する
     show_diag_fifo_error = cf.get_option_bool( "show_diag_fifo_error", CONF_SHOW_DIAG_FIFO_ERROR );
 
@@ -962,6 +965,7 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "delete_img_in_thread", delete_img_in_thread );
     cf.update( "max_resnumber", max_resnumber );
     cf.update( "text_rendering_method", text_rendering_method );
+    cf.update( "share_query_among_tabs", share_query_among_tabs );
     cf.update( "show_diag_fifo_error", show_diag_fifo_error );
     cf.update( "save_session", save_session );
 

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -544,6 +544,9 @@ namespace CONFIG
         /// @brief スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )
         int text_rendering_method{};
 
+        /// @brief (実験的な機能) スレビューの検索クエリをタブ間で共有する
+        bool share_query_among_tabs{};
+
         // FIFOの作成などにエラーがあったらダイアログを表示する
         bool show_diag_fifo_error{};
 

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -171,6 +171,7 @@ namespace CONFIG
 #else
         CONF_TEXT_RENDERING_METHOD = 0, ///< スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )
 #endif
+        CONF_SHARE_QUERY_AMONG_TABS = 0, ///< (実験的な機能) スレビューの検索クエリをタブ間で共有する
         CONF_SHOW_DIAG_FIFO_ERROR = 1, // FIFOの作成などにエラーがあったらダイアログを表示する
         CONF_SAVE_SESSION = 0, // 指定した分ごとにセッションを自動保存 (0: 保存しない)
         CONF_BROKEN_SJIS_BE_UTF8 = 0, ///< 不正なMS932文字列をUTF-8と見なす

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -623,6 +623,9 @@ void CONFIG::set_max_resnumber( const int set ){ get_confitem()->max_resnumber =
 /// @brief スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )
 int CONFIG::get_text_rendering_method() { return get_confitem()->text_rendering_method; }
 
+/// @brief (実験的な機能) スレビューの検索クエリをタブ間で共有する
+bool CONFIG::get_share_query_among_tabs() { return get_confitem()->share_query_among_tabs; }
+
 // FIFOの作成などにエラーがあったらダイアログを表示する
 bool CONFIG::get_show_diag_fifo_error(){ return get_confitem()->show_diag_fifo_error; }
 void CONFIG::set_show_diag_fifo_error( const bool set ){ get_confitem()->show_diag_fifo_error = set; }

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -627,6 +627,9 @@ namespace CONFIG
     // スレビューのテキストを描画する方法 ( 0: PangoGlyphString 1: PangoLayout )
     int get_text_rendering_method();
 
+    // (実験的な機能) スレビューの検索クエリをタブ間で共有する
+    bool get_share_query_among_tabs();
+
     // FIFOの作成などにエラーがあったらダイアログを表示する
     bool get_show_diag_fifo_error();
     void set_show_diag_fifo_error( const bool set );

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -56,11 +56,13 @@ void ToolBar::set_url( const std::string& url )
 }
 
 
-//
-// タブが切り替わった時にDragableNoteBook::set_current_toolbar()から呼び出される( Viewの情報を取得する )
-//
-// virtual
-void ToolBar::set_view( SKELETON::View* view )
+/**
+ * @brief タブが切り替わった時にDragableNoteBook::set_current_toolbar()から呼び出される( Viewの情報をGUIに反映する )
+ *
+ * @param[in] view        Viewの情報を取得する
+ * @param[in] share_query true ならビューの検索クエリをタブ間で共有する
+ */
+void ToolBar::set_view( SKELETON::View* view, const bool share_query )
 {
     if( ! view ) return;
 
@@ -92,7 +94,11 @@ void ToolBar::set_view( SKELETON::View* view )
 
     if( m_button_write ) m_button_write->set_sensitive( view->is_writeable() );
 
-    if( m_entry_search ) m_entry_search->set_text( view->get_search_query() );
+    if( m_entry_search ) {
+        // 共有する設定のときは検索ボックスのクエリをビューに反映する
+        if( share_query ) view->set_search_query( m_entry_search->get_text() );
+        else m_entry_search->set_text( view->get_search_query() );
+    }
 
     if( m_label_board ) m_label_board->set_text( DBTREE::board_name( get_url() ) );
 

--- a/src/skeleton/toolbar.h
+++ b/src/skeleton/toolbar.h
@@ -81,7 +81,8 @@ namespace SKELETON
         const std::string& get_url() const { return m_url; }
 
         // タブが切り替わった時にDragableNoteBookから呼び出される( Viewの情報を取得する )
-        virtual void set_view( SKELETON::View * view );
+        void set_view( SKELETON::View* view, const bool share_query );
+        virtual void set_view( SKELETON::View* view ) { set_view( view, false ); }
 
         // タブが切り替わった時にDragableNoteBookから呼び出される( ツールバーを表示する )
         void show_toolbar();


### PR DESCRIPTION
### Add "Share thread view search query among tabs" to about:config

about:config に「スレビューの検索クエリをタブ間で共有する」設定(はい・いいえ)を追加します。

- 「はい」はスレビューの検索バーの入力状態がタブ間で共有される
- 「いいえ」は検索バーの入力状態はタブ毎に保持される(従来の動作)

デフォルト設定は「いいえ」(従来の動作)にします。

この機能は実験的なサポートとして追加します。
設定や動作は変更または廃止の可能性があります。

### Implement feature to share thread view search query among tabs

スレビューの検索クエリをタブ間で共有する機能を実装します。

需要や必要性が明らかでないためスレビュー以外の検索クエリは従来の通り別個に保持する仕組みを維持します。

Closes #1352
