### PR TITLE
Fix compiler warnings for -Wextra-semi-stmt part1,2

### DIFF
--- a/src/article/articleview.cpp
+++ b/src/article/articleview.cpp
@@ -485,7 +485,7 @@ void ArticleViewMain::update_finish()
 
 #ifdef _DEBUG
     const int code = DBTREE::article_code( url_article() );
-    std::cout << "ArticleViewMain::update_finish " << str_tablabel << " code = " << code << std::endl;;
+    std::cout << "ArticleViewMain::update_finish " << str_tablabel << " code = " << code << std::endl;
 #endif
 
     // 新着セパレータを消す
@@ -669,7 +669,7 @@ void ArticleViewMain::show_instruct_diag()
 void ArticleViewMain::relayout( const bool completely )
 {
 #ifdef _DEBUG
-    std::cout << "ArticleViewMain::relayout " << DBTREE::article_subject( url_article() ) << std::endl;;
+    std::cout << "ArticleViewMain::relayout " << DBTREE::article_subject( url_article() ) << std::endl;
 #endif
 
     hide_popup( true );
@@ -691,7 +691,7 @@ void ArticleViewMain::relayout( const bool completely )
 void ArticleViewMain::do_relayout( const bool completely )
 {
 #ifdef _DEBUG
-    std::cout << "ArticleViewMain::do_relayout " << url_article() << std::endl;;
+    std::cout << "ArticleViewMain::do_relayout " << url_article() << std::endl;
 #endif
 
     int seen = drawarea()->get_seen_current();

--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -1039,7 +1039,7 @@ bool ArticleViewBase::operate_view( const int control )
 
     if( CONTROL::operate_common( control, get_url(), ARTICLE::get_admin() ) ) return true;
 
-    if( control == CONTROL::None ) return false;;
+    if( control == CONTROL::None ) return false;
 
     // スクロール系操作
     if( m_drawarea->set_scroll( control ) ) return true;
@@ -3757,7 +3757,7 @@ void ArticleViewBase::set_favorite()
     CORE::DATA_INFO info;
     info.type = TYPE_THREAD;
     info.parent = ARTICLE::get_admin()->get_win();
-    info.url = m_url_article;;
+    info.url = m_url_article;
     info.name = MISC::to_plain( DBTREE::article_modified_subject( m_url_article ) );
     info.path = Gtk::TreePath( "0" ).to_string();
 

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -2195,8 +2195,8 @@ void DrawAreaBase::draw_div( LAYOUT* layout_div, const CLIPINFO& ci )
 
     int border_left = layout_div->css->border_left_width;
     int border_right = layout_div->css->border_right_width;
-    int border_top = layout_div->css->border_top_width;;
-    int border_bottom = layout_div->css->border_bottom_width;;
+    int border_top = layout_div->css->border_top_width;
+    int border_bottom = layout_div->css->border_bottom_width;
 
     int border_style = layout_div->css->border_style;
 
@@ -3392,7 +3392,7 @@ void DrawAreaBase::goto_num( int num )
         m_goto_num_reserve = num;
 
 #ifdef _DEBUG
-        std::cout << "reserve goto_num(2) num = " << m_goto_num_reserve << std::endl;;
+        std::cout << "reserve goto_num(2) num = " << m_goto_num_reserve << std::endl;
 #endif
         return;
     }
@@ -4302,7 +4302,7 @@ bool DrawAreaBase::set_selection( const CARET_POSITION& caret_pos, RECTANGLE* re
     // 前回の呼び出しからキャレット位置が変わってない
     if( m_caret_pos == caret_pos ) return false;
 
-    m_caret_pos_pre = m_caret_pos;;
+    m_caret_pos_pre = m_caret_pos;
     m_caret_pos = caret_pos;
 
 #ifdef _DEBUG
@@ -4321,7 +4321,7 @@ bool DrawAreaBase::set_selection( const CARET_POSITION& caret_pos, RECTANGLE* re
         m_selection.select = true;
 
         if( m_caret_pos_dragstart > m_caret_pos ){
-            m_selection.caret_from = m_caret_pos;;
+            m_selection.caret_from = m_caret_pos;
             m_selection.caret_to = m_caret_pos_dragstart;
         }
         else{
@@ -5152,7 +5152,7 @@ bool DrawAreaBase::motion_mouse()
 
 #ifdef _DEBUG
                 std::cout << "slot_motion_notify_drawarea : enter link = " << m_link_current
-                          << " imgurl = " << imgurl << std::endl;;
+                          << " imgurl = " << imgurl << std::endl;
 #endif
                 m_sig_on_url.emit( m_link_current, imgurl, res_num );
             }

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -130,7 +130,7 @@ DrawAreaBase::DrawAreaBase( const std::string& url )
                                                               : &DrawAreaBase::render_text_pangolayout }
 {
 #ifdef _DEBUG
-    std::cout << "DrawAreaBase::DrawAreaBase " << m_url << std::endl;;
+    std::cout << "DrawAreaBase::DrawAreaBase " << m_url << std::endl;
 #endif
 
     // フォント設定
@@ -152,7 +152,7 @@ DrawAreaBase::DrawAreaBase( const std::string& url )
 DrawAreaBase::~DrawAreaBase()
 {
 #ifdef _DEBUG
-    std::cout << "DrawAreaBase::~DrawAreaBase " << m_url << std::endl;;
+    std::cout << "DrawAreaBase::~DrawAreaBase " << m_url << std::endl;
 #endif
 
     cancel_deceleration();

--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -662,7 +662,7 @@ void LayoutTree::hide_separator()
 
         // あぼーんしているレスは飛ばす
         LAYOUT* header_before;
-        int num_tmp = m_separator_new -1;;
+        int num_tmp = m_separator_new -1;
         while( ! ( header_before = get_header_of_res( num_tmp ) ) && num_tmp-- > 1 );
         if( header_before ) header_before->next_header = m_separator_header->next_header;
     }

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -724,7 +724,7 @@ void BoardViewBase::update_columns()
             rentext->property_xpad() = 4;
 
             // 行間スペース
-            rentext->property_ypad() = CONFIG::get_tree_ypad();;
+            rentext->property_ypad() = CONFIG::get_tree_ypad();
 
             // 文字位置
             switch( id ){
@@ -1447,7 +1447,7 @@ bool BoardViewBase::operate_view( const int control )
 
     bool open_tab = false;
 
-    Gtk::TreePath path = m_treeview.get_current_path();;
+    Gtk::TreePath path = m_treeview.get_current_path();
 
     switch( control ){
 
@@ -1936,7 +1936,7 @@ void BoardViewBase::update_row_common( const Gtk::TreeModel::Row& row )
     if( load ){
         row[ m_columns.m_col_str_load ] = Glib::ustring::compose( "%1", load );
         const int new_arrival = res - load;
-        row[ m_columns.m_col_str_new ] = Glib::ustring::compose( "%1", new_arrival );;
+        row[ m_columns.m_col_str_new ] = Glib::ustring::compose( "%1", new_arrival );
         row[ m_columns.m_col_new ] = new_arrival;
     }
     else{
@@ -2516,7 +2516,7 @@ bool BoardViewBase::open_row( const Gtk::TreePath& path, const bool tab, const b
     std::string str_tab = "false";
     if( tab ) str_tab = "opentab";
 
-    std::string mode = std::string();;
+    std::string mode;
 
     const std::string url_target = path2daturl( path );
 
@@ -2566,7 +2566,7 @@ bool BoardViewBase::open_row( const Gtk::TreePath& path, const bool tab, const b
 //
 void BoardViewBase::open_selected_rows( const bool reget )
 {
-    std::string mode = std::string();;
+    std::string mode;
     std::string list_url;
     std::list< Gtk::TreeModel::iterator > list_it = m_treeview.get_selected_iterators();
 
@@ -2735,7 +2735,7 @@ void BoardViewBase::exec_search()
     focus_view();
     if( query.empty() ) return;
 
-    Gtk::TreePath path = m_treeview.get_current_path();;
+    Gtk::TreePath path = m_treeview.get_current_path();
     if( path.empty() ){
         if( m_search_invert ) path = GET_PATH( *( m_liststore->children().begin() ) );
         else {

--- a/src/control/controlutil.cpp
+++ b/src/control/controlutil.cpp
@@ -554,7 +554,7 @@ std::string CONTROL::get_label_motions( const int id )
 // 共通操作
 bool CONTROL::operate_common( const int control, const std::string& url, SKELETON::Admin* admin )
 {
-    if( control == CONTROL::None ) return false;;
+    if( control == CONTROL::None ) return false;
 
     switch( control ){
             

--- a/src/control/mousekeyconf.cpp
+++ b/src/control/mousekeyconf.cpp
@@ -61,7 +61,7 @@ int MouseKeyConf::get_id( const int mode,
                           const guint motion, const bool ctrl, const bool shift, const bool alt,
                           const bool dblclick, const bool trpclick ) const
 {
-    int id = CONTROL::None;;
+    int id = CONTROL::None;
     for( const MouseKeyItem& item : m_vec_items ) {
 
         id = item.is_activated( mode, motion, ctrl, shift, alt, dblclick, trpclick );

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -2790,7 +2790,7 @@ void Core::set_command( const COMMAND_ARGS& command )
 #ifdef _DEBUG
             std::cout << "Core::set_command : open_message subject = "
                       << DBTREE::article_modified_subject( command.url )
-                      << ", max lng = " << max_lng << std::endl;;
+                      << ", max lng = " << max_lng << std::endl;
 #endif
 
             if( max_lng == 0 ) max_lng = DBTREE::board_get_max_dat_lng( command.url );

--- a/src/dbtree/bbsmenu.cpp
+++ b/src/dbtree/bbsmenu.cpp
@@ -282,6 +282,6 @@ void BBSMenu::bbsmenu2xml( const std::string& menu )
     CACHE::save_rawdata( path, m_xml_document.get_xml() );
 
 #ifdef _DEBUG
-    std::cout << "BBSMenu::bbsmenu2xml : save " << path << std::endl;;
+    std::cout << "BBSMenu::bbsmenu2xml : save " << path << std::endl;
 #endif
 }

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -2190,7 +2190,6 @@ void BoardBase::save_jdboard_info()
          << "user_agent = " << m_board_agent << std::endl
          << "encoding_analysis_method = " << m_encoding_analysis_method << std::endl
          << "abone_consecutive = " << m_abone_consecutive << std::endl;
-    ;
 
     CACHE::save_rawdata( path_info, sstr.str() );
 }

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -192,7 +192,7 @@ BoardBase* Root::get_board( const std::string& url, const int count )
 #ifdef _SHOW_GETBOARD
             std::cout << "found\n";
 #endif
-        return m_get_board;;
+        return m_get_board;
     }
 
     // 見つからなかった
@@ -257,7 +257,7 @@ BoardBase* Root::get_board( const std::string& url, const int count )
     }
 
 #ifdef _DEBUG            
-    std::cout << "Root::get_board: not found url = " << url << std::endl;;
+    std::cout << "Root::get_board: not found url = " << url << std::endl;
 #endif
     
     // それでも見つからなかったらNullクラスを返す

--- a/src/image/imageview.cpp
+++ b/src/image/imageview.cpp
@@ -396,7 +396,7 @@ void ImageViewMain::add_tab_number()
                 + " (" + MISC::get_hostname( get_url(), false ) + ")]" );
 
 #ifdef _DEBUG
-    std::cout << "ImageViewMain::add_tab_number : " << get_status() << std::endl;;
+    std::cout << "ImageViewMain::add_tab_number : " << get_status() << std::endl;
 #endif
 }
 

--- a/src/image/imageviewicon.cpp
+++ b/src/image/imageviewicon.cpp
@@ -214,7 +214,7 @@ void ImageViewIcon::slot_drag_data_get( const Glib::RefPtr<Gdk::DragContext>& co
 {
 #ifdef _DEBUG
     std::cout << "ImageViewIcon::on_drag_data_get target = " << selection_data.get_target()
-              << " url = " << get_url() << std::endl;;
+              << " url = " << get_url() << std::endl;
 #endif
 
     set_image_to_buffer();

--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -1006,9 +1006,9 @@ EXIT_LOADING:
     finish_loading();
 
 #ifdef _DEBUG
-    std::cout << "Loader::run_main : finish loading : " << m_data.url << std::endl;;
-    std::cout << "read size : " << m_data.length_current << " / " << m_data.length << std::endl;;    
-    std::cout << "data size : " << m_data.size_data << std::endl;;
+    std::cout << "Loader::run_main : finish loading : " << m_data.url << std::endl;
+    std::cout << "read size : " << m_data.length_current << " / " << m_data.length << std::endl;
+    std::cout << "data size : " << m_data.size_data << std::endl;
     std::cout << "code : " << m_data.code << std::endl << std::endl;
 #endif    
 }

--- a/src/searchloader.cpp
+++ b/src/searchloader.cpp
@@ -38,7 +38,7 @@ SearchLoader::SearchLoader()
     set_default_encoding( enc );
 
 #ifdef _DEBUG
-    std::cout << "SearchLoader::SearchLoader encoding = " << MISC::encoding_to_cstr( enc ) << std::endl;;
+    std::cout << "SearchLoader::SearchLoader encoding = " << MISC::encoding_to_cstr( enc ) << std::endl;
 #endif
 }
 

--- a/src/skeleton/tablabel.cpp
+++ b/src/skeleton/tablabel.cpp
@@ -186,7 +186,7 @@ void TabLabel::on_drag_data_get( const Glib::RefPtr<Gdk::DragContext>& context,
 {
 #ifdef _DEBUG
     std::cout << "TabLabel::on_drag_data_get target = " << selection_data.get_target()
-              << " " << m_fulltext << std::endl;;
+              << " " << m_fulltext << std::endl;
 #endif
 
     Gtk::EventBox::on_drag_data_get( context, selection_data, info, time );
@@ -201,7 +201,7 @@ void TabLabel::on_drag_data_get( const Glib::RefPtr<Gdk::DragContext>& context,
 void TabLabel::on_drag_end( const Glib::RefPtr< Gdk::DragContext >& context )
 {
 #ifdef _DEBUG
-    std::cout << "TabLabel::on_drag_end " << m_fulltext << std::endl;;
+    std::cout << "TabLabel::on_drag_end " << m_fulltext << std::endl;
 #endif
 
     Gtk::EventBox::on_drag_end( context );

--- a/src/skeleton/treeviewbase.cpp
+++ b/src/skeleton/treeviewbase.cpp
@@ -288,7 +288,7 @@ Gtk::TreePath JDTreeViewBase::prev_path( const Gtk::TreePath& path, bool check_e
     path_out = path;
     if( ! path_out.prev() && path_out.size() >= 2 ) path_out.up();
 
-    return path_out;;
+    return path_out;
 }
 
 

--- a/src/usrcmdpref.cpp
+++ b/src/usrcmdpref.cpp
@@ -160,7 +160,7 @@ bool UsrCmdPref::slot_button_release( GdkEventButton* event )
     m_path_selected = m_treeview.get_path_under_xy( (int)event->x, (int)event->y );
 
 #ifdef _DEBUG
-    std::cout << "UsrCmdPref::slot_button_release path = " << m_path_selected.to_string() << std::endl;;
+    std::cout << "UsrCmdPref::slot_button_release path = " << m_path_selected.to_string() << std::endl;
 #endif
 
     if( m_control.button_alloted( event, CONTROL::PopupmenuButton ) ) show_popupmenu();


### PR DESCRIPTION
### Fix compiler warnings for -Wextra-semi-stmt part1

ステートメントの後ろに余分なセミコロンが付いており効果がないとclangに指摘されたため取り除きます。

<details>
<summary>clang-17のレポート (file pathを一部省略)</summary>

```
src/article/articleview.cpp:488:103: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/article/articleview.cpp:672:104: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/article/articleview.cpp:694:80: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/article/articleviewbase.cpp:1042:49: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/article/articleviewbase.cpp:3760:30: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/article/drawareabase.cpp:133:70: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/article/drawareabase.cpp:155:71: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/board/boardviewbase.cpp:1450:56: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/board/boardviewbase.cpp:1939:86: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/board/boardviewbase.cpp:2519:38: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/board/boardviewbase.cpp:2569:38: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/board/boardviewbase.cpp:2738:56: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/board/boardviewbase.cpp:727:64: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/control/controlutil.cpp:557:49: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/control/mousekeyconf.cpp:64:28: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/image/imageview.cpp:399:82: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/image/imageviewicon.cpp:217:54: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/jdlib/loader.cpp:1009:84: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/jdlib/loader.cpp:1010:97: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/jdlib/loader.cpp:1011:66: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
```

</details>

### Fix compiler warnings for -Wextra-semi-stmt part2

ステートメントの後ろに余分なセミコロンが付いており効果がないとclangに指摘されたため取り除きます。

<details>
<summary>clang-17のレポート (file pathを一部省略)</summary>

```
src/article/drawareabase.cpp:2198:56: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/article/drawareabase.cpp:2199:62: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/article/drawareabase.cpp:3395:86: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/article/drawareabase.cpp:4305:35: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/article/drawareabase.cpp:4324:50: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/article/drawareabase.cpp:5155:66: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/article/layouttree.cpp:659:42: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/core.cpp:2787:65: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/dbtree/bbsmenu.cpp:285:70: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/dbtree/boardbase.cpp:2193:5: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/dbtree/root.cpp:195:28: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/dbtree/root.cpp:260:74: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/searchloader.cpp:41:105: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/skeleton/tablabel.cpp:189:49: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/skeleton/tablabel.cpp:204:70: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/skeleton/treeviewbase.cpp:291:21: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
src/usrcmdpref.cpp:163:104: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
```

</details>
