### PR TITLE
Fix compiler warnings for -Wimplicit-int-conversion part1

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -2439,7 +2439,7 @@ bool DrawAreaBase::get_selection_byte( const LAYOUT* layout, const SELECTION& se
 //
 // ノードで使うフォントを得る
 //
-char DrawAreaBase::get_layout_fontid( LAYOUT* layout ) const
+int DrawAreaBase::get_layout_fontid( LAYOUT* layout ) const
 {
     if( ! layout->node ) return m_fontid;
 
@@ -2479,7 +2479,7 @@ void DrawAreaBase::set_node_font( LAYOUT* layout )
     if( ! layout->node ) return;
 
     // フォント設定
-    char layout_fontid = get_layout_fontid( layout );
+    const int layout_fontid = get_layout_fontid( layout );
     if( m_fontid != layout_fontid ){
         m_fontid = layout_fontid; // 新しいフォントIDをセット
         switch( m_fontid ){

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -445,7 +445,7 @@ namespace ARTICLE
         void render_text_glyphstring( RenderTextArguments& args );
         void render_text_pangolayout( RenderTextArguments& args );
         bool draw_one_img_node( LAYOUT* layout, const CLIPINFO& ci );
-        char get_layout_fontid(LAYOUT *layout ) const;
+        int get_layout_fontid( LAYOUT *layout ) const;
         void set_node_font( LAYOUT* layout );
 
         // drawarea がリサイズ実行

--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -119,7 +119,7 @@ RECTANGLE* LayoutTree::create_rect()
 LAYOUT* LayoutTree::create_layout( const int type )
 {
     LAYOUT* tmplayout = m_heap.heap_alloc<LAYOUT>();
-    tmplayout->type = type;
+    tmplayout->type = static_cast<unsigned char>( type );
     tmplayout->id_header = m_id_header; 
     tmplayout->id = m_id_layout++;
     tmplayout->header = m_last_header;

--- a/src/control/controlutil.cpp
+++ b/src/control/controlutil.cpp
@@ -288,7 +288,7 @@ std::string CONTROL::get_keyname( const guint keysym )
     // データベース内に見つからなかったらアスキー文字を返す
     if( CONTROL::is_ascii( keysym ) ){
         char c[ 2 ];
-        c[ 0 ] = keysym;
+        c[ 0 ] = static_cast<char>( keysym );
         c[ 1 ] = '\0';
         return std::string( c );
     }

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -861,9 +861,9 @@ NODE* NodeTreeBase::create_node_space( const int type, const int bg )
                              && m_node_previous->type != NODE_MULTISP
                              && m_node_previous->type != NODE_HTAB ) ) {
         tmpnode = create_node();
-        tmpnode->type = type;
+        tmpnode->type = static_cast<unsigned char>( type );
         tmpnode->color_text = COLOR_CHAR;
-        tmpnode->color_back = bg;
+        tmpnode->color_back = static_cast<unsigned char>( bg );
         tmpnode->bold = false;
     }
     else {

--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -490,25 +490,25 @@ int MISC::utf32toutf8( const char32_t uch,  char* utf8str )
 
     if( uch <= 0x7F ){ // ascii
         byte = 1;
-        utf8str[0] = uch;
+        utf8str[0] = static_cast<char>( uch );
     }
     else if( uch <= 0x07FF ){
         byte = 2;
-        utf8str[0] = ( 0xC0 ) + ( uch >> 6 );
-        utf8str[1] = ( 0x80 ) + ( uch & 0x3F );
+        utf8str[0] = static_cast<char>( 0xC0 + ( uch >> 6 ) );
+        utf8str[1] = static_cast<char>( 0x80 + ( uch & 0x3F ) );
     }
     else if( uch <= 0xFFFF ){
         byte = 3;
-        utf8str[0] = ( 0xE0 ) + ( uch >> 12 );
-        utf8str[1] = ( 0x80 ) + ( ( uch >> 6 ) & 0x3F );
-        utf8str[2] = ( 0x80 ) + ( uch & 0x3F );
+        utf8str[0] = static_cast<char>( 0xE0 + ( uch >> 12 ) );
+        utf8str[1] = static_cast<char>( 0x80 + ( ( uch >> 6 ) & 0x3F ) );
+        utf8str[2] = static_cast<char>( 0x80 + ( uch & 0x3F ) );
     }
     else if( uch <= 0x10FFFF ){
         byte = 4;
-        utf8str[0] = ( 0xF0 ) + ( uch >> 18 );
-        utf8str[1] = ( 0x80 ) + ( ( uch >> 12 ) & 0x3F );
-        utf8str[2] = ( 0x80 ) + ( ( uch >> 6 ) & 0x3F );
-        utf8str[3] = ( 0x80 ) + ( uch & 0x3F );
+        utf8str[0] = static_cast<char>( 0xF0 + ( uch >> 18 ) );
+        utf8str[1] = static_cast<char>( 0x80 + ( ( uch >> 12 ) & 0x3F ) );
+        utf8str[2] = static_cast<char>( 0x80 + ( ( uch >> 6 ) & 0x3F ) );
+        utf8str[3] = static_cast<char>( 0x80 + ( uch & 0x3F ) );
     }
 #ifdef _DEBUG
     else{

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1473,8 +1473,8 @@ std::string MISC::base64( const std::string& str )
         unsigned char key[ 4 ];
 
         key[ 0 ] = (*cstr) >> 2;
-        key[ 1 ] = ( ( (*cstr) << 4 ) + ( (*(cstr+1)) >> 4 ) );
-        key[ 2 ] = ( ( (*(cstr+1)) << 2 ) + ( (*(cstr+2)) >> 6 ) );
+        key[ 1 ] = static_cast<unsigned char>( ( (*cstr) << 4 ) + ( (*(cstr+1)) >> 4 ) );
+        key[ 2 ] = static_cast<unsigned char>( ( (*(cstr+1)) << 2 ) + ( (*(cstr+2)) >> 6 ) );
         key[ 3 ] = *(cstr+2);
 
         for( int j = 0; j < 4; ++j ){


### PR DESCRIPTION
整数型の変数をサイズが小さい整数型へ暗黙的に変換している箇所は精度が失う可能性があるとclangに指摘されたため明示的にキャスト`static_cast<...>()`を使ったり、整数型を変更してコンパイラに意図した変更であると伝えます。

clang 17のレポート (file pathを一部省略)
```
src/article/drawareabase.cpp:2444:33: warning: implicit conversion loses integer precision: 'const int' to 'char' [-Wimplicit-int-conversion]
src/article/drawareabase.cpp:2451:20: warning: implicit conversion loses integer precision: 'const int' to 'char' [-Wimplicit-int-conversion]
src/article/drawareabase.cpp:2460:20: warning: implicit conversion loses integer precision: 'const int' to 'char' [-Wimplicit-int-conversion]
src/article/drawareabase.cpp:2467:16: warning: implicit conversion loses integer precision: 'const int' to 'char' [-Wimplicit-int-conversion]
src/article/drawareabase.cpp:2471:12: warning: implicit conversion loses integer precision: 'const int' to 'char' [-Wimplicit-int-conversion]
src/article/layouttree.cpp:122:23: warning: implicit conversion loses integer precision: 'const int' to 'unsigned char' [-Wimplicit-int-conversion]
src/control/controlutil.cpp:291:18: warning: implicit conversion loses integer precision: 'const guint' (aka 'const unsigned int') to 'char' [-Wimplicit-int-conversion]
src/dbtree/nodetreebase.cpp:864:25: warning: implicit conversion loses integer precision: 'const int' to 'unsigned char' [-Wimplicit-int-conversion]
src/dbtree/nodetreebase.cpp:866:31: warning: implicit conversion loses integer precision: 'const int' to 'unsigned char' [-Wimplicit-int-conversion]
src/jdlib/misccharcode.cpp:493:22: warning: implicit conversion loses integer precision: 'const char32_t' to 'char' [-Wimplicit-int-conversion]
src/jdlib/misccharcode.cpp:497:31: warning: implicit conversion loses integer precision: 'unsigned int' to 'char' [-Wimplicit-int-conversion]
src/jdlib/misccharcode.cpp:498:31: warning: implicit conversion changes signedness: 'unsigned int' to 'char' [-Wsign-conversion]
src/jdlib/misccharcode.cpp:502:31: warning: implicit conversion loses integer precision: 'unsigned int' to 'char' [-Wimplicit-int-conversion]
src/jdlib/misccharcode.cpp:503:31: warning: implicit conversion changes signedness: 'unsigned int' to 'char' [-Wsign-conversion]
src/jdlib/misccharcode.cpp:504:31: warning: implicit conversion changes signedness: 'unsigned int' to 'char' [-Wsign-conversion]
src/jdlib/misccharcode.cpp:508:31: warning: implicit conversion loses integer precision: 'unsigned int' to 'char' [-Wimplicit-int-conversion]
src/jdlib/miscutil.cpp:1476:39: warning: implicit conversion loses integer precision: 'int' to 'unsigned char' [-Wimplicit-int-conversion]
src/jdlib/miscutil.cpp:1477:43: warning: implicit conversion loses integer precision: 'int' to 'unsigned char' [-Wimplicit-int-conversion]
```
