### PR TITLE
DrawAreaBase: Fix crash for mouse wheel scrolling to upper

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -3283,7 +3283,7 @@ void DrawAreaBase::exec_scroll()
             break;
     }
 
-    const int y_new = static_cast<int>(std::clamp<double>( adjust->get_upper() - adjust->get_page_size(), 0, y ));
+    const int y_new = static_cast<int>(std::clamp<double>( y, 0, adjust->get_upper() - adjust->get_page_size() ));
     if( current_y != y_new ){
 
         m_cancel_change_adjust = true;


### PR DESCRIPTION
スレビューでマウスホイールを使ってスクロールしたときに異常終了することがあったため修正します。
修正前は値の範囲を調べる変数を間違えていました。

修正にあたり不具合報告をしていただきありがとうございました。
https://next2ch.net/linux/1654053581/195

Closes #1390
