### PR TITLE
Fix compiler warnings for -Wmissing-prototypes

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -4073,7 +4073,7 @@ LAYOUT* DrawAreaBase::set_caret( CARET_POSITION& caret_pos, int x, int y )
 //
 
 // 区切り文字
-bool is_separate_char( const char32_t unich )
+static bool is_separate_char( const char32_t unich )
 {
     if( unich == ' '
 

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -33,7 +33,7 @@ using namespace CONFIG;
 
 #define IS_DEFAULT_FONT( name ) do{ if( set_fonts.find( name ) != set_fonts.end() ) return name; } while(0)
 
-std::string get_default_font()
+static std::string get_default_font()
 {
     std::set< std::string > set_fonts = MISC::get_font_families();
 

--- a/src/control/controlutil.cpp
+++ b/src/control/controlutil.cpp
@@ -790,7 +790,7 @@ Gtk::AccelKey CONTROL::get_accelkey( const int id )
 /////////////////////////////////////////////////////////
 
 
-const std::string convert_mouse_motions( std::string motions )
+static std::string convert_mouse_motions( std::string motions )
 {
     motions = MISC::replace_str( motions, "8", "↑" );
     motions = MISC::replace_str( motions, "6", "→" );
@@ -801,7 +801,7 @@ const std::string convert_mouse_motions( std::string motions )
 }
 
 
-const std::string convert_mouse_motions_reverse( std::string motions )
+static std::string convert_mouse_motions_reverse( std::string motions )
 {
     motions = MISC::replace_str( motions, "↑", "8" );
     motions = MISC::replace_str( motions, "→", "6" );

--- a/src/dbtree/spchar_decoder.cpp
+++ b/src/dbtree/spchar_decoder.cpp
@@ -15,19 +15,6 @@
 #include <stdlib.h>
 
 
-bool check_spchar( const char* n_in, const char* spchar )
-{
-    int i = 0;
-    while( spchar[ i ] != '\0' ){
-
-        if( n_in[ i ] != spchar[ i ] ) return false;
-        ++i;
-    }
-
-    return true;
-}
-
-
 /**
  * @brief HTMLの数値文字参照 `&#数字;` をUTF-8文字列にデコードする
  *

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -107,7 +107,7 @@ std::string ENVIRONMENT::get_configure_args( const int mode )
 // リビジョンが得られなかった場合（tarballのソース等）は、fallbackの日付を返す
 // git_dirtyは、まだcommitされてない変更があるかどうか
 //
-std::string get_git_revision (const char *git_date, const char *git_hash, const int git_dirty, const char *fallback_date)
+static std::string get_git_revision (const char *git_date, const char *git_hash, const int git_dirty, const char *fallback_date)
 {
     bool date_valid = false;
     if( git_date )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,7 @@ static JDWinMain* Win_Main = nullptr;
 
 // SIGINTのハンドラ
 [[noreturn]]
-void sig_handler( int sig )
+static void sig_handler( int sig )
 {
     if( sig == SIGHUP || sig == SIGINT || sig == SIGQUIT ){
 
@@ -62,12 +62,12 @@ void sig_handler( int sig )
 #ifdef USE_XSMP
 
 // セッションが終了したので情報を保存するコールバック関数
-void xsmp_session_save_yourself( SmcConn smc_connect,
-                                 SmPointer client_data,
-                                 int save_type,
-                                 Bool shutdown,
-                                 int interact_style,
-                                 Bool fast )
+static void xsmp_session_save_yourself( SmcConn smc_connect,
+                                        SmPointer client_data,
+                                        int save_type,
+                                        Bool shutdown,
+                                        int interact_style,
+                                        Bool fast )
 {
     if( shutdown && !fast ){
 #ifdef _DEBUG
@@ -81,15 +81,15 @@ void xsmp_session_save_yourself( SmcConn smc_connect,
 
 
 // ダミー
-void xsmp_session_die( SmcConn conn, SmPointer data ){}
-void xsmp_session_save_complete( SmcConn conn, SmPointer data ){}
-void xsmp_session_shutdown_cancelled( SmcConn conn, SmPointer data ){} 
+static void xsmp_session_die( SmcConn conn, SmPointer data ) {}
+static void xsmp_session_save_complete( SmcConn conn, SmPointer data ) {}
+static void xsmp_session_shutdown_cancelled( SmcConn conn, SmPointer data ) {}
 
 
 
-gboolean ice_process_message( GIOChannel *channel,
-                              GIOCondition condition,
-                              XSMPDATA *xsmpdata )
+static gboolean ice_process_message( GIOChannel *channel,
+                                     GIOCondition condition,
+                                     XSMPDATA *xsmpdata )
 {
     if( ! xsmpdata->ice_connect ) return FALSE;
 
@@ -114,10 +114,10 @@ gboolean ice_process_message( GIOChannel *channel,
 }
 
 
-void ice_watch_proc( IceConn ice_connect,
-                     IcePointer client_data,
-                     Bool opening,
-                     IcePointer *watch_data )
+static void ice_watch_proc( IceConn ice_connect,
+                            IcePointer client_data,
+                            Bool opening,
+                            IcePointer *watch_data )
 {
     XSMPDATA *xsmpdata = reinterpret_cast<XSMPDATA*>( client_data );
     xsmpdata->ice_connect = ice_connect;
@@ -156,7 +156,7 @@ void ice_watch_proc( IceConn ice_connect,
 
 
 // XSMP初期化関数
-void xsmp_session_init( XSMPDATA* xsmpdata )
+static void xsmp_session_init( XSMPDATA* xsmpdata )
 {
     if( xsmpdata->smc_connect ) return;
     if( g_getenv("SESSION_MANAGER") == nullptr ) return;
@@ -192,7 +192,7 @@ void xsmp_session_init( XSMPDATA* xsmpdata )
 
 
 // XSMP終了関数
-void xsmp_session_end( XSMPDATA* xsmpdata )
+static void xsmp_session_end( XSMPDATA* xsmpdata )
 {
     if( xsmpdata->smc_connect ) SmcCloseConnection( xsmpdata->smc_connect, 0, nullptr );
     xsmpdata->smc_connect = nullptr;

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -268,7 +268,7 @@ int SESSION::parse_item( const std::string& item_name )
 }
 
 
-std::vector< int > parse_items( const std::string& items_str )
+static std::vector<int> parse_items( const std::string& items_str )
 {
     std::vector< int > items;
     const std::list< std::string > list_order = MISC::split_line( items_str );
@@ -283,7 +283,7 @@ std::vector< int > parse_items( const std::string& items_str )
 }
 
 
-void read_list_urls( JDLIB::ConfLoader& cf, const std::string& id_urls,  std::list< std::string >& list_urls )
+static void read_list_urls( JDLIB::ConfLoader& cf, const std::string& id_urls,  std::list< std::string >& list_urls )
 {
     list_urls.clear();
 
@@ -295,7 +295,7 @@ void read_list_urls( JDLIB::ConfLoader& cf, const std::string& id_urls,  std::li
 }
 
 
-void read_list_locked( JDLIB::ConfLoader& cf, const std::string& id_locked, std::list< bool >& list_locked )
+static void read_list_locked( JDLIB::ConfLoader& cf, const std::string& id_locked, std::list< bool >& list_locked )
 {
     list_locked.clear();
 

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -38,7 +38,7 @@ enum
 //
 // 行の最新アドレスを取得
 //
-const std::string get_uptodate_url( const std::string& url_org, const int type )
+static std::string get_uptodate_url( const std::string& url_org, const int type )
 {
     std::string url = url_org;
 
@@ -58,7 +58,7 @@ const std::string get_uptodate_url( const std::string& url_org, const int type )
 //
 // 行の最新状態を取得
 //
-int get_uptodate_type( const std::string& url, const int type_org )
+static int get_uptodate_type( const std::string& url, const int type_org )
 {
     int type = type_org;
 


### PR DESCRIPTION
関数のプロトタイプが宣言されていないとclangに指摘されたためstaticキーワードを追加して定義されたファイル限定で使われることを示します。

clang-17のレポート (file pathを一部省略)
```
src/article/drawareabase.cpp:4076:6: warning: no previous prototype for function 'is_separate_char' [-Wmissing-prototypes]
src/config/configitems.cpp:36:13: warning: no previous prototype for function 'get_default_font' [-Wmissing-prototypes]
src/control/controlutil.cpp:793:19: warning: no previous prototype for function 'convert_mouse_motions' [-Wmissing-prototypes]
src/control/controlutil.cpp:804:19: warning: no previous prototype for function 'convert_mouse_motions_reverse' [-Wmissing-prototypes]
src/dbtree/spchar_decoder.cpp:18:6: warning: no previous prototype for function 'check_spchar' [-Wmissing-prototypes]
src/environment.cpp:110:13: warning: no previous prototype for function 'get_git_revision' [-Wmissing-prototypes]
src/main.cpp:117:6: warning: no previous prototype for function 'ice_watch_proc' [-Wmissing-prototypes]
src/main.cpp:159:6: warning: no previous prototype for function 'xsmp_session_init' [-Wmissing-prototypes]
src/main.cpp:195:6: warning: no previous prototype for function 'xsmp_session_end' [-Wmissing-prototypes]
src/main.cpp:46:6: warning: no previous prototype for function 'sig_handler' [-Wmissing-prototypes]
src/main.cpp:65:6: warning: no previous prototype for function 'xsmp_session_save_yourself' [-Wmissing-prototypes]
src/main.cpp:84:6: warning: no previous prototype for function 'xsmp_session_die' [-Wmissing-prototypes]
src/main.cpp:85:6: warning: no previous prototype for function 'xsmp_session_save_complete' [-Wmissing-prototypes]
src/main.cpp:86:6: warning: no previous prototype for function 'xsmp_session_shutdown_cancelled' [-Wmissing-prototypes]
src/main.cpp:90:10: warning: no previous prototype for function 'ice_process_message' [-Wmissing-prototypes]
src/session.cpp:275:20: warning: no previous prototype for function 'parse_items' [-Wmissing-prototypes]
src/session.cpp:290:6: warning: no previous prototype for function 'read_list_urls' [-Wmissing-prototypes]
src/session.cpp:302:6: warning: no previous prototype for function 'read_list_locked' [-Wmissing-prototypes]
src/skeleton/edittreeview.cpp:41:19: warning: no previous prototype for function 'get_uptodate_url' [-Wmissing-prototypes]
src/skeleton/edittreeview.cpp:61:5: warning: no previous prototype for function 'get_uptodate_type' [-Wmissing-prototypes]
```
