### PR TITLE
Fix compiler warnings for -Wolg-style-cast part9,10,11

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -3283,7 +3283,7 @@ void DrawAreaBase::exec_scroll()
             break;
     }
 
-    const int y_new = (int)MAX( 0, MIN( adjust->get_upper() - adjust->get_page_size() , y ) );
+    const int y_new = static_cast<int>(std::clamp<double>( adjust->get_upper() - adjust->get_page_size(), 0, y ));
     if( current_y != y_new ){
 
         m_cancel_change_adjust = true;

--- a/src/article/preference.cpp
+++ b/src/article/preference.cpp
@@ -15,6 +15,8 @@
 #include "cache.h"
 #include "command.h"
 
+#include <algorithm>
+#include <cstdlib>
 #include <list>
 #include <set>
 #include <string>
@@ -316,7 +318,10 @@ void Preferences::slot_ok_clicked()
         if( number >= 1 ){
             int number_end = number;
             size_t pos = num_str.find( '-' );
-            if( pos != std::string::npos ) number_end = MIN( (int)vec_abone_res.size(), MAX( number, atoi( num_str.substr( pos + 1 ).c_str() ) ) );
+            if( pos != std::string::npos ) {
+                number_end = std::clamp( std::atoi( num_str.substr( pos + 1 ).c_str() ),
+                                         number, static_cast<int>(vec_abone_res.size()) );
+            }
             for( int i = number; i <= number_end; ++i ) vec_abone_res[ i ] = true;
         }
     }

--- a/src/cssmanager.cpp
+++ b/src/cssmanager.cpp
@@ -517,10 +517,22 @@ CSS_PROPERTY Css_Manager::create_property( const std::map<std::string, std::stri
 #ifdef _DEBUG
             std::cout << "padding-" << mode << " size = " << size << " type = " << type << std::endl;
 #endif
-            if( mode == "left" ){ if( type == SIZETYPE_EM ) css.padding_left_em = size; else css.padding_left_px = (int)size; }
-            else if( mode == "right" ){ if( type == SIZETYPE_EM ) css.padding_right_em = size; else css.padding_right_px = (int)size; }
-            else if( mode == "top" ){ if( type == SIZETYPE_EM ) css.padding_top_em = size; else css.padding_top_px = (int)size; }
-            else if( mode == "bottom" ){ if( type == SIZETYPE_EM ) css.padding_bottom_em = size; else css.padding_bottom_px = (int)size; }
+            if( mode == "left" ) {
+                if( type == SIZETYPE_EM ) css.padding_left_em = size;
+                else css.padding_left_px = static_cast<int>(size);
+            }
+            else if( mode == "right" ) {
+                if( type == SIZETYPE_EM ) css.padding_right_em = size;
+                else css.padding_right_px = static_cast<int>(size);
+            }
+            else if( mode == "top" ) {
+                if( type == SIZETYPE_EM ) css.padding_top_em = size;
+                else css.padding_top_px = static_cast<int>(size);
+            }
+            else if( mode == "bottom" ) {
+                if( type == SIZETYPE_EM ) css.padding_bottom_em = size;
+                else css.padding_bottom_px = static_cast<int>(size);
+            }
         }
         // text-align
         else if( key == "text-align" )
@@ -602,10 +614,10 @@ void Css_Manager::set_size( CSS_PROPERTY* css, double height ) const
     if( css->padding_top_px > 0 ) css->padding_top = css->padding_top_px;
     if( css->padding_bottom_px > 0 ) css->padding_bottom = css->padding_bottom_px;
 
-    if( css->padding_left_em > 0 ) css->padding_left = (int)(height * css->padding_left_em);
-    if( css->padding_right_em > 0 ) css->padding_right = (int)(height * css->padding_right_em);
-    if( css->padding_top_em > 0 ) css->padding_top = (int)(height * css->padding_top_em);
-    if( css->padding_bottom_em > 0 ) css->padding_bottom = (int)(height * css->padding_bottom_em);
+    if( css->padding_left_em > 0 ) css->padding_left = static_cast<int>(height * css->padding_left_em);
+    if( css->padding_right_em > 0 ) css->padding_right = static_cast<int>(height * css->padding_right_em);
+    if( css->padding_top_em > 0 ) css->padding_top = static_cast<int>(height * css->padding_top_em);
+    if( css->padding_bottom_em > 0 ) css->padding_bottom = static_cast<int>(height * css->padding_bottom_em);
 
     ///////////////////////////////////////
 
@@ -619,10 +631,10 @@ void Css_Manager::set_size( CSS_PROPERTY* css, double height ) const
     if( css->mrg_top_px > 0 ) css->mrg_top = css->mrg_top_px;
     if( css->mrg_bottom_px > 0 ) css->mrg_bottom = css->mrg_bottom_px;
 
-    if( css->mrg_left_em > 0 ) css->mrg_left = (int)(height * css->mrg_left_em);
-    if( css->mrg_right_em > 0 ) css->mrg_right = (int)(height * css->mrg_right_em);
-    if( css->mrg_top_em > 0 ) css->mrg_top = (int)(height * css->mrg_top_em);
-    if( css->mrg_bottom_em > 0 ) css->mrg_bottom = (int)(height * css->mrg_bottom_em);
+    if( css->mrg_left_em > 0 ) css->mrg_left = static_cast<int>(height * css->mrg_left_em);
+    if( css->mrg_right_em > 0 ) css->mrg_right = static_cast<int>(height * css->mrg_right_em);
+    if( css->mrg_top_em > 0 ) css->mrg_top = static_cast<int>(height * css->mrg_top_em);
+    if( css->mrg_bottom_em > 0 ) css->mrg_bottom = static_cast<int>(height * css->mrg_bottom_em);
 
     ///////////////////////////////////////
 
@@ -636,10 +648,18 @@ void Css_Manager::set_size( CSS_PROPERTY* css, double height ) const
     if( css->border_top_width_px > 0 ) css->border_top_width = css->border_top_width_px;
     if( css->border_bottom_width_px > 0 ) css->border_bottom_width = css->border_bottom_width_px;
 
-    if( css->border_left_width_em > 0 ) css->border_left_width = (int)(height * css->border_left_width_em);
-    if( css->border_right_width_em > 0 ) css->border_right_width = (int)(height * css->border_right_width_em);
-    if( css->border_top_width_em > 0 ) css->border_top_width = (int)( height * css->border_top_width_em);
-    if( css->border_bottom_width_em > 0 ) css->border_bottom_width = (int)(height * css->border_bottom_width_em);
+    if( css->border_left_width_em > 0 ) {
+        css->border_left_width = static_cast<int>(height * css->border_left_width_em);
+    }
+    if( css->border_right_width_em > 0 ) {
+        css->border_right_width = static_cast<int>(height * css->border_right_width_em);
+    }
+    if( css->border_top_width_em > 0 ) {
+        css->border_top_width = static_cast<int>(height * css->border_top_width_em);
+    }
+    if( css->border_bottom_width_em > 0 ) {
+        css->border_bottom_width = static_cast<int>(height * css->border_bottom_width_em);
+    }
 
     ///////////////////////////////////////
 

--- a/src/history/historysubmenu.cpp
+++ b/src/history/historysubmenu.cpp
@@ -61,7 +61,7 @@ HistorySubMenu::HistorySubMenu( const std::string& url_history )
     append( *item );
 
     // 履歴項目
-    for( int i = 0; i < CONFIG::get_history_size(); ++i ){
+    for( unsigned int i = 0, end = static_cast<unsigned int>(CONFIG::get_history_size()); i < end; ++i ) {
 
         Gtk::Image* image = Gtk::manage( new Gtk::Image() );
         m_vec_images.push_back( image );
@@ -80,8 +80,8 @@ HistorySubMenu::HistorySubMenu( const std::string& url_history )
 
         item = Gtk::manage( new Gtk::MenuItem( *hbox ) );
         append( *item );
-        item->signal_activate().connect( sigc::bind< int >( sigc::mem_fun( *this, &HistorySubMenu::slot_active ), i ) );
-        item->signal_button_press_event().connect( sigc::bind< int >( sigc::mem_fun( *this, &HistorySubMenu::slot_button_press ), i ) );
+        item->signal_activate().connect( sigc::bind( sigc::mem_fun( *this, &HistorySubMenu::slot_active ), i ) );
+        item->signal_button_press_event().connect( sigc::bind( sigc::mem_fun( *this, &HistorySubMenu::slot_button_press ), i ) );
     }
 
     // ポップアップメニュー作成
@@ -129,12 +129,12 @@ void HistorySubMenu::restore_history()
 
 
 // 履歴を開く
-bool HistorySubMenu::open_history( const int i )
+bool HistorySubMenu::open_history( const unsigned int i )
 {
     bool ret = false;
     CORE::DATA_INFO_LIST info_list;
     SESSION::get_history( m_url_history, info_list );
-    if( (int)info_list.size() <= i ) return ret;
+    if( info_list.size() <= i ) return ret;
 
     if( ! info_list[ i ].url.empty() ){
 
@@ -186,7 +186,7 @@ bool HistorySubMenu::open_history( const int i )
 
 
 // メニューアイテムがactiveになった
-void HistorySubMenu::slot_active( const int i )
+void HistorySubMenu::slot_active( const unsigned int i )
 {
 #ifdef _DEBUG
     std::cout << "HistorySubMenu::slot_key_press key = " << "no = " << i << std::endl;
@@ -199,7 +199,7 @@ void HistorySubMenu::slot_active( const int i )
 
 
 // マウスボタンをクリックした
-bool HistorySubMenu::slot_button_press( GdkEventButton* event, int i )
+bool HistorySubMenu::slot_button_press( GdkEventButton* event, unsigned int i )
 {
 #ifdef _DEBUG
     std::cout << "HistorySubMenu::slot_button_press button = " << event->button << " no = " << i << std::endl;
@@ -289,11 +289,11 @@ void HistorySubMenu::slot_remove_history()
     std::cout << "HistorySubMenu::slot_remove_history no = " << m_number_menuitem << std::endl;
 #endif 
 
-    const int i = m_number_menuitem;
+    const unsigned int i = m_number_menuitem;
 
     CORE::DATA_INFO_LIST info_list;
     SESSION::get_history( m_url_history, info_list );
-    if( (int)info_list.size() <= i ) return;
+    if( info_list.size() <= i ) return;
 
     CORE::core_set_command( "remove_history", m_url_history, info_list[ i ].url );
 }
@@ -307,11 +307,11 @@ void HistorySubMenu::slot_show_property()
     std::cout << "HistorySubMenu::slot_show_property no = " << m_number_menuitem << std::endl;
 #endif
 
-    const int i = m_number_menuitem;
+    const unsigned int i = m_number_menuitem;
 
     CORE::DATA_INFO_LIST info_list;
     SESSION::get_history( m_url_history, info_list );
-    if( (int)info_list.size() <= i ) return;
+    if( info_list.size() <= i ) return;
 
     if( ! info_list[ i ].url.empty() ){
 

--- a/src/history/historysubmenu.h
+++ b/src/history/historysubmenu.h
@@ -21,7 +21,7 @@ namespace HISTORY
 
         // ポップアップメニュー
         Gtk::Menu m_popupmenu;
-        int m_number_menuitem{};
+        unsigned int m_number_menuitem{};
 
       public:
 
@@ -36,15 +36,15 @@ namespace HISTORY
 
       private:
 
-        bool open_history( const int i );
+        bool open_history( const unsigned int i );
 
         // メニューのslot関数
         void slot_clear();
         void slot_switch_sideber();
 
         // メニューアイテムがactiveになった
-        void slot_active( const int i );
-        bool slot_button_press( GdkEventButton* event, int i );
+        void slot_active( const unsigned int i );
+        bool slot_button_press( GdkEventButton* event, unsigned int i );
 
         // ポップアップメニューのslot
         void slot_open_history();


### PR DESCRIPTION
### Fix compiler warning for -Wold-style-cast part9

C言語スタイルのキャストを使用しているとclangに指摘されたためC++スタイルのキャスト`static_cast<...>(value)`に変更してコンパイラー警告を修正します。

clang-17のレポート (file pathを一部省略)
```
src/cssmanager.cpp:520:116: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:521:124: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:522:118: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:523:127: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:622:48: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:623:50: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:624:46: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:625:52: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:639:66: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:640:68: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:641:64: warning: use of old-style cast [-Wold-style-cast]
src/cssmanager.cpp:642:70: warning: use of old-style cast [-Wold-style-cast]
```

### Fix compiler warning for -Wold-style-cast part10

C言語スタイルのキャストを使用しているとclangに指摘されたためC++スタイルのキャスト`static_cast<...>(value)`に変更してコンパイラー警告を修正します。

また、関数形式マクロの`MIN()`と`MAX()`を組み合わせて値を範囲内に収める処理を`std::clamp()`に置き換えます。

clang-17のレポート (file pathを一部省略)
```
src/article/drawareabase.cpp:3290:23: warning: use of old-style cast [-Wold-style-cast]
 3290 |     const int y_new = (int)MAX( 0, MIN( adjust->get_upper() - adjust->get_page_size() , y ) );
      |                       ^    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/article/preference.cpp:319:62: warning: use of old-style cast [-Wold-style-cast]
  319 |             if( pos != std::string::npos ) number_end = MIN( (int)vec_abone_res.size(), MAX( number, atoi( num_str.substr( pos + 1 ).c_str() ) ) );
      |                                                              ^    ~~~~~~~~~~~~~~~~~~~~
src/article/preference.cpp:319:62: warning: use of old-style cast [-Wold-style-cast]
  319 |             if( pos != std::string::npos ) number_end = MIN( (int)vec_abone_res.size(), MAX( number, atoi( num_str.substr( pos + 1 ).c_str() ) ) );
      |                                                              ^    ~~~~~~~~~~~~~~~~~~~~
```

### Fix compiler warning for -Wold-style-cast part11

C言語スタイルのキャストを使用しているとclangに指摘されたため変数の型を符号なし整数に変更し符号を一致させてキャストを取り除きます。

clang-17のレポート (file pathを一部省略)
```
src/history/historysubmenu.cpp:137:9: warning: use of old-style cast [-Wold-style-cast]
  137 |     if( (int)info_list.size() <= i ) return ret;
      |         ^    ~~~~~~~~~~~~~~~~
src/history/historysubmenu.cpp:296:9: warning: use of old-style cast [-Wold-style-cast]
  296 |     if( (int)info_list.size() <= i ) return;
      |         ^    ~~~~~~~~~~~~~~~~
src/history/historysubmenu.cpp:314:9: warning: use of old-style cast [-Wold-style-cast]
  314 |     if( (int)info_list.size() <= i ) return;
      |         ^    ~~~~~~~~~~~~~~~~
```

