### PR TITLE
Add imgur.com URL to default setting file for urlreplace.conf

### DIFF
--- a/docs/manual/urlreplace.md
+++ b/docs/manual/urlreplace.md
@@ -84,12 +84,14 @@ http://www\.foobar\.com/view/([0-9]+)	$0	$0	$IMAGE
   </dd>
   <dt>imgurの拡張子無しURLを画像リンク(jpg)にする</dt>
   <dd>
-<pre><code>^https?://imgur\.com/([0-9A-Za-z]{7})$	https://i.imgur.com/$1.jpg		$IMAGE
+<pre><code>^https?://imgur\.com/([0-9A-Za-z]{7})$	https://i.imgur.com/$1.jpg	https://imgur.com/	$IMAGE
 </code></pre>
   </dd>
   <dt>imgurの画像URLは偽装チェックしない</dt>
   <dd>
-<pre><code>^https?://i\.imgur\.com/([^#&=/]+)$	$0		$GENUINE
+<pre><code>^https?://(?:i\.)?imgur\.com/([^#&=/]+)$	$0	https://imgur.com/	$GENUINE
 </code></pre>
+imgur.com の画像URLはリファラを送信しないと開けないことがある。
+(<a href="https://github.com/JDimproved/JDim/issues/1353">Issue 1353</a>)。
   </dd>
 </dl>

--- a/src/urlreplacemanager.cpp
+++ b/src/urlreplacemanager.cpp
@@ -51,6 +51,7 @@ using namespace CORE;
     "https?://www\\.youtube\\.com/watch\\?(|[^#]+&)v=([^&#/]+)	http://img.youtube.com/vi/$2/0.jpg\n" \
     "https?://youtu\\.be/([^#&=/]+)	http://img.youtube.com/vi/$1/0.jpg\n" \
     "https?://img\\.youtube\\.com/vi/[^/]+/0.jpg	$0		$THUMBNAIL\n" \
+    "^https?://(?:i\\.)?imgur\\.com/([^#&=/]+)$\t$0\thttps://imgur.com/\n" \
     "\n"
 
 


### PR DESCRIPTION
### Add imgur.com image URL to default setting file for urlreplace.conf

(i.)imgur.com の画像URLに imgur.com のリファラを送信する設定をURL変換のデフォルト設定ファイルに追加します。

2024-02-27 ころからリファラを設定せずに imgur.com にアクセスすると画像データではなくHTMLテキストが送られてきて読み込みに失敗するようになりました。
imgur.com は広く利用されており新規キャッシュでURL変換の設定をするユーザーは少なくないと予想されるためデフォルト設定に追加します。

### manual: Add referer URL to imgur.com example for urlreplace.conf

オンラインマニュアルにあるURL変換の設定例のうち imgur.com の例にリファラを追加し、補足説明を書いておきます。

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1640504277/356

Closes #1353
