### PR TITLE
Improve date string parsing to handle 5ch.net's date format

### DIFF
--- a/test/gtest_jdlib_misctime.cpp
+++ b/test/gtest_jdlib_misctime.cpp
@@ -55,6 +55,31 @@ TEST_F(MISC_DateToTimeTest, wrong_day_will_be_parsed)
     EXPECT_EQ( result, 1'000'000'000 );
 }
 
+TEST_F(MISC_DateToTimeTest, unix_epoch_date_with_ascii_hyphen)
+{
+    const std::time_t result = MISC::datetotime( "Thu, 01-Jan-1970 00:00:00 GMT" );
+    EXPECT_EQ( result, 0 );
+}
+
+TEST_F(MISC_DateToTimeTest, non_gmt_wont_be_parsed_with_ascii_hyphen)
+{
+    const std::time_t result = MISC::datetotime( "Wed, 01-Jan-2020 12:34:56 JST" );
+    EXPECT_EQ( result, 0 );
+}
+
+TEST_F(MISC_DateToTimeTest, one_hundred_million_with_ascii_hyphen)
+{
+    const std::time_t result = MISC::datetotime( "Sat, 03-Mar-1973 09:46:40 GMT" );
+    EXPECT_EQ( result, 100'000'000 );
+}
+
+TEST_F(MISC_DateToTimeTest, wrong_day_will_be_parsed_with_ascii_hyphen)
+{
+    // Although correct day of 2001-09-09 is Sunday, parsed time is right.
+    const std::time_t result = MISC::datetotime( "Mon, 09-Sep-2001 01:46:40 GMT" );
+    EXPECT_EQ( result, 1'000'000'000 );
+}
+
 } // namespace
 
 


### PR DESCRIPTION
### Improve date string parsing to handle 5ch.net's date format

5ch.netが送信するHTTP Set-Cookieヘッダーのexpires属性の日付形式に対応するため解析処理を更新します。

##### 背景事情
5ch.netが送信するHTTP Set-Cookieヘッダーのexpires属性にはIMF-fixdate形式とほぼ同じ形式の日付文字列が設定されていますが、年月日の区切り文字にハイフンマイナス(-)が使われています。
この修正では、`MISC::datetotime()`がこの形式の日付文字列も解析できるようにハイフンマイナスを半角空白に置換する処理を追加しました。
これにより5ch.netのCookieの有効期限を正しく取得できるようになります。

##### Background
The expires attribute in the HTTP Set-Cookie header sent by 5ch.net contains a date string in a format that is almost the same as IMF-fixdate, but it uses hyphens (-) instead of spaces as the separators between year, month, and day.
This commit adds a temporary replacement of hyphens with spaces to `MISC::datetotime()`, allowing it to parse the date format correctly.
This enables proper retrieval of cookie expiration dates from 5ch.net.

### Add test cases for MISC::datetotime()

関連のissue: #1376
