### PR TITLE
DrawAreaBase: Fix crash if scroll thumb maximized

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -3283,7 +3283,8 @@ void DrawAreaBase::exec_scroll()
             break;
     }
 
-    const int y_new = static_cast<int>(std::clamp<double>( y, 0, adjust->get_upper() - adjust->get_page_size() ));
+    // (upper - page_size) と y はどちらもマイナス値になることがある
+    const int y_new = (std::max)( 0, (std::min)( static_cast<int>(adjust->get_upper() - adjust->get_page_size()), y ) );
     if( current_y != y_new ){
 
         m_cancel_change_adjust = true;


### PR DESCRIPTION
スレビューでレスの少ないスレを開きスクロールバーのノブがバー一杯に広がると異常終了することががあったため修正します。
修正前は変数値の取りうる範囲を間違えていました。

修正にあたり不具合報告をしていただきありがとうございました。
https://next2ch.net/linux/1654053581/197

Closes #1392
