### PR TITLE
Board2ch::update_hap(): Fix cookie retrieval method

### DIFF
--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -343,7 +343,7 @@ void Board2ch::update_hap()
 {
     if( ! CONFIG::get_use_cookie_hap() ) return;
 
-    const std::string new_cookie = Board2chCompati::cookie_for_request();
+    const std::string new_cookie = cookie_by_host();
 
     if( ! new_cookie.empty() ) {
 #ifdef _DEBUG


### PR DESCRIPTION
about:configの「2chのクッキーを保存する」を"はい"にしたときに行われる2ch.net(5ch.net)のクッキーを更新する処理を修正します。

##### 背景事情
`Board2ch::update_hap()`では`Board2chCompati::cookie_for_request()`を使ってクッキーを取得していましたがこの関数は5ch.net以外のサイトにアクセスする際に使うプロキシ設定に依存するため適切なクッキーが取得できない可能性があります。
この修正では、プロキシ設定に依存しない`cookie_by_host()`関数を使うように変更します。

##### Background
Previously, `Board2ch::update_hap()` method has used `Board2chCompati::cookie_for_request()` to retrieve cookies, but this function might not retrieve the correct cookie to depend proxy settings for accessing sites other than 5ch.net.
This commit changes to use the `cookie_by_host()` function, which does not depend on proxy settings. This ensures that the appropriate cookie is always retrieved.

関連のissue: #1376
