### PR TITLE
Update to count bytes of thread subject when creating new thread

### DIFF
--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -62,6 +62,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     , m_label_noname_value{ DBTREE::default_noname( get_url() ) }
     , m_label_max_line{ "1レスの最大改行数:" }
     , m_label_max_byte{ "1レスの最大バイト数:" }
+    , m_label_max_subject_byte{ "スレタイトルの最大バイト数:" }
     , m_label_maxres{ "最大レス数 (0 : 未設定):" }
     , m_label_last_access{ "最終アクセス日時:" }
     , m_hbox_modified{ Gtk::ORIENTATION_HORIZONTAL, 10 }
@@ -266,6 +267,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     // 一般ページのパッキング
     m_label_max_line_value.set_text( std::to_string( DBTREE::line_number( get_url() ) * 2 ) );
     m_label_max_byte_value.set_text( std::to_string( DBTREE::message_count( get_url() ) ) );
+    m_label_max_subject_byte_value.set_text( std::to_string( DBTREE::subject_count( get_url() ) ) );
 
     // 最大レス数
     const int max_res = DBTREE::board_get_number_max_res( get_url() );
@@ -331,37 +333,39 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     m_grid_general.set_column_spacing( 10 );
     m_grid_general.set_row_spacing( 8 );
 
-    m_grid_general.attach( m_label_name,           0, 0, 1, 1 );
-    m_grid_general.attach( m_label_name_value,     1, 0, 1, 1 );
-    m_grid_general.attach( m_label_url,            0, 1, 1, 1 );
-    m_grid_general.attach( m_label_url_value,      1, 1, 1, 1 );
-    m_grid_general.attach( m_label_cache,          0, 2, 1, 1 );
-    m_grid_general.attach( m_label_cache_value,    1, 2, 1, 1 );
-    m_grid_general.attach( m_label_noname,         0, 3, 1, 1 );
-    m_grid_general.attach( m_label_noname_value,   1, 3, 1, 1 );
-    m_grid_general.attach( m_label_max_line,       0, 4, 1, 1 );
-    m_grid_general.attach( m_label_max_line_value, 1, 4, 1, 1 );
-    m_grid_general.attach( m_label_max_byte,       0, 5, 1, 1 );
-    m_grid_general.attach( m_label_max_byte_value, 1, 5, 1, 1 );
+    m_grid_general.attach( m_label_name,                   0, 0, 1, 1 );
+    m_grid_general.attach( m_label_name_value,             1, 0, 1, 1 );
+    m_grid_general.attach( m_label_url,                    0, 1, 1, 1 );
+    m_grid_general.attach( m_label_url_value,              1, 1, 1, 1 );
+    m_grid_general.attach( m_label_cache,                  0, 2, 1, 1 );
+    m_grid_general.attach( m_label_cache_value,            1, 2, 1, 1 );
+    m_grid_general.attach( m_label_noname,                 0, 3, 1, 1 );
+    m_grid_general.attach( m_label_noname_value,           1, 3, 1, 1 );
+    m_grid_general.attach( m_label_max_line,               0, 4, 1, 1 );
+    m_grid_general.attach( m_label_max_line_value,         1, 4, 1, 1 );
+    m_grid_general.attach( m_label_max_byte,               0, 5, 1, 1 );
+    m_grid_general.attach( m_label_max_byte_value,         1, 5, 1, 1 );
+    m_grid_general.attach( m_label_max_subject_byte,       0, 6, 1, 1 );
+    m_grid_general.attach( m_label_max_subject_byte_value, 1, 6, 1, 1 );
 
-    m_grid_general.attach( m_label_maxres,            0, 6, 1, 1 );
-    m_grid_general.attach( m_spin_maxres,             1, 6, 1, 1 );
-    m_grid_general.attach( m_label_last_access,       0, 7, 1, 1 );
-    m_grid_general.attach( m_label_last_access_value, 1, 7, 1, 1 );
-    m_grid_general.attach( m_label_modified,          0, 8, 1, 1 );
-    m_grid_general.attach( m_hbox_modified,           1, 8, 1, 1 );
-    m_grid_general.attach( m_label_live,              0, 9, 1, 1 );
-    m_grid_general.attach( m_hbox_live,               1, 9, 1, 1 );
-    m_grid_general.attach( m_label_charset,           0, 10, 1, 1 );
-    m_grid_general.attach( m_hbox_charset,            1, 10, 1, 1 );
+    m_grid_general.attach( m_label_maxres,            0, 7, 1, 1 );
+    m_grid_general.attach( m_spin_maxres,             1, 7, 1, 1 );
+    m_grid_general.attach( m_label_last_access,       0, 8, 1, 1 );
+    m_grid_general.attach( m_label_last_access_value, 1, 8, 1, 1 );
+    m_grid_general.attach( m_label_modified,          0, 9, 1, 1 );
+    m_grid_general.attach( m_hbox_modified,           1, 9, 1, 1 );
+    m_grid_general.attach( m_label_live,              0, 10, 1, 1 );
+    m_grid_general.attach( m_hbox_live,               1, 10, 1, 1 );
+    m_grid_general.attach( m_label_charset,           0, 11, 1, 1 );
+    m_grid_general.attach( m_hbox_charset,            1, 11, 1, 1 );
 
-    m_grid_general.attach( m_revealer_encoding, 0, 11, 2, 1 );
-    m_grid_general.attach( m_check_oldlog,      1, 12, 1, 1 );
-    m_grid_general.attach( m_frame_write,       0, 13, 2, 1 );
-    m_grid_general.attach( m_frame_cookie,      0, 14, 2, 1 );
+    m_grid_general.attach( m_revealer_encoding, 0, 12, 2, 1 );
+    m_grid_general.attach( m_check_oldlog,      1, 13, 1, 1 );
+    m_grid_general.attach( m_frame_write,       0, 14, 2, 1 );
+    m_grid_general.attach( m_frame_cookie,      0, 15, 2, 1 );
 
     // 項目名と値のラベルを設定する
-    for( int y = 0; y < 6; ++y ) {
+    for( int y = 0; y < 7; ++y ) {
         // label column
         Gtk::Widget* child = m_grid_general.get_child_at( 0, y );
         child->set_halign( Gtk::ALIGN_START );
@@ -373,7 +377,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
         static_cast<Gtk::Label*>( child )->set_selectable( true );
     }
     // 項目名を設定する
-    for( int y = 6; y < 11; ++y ) {
+    for( int y = 7; y < 12; ++y ) {
         // label column
         Gtk::Widget* child = m_grid_general.get_child_at( 0, y );
         child->set_halign( Gtk::ALIGN_START );

--- a/src/board/preference.h
+++ b/src/board/preference.h
@@ -130,6 +130,8 @@ namespace BOARD
         Gtk::Label m_label_max_line_value;
         Gtk::Label m_label_max_byte;
         Gtk::Label m_label_max_byte_value;
+        Gtk::Label m_label_max_subject_byte;
+        Gtk::Label m_label_max_subject_byte_value;
 
         // 最大レス数
         Gtk::Label m_label_maxres;

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -456,6 +456,18 @@ int Board2chCompati::line_number() const
 }
 
 
+/**
+ * @brief スレタイトルの最大バイト数
+ */
+int Board2chCompati::subject_count() const
+{
+    if( m_settingloader
+        && m_settingloader->get_code() == HTTP_OK ) return m_settingloader->subject_count();
+
+    return BoardBase::subject_count();
+}
+
+
 int Board2chCompati::message_count() const
 {
     if( m_settingloader

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -58,6 +58,7 @@ namespace DBTREE
         std::string settingtxt() const override;
         std::string default_noname() const override;
         int line_number() const override;
+        int subject_count() const override;
         int message_count() const override;
         std::string get_unicode() const override;
 

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -247,6 +247,15 @@ int BoardBase::line_number() const
 }
 
 
+/**
+ * @brief スレタイトルの最大バイト数
+ */
+int BoardBase::subject_count() const
+{
+    return 0;
+}
+
+
 // 最大書き込みバイト数
 int BoardBase::message_count() const
 {

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -344,6 +344,9 @@ namespace DBTREE
         // 最大改行数/2
         virtual int line_number() const;
 
+        /// @brief スレタイトルの最大バイト数
+        virtual int subject_count() const;
+
         // 最大書き込みバイト数
         virtual int message_count() const;
 

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -1220,6 +1220,11 @@ int DBTREE::line_number( const std::string& url )
     return DBTREE::get_board( url )->line_number();
 }
 
+int DBTREE::subject_count( const std::string& url )
+{
+    return DBTREE::get_board( url )->subject_count();
+}
+
 int DBTREE::message_count( const std::string& url )
 {
     return DBTREE::get_board( url )->message_count();

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -324,6 +324,9 @@ namespace DBTREE
     // 最大改行数/2
     int line_number( const std::string& url );
 
+    /// @brief スレタイトルの最大バイト数
+    int subject_count( const std::string& url );
+
     // 最大書き込みバイト数
     int message_count( const std::string& url );
 

--- a/src/dbtree/settingloader.cpp
+++ b/src/dbtree/settingloader.cpp
@@ -78,6 +78,7 @@ void SettingLoader::parse_data()
 
     m_default_noname = cf.get_option_str( "BBS_NONAME_NAME", "No Name" );
     m_line_number = cf.get_option_int( "BBS_LINE_NUMBER", 0, 0, 8192 );
+    m_subject_count = cf.get_option_int( "BBS_SUBJECT_COUNT", 0, 0, 8192 );
     m_message_count = cf.get_option_int( "BBS_MESSAGE_COUNT", 0, 0, 81920 );
     m_unicode = cf.get_option_str( "BBS_UNICODE", "" );
     const int num_stop = cf.get_option_int( "BBS_THREAD_STOP", 0, 0, CONFIG::get_max_resnumber() );
@@ -94,6 +95,7 @@ void SettingLoader::parse_data()
     std::cout << "SettingLoader::parse url = " << get_url() << std::endl
               << "default_noname = " << m_default_noname << std::endl
               << "line_number = " << m_line_number << std::endl
+              << "subject_count = " << m_subject_count << std::endl
               << "message_count = " << m_message_count << std::endl
               << "unicode = " << m_unicode << std::endl;
 #endif

--- a/src/dbtree/settingloader.h
+++ b/src/dbtree/settingloader.h
@@ -30,6 +30,9 @@ namespace DBTREE
         // 最大改行数/2
         int m_line_number{};
 
+        /// @brief スレタイトルの最大バイト数
+        int m_subject_count{};
+
         // 最大書き込みバイト数
         int m_message_count{};
 
@@ -43,6 +46,7 @@ namespace DBTREE
 
         const std::string& default_noname() const { return m_default_noname; }
         int line_number() const noexcept { return m_line_number; }
+        int subject_count() const noexcept { return m_subject_count; }
         int message_count() const noexcept { return m_message_count; }
         const std::string& get_unicode() const { return m_unicode; }
 

--- a/src/message/messageadmin.h
+++ b/src/message/messageadmin.h
@@ -41,6 +41,7 @@ namespace MESSAGE
         // インスタンスを破棄しないで、前回書き込みビューを閉じた時の
         // 日本語のON/OFF状態を次回開いたときに継続させる
         std::unique_ptr<SKELETON::EditView> m_text_message;
+        sigc::signal<void> m_sig_new_subject_changed;
 
       public:
 
@@ -51,6 +52,10 @@ namespace MESSAGE
 
         void show_entry_new_subject( bool show );
         std::string get_new_subject() const;
+        /// @brief ツールバーにあるスレタイトル入力欄のmap, changedシグナルにつなげたいハンドラをここに接続する
+        sigc::signal<void> sig_new_subject_changed() { return m_sig_new_subject_changed; }
+        /// @brief ツールバーのスレタイトル入力欄に接続して橋渡しするシグナルハンドラ
+        void slot_new_subject_changed() { m_sig_new_subject_changed.emit(); }
 
         SKELETON::EditView* get_text_message();
 

--- a/src/message/messageview.h
+++ b/src/message/messageview.h
@@ -25,6 +25,8 @@ namespace MESSAGE
     // 新スレ立て用ビュー
     class MessageViewNew : public MessageViewBase
     {
+        int m_max_subject; ///< @brief スレタイトルの最大バイト数
+
       public:
         MessageViewNew( const std::string& url, const std::string& msg );
         ~MessageViewNew() noexcept override = default;
@@ -34,6 +36,7 @@ namespace MESSAGE
       private:
         void write_impl( const std::string& msg ) override;
         std::string create_message( const bool utf8_post ) override;
+        int get_max_subject() const noexcept override { return m_max_subject; }
     };
 
 }

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -1001,18 +1001,7 @@ void MessageViewBase::show_status()
     {
         const std::string& str_enc = m_iconv->convert( message.data(), message.size() );
         m_lng_str_enc = str_enc.length();
-
-        // 特殊文字の文字数を計算
-        for( const char c : str_enc ) {
-            if( c == '\n' || c == '"' ) {
-                // " <br> " = 6バイト,  &quot; = 6バイト
-                m_lng_str_enc += 5;
-            }
-            else if( c == '<' || c == '>' ) {
-                // &lt; = 4バイト, &gt; = 4バイト
-                m_lng_str_enc += 3;
-            }
-        }
+        m_lng_str_enc += count_diffs_for_special_char( str_enc );
 
         ss << m_lng_str_enc;
     }
@@ -1079,4 +1068,27 @@ void MessageViewBase::save_postlog()
     const std::string mail = get_entry_mail().get_text();
 
     MESSAGE::get_log_manager()->save( get_url(), subject, msg, name, mail );
+}
+
+
+/** @brief 特殊文字で増加する文字数を計算する
+ *
+ * @details 書き込み内容に含まれるいくつかの文字(=特殊文字)は変換されて文字数が増える。
+ * @param[in] source 特殊文字が含まれているかもしれない文字列
+ * @return 特殊文字を変換したとき入力文字列より増加した分の文字数を返す
+ */
+int MessageViewBase::count_diffs_for_special_char( std::string_view source )
+{
+    int diff = 0;
+    for( const char c : source ) {
+        if( c == '\n' || c == '"' ) {
+            // " <br> " = 6バイト,  &quot; = 6バイト
+            diff += 5;
+        }
+        else if( c == '<' || c == '>' ) {
+            // &lt; = 4バイト, &gt; = 4バイト
+            diff += 3;
+        }
+    }
+    return diff;
 }

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -969,6 +969,17 @@ void MessageViewBase::slot_text_changed()
 }
 
 
+/**
+ * @brief 書き込み欄のスレタイトルが更新された
+ */
+void MessageViewBase::slot_new_subject_changed()
+{
+    m_new_subject_changed = true;
+    show_status();
+    m_new_subject_changed = false;
+}
+
+
 //
 // ステータス表示
 //
@@ -1011,6 +1022,18 @@ void MessageViewBase::show_status()
         ss << "/ " << m_max_str;
         if( m_max_str < m_lng_str_enc ) m_over_lng = true;
         else m_over_lng = false;
+    }
+
+    // スレタイトルの最大バイト数が設定されている板は文字(バイト)数をカウントして表示する
+    if( const int max_subject = get_max_subject(); max_subject ) {
+        if( m_new_subject_changed ) {
+            std::string new_subject = MESSAGE::get_admin()->get_new_subject();
+            const std::string& encoded_subject = m_iconv->convert( new_subject.data(), new_subject.size() );
+            m_lng_encoded_subject = static_cast<int>( encoded_subject.size() );
+            m_lng_encoded_subject += count_diffs_for_special_char( encoded_subject );
+        }
+        ss << "   /  スレタイトルの文字数 " << m_lng_encoded_subject << "/ " << max_subject;
+        m_over_subject = max_subject < m_lng_encoded_subject;
     }
 
     if( DBTREE::get_unicode( get_url() ) == "pass" ) ss << " / unicode ○";

--- a/src/message/messageviewbase.h
+++ b/src/message/messageviewbase.h
@@ -64,6 +64,7 @@ namespace MESSAGE
         int m_max_line;
         int m_max_str;
         int m_lng_str_enc{};
+        int m_lng_encoded_subject{}; ///< @brief エンコードしたスレタイトルのバイト数
         int m_lng_iconv;
 
         // 経過時間表示用
@@ -71,9 +72,11 @@ namespace MESSAGE
         std::string m_str_pass;
 
         bool m_text_changed{};
+        bool m_new_subject_changed{}; ///< @brief true なら新スレ作成でスレタイトルが編集された
 
         bool m_over_lines{};
         bool m_over_lng{};
+        bool m_over_subject{}; ///< @brief true ならスレタイトルの最大バイト数を超過した
 
       public:
 
@@ -101,10 +104,15 @@ namespace MESSAGE
         bool is_loading() const override;
 
         // 規制中や行数や文字列がオーバーして書き込めない
-        bool is_broken() const override { return ( ! m_str_pass.empty() || m_over_lines || m_over_lng ); }
+        bool is_broken() const override
+        {
+            return ( ! m_str_pass.empty() || m_over_lines || m_over_lng || m_over_subject );
+        }
 
         // キーを押した        
         bool slot_key_press( GdkEventKey* event ) override;
+
+        void slot_new_subject_changed();
 
         void clock_in() override;
         void write() override;
@@ -115,6 +123,7 @@ namespace MESSAGE
         void focus_view() override;
         bool operate_view( const int control ) override;
 
+        // 特殊文字で増加する文字数を計算する
         static int count_diffs_for_special_char( std::string_view source );
 
       private:
@@ -157,6 +166,9 @@ namespace MESSAGE
 
         void show_status();
 
+        /// @brief スレタイトルの最大バイト数
+        virtual int get_max_subject() const noexcept { return 0; }
+
       protected:
 
         // Viewが所属するAdminクラス
@@ -178,6 +190,9 @@ namespace MESSAGE
 
         // テキストの折り返し
         void set_wrap();
+
+        /// @brief エンコードしたスレタイトルのバイト数
+        int get_lng_encoded_subject() const noexcept { return m_lng_encoded_subject; }
     };
 }
 

--- a/src/message/messageviewbase.h
+++ b/src/message/messageviewbase.h
@@ -10,6 +10,7 @@
 #include "skeleton/jdtoolbar.h"
 
 #include <memory>
+#include <string_view>
 
 
 namespace JDLIB
@@ -113,6 +114,8 @@ namespace MESSAGE
         void redraw_view() override;
         void focus_view() override;
         bool operate_view( const int control ) override;
+
+        static int count_diffs_for_special_char( std::string_view source );
 
       private:
 

--- a/src/message/toolbar.cpp
+++ b/src/message/toolbar.cpp
@@ -149,6 +149,11 @@ void MessageToolBar::pack_buttons()
 
                         m_tool_new_subject = Gtk::manage( new Gtk::ToolItem );
                         m_entry_new_subject = Gtk::manage( new Gtk::Entry );
+                        // map(表示)したときと新規スレ名を入力したときに処理するシグナル
+                        m_entry_new_subject->signal_map().connect(
+                            sigc::mem_fun( MESSAGE::get_admin(), &MessageAdmin::slot_new_subject_changed ) );
+                        m_entry_new_subject->signal_changed().connect(
+                            sigc::mem_fun( MESSAGE::get_admin(), &MessageAdmin::slot_new_subject_changed ) );
 
                         m_entry_new_subject->set_size_request( 0 );
 

--- a/test/gtest_message_messageviewbase.cpp
+++ b/test/gtest_message_messageviewbase.cpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "message/messageviewbase.h"
+
+#include "gtest/gtest.h"
+
+
+namespace {
+
+class MESSAGE_MessageViewBase_CountDiffsForSpecialCharTest : public ::testing::Test {};
+
+TEST_F(MESSAGE_MessageViewBase_CountDiffsForSpecialCharTest, empty_string)
+{
+    EXPECT_EQ( 0, MESSAGE::MessageViewBase::count_diffs_for_special_char( "" ) );
+}
+
+TEST_F(MESSAGE_MessageViewBase_CountDiffsForSpecialCharTest, not_include_special_characters)
+{
+    EXPECT_EQ( 0, MESSAGE::MessageViewBase::count_diffs_for_special_char( "abcdefghijklmnopqrstuvwxyz" ) );
+    EXPECT_EQ( 0, MESSAGE::MessageViewBase::count_diffs_for_special_char( "0123456789" ) );
+    EXPECT_EQ( 0, MESSAGE::MessageViewBase::count_diffs_for_special_char( "!#$%&'zz89=~|-^\\@`{}[];:+*,./?_" ) );
+}
+
+TEST_F(MESSAGE_MessageViewBase_CountDiffsForSpecialCharTest, include_line_feed)
+{
+    EXPECT_EQ( 5, MESSAGE::MessageViewBase::count_diffs_for_special_char( "abc\ndef" ) );
+    EXPECT_EQ( 15, MESSAGE::MessageViewBase::count_diffs_for_special_char( "\n\n0123456789\n" ) );
+}
+
+TEST_F(MESSAGE_MessageViewBase_CountDiffsForSpecialCharTest, include_double_quote)
+{
+    EXPECT_EQ( 5, MESSAGE::MessageViewBase::count_diffs_for_special_char( R"(abc"def)" ) );
+    EXPECT_EQ( 10, MESSAGE::MessageViewBase::count_diffs_for_special_char( R"( "hello world" )" ) );
+}
+
+TEST_F(MESSAGE_MessageViewBase_CountDiffsForSpecialCharTest, include_less_than_sign)
+{
+    EXPECT_EQ( 3, MESSAGE::MessageViewBase::count_diffs_for_special_char( "abc<def" ) );
+    EXPECT_EQ( 6, MESSAGE::MessageViewBase::count_diffs_for_special_char( "<hello world<" ) );
+}
+
+TEST_F(MESSAGE_MessageViewBase_CountDiffsForSpecialCharTest, include_greater_than_sign)
+{
+    EXPECT_EQ( 3, MESSAGE::MessageViewBase::count_diffs_for_special_char( "abc>def" ) );
+    EXPECT_EQ( 6, MESSAGE::MessageViewBase::count_diffs_for_special_char( ">hello world>" ) );
+}
+
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -14,6 +14,7 @@ sources = [
   'gtest_jdlib_misctrip.cpp',
   'gtest_jdlib_miscutil.cpp',
   'gtest_jdlib_span.cpp',
+  'gtest_message_messageviewbase.cpp',
   'gtest_xml_dom.cpp',
 ]
 


### PR DESCRIPTION
### Update setting parser to retrieve max byte count for thread subject

板ごとの各種設定を記載しているテキストファイル(SETTING.TXT)の解析を更新してスレタイトルの最大バイト数(BBS\_SUBJECT\_COUNT)を取得します。

### BOARD::Preferences: Show max byte count for thread subject

板のプロパティに「スレタイトルの最大バイト数」の項目を追加します。
未設定のときは0と表示します。

### MessageViewBase: Implement `count_diffs_for_special_char()`

書き込みビューのbaseクラスに特殊文字で増加する文字数を計算して返す関数を実装します。
書き込み内容に含まれるいくつかの文字(=特殊文字)は変換されて文字数が増えます。

特殊文字       | 変換前 | 変換後   | 増加分の文字数
---            | ---    | ---      | ---
改行           | `'\n'`   | `" <br> "` | 5
引用符         | `'"'`    | `"&quot;"` | 5
不等号(より小) | `'<'`    | `"&lt;"`   | 3
不等号(より大) | `'>'`    | `"&gt;"`   | 3

### Add test cases for `MessageViewBase::count_increment_chars_for_special_char()`

### Update to count bytes of thread subject when creating new thread

新しいスレッドを作成する際に、スレタイトルのバイト数をカウントしてメインステータスバーに表示するように更新します。

スレタイトルのバイト数が板設定の最大バイト数を超えたときはメインステータスバーの色が変わります(about:configの設定でon/off可能)。
また、バイト数が超過しているときに投稿ボタンを押すとキャンセルされてダイアログで通知します。

板設定にスレタイトルの最大バイト数が設定されていないときはカウントや表示を行いません。

Closes #1362
