### PR TITLE
Implement option to display reasons for abone posts

### DIFF
--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -298,8 +298,12 @@ void LayoutTree::append_node( DBTREE::NODE* node_header, const bool joint )
 #endif
 
     // あぼーん
-    if( ! m_article->empty() && ! m_show_abone && m_article->get_abone( res_number ) ){
-        append_abone_node( node_header );
+    DBTREE::Abone abone{};
+    if( ! m_article->empty() && ! m_show_abone && m_article->get_abone( res_number, &abone ) ){
+        const char* abone_reason = nullptr;
+        if( CONFIG::get_show_abone_reason() ) abone_reason = DBTREE::NodeTreeBase::get_abone_reason( abone );
+
+        append_abone_node( node_header, abone_reason );
         return;
     }
 
@@ -460,10 +464,12 @@ void LayoutTree::append_block( DBTREE::NODE* block, const int res_number, IMGDAT
 
 
 
-//
-// レイアウトツリーの一番最後にあぼーんノード追加
-//
-void LayoutTree::append_abone_node( DBTREE::NODE* node_header )
+/** @brief レイアウトツリーの一番最後にあぼーんノード追加
+ *
+ * @param[in] node_header  レス番号のテキストを含むノード
+ * @param[in] abone_reason あぼーんされた理由のテキスト (nullable)
+ */
+void LayoutTree::append_abone_node( DBTREE::NODE* node_header, const char* abone_reason )
 {
     const int res_number = node_header->id_header;
     if( res_number > m_max_res_number ) m_max_res_number = res_number;
@@ -487,7 +493,7 @@ void LayoutTree::append_abone_node( DBTREE::NODE* node_header )
 
     create_layout_link( node->text, node->linkinfo->link, &node->color_text, node->bold );
     create_layout_text( " ", nullptr, false );
-    create_layout_link( "あぼ〜ん", PROTO_ABONE, nullptr, false );
+    create_layout_link( abone_reason ? abone_reason : "あぼ〜ん", PROTO_ABONE, nullptr, false );
 
     classid = CORE::get_css_manager()->get_classid( "mes" );
     layout = create_layout_div( classid );

--- a/src/article/layouttree.h
+++ b/src/article/layouttree.h
@@ -173,7 +173,7 @@ namespace ARTICLE
         LAYOUT* create_layout_img( const char* link );
         LAYOUT* create_layout_sssp( const char* link );
 
-        void append_abone_node( DBTREE::NODE* node_header );
+        void append_abone_node( DBTREE::NODE* node_header, const char* abone_reason );
         LAYOUT* create_separator();
     };
 }

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -533,6 +533,9 @@ bool ConfigItems::load( const bool restore )
     abone_icase = cf.get_option_bool( "abone_icase", CONF_ABONE_ICASE );
     abone_wchar = cf.get_option_bool( "abone_wchar", CONF_ABONE_WCHAR );
 
+    // (実験的な機能) あぼーんしたレスに判定理由を表示するか
+    show_abone_reason = cf.get_option_bool( "show_abone_reason", CONF_SHOW_ABONE_REASON );
+
     // 右ペーンが空の時にサイドバーを閉じるか
     expand_sidebar = cf.get_option_bool( "expand_sidebar", CONF_EXPAND_SIDEBAR );
 
@@ -940,6 +943,8 @@ void ConfigItems::save_impl( const std::string& path )
 
     cf.update( "abone_icase", abone_icase );
     cf.update( "abone_wchar", abone_wchar );
+
+    cf.update( "show_abone_reason", show_abone_reason );
 
     cf.update( "expand_sidebar", expand_sidebar );
     cf.update( "expand_rpane", expand_rpane );

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -478,6 +478,9 @@ namespace CONFIG
         bool abone_icase{};
         bool abone_wchar{};
 
+        /// @brief (実験的な機能) あぼーんしたレスに判定理由を表示するか
+        bool show_abone_reason{};
+
         // 右ペーンが空の時にサイドバーを閉じるか
         bool expand_sidebar{};
 

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -146,6 +146,7 @@ namespace CONFIG
         CONF_ABONE_CHAIN = 0,       // デフォルトで連鎖あぼーんをする
         CONF_ABONE_ICASE = 0,       // NG正規表現によるあぼーん時に大小文字の違いを無視
         CONF_ABONE_WCHAR = 0,       // NG正規表現によるあぼーん時に全角半角文字の違いを無視
+        CONF_SHOW_ABONE_REASON = 0, ///< (実験的な機能) あぼーんしたレスに判定理由を表示するか
         CONF_EXPAND_SIDEBAR = 0,      // 右ペーンが空の時にサイドバーを閉じる
         CONF_EXPAND_RPANE = 1,        // 3ペーン時にスレ一覧やスレビューを最大化する
         CONF_OPEN_SIDEBAR_BY_CLICK = 1, // ペーンの境界をクリックしてサイドバーを開け閉めする

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -552,6 +552,9 @@ void CONFIG::set_abone_icase( const bool set ){ get_confitem()->abone_icase = se
 bool CONFIG::get_abone_wchar(){ return get_confitem()->abone_wchar; }
 void CONFIG::set_abone_wchar( const bool set ){ get_confitem()->abone_wchar = set; }
 
+// (実験的な機能) あぼーんしたレスに判定理由を表示するか
+bool CONFIG::get_show_abone_reason() { return get_confitem()->show_abone_reason; }
+void CONFIG::set_show_abone_reason( const bool set ) { get_confitem()->show_abone_reason = set; }
 
 bool CONFIG::get_expand_sidebar(){ return get_confitem()->expand_sidebar; }
 

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -555,6 +555,10 @@ namespace CONFIG
     bool get_abone_wchar();
     void set_abone_wchar( const bool set );
 
+    // (実験的な機能) あぼーんしたレスに判定理由を表示するか
+    bool get_show_abone_reason();
+    void set_show_abone_reason( const bool set );
+
     // 右ペーンが空の時にサイドバーを閉じるか
     bool get_expand_sidebar();
 

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -686,6 +686,10 @@ void Core::run( const bool init, const bool skip_setupdiag )
                                                     ( CONFIG::get_abone_icase() && CONFIG::get_abone_wchar() ) ),
                                                     sigc::mem_fun( *this, &Core::slot_toggle_abone_icase_wchar ) );
 
+    m_action_group->add( Gtk::ToggleAction::create( "ShowAboneReason", "(実験的な機能) あぼーんしたレスに判定理由を表示する(_R)",
+                                                    Glib::ustring{}, CONFIG::get_show_abone_reason() ),
+                                                    sigc::mem_fun( *this, &Core::slot_toggle_show_abone_reason ) );
+
     // その他
     m_action_group->add( Gtk::Action::create( "Etc_Menu", "その他(_O)" ) );    
     m_action_group->add( Gtk::Action::create( "LivePref", "実況設定(_L)..." ), sigc::mem_fun( *this, &Core::slot_setup_live ) );
@@ -1025,6 +1029,7 @@ void Core::run( const bool init, const bool skip_setupdiag )
                 "<separator/>"
                 "<menuitem action='TranspChainAbone'/>"
                 "<menuitem action='IcaseWcharAbone'/>"
+                "<menuitem action='ShowAboneReason'/>"
             "</menu>"
             "<separator/>"
 

--- a/src/core.h
+++ b/src/core.h
@@ -309,6 +309,7 @@ namespace CORE
         void slot_setup_abone_thread();
         void slot_toggle_abone_transp_chain();
         void slot_toggle_abone_icase_wchar();
+        void slot_toggle_show_abone_reason();
         void slot_setup_live();
         void slot_usrcmd_pref();
         void slot_filter_pref();

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -649,12 +649,15 @@ bool ArticleBase::get_abone_chain() const
 }
 
 
-//
-// あぼーんしてるか
-//
-bool ArticleBase::get_abone( int number )
+/** @brief あぼーんしてるか
+ *
+ * @param[in]  number レス番号
+ * @param[out] abone  あぼーんした理由を表す列挙型を返す (nullable)
+ * @return あばーんしてるなら true
+ */
+bool ArticleBase::get_abone( int number, Abone* abone )
 {
-    return get_nodetree()->get_abone( number );
+    return get_nodetree()->get_abone( number, abone );
 }
 
 

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -24,6 +24,7 @@
 
 namespace DBTREE
 {
+    enum class Abone : unsigned char;
     class NodeTreeBase;
     struct NODE;
 
@@ -357,7 +358,7 @@ namespace DBTREE
         bool get_abone_global() const { return m_abone_global; }
 
         // number番のレスがあぼーんされているか
-        bool get_abone( int number );
+        bool get_abone( int number, Abone* abone = nullptr );
 
         // 全レスのあぼーん状態の更新
         void update_abone();

--- a/src/dbtree/node.h
+++ b/src/dbtree/node.h
@@ -96,7 +96,7 @@ namespace DBTREE
     {
         NODE* next_header; // 次のヘッダノードのアドレス
 
-        bool abone; // あぼーんされているか
+        Abone abone; ///< @brief あぼーんの有無と理由
         int num_reference; // 他のレスから参照されている数
         char* name; // 名前
         bool sage; // メール欄がsageか

--- a/src/dbtree/node.h
+++ b/src/dbtree/node.h
@@ -59,6 +59,28 @@ namespace DBTREE
         BLOCK_NUM
     };
 
+    /// @brief あぼーんした理由を表す列挙型
+    enum class Abone : unsigned char
+    {
+        none = 0,     ///< あぼ〜んしていない
+        res,          ///< NG レス番号
+        noid,         ///< ID無しをあぼ〜ん
+        id_thread,    ///< NG ID:スレ
+        id_board,     ///< NG ID:板
+        default_name, ///< デフォルト名無しをあぼ〜ん
+        name_thread,  ///< NG 名前:スレ
+        name_board,   ///< NG 名前:板
+        name_global,  ///< NG 名前:全体
+        not_sage,     ///< sage以外
+        word_thread,  ///< NG ワード:スレ
+        regex_thread, ///< NG 正規表現:スレ
+        word_board,   ///< NG ワード:板
+        regex_board,  ///< NG 正規表現:板
+        word_global,  ///< NG ワード:全体
+        regex_global, ///< NG 正規表現:全体
+        chain,        ///< 連鎖あぼ〜ん
+    };
+
     struct NODE;
 
     // アンカー情報

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -513,7 +513,7 @@ std::list< ANCINFO* > NodeTreeBase::get_res_anchors( const int number )
 
     NODE* head = res_header( number );
     if( head && head->headinfo
-            && ! head->headinfo->abone ){
+             && head->headinfo->abone == Abone::none ){
 
         for( int block = 0; block < BLOCK_NUM; ++block ){
 
@@ -3238,14 +3238,20 @@ int NodeTreeBase::check_link( const char* str_in, int& lng_in, std::string& str_
 
 
 
-// あぼーんしているか
-bool NodeTreeBase::get_abone( int number ) const
+/** @brief あぼーんしてるか
+ *
+ * @param[in]  number レス番号
+ * @param[out] abone  あぼーんした理由を表す列挙型を返す (nullable)
+ * @return あばーんしてるなら true
+ */
+bool NodeTreeBase::get_abone( int number, Abone* abone ) const
 {
     const NODE* head = res_header( number );
     if( ! head ) return false;
     if( ! head->headinfo ) return false;
 
-    return head->headinfo->abone;
+    if( abone ) *abone = head->headinfo->abone;
+    return head->headinfo->abone != Abone::none;
 }
 
 
@@ -3255,7 +3261,7 @@ void NodeTreeBase::clear_abone()
 {
     for( int i = 1; i <= m_id_header; ++i ){
         NODE* tmphead = m_vec_header[ i ];
-        if( tmphead && tmphead->headinfo ) tmphead->headinfo->abone = false;
+        if( tmphead && tmphead->headinfo ) tmphead->headinfo->abone = Abone::none;
     }
     m_consecutive_count = 0;
     m_prev_link_id = nullptr;
@@ -3384,7 +3390,7 @@ bool NodeTreeBase::check_abone_res( const int number )
     if( ! head ) return false;
     if( ! head->headinfo ) return false;
 
-    head->headinfo->abone = true;
+    head->headinfo->abone = Abone::res;
     return true;
 }
 
@@ -3405,7 +3411,7 @@ bool NodeTreeBase::check_abone_id( const int number )
     NODE* head = res_header( number );
     if( ! head ) return false;
     if( ! head->headinfo ) return false;
-    if( head->headinfo->abone ) {
+    if( head->headinfo->abone != Abone::none ) {
         m_prev_link_id = nullptr;
         return true;
     }
@@ -3413,7 +3419,7 @@ bool NodeTreeBase::check_abone_id( const int number )
         m_prev_link_id = nullptr;
         // ID無し
         if( m_abone_noid ) {
-            head->headinfo->abone = true;
+            head->headinfo->abone = Abone::noid;
             return true;
         }
         return false;
@@ -3431,7 +3437,7 @@ bool NodeTreeBase::check_abone_id( const int number )
     // ローカルID
     if( check_id ){
         if( std::any_of( m_list_abone_id.cbegin(), m_list_abone_id.cend(), equal_id ) ) {
-            head->headinfo->abone = true;
+            head->headinfo->abone = Abone::id_thread;
             m_prev_link_id = nullptr;
             return true;
         }
@@ -3440,7 +3446,7 @@ bool NodeTreeBase::check_abone_id( const int number )
     // 板レベル ID
     if( check_id_board ){
         if( std::any_of( m_list_abone_id_board.cbegin(), m_list_abone_id_board.cend(), equal_id ) ) {
-            head->headinfo->abone = true;
+            head->headinfo->abone = Abone::id_board;
             m_prev_link_id = nullptr;
             return true;
         }
@@ -3459,7 +3465,7 @@ bool NodeTreeBase::check_abone_id( const int number )
 
     // 連続投稿した回数が設定値以上になったらスレのNG IDに追加する
     if( m_abone_consecutive <= m_consecutive_count ) {
-        head->headinfo->abone = true;
+        head->headinfo->abone = Abone::id_thread;
         m_prev_link_id = nullptr;
         // NG IDが重複しないように一時的にローカルのあぼーんするIDに追加する
         m_list_abone_id.emplace_back( link_id );
@@ -3489,7 +3495,7 @@ bool NodeTreeBase::check_abone_name( const int number )
     NODE* head = res_header( number );
     if( ! head ) return false;
     if( ! head->headinfo ) return false;
-    if( head->headinfo->abone ) return true;
+    if( head->headinfo->abone != Abone::none ) return true;
     if( ! head->headinfo->name ) return false;
 
     // デフォルト名無し
@@ -3497,7 +3503,7 @@ bool NodeTreeBase::check_abone_name( const int number )
         const NODE* idnode = head->headinfo->block[ BLOCK_NAMELINK ]->next_node;
         // デフォルトのときはリンクがない
         if( idnode && ! idnode->linkinfo ){
-            head->headinfo->abone = true;
+            head->headinfo->abone = Abone::default_name;
             return true;
         }
     }
@@ -3509,7 +3515,7 @@ bool NodeTreeBase::check_abone_name( const int number )
         const auto& list = m_list_abone_name;
         if( std::any_of( list.cbegin(), list.cend(), [&]( const std::string& name )
                          { return name_str.find( name ) != std::string_view::npos; } ) ) {
-            head->headinfo->abone = true;
+            head->headinfo->abone = Abone::name_thread;
             return true;
         }
     }
@@ -3519,7 +3525,7 @@ bool NodeTreeBase::check_abone_name( const int number )
         const auto& list = m_list_abone_name_board;
         if( std::any_of( list.cbegin(), list.cend(), [&]( const std::string& name )
                          { return name_str.find( name ) != std::string_view::npos; } ) ) {
-            head->headinfo->abone = true;
+            head->headinfo->abone = Abone::name_board;
             return true;
         }
     }
@@ -3529,7 +3535,7 @@ bool NodeTreeBase::check_abone_name( const int number )
         const auto& list = CONFIG::get_list_abone_name();
         if( std::any_of( list.cbegin(), list.cend(), [&]( const std::string& name )
                          { return name_str.find( name ) != std::string_view::npos; } ) ) {
-            head->headinfo->abone = true;
+            head->headinfo->abone = Abone::name_global;
             return true;
         }
     }
@@ -3550,10 +3556,10 @@ bool NodeTreeBase::check_abone_mail( const int number )
     NODE* head = res_header( number );
     if( ! head ) return false;
     if( ! head->headinfo ) return false;
-    if( head->headinfo->abone ) return true;
+    if( head->headinfo->abone != Abone::none ) return true;
 
     if( ! head->headinfo->sage ){
-        head->headinfo->abone = true;        
+        head->headinfo->abone = Abone::not_sage;
         return true;
     }
 
@@ -3584,7 +3590,7 @@ bool NodeTreeBase::check_abone_word( const int number )
     NODE* head = res_header( number );
     if( ! head ) return false;
     if( ! head->headinfo ) return false;
-    if( head->headinfo->abone ) return true;
+    if( head->headinfo->abone != Abone::none ) return true;
 
     const std::string res_str = get_res_str( number );
     JDLIB::Regex regex;
@@ -3596,7 +3602,7 @@ bool NodeTreeBase::check_abone_word( const int number )
         const auto& list = m_list_abone_word;
         if( std::any_of( list.cbegin(), list.cend(), [&]( const std::string& word )
                          { return res_str.find( word ) != std::string::npos; } ) ) {
-            head->headinfo->abone = true;
+            head->headinfo->abone = Abone::word_thread;
             return true;
         }
     }
@@ -3607,7 +3613,7 @@ bool NodeTreeBase::check_abone_word( const int number )
         const auto& list = m_list_abone_regex;
         if( std::any_of( list.cbegin(), list.cend(), [&]( const JDLIB::RegexPattern& pattern )
                          { return regex.match( pattern, res_str, offset ); } ) ) {
-            head->headinfo->abone = true;
+            head->headinfo->abone = Abone::regex_thread;
             return true;
         }
     }
@@ -3618,7 +3624,7 @@ bool NodeTreeBase::check_abone_word( const int number )
         const auto& list = m_list_abone_word_board;
         if( std::any_of( list.cbegin(), list.cend(), [&]( const std::string& word )
                          { return res_str.find( word ) != std::string::npos; } ) ) {
-            head->headinfo->abone = true;
+            head->headinfo->abone = Abone::word_board;
             return true;
         }
     }
@@ -3629,7 +3635,7 @@ bool NodeTreeBase::check_abone_word( const int number )
         const auto& list = m_list_abone_regex_board;
         if( std::any_of( list.cbegin(), list.cend(), [&]( const JDLIB::RegexPattern& pattern )
                          { return regex.match( pattern, res_str, offset ); } ) ) {
-            head->headinfo->abone = true;
+            head->headinfo->abone = Abone::regex_board;
             return true;
         }
     }
@@ -3640,7 +3646,7 @@ bool NodeTreeBase::check_abone_word( const int number )
         const auto& list = m_list_abone_word_global;
         if( std::any_of( list.cbegin(), list.cend(), [&]( const std::string& word )
                          { return res_str.find( word ) != std::string::npos; } ) ) {
-            head->headinfo->abone = true;
+            head->headinfo->abone = Abone::word_global;
             return true;
         }
     }
@@ -3651,7 +3657,7 @@ bool NodeTreeBase::check_abone_word( const int number )
         const auto& list = m_list_abone_regex_global;
         if( std::any_of( list.cbegin(), list.cend(), [&]( const JDLIB::RegexPattern& pattern )
                          { return regex.match( pattern, res_str, offset ); } ) ) {
-            head->headinfo->abone = true;
+            head->headinfo->abone = Abone::regex_global;
             return true;
         }
     }
@@ -3674,7 +3680,7 @@ bool NodeTreeBase::check_abone_chain( const int number )
     NODE* head = res_header( number );
     if( ! head ) return false;
     if( ! head->headinfo ) return false;
-    if( head->headinfo->abone ) return true;
+    if( head->headinfo->abone != Abone::none ) return true;
 
     bool abone = false;
     for( int block = 0; block < BLOCK_NUM; ++block ){
@@ -3702,7 +3708,7 @@ bool NodeTreeBase::check_abone_chain( const int number )
                     while( anc_from <= anc_to ){
 
                         const NODE* tmphead = res_header( anc_from++ );
-                        if( tmphead && ! tmphead->headinfo->abone ) return false;
+                        if( tmphead && tmphead->headinfo->abone == Abone::none ) return false;
                     }
 
                     abone = true;
@@ -3712,7 +3718,7 @@ bool NodeTreeBase::check_abone_chain( const int number )
         }
     }
 
-    head->headinfo->abone = abone;
+    head->headinfo->abone = abone ? Abone::chain : Abone::none;
     return abone;
 }
 
@@ -3754,7 +3760,7 @@ void NodeTreeBase::check_reference( const int number )
     if( ! head ) return;
 
     // 既にあぼーんしているならチェックしない
-    if( head->headinfo->abone ) return;
+    if( head->headinfo->abone != Abone::none ) return;
 
     // 2重チェック防止用
     std::unordered_set< int > checked;
@@ -3783,7 +3789,7 @@ void NodeTreeBase::check_reference( const int number )
                     std::cout << "from " << from << std::endl;
 #endif
                     const NODE* tmphead = res_header( from );
-                    if( tmphead && ! tmphead->headinfo->abone ){
+                    if( tmphead && tmphead->headinfo->abone == Abone::none ){
                         m_refer_posts.insert( from );
                     }
                 }
@@ -3859,7 +3865,7 @@ void NodeTreeBase::check_reference( const int number )
                             // 過去へのレス
                             NODE* tmphead = res_header( i );
                             if( tmphead
-                                && ! tmphead->headinfo->abone // 対象スレがあぼーんしていたらカウントしない
+                                && tmphead->headinfo->abone == Abone::none // 対象スレがあぼーんしていたらカウントしない
                                 && tmphead->headinfo->block[ BLOCK_NUMBER ]
                                 ){
 

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -4145,3 +4145,35 @@ void NodeTreeBase::clear_post_history()
     m_posts.clear();
     m_refer_posts.clear();
 }
+
+
+/** @brief あぼーんした理由をテキストで取得する
+ *
+ * @param[in] abone あぼーんした理由を表す列挙型
+ * @return あぼーんした理由のテキスト
+ */
+const char* NodeTreeBase::get_abone_reason( Abone abone )
+{
+    if( abone > Abone::chain ) abone = Abone::none;
+
+    constexpr const char* reason_strings[] = {
+        "",                             // none
+        "あぼ〜ん [NG レス番号]",       // res
+        "あぼ〜ん [ID無し]",            // noid
+        "あぼ〜ん [NG ID:スレ]",        // id_thread
+        "あぼ〜ん [NG ID:板]",          // id_board
+        "あぼ〜ん [デフォルト名無し]",  // default_name
+        "あぼ〜ん [NG 名前:スレ]",      // name_thread
+        "あぼ〜ん [NG 名前:板]",        // name_board
+        "あぼ〜ん [NG 名前:全体]",      // name_global
+        "あぼ〜ん [sage以外]",          // not_sage
+        "あぼ〜ん [NG ワード:スレ]",    // word_thread
+        "あぼ〜ん [NG 正規表現:スレ]",  // regex_thread
+        "あぼ〜ん [NG ワード:板]",      // word_board
+        "あぼ〜ん [NG 正規表現:板]",    // regex_board
+        "あぼ〜ん [NG ワード:全体]",    // word_global
+        "あぼ〜ん [NG 正規表現:全体]",  // regex_global
+        "連鎖あぼ〜ん",                 // chain
+    };
+    return reason_strings[ static_cast<unsigned>( abone ) ];
+}

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -258,7 +258,7 @@ namespace DBTREE
         virtual void download_dat( const bool check_update );
 
         // あぼーんしているか
-        bool get_abone( int number ) const;
+        bool get_abone( int number, Abone* abone = nullptr ) const;
 
         // あぼーん情報を親クラスのarticlebaseからコピーする
         void copy_abone_info( const std::list< std::string >& list_abone_id,

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -418,6 +418,9 @@ namespace DBTREE
       public:
         // http://ime.nu/ などをリンクから削除
         static bool remove_imenu( std::string& str_link );
+
+        // あぼーんした理由をテキストで取得する
+        static const char* get_abone_reason( Abone abone );
     };
 }
 

--- a/src/menuslots.cpp
+++ b/src/menuslots.cpp
@@ -983,6 +983,17 @@ void Core::slot_toggle_abone_icase_wchar()
 }
 
 
+/**
+ * @brief (実験的な機能) あぼーんしたレスの判定理由の表示を切り替え
+ */
+void Core::slot_toggle_show_abone_reason()
+{
+    CONFIG::set_show_abone_reason( ! CONFIG::get_show_abone_reason() );
+
+    CORE::core_set_command( "relayout_all_article" );
+}
+
+
 // 実況設定
 void Core::slot_setup_live()
 {

--- a/test/gtest_dbtree_nodetreebase.cpp
+++ b/test/gtest_dbtree_nodetreebase.cpp
@@ -153,4 +153,103 @@ TEST_F(NodeTreeBase_RemoveImenuTest, single_machi_to_bbs_link_cgi)
     }
 }
 
+
+class DBTREE_NodeTreeBase_GetAboneReasonTest : public ::testing::Test {};
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_none)
+{
+    EXPECT_STREQ( "", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::none ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_res)
+{
+    EXPECT_STREQ( "あぼ〜ん [NG レス番号]", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::res ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_noid)
+{
+    EXPECT_STREQ( "あぼ〜ん [ID無し]", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::noid ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_id_thread)
+{
+    EXPECT_STREQ( "あぼ〜ん [NG ID:スレ]", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::id_thread ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_id_board)
+{
+    EXPECT_STREQ( "あぼ〜ん [NG ID:板]", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::id_board ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_default_name)
+{
+    EXPECT_STREQ( "あぼ〜ん [デフォルト名無し]", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::default_name ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_name_thread)
+{
+    EXPECT_STREQ( "あぼ〜ん [NG 名前:スレ]", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::name_thread ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_name_board)
+{
+    EXPECT_STREQ( "あぼ〜ん [NG 名前:板]", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::name_board ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_name_global)
+{
+    EXPECT_STREQ( "あぼ〜ん [NG 名前:全体]", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::name_global ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_not_sage)
+{
+    EXPECT_STREQ( "あぼ〜ん [sage以外]", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::not_sage ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_word_thread)
+{
+    EXPECT_STREQ( "あぼ〜ん [NG ワード:スレ]", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::word_thread ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_regex_thread)
+{
+    EXPECT_STREQ( "あぼ〜ん [NG 正規表現:スレ]", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::regex_thread ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_word_board)
+{
+    EXPECT_STREQ( "あぼ〜ん [NG ワード:板]", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::word_board ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_regex_board)
+{
+    EXPECT_STREQ( "あぼ〜ん [NG 正規表現:板]", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::regex_board ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_word_global)
+{
+    EXPECT_STREQ( "あぼ〜ん [NG ワード:全体]", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::word_global ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_regex_global)
+{
+    EXPECT_STREQ( "あぼ〜ん [NG 正規表現:全体]", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::regex_global ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_chain)
+{
+    EXPECT_STREQ( "連鎖あぼ〜ん", DBTREE::NodeTreeBase::get_abone_reason( DBTREE::Abone::chain ) );
+}
+
+TEST_F(DBTREE_NodeTreeBase_GetAboneReasonTest, abone_out_of_range)
+{
+    DBTREE::Abone out_of_range;
+
+    out_of_range = static_cast<DBTREE::Abone>( static_cast<unsigned char>( DBTREE::Abone::none ) - 1 );
+    EXPECT_STREQ( "", DBTREE::NodeTreeBase::get_abone_reason( out_of_range ) );
+
+    out_of_range = static_cast<DBTREE::Abone>( static_cast<unsigned char>( DBTREE::Abone::chain ) + 1 );
+    EXPECT_STREQ( "", DBTREE::NodeTreeBase::get_abone_reason( out_of_range ) );
+}
+
 } // namespace


### PR DESCRIPTION
### Implement enum Abone and `NodeTreeBase::get_abone_reason()`

あぼ〜んした判定理由を表す`Abone`列挙型と`Abone`変数から理由のテキストを取得する関数を実装します。

現状の実装では連続投稿したIDをスレのNG IDに追加する処理は判定できないため除外しています。

### Add test cases for DBTREE::NodeTreeBase::get_abone_reason()

### Implement configuration to display reasons for abone posts

あぼーんしたレスに判定理由を表示する状態かどうか表す設定を実装します。
デフォルト設定は判定理由を表示しない(既存の動作)です。

### Implement process to display reasons for abone posts

あぼーんしたレスの判定理由を表示する処理を実装します。

連続投稿したIDをスレのNG IDに追加する処理はスレのNG IDリストを利用してあぼーんにするため連続投稿ではなくスレのNG IDと判定されます。

### Add toggle menu item to display reasons for abone posts

あぼーんしたレスの判定理由の表示・非表示を切り替えるチェックメニューをメニュバーの`設定(C)`＞`あぼ〜ん(A)`の中に追加します。

この機能は実験的なサポートとして追加します。
設定や動作は変更または廃止の可能性があります。

Closes #1357
