### PR TITLE
Fix compiler warnings for -Wconditional-uninitialized

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -4151,7 +4151,7 @@ bool DrawAreaBase::set_carets_dclick( CARET_POSITION& caret_left, CARET_POSITION
                 set_node_font( layout );
 
                 // ポインタの下にあるノードを探す
-                int pos;
+                int pos = 0;
                 while( rect ){
 
                     int width_line;

--- a/src/skeleton/dragnote.cpp
+++ b/src/skeleton/dragnote.cpp
@@ -501,7 +501,7 @@ bool DragableNoteBook::slot_scroll_event( GdkEventScroll* event )
 #endif
 
     bool ret = false;
-    int next_page;
+    int next_page = 0;
 
     if( event->direction == GDK_SCROLL_UP ) {
         next_page = get_current_page() - 1; // If negative, the last page will be used.


### PR DESCRIPTION
ローカル変数が初期されていない状態で使用されている可能性があるとclangに指摘されたため変数定義でゼロ初期化します。

clang-17のレポート (file pathを一部省略)
```
src/article/drawareabase.cpp:4188:80: warning: variable 'pos' may be uninitialized when used here [-Wconditional-uninitialized]
src/skeleton/dragnote.cpp:530:27: warning: variable 'next_page' may be uninitialized when used here [-Wconditional-uninitialized]
```
