### PR TITLE
Fix compiler warnings for -Wold-style-cast part1,2,3

### DIFF
--- a/src/article/articleadmin.cpp
+++ b/src/article/articleadmin.cpp
@@ -766,7 +766,7 @@ void ArticleAdmin::slot_drag_data_get( Gtk::SelectionData& selection_data, const
     std::cout << "ArticleAdmin::slot_drag_data_get page = " << page  << std::endl;
 #endif
 
-    SKELETON::View* view = ( SKELETON::View* )get_notebook()->get_nth_page( page );
+    SKELETON::View* view = dynamic_cast<SKELETON::View*>(get_notebook()->get_nth_page( page ));
     if( ! view ) return;
 
     const std::string url = view->get_url();

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -681,7 +681,8 @@ void BBSListViewBase::clock_in()
         if( adjust && adjust->get_upper() > m_jump_y ){
 
 #ifdef _DEBUG
-            std::cout << "BBSListViewBase::clock_in jump to = " << m_jump_y << " upper = " << (int)adjust->get_upper() << std::endl;
+            std::cout << "BBSListViewBase::clock_in jump to = " << m_jump_y
+                      << " upper = " << static_cast<int>(adjust->get_upper()) << std::endl;
 #endif
 
             // 何故か先頭にジャンプ出来ないので 1 にジャンプする
@@ -1206,7 +1207,7 @@ bool BBSListViewBase::slot_button_release( GdkEventButton* event )
 
     show_status();
 
-    m_path_selected = m_treeview.get_path_under_xy( (int)event->x, (int)event->y );
+    m_path_selected = m_treeview.get_path_under_xy( static_cast<int>(event->x), static_cast<int>(event->y) );
 
     // ダブルクリックの処理のため一時的にtypeを切替える
     GdkEventType type_copy = event->type;
@@ -1240,8 +1241,8 @@ bool BBSListViewBase::slot_motion_notify( GdkEventMotion* event )
     /// マウスジェスチャ
     get_control().MG_motion( event );
 
-    int x = (int)event->x;
-    int y = (int)event->y;
+    const int x = static_cast<int>(event->x);
+    const int y = static_cast<int>(event->y);
     Gtk::TreeModel::Path path;
     Gtk::TreeView::Column* column;
     int cell_x;
@@ -2499,7 +2500,7 @@ void BBSListViewBase::tree2xml( const std::string& root_name )
     if( adjust )
     {
         if( m_jump_y != -1 && adjust->get_upper() > m_jump_y ) y = m_jump_y;
-        else  y = ( int ) adjust->get_value();
+        else  y = static_cast<int>(adjust->get_value());
     }
     else if( m_jump_y != -1 ) y = m_jump_y;
 

--- a/src/board/boardadmin.cpp
+++ b/src/board/boardadmin.cpp
@@ -426,7 +426,7 @@ void BoardAdmin::slot_drag_data_get( Gtk::SelectionData& selection_data, const i
     std::cout << "BoardAdmin::slot_drag_data_get page = " << page  << std::endl;
 #endif
 
-    SKELETON::View* view = ( SKELETON::View* )get_notebook()->get_nth_page( page );
+    SKELETON::View* view = dynamic_cast<SKELETON::View*>(get_notebook()->get_nth_page( page ));
     if( ! view ) return;
 
     const std::string url = view->get_url();

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -2143,8 +2143,8 @@ bool BoardViewBase::slot_button_release( GdkEventButton* event )
         return true;
     }
 
-    const int x = (int)event->x;
-    const int y = (int)event->y;
+    const int x = static_cast<int>(event->x);
+    const int y = static_cast<int>(event->y);
     Gtk::TreeModel::Path path;
     Gtk::TreeViewColumn* column;
     int cell_x;

--- a/src/board/boardviewnext.cpp
+++ b/src/board/boardviewnext.cpp
@@ -126,7 +126,7 @@ void BoardViewNext::update_by_tfidf( std::vector< NEXT_ITEM >& next_items )
 
         const Glib::ustring subject = item.article->get_subject();
         MISC::tfidf_calc_vec_tfifd( vec_tfidf, subject, vec_idf, vec_words );
-        item.value = ( int )( MISC::tfidf_cos_similarity( vec_tfidf_src, vec_tfidf ) * 10 + .5 );
+        item.value = static_cast<int>( MISC::tfidf_cos_similarity( vec_tfidf_src, vec_tfidf ) * 10 + .5 );
         if( item.value >= CONFIG::get_threshold_next() ){
 
 #ifdef _DEBUG

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -431,10 +431,10 @@ bool ConfigItems::load( const bool restore )
     show_delartdiag = cf.get_option_bool( "show_delartdiag", CONF_SHOW_DELARTDIAG );
 
     // 下線位置
-    adjust_underline_pos = cf.get_option_double( "adjust_underline_pos", ( double )CONF_ADJUST_UNDERLINE_POS, ( double )0, ( double )64 );
+    adjust_underline_pos = cf.get_option_double( "adjust_underline_pos", CONF_ADJUST_UNDERLINE_POS, 0, 64 );
 
     // 行間スペース
-    adjust_line_space = cf.get_option_double( "adjust_line_space", ( double )CONF_ADJUST_LINE_SPACE, ( double )0, ( double )64 );
+    adjust_line_space = cf.get_option_double( "adjust_line_space", CONF_ADJUST_LINE_SPACE, 0, 64 );
 
     // リンク下線を表示
     draw_underline = cf.get_option_bool( "draw_underline", CONF_DRAW_UNDERLINE );

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -194,8 +194,8 @@ bool Control::MG_start( const GdkEventButton* event )
     if( ! button_alloted( event, CONTROL::GestureButton ) ) return false;
 
     m_mg = true;
-    m_mg_x = ( int ) event->x;
-    m_mg_y = ( int ) event->y;
+    m_mg_x = static_cast<int>( event->x );
+    m_mg_y = static_cast<int>( event->y );
 
 #ifdef _DEBUG
     std::cout << "Control::MG_start\n";
@@ -215,8 +215,8 @@ bool Control::MG_motion( const GdkEventMotion* event )
         if( m_send_mg_info ) CORE::core_set_command( "set_mginfo", "", "■" );
     }
 
-    const int x = ( int ) event->x;
-    const int y = ( int ) event->y;
+    const int x = static_cast<int>( event->x );
+    const int y = static_cast<int>( event->y );
 
     const int dx = x - m_mg_x;
     const int dy = y - m_mg_y;

--- a/src/control/controlutil.cpp
+++ b/src/control/controlutil.cpp
@@ -257,7 +257,7 @@ guint CONTROL::get_keysym( const std::string& keyname )
     // データベース内に見つからなかったらアスキー文字を返す
 
 #ifdef _DEBUG
-    std::cout << " not found sym = " << ( guint )keyname[ 0 ] << std::endl;
+    std::cout << " not found sym = " << static_cast<guint>(keyname[ 0 ]) << std::endl;
 #endif
 
     return keyname[ 0 ];

--- a/src/dbimg/img.cpp
+++ b/src/dbimg/img.cpp
@@ -635,7 +635,7 @@ void Img::receive_finish()
     }
 
     // 画像やファイルサイズが大きい
-    else if( current_length() > (size_t) CONFIG::get_max_img_size() * 1024 * 1024
+    else if( current_length() > static_cast<std::size_t>(CONFIG::get_max_img_size()) * 1024 * 1024
              || m_width * m_height > CONFIG::get_max_img_pixel() * 1000 * 1000
         ){
 
@@ -691,12 +691,12 @@ void Img::set_embedded_size()
 
     // 縮小比率を計算してサイズ取得
     double scale;
-    double scale_w = ( double ) CONFIG::get_embimg_width() / m_width;
-    double scale_h = ( double ) CONFIG::get_embimg_height() / m_height;
+    double scale_w = static_cast<double>(CONFIG::get_embimg_width()) / m_width;
+    double scale_h = static_cast<double>(CONFIG::get_embimg_height()) / m_height;
     scale = MIN( scale_w, scale_h );
     if( scale < 1.0 ){
-        m_width_emb = (int)( m_width * scale );
-        m_height_emb = (int)( m_height * scale );
+        m_width_emb = static_cast<int>( m_width * scale );
+        m_height_emb = static_cast<int>( m_height * scale );
     }
     else{
         m_width_emb = m_width;

--- a/src/history/viewhistory.cpp
+++ b/src/history/viewhistory.cpp
@@ -275,7 +275,7 @@ void ViewHistory::append( const std::string& url )
 #endif
 
             bool pback = ( m_items.size() < MAX_LOCAL_HISTORY
-                           && m_history_top == ( int )m_items.size() -1
+                           && m_history_top == static_cast<int>(m_items.size()) -1
                            && m_history_top == m_history_current
                 );
 

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -984,7 +984,7 @@ void ImageAdmin::scroll_tab( int scroll )
         else if( pos + width >= upper ) pos = upper - width;
 
         // ICON_SIZEの倍数にする
-        else pos = ICON_SIZE * ( ( (int)pos ) / ICON_SIZE );
+        else pos = ICON_SIZE * ( static_cast<int>(pos) / ICON_SIZE );
 
         adjust->set_value( pos );
     }

--- a/src/image/imagearea.cpp
+++ b/src/image/imagearea.cpp
@@ -73,23 +73,23 @@ void ImageAreaMain::show_image()
 
     // 画面サイズに合わせる
     if( zoom_to_fit && w_org && h_org ){
-        double scale_w = ( double ) width_max / w_org;
-        double scale_h = ( double ) height_max / h_org;
+        double scale_w = static_cast<double>(width_max) / w_org;
+        double scale_h = static_cast<double>(height_max) / h_org;
 
         const double scale = ( SESSION::get_img_fit_mode() == SESSION::IMG_FIT_NORMAL ) ? std::fmin( scale_w, scale_h )
                                                                                         : scale_w;
 
         if( scale < 1 ){
-            set_width( (int)( w_org * scale ) );
-            set_height( (int)( h_org * scale ) );
+            set_width( static_cast<int>( w_org * scale ) );
+            set_height( static_cast<int>( h_org * scale ) );
         }
     }
 
     // サイズ変更
     else if( size != 100 ){
         const double scale = size / 100.0;
-        set_width( (int)( w_org * scale ) );
-        set_height( (int)( h_org * scale ) );
+        set_width( static_cast<int>( w_org * scale ) );
+        set_height( static_cast<int>( h_org * scale ) );
     }
 
     //データベースのサイズ情報更新

--- a/src/image/imageareaicon.cpp
+++ b/src/image/imageareaicon.cpp
@@ -80,11 +80,11 @@ void ImageAreaIcon::show_image()
         double scale;
         int w_org = get_img()->get_width();
         int h_org = get_img()->get_height();
-        double scale_w = ( double ) ICON_SIZE / w_org;
-        double scale_h = ( double ) ICON_SIZE / h_org;
+        double scale_w = static_cast<double>(ICON_SIZE) / w_org;
+        double scale_h = static_cast<double>(ICON_SIZE) / h_org;
         scale = MIN( scale_w, scale_h );
-        set_width( (int)( w_org * scale ) );
-        set_height( (int)( h_org * scale ) );
+        set_width( static_cast<int>( w_org * scale ) );
+        set_height( static_cast<int>( h_org * scale ) );
 
         load_image();
     }

--- a/src/image/imageareapopup.cpp
+++ b/src/image/imageareapopup.cpp
@@ -52,13 +52,13 @@ void ImageAreaPopup::show_image()
     // 縮小比率を計算
     const int w_org = get_img()->get_width();
     const int h_org = get_img()->get_height();
-    const double scale_w = ( double ) width_max / w_org;
-    const double scale_h = ( double ) height_max / h_org;
+    const double scale_w = static_cast<double>(width_max) / w_org;
+    const double scale_h = static_cast<double>(height_max) / h_org;
     const double scale = MIN( scale_w, scale_h );
 
     if( scale < 1 ){
-        set_width( (int)( w_org * scale ) );
-        set_height( (int)( h_org * scale ) );
+        set_width( static_cast<int>( w_org * scale ) );
+        set_height( static_cast<int>( h_org * scale ) );
     }
     else{
         set_width( w_org );

--- a/src/jdlib/imgloader.cpp
+++ b/src/jdlib/imgloader.cpp
@@ -262,9 +262,9 @@ Glib::RefPtr< ImgLoader > ImgProvider::get_loader( const std::string& file )
 // NOT thread safe
 void ImgProvider::set_loader( Glib::RefPtr< ImgLoader > loader )
 {
-    int size = CONFIG::get_imgcache_size();
-    if( size ) {
-        if( m_cache.size() >= (size_t)size ) {
+    const int size = CONFIG::get_imgcache_size();
+    if( size > 0 ) {
+        if( m_cache.size() >= static_cast<std::size_t>(size) ) {
             m_cache.pop_back();
         }
         m_cache.push_front( loader );

--- a/src/jdlib/jdiconv.cpp
+++ b/src/jdlib/jdiconv.cpp
@@ -52,7 +52,7 @@ Iconv::Iconv( const Encoding to, const Encoding from, const bool broken_sjis_be_
     errno = 0;
     m_cd = g_iconv_open( to_str, from_str );
 
-    if( m_cd == ( GIConv) -1 ) open_by_alternative_names( to_str, from_str );
+    if( m_cd == reinterpret_cast<GIConv>(-1) ) open_by_alternative_names( to_str, from_str );
 }
 
 
@@ -63,7 +63,7 @@ void Iconv::open_by_alternative_names( const char* to_str, const char* from_str 
     else if( m_enc_from == Encoding::sjis ) m_cd = g_iconv_open( to_str, "CP932" );
 
     // "EUCJP-MS"で失敗したら"EUCJP"で試してみる
-    if( m_cd == ( GIConv ) - 1 && ( errno & EINVAL ) != 0 )
+    if( m_cd == reinterpret_cast<GIConv>(-1) && ( errno & EINVAL ) != 0 )
     {
         if( m_enc_to == Encoding::eucjp ) m_cd = g_iconv_open( "EUCJP//TRANSLIT", from_str );
         else if( m_enc_from == Encoding::eucjp )
@@ -73,7 +73,7 @@ void Iconv::open_by_alternative_names( const char* to_str, const char* from_str 
         }
     }
 
-    if( m_cd == ( GIConv ) -1 ){
+    if( m_cd == reinterpret_cast<GIConv>(-1) ){
         std::string msg = "can't open iconv coding = ";
         msg += MISC::encoding_to_iconv_cstr( m_enc_from );
         msg += " to ";
@@ -89,7 +89,7 @@ Iconv::~Iconv()
     std::cout << "Iconv::~Iconv\n";
 #endif
 
-    if( m_cd != ( GIConv ) -1 ) g_iconv_close( m_cd );
+    if( m_cd != reinterpret_cast<GIConv>(-1) ) g_iconv_close( m_cd );
 }
 
 
@@ -121,7 +121,7 @@ std::string& Iconv::convert( char* str_in, std::size_t size_in, std::string& out
     std::cout << "Iconv::convert size_in = " << size_in << std::endl;
 #endif
 
-    if( m_cd == ( GIConv ) -1 ) {
+    if( m_cd == reinterpret_cast<GIConv>(-1) ) {
         out_buf.clear();
         return out_buf;
     }

--- a/src/jdlib/misctrip.cpp
+++ b/src/jdlib/misctrip.cpp
@@ -131,7 +131,7 @@ std::string create_trip_newtype( const std::string& key )
                 for( n = 17; n < 19 && key[n]; ++n )
                 {
                     // [./0-9A-Za-z]
-                    if( isalnum( key[n] ) != 0 || (unsigned char)( key[n] - 0x2e ) < 2 )
+                    if( isalnum( key[n] ) != 0 || static_cast<unsigned char>( key[n] - 0x2e ) < 2 )
                     {
                         salt.push_back( key[n] );
                     }
@@ -209,17 +209,17 @@ std::string create_trip_conventional( const std::string& key )
     for( n = 0; n < salt_length; n++ )
     {
         // 0x2e〜0x7aの範囲にないものは '.'(0x2e)
-        if( (unsigned char)( salt[n] - 0x2E ) > 0x4C )
+        if( static_cast<unsigned char>( salt[n] - 0x2E ) > 0x4C )
         {
             salt[n] = 0x2e;
         }
         // :;<=>?@ (0x3a〜0x40) は A〜G (0x41〜0x47)
-        else if( (unsigned char)( salt[n] - 0x3A ) < 0x07 )
+        else if( static_cast<unsigned char>( salt[n] - 0x3A ) < 0x07 )
         {
             salt[n] += 7;
         }
         // [\]^_` (0x5b〜0x60) は a〜f (0x61〜0x66)
-        else if( (unsigned char)( salt[n] - 0x5B ) < 0x06 )
+        else if( static_cast<unsigned char>( salt[n] - 0x5B ) < 0x06 )
         {
             salt[n] += 6;
         }

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1280,7 +1280,7 @@ static const char s_url_char[ 128 ] = {
 };
 bool MISC::is_url_char( const char* str_in, const bool loose_url )
 {
-    unsigned char c = (unsigned char)(*str_in);
+    const unsigned char c = static_cast<unsigned char>(*str_in);
 
     // 128以上のテーブルはないので先に判定
     if( c & 0x80 ) return false;

--- a/src/message/logmanager.cpp
+++ b/src/message/logmanager.cpp
@@ -205,7 +205,7 @@ bool Log_Manager::check_write( const std::string& url, const bool newthread, con
                 while( item.head[ i ] == ' ' ) ++i;
                 while( msg[ i2 ] == ' ' ) ++i2;
 #ifdef _DEBUG
-                std::cout << (int)( item.head[ i ] ) << " - " << (int)( msg[ i2 ] ) << std::endl;
+                std::cout << static_cast<int>( item.head[ i ] ) << " - " << static_cast<int>( msg[ i2 ] ) << std::endl;
 #endif
                 // もしバッファの最後が空白で終わっていたら成功と見なす
                 if( i && i2

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -1004,7 +1004,7 @@ void MessageViewBase::show_status()
 
     ss << "   /  文字数 ";
 
-    if( ( int ) message.size() > m_lng_iconv )
+    if( static_cast<int>(message.size()) > m_lng_iconv )
     {
         ss << "過多";
     }

--- a/src/skeleton/undobuffer.cpp
+++ b/src/skeleton/undobuffer.cpp
@@ -124,7 +124,7 @@ void UNDO_BUFFER::commit()
 
     ++m_pos;
     m_max = m_pos;
-    if( (int)m_vec_undo.size() == m_pos ) m_vec_undo.push_back( UNDO_DATA() );
+    if( static_cast<int>(m_vec_undo.size()) == m_pos ) m_vec_undo.push_back( UNDO_DATA() );
     m_first = true;
     m_sig_commit.emit();
 

--- a/src/sound/playsound.cpp
+++ b/src/sound/playsound.cpp
@@ -168,7 +168,7 @@ void Play_Sound::play_wavfile()
         std::cout << "rate = " << wavefmt.rate << std::endl
                   << "chn = " << wavefmt.chn << std::endl
                   << "bit = " << wavefmt.bit << std::endl
-                  << "sec = " << (double)datachk.size/wavefmt.average << std::endl;
+                  << "sec = " << static_cast<double>(datachk.size)/wavefmt.average << std::endl;
 #endif
 
         // デバイスオープン
@@ -214,7 +214,7 @@ void Play_Sound::play_wavfile()
 
             snd_pcm_sframes_t frames = snd_pcm_writei( handle, buffer.data(), readsize / wavefmt.block );
             if( frames < 0 ) frames = snd_pcm_recover( handle, frames, 0 );  // レジューム
-            if( frames < 0 || frames < ( snd_pcm_sframes_t ) ( readsize / wavefmt.block ) )
+            if( frames < 0 || frames < static_cast<snd_pcm_sframes_t>( readsize / wavefmt.block ) )
                 throw std::string( "failed to snd_pcm_write : " ) + snd_strerror( err );
         }
     }


### PR DESCRIPTION
### Fix compiler warning for -Wold-style-cast part1

C言語スタイルのキャストを使用しているとclangに指摘されたためC++スタイルのキャスト`static_cast<...>(value)`に変更したりキャストを外したりしてコンパイラー警告を修正します。

clang-17のレポート (file pathを一部省略)
```
src/sound/playsound.cpp:171:34: warning: use of old-style cast [-Wold-style-cast]
src/sound/playsound.cpp:217:40: warning: use of old-style cast [-Wold-style-cast]
src/dbimg/img.cpp:638:33: warning: use of old-style cast [-Wold-style-cast]
src/dbimg/img.cpp:694:22: warning: use of old-style cast [-Wold-style-cast]
src/dbimg/img.cpp:695:22: warning: use of old-style cast [-Wold-style-cast]
src/dbimg/img.cpp:698:23: warning: use of old-style cast [-Wold-style-cast]
src/dbimg/img.cpp:699:24: warning: use of old-style cast [-Wold-style-cast]
src/history/viewhistory.cpp:278:48: warning: use of old-style cast [-Wold-style-cast]
src/config/configitems.cpp:434:74: warning: use of old-style cast [-Wold-style-cast]
src/config/configitems.cpp:434:111: warning: use of old-style cast [-Wold-style-cast]
src/config/configitems.cpp:434:124: warning: use of old-style cast [-Wold-style-cast]
src/config/configitems.cpp:437:68: warning: use of old-style cast [-Wold-style-cast]
src/config/configitems.cpp:437:102: warning: use of old-style cast [-Wold-style-cast]
src/config/configitems.cpp:437:115: warning: use of old-style cast [-Wold-style-cast]
src/control/control.cpp:197:14: warning: use of old-style cast [-Wold-style-cast]
src/control/control.cpp:198:14: warning: use of old-style cast [-Wold-style-cast]
src/control/control.cpp:218:19: warning: use of old-style cast [-Wold-style-cast]
src/control/control.cpp:219:19: warning: use of old-style cast [-Wold-style-cast]
src/control/controlutil.cpp:260:41: warning: use of old-style cast [-Wold-style-cast]
src/message/messageviewbase.cpp:996:9: warning: use of old-style cast [-Wold-style-cast]
```

### Fix compiler warning for -Wold-style-cast part2

C言語スタイルのキャストを使用しているとclangに指摘されたためC++スタイルのキャスト`static_cast<...>(value)`や`dynamic_cast<...>(value)`に変更してコンパイラー警告を修正します。

clang-17のレポート (file pathを一部省略)
```
src/board/boardadmin.cpp:429:28: warning: use of old-style cast [-Wold-style-cast]
src/board/boardviewbase.cpp:2146:19: warning: use of old-style cast [-Wold-style-cast]
src/board/boardviewbase.cpp:2147:19: warning: use of old-style cast [-Wold-style-cast]
src/board/boardviewnext.cpp:129:22: warning: use of old-style cast [-Wold-style-cast]
src/image/imageadmin.cpp:987:36: warning: use of old-style cast [-Wold-style-cast]
src/image/imagearea.cpp:76:26: warning: use of old-style cast [-Wold-style-cast]
src/image/imagearea.cpp:77:26: warning: use of old-style cast [-Wold-style-cast]
src/image/imagearea.cpp:83:24: warning: use of old-style cast [-Wold-style-cast]
src/image/imagearea.cpp:84:25: warning: use of old-style cast [-Wold-style-cast]
src/image/imagearea.cpp:91:20: warning: use of old-style cast [-Wold-style-cast]
src/image/imagearea.cpp:92:21: warning: use of old-style cast [-Wold-style-cast]
src/image/imageareaicon.cpp:83:26: warning: use of old-style cast [-Wold-style-cast]
src/image/imageareaicon.cpp:84:26: warning: use of old-style cast [-Wold-style-cast]
src/image/imageareaicon.cpp:86:20: warning: use of old-style cast [-Wold-style-cast]
src/image/imageareaicon.cpp:87:21: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/imgloader.cpp:267:31: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/miscutil.cpp:1283:23: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/miscutil.cpp:1283:23: warning: use of old-style cast [-Wold-style-cast]
src/message/logmanager.cpp:208:30: warning: use of old-style cast [-Wold-style-cast]
src/message/logmanager.cpp:208:66: warning: use of old-style cast [-Wold-style-cast]
```

### Fix compiler warning for -Wold-style-cast part3

C言語スタイルのキャストを使用しているとclangに指摘されたためC++スタイルのキャスト`static_cast<T>(value)`や`reinterpret_cast<T>(value)`に変更してコンパイラー警告を修正します。

clang-17のレポート (file pathを一部省略)
```
src/bbslist/bbslistviewbase.cpp:1209:53: warning: use of old-style cast [-Wold-style-cast]
src/bbslist/bbslistviewbase.cpp:1209:68: warning: use of old-style cast [-Wold-style-cast]
src/bbslist/bbslistviewbase.cpp:1243:13: warning: use of old-style cast [-Wold-style-cast]
src/bbslist/bbslistviewbase.cpp:1244:13: warning: use of old-style cast [-Wold-style-cast]
src/bbslist/bbslistviewbase.cpp:2502:19: warning: use of old-style cast [-Wold-style-cast]
src/bbslist/bbslistviewbase.cpp:684:95: warning: use of old-style cast [-Wold-style-cast]
src/image/imageareapopup.cpp:55:28: warning: use of old-style cast [-Wold-style-cast]
src/image/imageareapopup.cpp:56:28: warning: use of old-style cast [-Wold-style-cast]
src/image/imageareapopup.cpp:60:20: warning: use of old-style cast [-Wold-style-cast]
src/image/imageareapopup.cpp:61:21: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/jdiconv.cpp:124:17: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/jdiconv.cpp:55:17: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/jdiconv.cpp:66:17: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/jdiconv.cpp:76:17: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/jdiconv.cpp:92:17: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misctrip.cpp:134:51: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misctrip.cpp:212:13: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misctrip.cpp:217:18: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misctrip.cpp:222:18: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/undobuffer.cpp:127:9: warning: use of old-style cast [-Wold-style-cast]
```
