### PR TITLE
Fix compiler warning for -Wmissing-variable-declarations part2

### DIFF
--- a/src/browsers.cpp
+++ b/src/browsers.cpp
@@ -11,7 +11,7 @@ enum
 
 namespace CORE
 {
-    char browsers[ BROWSER_NUM ][ 2 ][ MAX_TEXT ]={
+    constexpr const char browsers[ BROWSER_NUM ][ 2 ][ MAX_TEXT ]={
 
         { "ユーザ設定", "" },
         { "標準ブラウザ(xdg-open)",   "xdg-open \"%LINK\"" },

--- a/src/control/controllabel.h
+++ b/src/control/controllabel.h
@@ -21,7 +21,7 @@ namespace CONTROL
 //
 // モード名
 //
-    char mode_label[][ MAX_CONTROL_LABEL ] ={
+    constexpr const char mode_label[][ MAX_CONTROL_LABEL ] ={
         "共通",
         "板一覧／お気に入り",
         "スレ一覧",

--- a/src/control/keysyms.h
+++ b/src/control/keysyms.h
@@ -20,7 +20,7 @@ struct KEYSYMS
 
 namespace CONTROL
 {
-    KEYSYMS keysyms[] ={
+    constexpr KEYSYMS keysyms[] ={
 
         { "Space", GDK_KEY_space },
         { "Escape", GDK_KEY_Escape },

--- a/src/icons/iconfiles.h
+++ b/src/icons/iconfiles.h
@@ -12,7 +12,7 @@ enum
 
 namespace ICON
 {
-    char iconfiles[][ MAX_ICON_FILES ]={
+    constexpr const char iconfiles[][ MAX_ICON_FILES ]={
 
         "jd16",
         "jd32",

--- a/src/jdlib/hkana.h
+++ b/src/jdlib/hkana.h
@@ -5,7 +5,7 @@
 #ifndef _HKANA_H_
 #define _HKANA_H_
 
-unsigned char hkana_table1[][2][8] =
+constexpr const unsigned char hkana_table1[][2][8] =
 {
     { "｡", "。" }, { "｢", "「" }, { "｣", "」" }, { "､", "、" }, { "･", "・" },
     { "ｦ", "ヲ" },


### PR DESCRIPTION
静的でないグローバル変数に変数宣言がないとclangに指摘されたため配列変数をconstexpr変数に変更してコンパイラー警告を修正します。

clang-17のレポート (file pathを一部省略)
```
src/icons/iconfiles.h:15:10: warning: no previous extern declaration for non-static variable 'iconfiles' [-Wmissing-variable-declarations]
   15 |     char iconfiles[][ MAX_ICON_FILES ]={
      |          ^
src/control/controllabel.h:24:10: warning: no previous extern declaration for non-static variable 'mode_label' [-Wmissing-variable-declarations]
   24 |     char mode_label[][ MAX_CONTROL_LABEL ] ={
      |          ^
src/control/keysyms.h:23:13: warning: no previous extern declaration for non-static variable 'keysyms' [-Wmissing-variable-declarations]
   23 |     KEYSYMS keysyms[] ={
      |             ^
src/control/controllabel.h:24:5: note: declare 'static' if the variable is not intended to be used outside of this translation unit
   24 |     char mode_label[][ MAX_CONTROL_LABEL ] ={
      |     ^
src/browsers.cpp:14:10: warning: no previous extern declaration for non-static variable 'browsers' [-Wmissing-variable-declarations]
   14 |     char browsers[ BROWSER_NUM ][ 2 ][ MAX_TEXT ]={
      |          ^
```
