### PR TITLE
Fix compiler warnings for -Wextra-semi

### DIFF
--- a/src/article/articleviewbase.h
+++ b/src/article/articleviewbase.h
@@ -160,8 +160,8 @@ namespace ARTICLE
         // Viewが所属するAdminクラス
         SKELETON::Admin* get_admin() override;
 
-        JDLIB::RefPtr_Lock< DBTREE::ArticleBase >& get_article() noexcept { return m_article; };
-        const JDLIB::RefPtr_Lock< DBTREE::ArticleBase >& get_article() const noexcept { return m_article; };
+        JDLIB::RefPtr_Lock< DBTREE::ArticleBase >& get_article() noexcept { return m_article; }
+        const JDLIB::RefPtr_Lock< DBTREE::ArticleBase >& get_article() const noexcept { return m_article; }
 
         // ポップアップメニューを表示する前にメニューのアクティブ状態を切り替える
         void activate_act_before_popupmenu( const std::string& url ) override;

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -278,7 +278,7 @@ namespace DBTREE
         void clear_post_history();
 
         // スレ立て時刻
-        time_t get_since_time() const noexcept { return m_since_time; };
+        std::time_t get_since_time() const noexcept { return m_since_time; }
         const std::string& get_since_date();
         void reset_since_date(){ m_since_date = std::string(); }
 

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -311,7 +311,7 @@ namespace DBTREE
         void sweep_buffer();
 
         // 拡張属性を取り出す
-        virtual void parse_extattr( std::string_view str ) {};
+        virtual void parse_extattr( std::string_view str ) {}
 
       private:
 

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -191,7 +191,7 @@ namespace SKELETON
         virtual std::string command_to_url( const COMMAND_ARGS& command ){ return command.url; }
 
         // view_modeに該当するページを探す
-        virtual int find_view( const std::string& view_mode ){ return -1; };
+        virtual int find_view( const std::string& view_mode ) { return -1; }
 
         virtual void open_view( const COMMAND_ARGS& command );
         virtual void switch_admin() = 0;  // CORE::core_set_command( "switch_*" )　を送る
@@ -246,7 +246,7 @@ namespace SKELETON
 
         void open_list( const COMMAND_ARGS& command_list );
         virtual COMMAND_ARGS get_open_list_args( const std::string& url, const COMMAND_ARGS& command_list ){ return COMMAND_ARGS(); }
-        virtual View* create_view( const COMMAND_ARGS& command ){ return nullptr; };
+        virtual View* create_view( const COMMAND_ARGS& command ) { return nullptr; }
         virtual View* get_view( const std::string& url );
 
         // url を含むビュークラスをリストで取得 ( url と一致するビューでは無い )

--- a/src/skeleton/edittreeview.h
+++ b/src/skeleton/edittreeview.h
@@ -95,7 +95,7 @@ namespace SKELETON
 
         void set_undo_buffer( UNDO_BUFFER* undo_buffer ){ m_undo_buffer = undo_buffer; }
 
-        bool is_updated() const { return m_updated; };
+        bool is_updated() const { return m_updated; }
         void set_updated( const bool set ){ m_updated = set; }
 
         // treestoreのセット

--- a/src/skeleton/loadable.h
+++ b/src/skeleton/loadable.h
@@ -153,7 +153,7 @@ namespace SKELETON
       private:
 
         virtual void receive_data( std::string_view ) {}
-        virtual void receive_finish(){};
+        virtual void receive_finish() {}
 
         void callback_dispatch() override;
 

--- a/src/skeleton/view.h
+++ b/src/skeleton/view.h
@@ -289,7 +289,7 @@ namespace SKELETON
         // クロック入力
         // clock_in()はビューがアクティブのときに呼び出される
         // clock_in_always()はviewの種類に依らず常に呼び出されるので重い処理を含めてはいけない
-        virtual void clock_in(){};
+        virtual void clock_in() {}
         virtual void clock_in_always();
 
         virtual void write(){}


### PR DESCRIPTION
メンバー関数定義の後ろに余分なセミコロンが付いているとclangに指摘されたため取り除きます。

clang-17のレポート (file pathを一部省略)
```
src/article/articleviewbase.h:163:96: warning: extra ';' after member function definition [-Wextra-semi]
src/article/articleviewbase.h:164:108: warning: extra ';' after member function definition [-Wextra-semi]
src/dbtree/articlebase.h:281:72: warning: extra ';' after member function definition [-Wextra-semi]
src/dbtree/nodetreebase.h:314:62: warning: extra ';' after member function definition [-Wextra-semi]
src/skeleton/admin.h:194:76: warning: extra ';' after member function definition [-Wextra-semi]
src/skeleton/admin.h:249:84: warning: extra ';' after member function definition [-Wextra-semi]
src/skeleton/edittreeview.h:98:54: warning: extra ';' after member function definition [-Wextra-semi]
src/skeleton/loadable.h:156:40: warning: extra ';' after member function definition [-Wextra-semi]
src/skeleton/view.h:292:34: warning: extra ';' after member function definition [-Wextra-semi]
```
