### PR TITLE
Fix compiler warnings for -Wimplicit-int-float-conversion

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -5449,7 +5449,7 @@ gboolean DrawAreaBase::deceleration_tick_cb( GtkWidget* cwidget, GdkFrameClock* 
 gboolean DrawAreaBase::deceleration_tick_impl( GdkFrameClock* clock )
 {
     const gint64 current_time = gdk_frame_clock_get_frame_time( clock );
-    m_deceleration.elapsed += ( current_time - m_deceleration.last_time ) * kDecelerationRatio;
+    m_deceleration.elapsed += static_cast<double>( current_time - m_deceleration.last_time ) * kDecelerationRatio;
     m_deceleration.last_time = current_time;
     const double exp_part = std::exp( -kDecelerationFriction * m_deceleration.elapsed );
     const double dy = -kDecelerationFriction * exp_part * m_deceleration.initial_dy;

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -847,7 +847,7 @@ void ImageAdmin::switch_img( const std::string& url )
     auto adjust = m_scrwin.get_hadjustment();
     if( page != -1 && adjust ){
         double pos = adjust->get_value();
-        double upper =  m_list_view.size() * ICON_SIZE;
+        double upper = static_cast<double>( m_list_view.size() * ICON_SIZE );
         double width = adjust->get_page_size();
         double pos_to = page * ICON_SIZE;
 


### PR DESCRIPTION
longやunsigned longの変数をdoubleに暗黙的に変換している箇所は精度が失う可能性があるとclangに指摘されたため明示的にキャスト`static_cast<double>()`を使いコンパイラに意図した変更であると伝えます。

clang 17のレポート (file pathを一部省略)
```
src/article/drawareabase.cpp:5452:46: warning: implicit conversion from 'gint64' (aka 'long') to 'double' may lose precision [-Wimplicit-int-float-conversion]
 5452 |     m_deceleration.elapsed += ( current_time - m_deceleration.last_time ) * kDecelerationRatio;
      |                                 ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~   ~
src/image/imageadmin.cpp:850:44: warning: implicit conversion from 'size_type' (aka 'unsigned long') to 'double' may lose precision [-Wimplicit-int-float-conversion]
  850 |         double upper =  m_list_view.size() * ICON_SIZE;
      |                ~~~~~    ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
```
