### PR TITLE
Fix compiler warnings for -Wimplicit-int-conversion part2

### DIFF
--- a/src/aamanager.cpp
+++ b/src/aamanager.cpp
@@ -119,9 +119,9 @@ void AAManager::load_label()
             m_vec_aa.push_back( asciiart );
 
             // ショートカット
-            char shortcut = 0;
-            const int base_a = 10;
-            const int base_A = base_a + 'z' - 'a' -4 + 1;
+            int shortcut = 0;
+            constexpr int base_a = 10;
+            constexpr int base_A = base_a + 'z' - 'a' -4 + 1;
             if( id <= 9 ) shortcut = '0' + id;
             else if( id <= base_a + 'z' - 'a' -4 ){
                 shortcut = 'a' + id - base_a;
@@ -131,7 +131,7 @@ void AAManager::load_label()
             else if( id <= base_A + 'Z' - 'A' ){
                 shortcut = 'A' + id - base_A;
             }
-            if( shortcut ) m_map_shortcut.insert( std::make_pair( id, shortcut ) );
+            if( shortcut ) m_map_shortcut.try_emplace( id, static_cast<char>( shortcut ) );
         }
     }
 }
@@ -249,7 +249,7 @@ std::string AAManager::id2shortcut( const int id )
     std::cout << "AAManager::id2shortcut id = " << id << std::endl;
 #endif
 
-    int key = m_map_shortcut[ id ];
+    const char key = m_map_shortcut[ id ];
     if( !key ) return std::string();
 
     char tmpchar[2];

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1016,8 +1016,8 @@ NODE* NodeTreeBase::create_node_ntext( const char* text, const int n, const int 
 
         tmpnode->text = m_heap.heap_alloc<char>( n + MAX_RES_DIGIT + 4 );
         memcpy( tmpnode->text, text, n ); tmpnode->text[ n ] = '\0';
-        tmpnode->color_text = color_text;
-        tmpnode->color_back = color_back;
+        tmpnode->color_text = static_cast<unsigned char>( color_text );
+        tmpnode->color_back = static_cast<unsigned char>( color_back );
         tmpnode->bold = bold;
         if ( fontid != FONT_MAIN ) tmpnode->fontid = fontid;
     }

--- a/src/urlreplacemanager.cpp
+++ b/src/urlreplacemanager.cpp
@@ -111,7 +111,7 @@ void Urlreplace_Manager::conf2list( const std::string& conf )
         item.replace = std::move( *str );
         std::string tgt_text = "$0";
         std::string rep_text = "\\0";
-        for( int n = '0'; n <= '9'; ++n ) {
+        for( char n = '0'; n <= '9'; ++n ) {
             tgt_text[1] = rep_text[1] = n;
             item.replace = MISC::replace_str( item.replace, tgt_text, rep_text );
         }

--- a/test/gtest_jdlib_misccharcode.cpp
+++ b/test/gtest_jdlib_misccharcode.cpp
@@ -527,7 +527,7 @@ TEST_F(IsUtf8Test, invalid_byte)
     // マルチバイトの後続部分
     char invalid_seq[2]{};
     for( int i = 0x80; i < 0xC0; ++i ) {
-        invalid_seq[0] = i;
+        invalid_seq[0] = static_cast<char>( i );
         EXPECT_FALSE( MISC::is_utf8( invalid_seq, 0 ) );
     }
 
@@ -596,7 +596,7 @@ TEST_F(Utf8BytesTest, ascii)
 {
     char ascii_seq[2]{};
     for( int i = 1; i < 0x80; ++i ) {
-        ascii_seq[0] = i;
+        ascii_seq[0] = static_cast<char>( i );
         EXPECT_EQ( 1, MISC::utf8bytes( ascii_seq ) );
     }
 }
@@ -655,7 +655,7 @@ TEST_F(Utf8BytesTest, invalid_byte)
     // マルチバイトの後続部分
     char invalid_seq[2]{};
     for( int i = 0x80; i < 0xC0; ++i ) {
-        invalid_seq[0] = i;
+        invalid_seq[0] = static_cast<char>( i );
         EXPECT_EQ( 0, MISC::utf8bytes( invalid_seq ) );
     }
 


### PR DESCRIPTION
整数型の変数をサイズが小さい整数型へ暗黙的に変換している箇所は精度が失う可能性があるとclangに指摘されたため明示的にキャスト`static_cast<...>()`を使ったり、整数型を変更してコンパイラに意図した変更であると伝えます。

clang 17のレポート (file pathを一部省略)
```
src/aamanager.cpp:125:42: warning: implicit conversion loses integer precision: 'int' to 'char' [-Wimplicit-int-conversion]
  125 |             if( id <= 9 ) shortcut = '0' + id;
      |                                    ~ ~~~~^~~~
src/aamanager.cpp:127:37: warning: implicit conversion loses integer precision: 'int' to 'char' [-Wimplicit-int-conversion]
  127 |                 shortcut = 'a' + id - base_a;
      |                          ~ ~~~~~~~~~^~~~~~~~
src/aamanager.cpp:132:37: warning: implicit conversion loses integer precision: 'int' to 'char' [-Wimplicit-int-conversion]
  132 |                 shortcut = 'A' + id - base_A;
      |                          ~ ~~~~~~~~~^~~~~~~~
src/aamanager.cpp:256:18: warning: implicit conversion loses integer precision: 'int' to 'char' [-Wimplicit-int-conversion]
  256 |     tmpchar[0] = key;
      |                ~ ^~~
src/dbtree/nodetreebase.cpp:1019:31: warning: implicit conversion loses integer precision: 'const int' to 'unsigned char' [-Wimplicit-int-conversion]
 1019 |         tmpnode->color_text = color_text;
      |                             ~ ^~~~~~~~~~
src/dbtree/nodetreebase.cpp:1020:31: warning: implicit conversion loses integer precision: 'const int' to 'unsigned char' [-Wimplicit-int-conversion]
 1020 |         tmpnode->color_back = color_back;
      |                             ~ ^~~~~~~~~~
src/urlreplacemanager.cpp:114:41: warning: implicit conversion loses integer precision: 'int' to 'value_type' (aka 'char') [-Wimplicit-int-conversion]
  114 |             tgt_text[1] = rep_text[1] = n;
      |                                       ~ ^
```
