### PR TITLE
CI: Set timeout to ccpp job ASan-22

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -31,9 +31,13 @@ jobs:
       - name: ninja -C builddir
         run: ninja -C builddir
         # Since Meson 0.57, `test` subcommand will only rebuild test program.
-      - name: meson test -v -C builddir
-        run: meson test -v -C builddir
+        # Set a timeout for test program using AddressSanitizer to prevent hang-ups.
+      - name: meson test -v -C builddir --timeout-multiplier 1
+        run: meson test -v -C builddir --timeout-multiplier 1
+        continue-on-error: true
+        id: meson_test
       - name: ./builddir/src/jdim -V
+        if: ${{ steps.meson_test.outcome == 'success' }}
         run: ./builddir/src/jdim -V
 
   compiler-20:


### PR DESCRIPTION
AddressSanitizer を使うCIジョブ ASan-22 のテストでハングアップすることがありました。
ハングアップするとCIの制限時間が過ぎるまで実行が続くためテストのタイムアウトを設定して一定時間で実行を打ち切るようにします。
テストがタイムアウトしたときはジョブをスキップします。

ハングアップを確認したPull request: #1363
googletestのissue: google/googletest 4491
