### PR TITLE
Fix compiler warnings for -Wold-style-cast part4,5,6,7,8

### DIFF
--- a/src/aamanager.cpp
+++ b/src/aamanager.cpp
@@ -227,13 +227,13 @@ void AAManager::save_history()
 // ラベル、AA取得
 std::string AAManager::get_label( const int id ) const
 {
-    if( id >= (int) m_vec_label.size() ) return std::string();
+    if( id >= static_cast<int>(m_vec_label.size()) ) return std::string();
     return m_vec_label[ id ];
 }
 
 std::string AAManager::get_aa( const int id ) const
 {
-    if( id >= (int) m_vec_aa.size() ) return std::string();
+    if( id >= static_cast<int>(m_vec_aa.size()) ) return std::string();
     return m_vec_aa[ id ]; 
 }
 
@@ -243,7 +243,7 @@ std::string AAManager::get_aa( const int id ) const
 //
 std::string AAManager::id2shortcut( const int id )
 {
-    if( id >= (int) m_map_shortcut.size() ) return std::string();
+    if( id >= static_cast<int>(m_map_shortcut.size()) ) return std::string();
 
 #ifdef _DEBUG
     std::cout << "AAManager::id2shortcut id = " << id << std::endl;

--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -380,10 +380,10 @@ CSS_PROPERTY Css_Manager::create_property( const std::map<std::string, std::stri
             }
             else
             {
-                css.border_left_width_px = (int)size;
-                css.border_right_width_px = (int)size;
-                css.border_top_width_px = (int)size;
-                css.border_bottom_width_px = (int)size;
+                css.border_left_width_px = static_cast<int>(size);
+                css.border_right_width_px = static_cast<int>(size);
+                css.border_top_width_px = static_cast<int>(size);
+                css.border_bottom_width_px = static_cast<int>(size);
             }
         }
         // border-*-width
@@ -397,10 +397,22 @@ CSS_PROPERTY Css_Manager::create_property( const std::map<std::string, std::stri
 #ifdef _DEBUG
             std::cout << "border-" << mode << "-width size = " << size << " type = " << type << std::endl;
 #endif
-            if( mode == "left" ){ if( type == SIZETYPE_EM ) css.border_left_width_em = size; else css.border_left_width_px = (int)size; }
-            else if( mode == "right" ){ if( type == SIZETYPE_EM ) css.border_right_width_em = size; else css.border_right_width_px = (int)size; }
-            else if( mode == "top" ){ if( type == SIZETYPE_EM ) css.border_top_width_em = size; else css.border_top_width_px = (int)size; }
-            else if( mode == "bottom" ){ if( type == SIZETYPE_EM ) css.border_bottom_width_em = size; else css.border_bottom_width_px = (int)size; }
+            if( mode == "left" ) {
+                if( type == SIZETYPE_EM ) css.border_left_width_em = size;
+                else css.border_left_width_px = static_cast<int>(size);
+            }
+            else if( mode == "right" ) {
+                if( type == SIZETYPE_EM ) css.border_right_width_em = size;
+                else css.border_right_width_px = static_cast<int>(size);
+            }
+            else if( mode == "top" ) {
+                if( type == SIZETYPE_EM ) css.border_top_width_em = size;
+                else css.border_top_width_px = static_cast<int>(size);
+            }
+            else if( mode == "bottom" ) {
+                if( type == SIZETYPE_EM ) css.border_bottom_width_em = size;
+                else css.border_bottom_width_px = static_cast<int>(size);
+            }
         }
         // color
         else if( key == "color" )
@@ -433,10 +445,10 @@ CSS_PROPERTY Css_Manager::create_property( const std::map<std::string, std::stri
             }
             else
             {
-                css.mrg_left_px = (int)size;
-                css.mrg_right_px = (int)size;
-                css.mrg_top_px = (int)size;
-                css.mrg_bottom_px = (int)size;
+                css.mrg_left_px = static_cast<int>(size);
+                css.mrg_right_px = static_cast<int>(size);
+                css.mrg_top_px = static_cast<int>(size);
+                css.mrg_bottom_px = static_cast<int>(size);
             }
         }
         // margin-*
@@ -451,11 +463,23 @@ CSS_PROPERTY Css_Manager::create_property( const std::map<std::string, std::stri
             std::cout << "margin-" << mode << " size = " << size << " type = " << type << std::endl;
 #endif
 
-            if( mode == "left" ){ if( type == SIZETYPE_EM ) css.mrg_left_em = size; else css.mrg_left_px = (int)size; }
-            else if( mode == "right" ){ if( type == SIZETYPE_EM ) css.mrg_right_em = size; else css.mrg_right_px = (int)size; }
-            else if( mode == "top" ){ if( type == SIZETYPE_EM ) css.mrg_top_em = size; else css.mrg_top_px = (int)size; }
-            else if( mode == "bottom" ){ if( type == SIZETYPE_EM ) css.mrg_bottom_em = size; else css.mrg_bottom_px = (int)size; }
-        }            
+            if( mode == "left" ) {
+                if( type == SIZETYPE_EM ) css.mrg_left_em = size;
+                else css.mrg_left_px = static_cast<int>(size);
+            }
+            else if( mode == "right" ) {
+                if( type == SIZETYPE_EM ) css.mrg_right_em = size;
+                else css.mrg_right_px = static_cast<int>(size);
+            }
+            else if( mode == "top" ) {
+                if( type == SIZETYPE_EM ) css.mrg_top_em = size;
+                else css.mrg_top_px = static_cast<int>(size);
+            }
+            else if( mode == "bottom" ) {
+                if( type == SIZETYPE_EM ) css.mrg_bottom_em = size;
+                else css.mrg_bottom_px = static_cast<int>(size);
+            }
+        }
         // padding
         else if( key == "padding" )
         {
@@ -476,10 +500,10 @@ CSS_PROPERTY Css_Manager::create_property( const std::map<std::string, std::stri
             }
             else
             {
-                css.padding_left_px = (int)size;
-                css.padding_right_px = (int)size;
-                css.padding_top_px = (int)size;
-                css.padding_bottom_px = (int)size;
+                css.padding_left_px = static_cast<int>(size);
+                css.padding_right_px = static_cast<int>(size);
+                css.padding_top_px = static_cast<int>(size);
+                css.padding_bottom_px = static_cast<int>(size);
             }
         }
         // padding-*

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -718,7 +718,8 @@ void ArticleBase::reset_abone( const std::list< std::string >& ids,
 
     if( vec_abone_res.size() ){
 
-        for( int i = 1; i <= MIN( m_number_load, (int)vec_abone_res.size() ) ; ++i ){
+        const int num = (std::min)( m_number_load, static_cast<int>(vec_abone_res.size()) );
+        for( int i = 1; i <= num; ++i ){
             if( vec_abone_res[ i ] ) {
                 m_abone_reses.insert( i );
             }
@@ -1510,7 +1511,7 @@ void ArticleBase::slot_load_finished()
                 MISC::tfidf_calc_vec_tfifd( vec_tfidf_src, pre_subject, vec_idf, vec_words );
                 MISC::tfidf_calc_vec_tfifd( vec_tfidf, m_subject, vec_idf, vec_words );
 
-                value = ( int )( MISC::tfidf_cos_similarity( vec_tfidf_src, vec_tfidf ) * 10 + .5 );
+                value = static_cast<int>( MISC::tfidf_cos_similarity( vec_tfidf_src, vec_tfidf ) * 10 + .5 );
             }
 
             // subject がキャッシュに無い場合はレーベンシュタイン距離を使って類似度チェック
@@ -1520,7 +1521,7 @@ void ArticleBase::slot_load_finished()
 #endif
                 const int MAXSTR = 256;
                 std::vector< std::vector< int > > dist( MAXSTR, std::vector< int >( MAXSTR ) );
-                value = 10 - ( int )( MISC::leven( dist, pre_subject, m_subject ) * 10 + .5 );
+                value = 10 - static_cast<int>( MISC::leven( dist, pre_subject, m_subject ) * 10 + .5 );
             }
 
 #ifdef _DEBUG

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -307,7 +307,7 @@ void Board2chCompati::parse_subject( const char* str_subject_txt )
             MISC::ERRMSG( "subject.txt is broken" );
             break;
         }
-        lng_subject = ( int )( pos - str_subject );
+        lng_subject = static_cast<int>( pos - str_subject );
 
         // レス数取得 (符号付き32bit整数より大きいと未定義)
         ++pos;

--- a/src/dbtree/boardjbbs.cpp
+++ b/src/dbtree/boardjbbs.cpp
@@ -289,7 +289,7 @@ void BoardJBBS::parse_subject( const char* str_subject_txt )
             MISC::ERRMSG( "subject.txt is broken" );
             break;
         }
-        lng_subject = ( int )( pos - str_subject );
+        lng_subject = static_cast<int>( pos - str_subject );
 
         // レス数取得 (符号付き32bit整数より大きいと未定義)
         ++pos;

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -276,7 +276,7 @@ void BoardMachi::parse_subject( const char* str_subject_txt )
             MISC::ERRMSG( "subject.txt is broken" );
             break;
         }
-        lng_subject = ( int )( pos - str_subject );
+        lng_subject = static_cast<int>( pos - str_subject );
 
         // レス数取得 (符号付き32bit整数より大きいと未定義)
         ++pos;

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -2989,8 +2989,8 @@ bool NodeTreeBase::check_anchor( const int mode, const char* str_in,
                 pos += 4;
             }
             // utf-8で"＞"
-            else if( ( unsigned char )( *pos ) == 0xef && ( unsigned char ) ( *( pos + 1 ) ) == 0xbc
-                     && ( unsigned char ) ( *( pos + 2 ) ) == 0x9e ){
+            else if( static_cast<unsigned char>( *pos ) == 0xef && static_cast<unsigned char>( *( pos + 1 ) ) == 0xbc
+                     && static_cast<unsigned char>( *( pos + 2 ) ) == 0x9e ){
                 tmp_out[ lng_out++ ] = static_cast< char >( 0xef );
                 tmp_out[ lng_out++ ] = static_cast< char >( 0xbc );
                 tmp_out[ lng_out++ ] = static_cast< char >( 0x9e );
@@ -3013,8 +3013,8 @@ bool NodeTreeBase::check_anchor( const int mode, const char* str_in,
         }
 
         // utf-8で"、"
-        else if( ( unsigned char )( *pos ) == 0xe3 && ( unsigned char ) ( *( pos + 1 ) ) == 0x80
-                 && ( unsigned char ) ( *( pos + 2 ) ) == 0x81 ){
+        else if( static_cast<unsigned char>( *pos ) == 0xe3 && static_cast<unsigned char>( *( pos + 1 ) ) == 0x80
+                 && static_cast<unsigned char>( *( pos + 2 ) ) == 0x81 ){
 
             tmp_out[ lng_out++ ] = static_cast< char >( 0xe3 );
             tmp_out[ lng_out++ ] = static_cast< char >( 0x80 );
@@ -3034,7 +3034,7 @@ bool NodeTreeBase::check_anchor( const int mode, const char* str_in,
     if( dig == 0 || dig > MAX_RES_DIGIT || num == 0 ){
 
         // モード2で数字が長すぎるときは飛ばす
-        if( mode == 2 && dig > MAX_RES_DIGIT ) n_in = ( int )( pos - str_in ) + n;
+        if( mode == 2 && dig > MAX_RES_DIGIT ) n_in = static_cast<int>( pos - str_in ) + n;
 
         return false;
     }
@@ -3075,12 +3075,12 @@ bool NodeTreeBase::check_anchor( const int mode, const char* str_in,
     if( *( pos ) == '-' ) offset = 1;
 
     // utf-8で"−"
-    else if( ( unsigned char )( * pos ) == 0xef && ( unsigned char ) ( *( pos + 1 ) ) == 0xbc
-             && ( unsigned char ) ( *( pos + 2 ) ) == 0x8d ) offset = 3;
+    else if( static_cast<unsigned char>( *pos ) == 0xef && static_cast<unsigned char>( *( pos + 1 ) ) == 0xbc
+             && static_cast<unsigned char>( *( pos + 2 ) ) == 0x8d ) offset = 3;
 
     // 半角"-"
-    else if( ( unsigned char )( * pos ) == 0xef && ( unsigned char ) ( *( pos + 1 ) ) == 0xbd
-             && ( unsigned char ) ( *( pos + 2 ) ) == 0xb0 ) offset = 3;
+    else if( static_cast<unsigned char>( *pos ) == 0xef && static_cast<unsigned char>( *( pos + 1 ) ) == 0xbd
+             && static_cast<unsigned char>( *( pos + 2 ) ) == 0xb0 ) offset = 3;
 
     if( offset ){
         
@@ -3101,7 +3101,7 @@ bool NodeTreeBase::check_anchor( const int mode, const char* str_in,
     //"&gt;&gt;数字-数字</a>"のパターンの時に</a>をのぞく
     if( *( pos ) == '<' && *( pos + 1 ) == '/' && ( *( pos + 2 ) == 'a' || *( pos + 2 ) == 'A' ) && *( pos + 3 ) == '>' ) pos += 4;
     
-    n_in = ( int )( pos - str_in );
+    n_in = static_cast<int>( pos - str_in );
 
     return true;
 }

--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -109,28 +109,28 @@ Encoding MISC::encoding_from_web_charset( std::string_view charset )
 #define CTRL_RNAGE( target ) ( target < 0x20 || target == 0x7F )
 
 // [ ASCII ] 0x20〜0x7E
-#define ASCII_RANGE( target ) ( (unsigned char)( target - 0x20 ) < 0x5F )
+#define ASCII_RANGE( target ) ( static_cast<unsigned char>( target - 0x20 ) < 0x5F )
 
 // [ 制御文字とASCII ] 0x00〜0x7F
-#define CTRL_AND_ASCII_RANGE( target ) ( (unsigned char)target < 0x80 )
+#define CTRL_AND_ASCII_RANGE( target ) ( static_cast<unsigned char>(target) < 0x80 )
 
 
 /*---- EUC-JP -------------------------------------------------------*/
 //
 // [ カナ ]
 // 1バイト目 0x8E
-#define EUC_CODE_KANA( target ) ( (unsigned char)target == 0x8E )
+#define EUC_CODE_KANA( target ) ( static_cast<unsigned char>(target) == 0x8E )
 // 2バイト目 0xA1〜0xDF
-#define EUC_RANGE_KANA( target ) ( (unsigned char)( target - 0xA1 ) < 0x3F )
+#define EUC_RANGE_KANA( target ) ( static_cast<unsigned char>( target - 0xA1 ) < 0x3F )
 //
 // [ 補助漢字 ]
 // 1バイト目 0x8F
-#define EUC_CODE_SUB_KANJI( target ) ( (unsigned char)target == 0x8F )
+#define EUC_CODE_SUB_KANJI( target ) ( static_cast<unsigned char>(target) == 0x8F )
 //
 // [ 漢字 ]
 // 1バイト目 0xA1〜0xFE
 // 2バイト目 0xA1〜0xFE
-#define EUC_RANGE_MULTI( target ) ( (unsigned char)( target - 0xA1 ) < 0x5E )
+#define EUC_RANGE_MULTI( target ) ( static_cast<unsigned char>( target - 0xA1 ) < 0x5E )
 //
 /** @brief 文字列のエンコーディングがEUC-JPかチェックする
  *
@@ -223,23 +223,23 @@ bool MISC::is_jis( std::string_view input, std::size_t& read_byte )
 /*---- Shift_JIS ----------------------------------------------------*/
 //
 // [ カナ ] 0xA1〜0xDF
-#define SJIS_RANGE_KANA( target ) ( (unsigned char)( target - 0xA1 ) < 0x3F )
+#define SJIS_RANGE_KANA( target ) ( static_cast<unsigned char>( target - 0xA1 ) < 0x3F )
 //
 // [ 漢字 ]
 // 1バイト目 0x81〜0x9F 0xE0〜0xFC( 0xEF )
 //#define SJIS_RANGE_1( target ) ( (unsigned char)( target ^ 0x20 ) - 0xA1 < 0x2F )
-#define SJIS_RANGE_1( target ) ( ( (unsigned char)target ^ 0x20 ) - 0xA1 < 0x3C )
+#define SJIS_RANGE_1( target ) ( ( static_cast<unsigned char>(target) ^ 0x20 ) - 0xA1 < 0x3C )
 // 0x81〜0x9F
-#define SJIS_RANGE_1_H( target ) ( (unsigned char)( target - 0x81 ) < 0x1F )
+#define SJIS_RANGE_1_H( target ) ( static_cast<unsigned char>( target - 0x81 ) < 0x1F )
 // 0xE0〜0xFC
-#define SJIS_RANGE_1_T( target ) ( (unsigned char)( target - 0xE0 ) < 0x1D )
+#define SJIS_RANGE_1_T( target ) ( static_cast<unsigned char>( target - 0xE0 ) < 0x1D )
 //
 // 2バイト目 0x40〜0x7E 0x80〜0xFC
-#define SJIS_RANGE_2( target ) ( (unsigned char)( target - 0x40 ) < 0xBD && target != 0x7F )
+#define SJIS_RANGE_2( target ) ( static_cast<unsigned char>( target - 0x40 ) < 0xBD && target != 0x7F )
 // 0x40〜0x7E
-#define SJIS_RANGE_2_H( target ) ( (unsigned char)( target - 0x40 ) < 0x3F )
+#define SJIS_RANGE_2_H( target ) ( static_cast<unsigned char>( target - 0x40 ) < 0x3F )
 // 0x80〜0xFC
-#define SJIS_RANGE_2_T( target ) ( (unsigned char)( target - 0x80 ) < 0x7D )
+#define SJIS_RANGE_2_T( target ) ( static_cast<unsigned char>( target - 0x80 ) < 0x7D )
 //
 /** @brief 文字列のエンコーディングがShift_JISか簡易チェックする
  *

--- a/src/jdlib/tfidf.cpp
+++ b/src/jdlib/tfidf.cpp
@@ -50,11 +50,11 @@ void MISC::tfidf_create_vec_words( VEC_WORDS& vec_words, const Glib::ustring& do
 //
 void MISC::tfidf_create_vec_idf( VEC_IDF& vec_idf, const Glib::ustring& document, const VEC_WORDS& vec_words )
 {
-    const int n = vec_words.size();
+    const std::size_t n = vec_words.size();
 
-    if( ! n || n != (int)vec_idf.size() ) return;
+    if( ! n || n != vec_idf.size() ) return;
 
-    for( int i = 0; i < n; ++i ){
+    for( std::size_t i = 0; i < n; ++i ){
         if( document.find( vec_words[ i ] ) != Glib::ustring::npos ) vec_idf[ i ] += 1;
     }
 }
@@ -77,7 +77,7 @@ void MISC::tfidf_calc_vec_tfifd( VEC_TFIDF& vec_tfidf, const Glib::ustring& docu
     std::cout << "n = " << n << " n_doc = " << n_doc << std::endl;
 #endif
 
-    if( ! n || n_doc <= 0 || n != (int)vec_tfidf.size() ) return;
+    if( ! n || n_doc <= 0 || n != static_cast<int>(vec_tfidf.size()) ) return;
 
     double total = 0;
     for( int i = 0; i < n; ++i ){
@@ -111,19 +111,19 @@ void MISC::tfidf_calc_vec_tfifd( VEC_TFIDF& vec_tfidf, const Glib::ustring& docu
 //
 double MISC::tfidf_cos_similarity( const VEC_TFIDF& vec_tfidf1, const VEC_TFIDF& vec_tfidf2 )
 {
-    const int n = vec_tfidf1.size();
+    const std::size_t n = vec_tfidf1.size();
 
 #ifdef _DEBUG
     std::cout << "MISC::tfidf_cos_similarity n = " << n << std::endl;
 #endif
 
-    if( ! n || n != (int)vec_tfidf1.size() ) return 0;
+    if( ! n || n != vec_tfidf1.size() ) return 0;
 
     double product = 0;
     double lng1 = 0;
     double lng2 = 0;
 
-    for( int i = 0; i < n; ++i ){
+    for( std::size_t i = 0; i < n; ++i ){
         product += vec_tfidf1[ i ] * vec_tfidf2[ i ];
         lng1 += vec_tfidf1[ i ] * vec_tfidf1[ i ];
         lng2 += vec_tfidf2[ i ] * vec_tfidf2[ i ];
@@ -172,10 +172,10 @@ void MISC::tfidf_create_vec_idf_from_board( VEC_IDF& vec_idf,
             ++D;
         }
     }
-    for( int i = 0; i < (int)vec_words.size(); ++i ){
+    for( std::size_t i = 0, end = vec_words.size(); i < end; ++i ){
 
 #ifdef _DEBUG
-        std::cout << vec_words[ i ].raw() << " hit = " << (int)vec_idf[ i ] << " / " << D;
+        std::cout << vec_words[ i ].raw() << " hit = " << static_cast<int>(vec_idf[ i ]) << " / " << D;
 #endif
 
         vec_idf[ i ] = log( D / vec_idf[ i ] );
@@ -252,6 +252,6 @@ double MISC::leven( std::vector< std::vector< int > >& dist,
 #endif
 
     // 0 - 1 の範囲に正規化
-    return ( double )dist[ lng1 ][ lng2 ] / MAX( dist[ lng1 ][ 0 ], dist[ 0 ][ lng2 ] );
+    return static_cast<double>(dist[ lng1 ][ lng2 ]) / MAX( dist[ lng1 ][ 0 ], dist[ 0 ][ lng2 ] );
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,8 +144,8 @@ static void ice_watch_proc( IceConn ice_connect,
             *watch_data =  xsmpdata;
             xsmpdata->id_process_message = g_io_add_watch_full( channel,
                                                                 G_PRIORITY_DEFAULT,
-                                                                ( GIOCondition )( G_IO_IN | G_IO_PRI | G_IO_ERR | G_IO_HUP ),
-                                                                ( GIOFunc ) ice_process_message,
+                                                                static_cast<GIOCondition>( G_IO_IN | G_IO_PRI | G_IO_ERR | G_IO_HUP ),
+                                                                reinterpret_cast<GIOFunc>(ice_process_message),
                                                                 xsmpdata,
                                                                 nullptr );
             g_io_channel_unref( channel );

--- a/src/skeleton/dragnote.cpp
+++ b/src/skeleton/dragnote.cpp
@@ -420,7 +420,7 @@ bool DragableNoteBook::slot_button_press_event( GdkEventButton* event )
 
 #ifdef _DEBUG
     std::cout << "DragableNoteBook::on_button_press_event page = " << m_page  << std::endl;
-    std::cout << "x = " << (int)event->x_root << " y = " << (int)event->y_root
+    std::cout << "x = " << static_cast<int>(event->x_root) << " y = " << static_cast<int>(event->y_root)
               << " dblclick = " << m_dblclick << std::endl;
 #endif
 
@@ -447,12 +447,12 @@ bool DragableNoteBook::slot_button_press_event( GdkEventButton* event )
 bool DragableNoteBook::slot_button_release_event( GdkEventButton* event )
 {
     const int page = m_notebook_tab.get_page_under_mouse();
-    const int x = (int)event->x_root;
-    const int y = (int)event->y_root;
+    const int x = static_cast<int>(event->x_root);
+    const int y = static_cast<int>(event->y_root);
 
 #ifdef _DEBUG
     std::cout << "DragableNoteBook::on_button_release_event\n";
-    std::cout << "x = " << (int)event->x_root << " y = " << (int)event->y_root << std::endl;
+    std::cout << "x = " << static_cast<int>(event->x_root) << " y = " << static_cast<int>(event->y_root) << std::endl;
 #endif
 
     if( ! m_dragging_tab && m_page >= 0 && m_page < get_n_pages() ){

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -271,7 +271,7 @@ void DragTreeView::delete_popup()
 //
 bool DragTreeView::on_button_press_event( GdkEventButton* event )
 {
-    Gtk::TreeModel::Path path = get_path_under_xy( (int)event->x, (int)event->y );
+    Gtk::TreeModel::Path path = get_path_under_xy( static_cast<int>(event->x), static_cast<int>(event->y) );
     m_dragging = false;
     m_selection_canceled = false;
     sig_button_press().emit( event );
@@ -314,7 +314,7 @@ bool DragTreeView::on_button_release_event( GdkEventButton* event )
 {
     bool emit_sig = false; // true なら m_sig_button_release をemitする
 
-    Gtk::TreeModel::Path path = get_path_under_xy( (int)event->x, (int)event->y );
+    Gtk::TreeModel::Path path = get_path_under_xy( static_cast<int>(event->x), static_cast<int>(event->y) );
 
     if( ! m_dragging // ドラッグ中ではない
         && !m_selection_canceled // on_button_press_event()で選択状態を解除していない
@@ -442,7 +442,7 @@ bool DragTreeView::on_motion_notify_event( GdkEventMotion* event )
     // drag_source_set() でセットしたボタン以外でドラッグして範囲選択
     // m_path_dragstart が empty で無いときに実行
     // DragTreeView::on_button_press_event() も参照せよ
-    Gtk::TreeModel::Path path = get_path_under_xy( (int)event->x, (int)event->y );
+    Gtk::TreeModel::Path path = get_path_under_xy( static_cast<int>(event->x), static_cast<int>(event->y) );
     if( ! m_path_dragstart.empty() && !path.empty() && path != m_path_dragpre ){
         get_selection()->unselect_all();
         get_selection()->select( path, m_path_dragstart );

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -289,7 +289,7 @@ void EditTreeView::clock_in()
 //
 void EditTreeView::set_scroll( const Gtk::TreePath& path )
 {
-    m_pre_adjust_upper = ( int )( get_vadjustment()->get_upper() );
+    m_pre_adjust_upper = static_cast<int>(get_vadjustment()->get_upper());
     m_jump_path = path;
     m_jump_count = 0;
 }

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -227,16 +227,17 @@ void EditTreeView::clock_in()
             if( get_row( path ) && adjust ){
 
                 const int height = get_height();
-                const int step = (int)adjust->get_step_increment() / 2;
+                const int step = static_cast<int>(adjust->get_step_increment()) / 2;
                 int val = -1;
                 int x,y;
                 MISC::get_pointer_at_window( get_window(), x, y );
 
                 if( y < step * 2 ){
-                    val = MAX( 0, (int)adjust->get_value() - step );
+                    val = MAX( 0, static_cast<int>(adjust->get_value()) - step );
                 }
                 else if( y > height - step * 2 ){
-                    val = MIN( (int)adjust->get_value() + step, (int)( adjust->get_upper() - adjust->get_page_size() ) );
+                    val = MIN( static_cast<int>(adjust->get_value()) + step,
+                               static_cast<int>(adjust->get_upper() - adjust->get_page_size()) );
                 }
 
                 if( val != -1 ){
@@ -252,7 +253,7 @@ void EditTreeView::clock_in()
     // 正しくスクロールしないので更新されてからスクロールする
     else if( m_pre_adjust_upper && ! m_jump_path.empty() ){
 
-        const int upper = ( int )( get_vadjustment()->get_upper() );
+        const int upper = static_cast<int>(get_vadjustment()->get_upper());
 
 #ifdef _DEBUG
         std::cout << "adjust_upper : " << m_pre_adjust_upper << " -> " << upper << " count = " << m_jump_count << std::endl;

--- a/src/skeleton/menubutton.cpp
+++ b/src/skeleton/menubutton.cpp
@@ -187,7 +187,7 @@ bool MenuButton::slot_enter( GdkEventCrossing* event )
     std::cout << "MenuButton::slot_enter\n";
 #endif
 
-    check_on_arrow( (int)event->x );
+    check_on_arrow( static_cast<int>(event->x) );
 
     return true;
 }

--- a/src/skeleton/menubutton.cpp
+++ b/src/skeleton/menubutton.cpp
@@ -207,7 +207,7 @@ bool MenuButton::slot_leave( GdkEventCrossing* event )
 
 bool MenuButton::slot_motion( GdkEventMotion* event )
 {
-    check_on_arrow( (int)event->x );
+    check_on_arrow( static_cast<int>(event->x) );
 
     return true;
 }

--- a/src/skeleton/tabnote.cpp
+++ b/src/skeleton/tabnote.cpp
@@ -325,7 +325,7 @@ bool TabNotebook::adjust_tabwidth()
     m_pre_width = get_width();
     const int width_notebook = m_pre_width - mrg_notebook;
 
-    int avg_width_tab = (int)( (double)width_notebook / MAX( 3, pages ) );  // タブ幅の平均値
+    int avg_width_tab = static_cast<int>( static_cast<double>(width_notebook) / MAX( 3, pages ) );  // タブ幅の平均値
     if( avg_width_tab < label_margin ){
         avg_width_tab = label_margin;
     }
@@ -385,7 +385,7 @@ bool TabNotebook::adjust_tabwidth()
                 }
 
                 // 最大値を越えていたら、概算で収まるように縮める
-                int n = label_width - (int)( (double)label_width * max_width / width );
+                int n = label_width - static_cast<int>( static_cast<double>(label_width) * max_width / width );
                 if( n < 1 ) n = 1;
                 if( label_width - n < CONFIG::get_tab_min_str() ){
                     n = label_width - CONFIG::get_tab_min_str();

--- a/src/skeleton/treeviewbase.cpp
+++ b/src/skeleton/treeviewbase.cpp
@@ -240,7 +240,7 @@ void JDTreeViewBase::page_up()
 
     // 選択行移動
     Gtk::TreePath path;
-    if( set_top ) path = get_path_under_xy( 0, (int)adj->get_page_size() - 4 );
+    if( set_top ) path = get_path_under_xy( 0, static_cast<int>(adj->get_page_size()) - 4 );
     else path = get_path_under_xy( 0, 0 );
     if( path.size() && get_row( path ) )set_cursor( path );
 }
@@ -263,7 +263,7 @@ void JDTreeViewBase::page_down()
     // 選択行移動
     Gtk::TreePath path;
     if( set_bottom ) path = get_path_under_xy( 0, 0 );
-    else path = get_path_under_xy( 0, (int)adj->get_page_size() - 4 );
+    else path = get_path_under_xy( 0, static_cast<int>(adj->get_page_size()) - 4 );
     if( path.size() && get_row( path ) ) set_cursor( path );
 }
 

--- a/src/usrcmdpref.cpp
+++ b/src/usrcmdpref.cpp
@@ -157,7 +157,7 @@ bool UsrCmdPref::slot_button_press( GdkEventButton* event )
 //
 bool UsrCmdPref::slot_button_release( GdkEventButton* event )
 {
-    m_path_selected = m_treeview.get_path_under_xy( (int)event->x, (int)event->y );
+    m_path_selected = m_treeview.get_path_under_xy( static_cast<int>(event->x), static_cast<int>(event->y) );
 
 #ifdef _DEBUG
     std::cout << "UsrCmdPref::slot_button_release path = " << m_path_selected.to_string() << std::endl;


### PR DESCRIPTION
### Fix compiler warning for -Wold-style-cast part4

C言語スタイルのキャストを使用しているとclangに指摘されたためC++スタイルのキャスト`static_cast<...>(value)`に変更してコンパイラー警告を修正します。

clang-17のレポート (file pathを一部省略)
```
src/dbtree/articlebase.cpp:1513:25: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/articlebase.cpp:1523:30: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/articlebase.cpp:721:50: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/board2chcompati.cpp:310:23: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/boardjbbs.cpp:292:23: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misccharcode.cpp:150:13: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misccharcode.cpp:157:21: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misccharcode.cpp:158:21: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misccharcode.cpp:164:21: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misccharcode.cpp:165:21: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misccharcode.cpp:166:21: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misccharcode.cpp:172:21: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misccharcode.cpp:173:21: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misccharcode.cpp:213:20: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misccharcode.cpp:259:13: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misccharcode.cpp:264:18: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misccharcode.cpp:271:21: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misccharcode.cpp:272:21: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/misccharcode.cpp:326:13: warning: use of old-style cast [-Wold-style-cast]
```

### Fix compiler warning for -Wold-style-cast part5

C言語スタイルのキャストを使用しているとclangに指摘されたためC++スタイルのキャスト`static_cast<...>(value)`に変更したり変数の型を変更してコンパイラー警告を修正します。

clang-17のレポート (file pathを一部省略)
```
src/dbtree/nodetreebase.cpp:2992:22: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/nodetreebase.cpp:2992:59: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/nodetreebase.cpp:2993:25: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/nodetreebase.cpp:3016:18: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/nodetreebase.cpp:3016:55: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/nodetreebase.cpp:3017:21: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/nodetreebase.cpp:3037:55: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/nodetreebase.cpp:3078:14: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/nodetreebase.cpp:3078:52: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/nodetreebase.cpp:3079:17: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/nodetreebase.cpp:3082:14: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/nodetreebase.cpp:3082:52: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/nodetreebase.cpp:3083:17: warning: use of old-style cast [-Wold-style-cast]
src/dbtree/nodetreebase.cpp:3104:12: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/tfidf.cpp:120:21: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/tfidf.cpp:175:25: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/tfidf.cpp:178:59: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/tfidf.cpp:255:12: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/tfidf.cpp:55:21: warning: use of old-style cast [-Wold-style-cast]
src/jdlib/tfidf.cpp:80:35: warning: use of old-style cast [-Wold-style-cast]
```

### Fix compiler warning for -Wold-style-cast part6

C言語スタイルのキャストを使用しているとclangに指摘されたためC++スタイルのキャスト`static_cast<...>(value)`に変更してコンパイラー警告を修正します。

clang-17のレポート (file pathを一部省略)
```
src/skeleton/dragnote.cpp:423:28: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/dragnote.cpp:423:61: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/dragnote.cpp:450:19: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/dragnote.cpp:451:19: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/dragnote.cpp:455:28: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/dragnote.cpp:455:61: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/dragtreeview.cpp:274:52: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/dragtreeview.cpp:274:67: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/dragtreeview.cpp:317:52: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/dragtreeview.cpp:317:67: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/dragtreeview.cpp:445:52: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/dragtreeview.cpp:445:67: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/edittreeview.cpp:230:34: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/edittreeview.cpp:236:35: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/edittreeview.cpp:239:32: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/edittreeview.cpp:239:65: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/edittreeview.cpp:255:27: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/edittreeview.cpp:291:26: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/menubutton.cpp:190:21: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/menubutton.cpp:210:21: warning: use of old-style cast [-Wold-style-cast]
```

### Fix compiler warning for -Wold-style-cast part7

C言語スタイルのキャストを使用しているとclangに指摘されたためC++スタイルのキャスト`static_cast<...>(value)`や`reinterpret_cast<...>(value)`に変更してコンパイラー警告を修正します。

clang-17のレポート (file pathを一部省略)
```
src/aamanager.cpp:230:15: warning: use of old-style cast [-Wold-style-cast]
src/aamanager.cpp:236:15: warning: use of old-style cast [-Wold-style-cast]
src/aamanager.cpp:246:15: warning: use of old-style cast [-Wold-style-cast]
src/main.cpp:148:65: warning: cast from 'gboolean (*)(GIOChannel *, GIOCondition, XSMPDATA *)' (aka 'int (*)(_GIOChannel *, GIOCondition, XSMPDATA *)') to 'GIOFunc' (aka 'int (*)(_GIOChannel *, GIOCondition, void *)') converts to incompatible function type [-Wcast-function-type-strict]
src/main.cpp:148:65: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/edittreeview.cpp:292:26: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/menubutton.cpp:210:21: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/tabnote.cpp:328:25: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/tabnote.cpp:328:32: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/tabnote.cpp:388:39: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/tabnote.cpp:388:46: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/treeviewbase.cpp:243:48: warning: use of old-style cast [-Wold-style-cast]
src/skeleton/treeviewbase.cpp:266:39: warning: use of old-style cast [-Wold-style-cast]
src/usrcmdpref.cpp:160:53: warning: use of old-style cast [-Wold-style-cast]
src/usrcmdpref.cpp:160:68: warning: use of old-style cast [-Wold-style-cast]
```

### Fix compiler warning for -Wold-style-cast part8

C言語スタイルのキャストを使用しているとclangに指摘されたためC++スタイルのキャスト`static_cast<...>(value)`に変更してコンパイラー警告を修正します。

clang-17のレポート (file pathを一部省略)
```
src/cssmanager.cpp:383:44: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:384:45: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:385:43: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:386:46: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:400:126: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:401:134: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:402:128: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:403:137: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:436:35: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:437:36: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:438:34: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:439:37: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:454:108: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:455:116: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:456:110: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:457:119: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:479:39: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:480:40: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:481:38: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:482:41: warning: use of old-style cast [-Wold-style-cast]
```

