### PR TITLE
Revert "CI: Set timeout to ccpp job ASan-22 (#1365)"

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -31,13 +31,9 @@ jobs:
       - name: ninja -C builddir
         run: ninja -C builddir
         # Since Meson 0.57, `test` subcommand will only rebuild test program.
-        # Set a timeout for test program using AddressSanitizer to prevent hang-ups.
-      - name: meson test -v -C builddir --timeout-multiplier 1
-        run: meson test -v -C builddir --timeout-multiplier 1
-        continue-on-error: true
-        id: meson_test
+      - name: meson test -v -C builddir
+        run: meson test -v -C builddir
       - name: ./builddir/src/jdim -V
-        if: ${{ steps.meson_test.outcome == 'success' }}
         run: ./builddir/src/jdim -V
 
   compiler-20:


### PR DESCRIPTION
This reverts commit a65876f7ede947e62d7b460c1a6c2a2a8642f1d8.

AddressSanitizerを使ったとき`AddressSanitizer:DEADLYSIGNAL`が出力され続けてハングアップする問題はGitHub Actionsのrunner-imagesに報告されています。
この不具合を回避する修正が入ったためCI job ASan-22の応急処置を差し戻します。

https://github.com/actions/runner-images/issues/9491#issuecomment-2010912636
