### PR TITLE
Implement base system of the NG image hash

### DIFF
--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -236,6 +236,9 @@ bool ConfigItems::load( const bool restore )
     // 画像のメモリキャッシュ枚数
     imgcache_size = cf.get_option_int( "imgcache_size", CONF_IMGCACHE_SIZE, 0, 20 );
 
+    // 画像のハッシュ値を計算してNG 画像ハッシュとの差がしきい値以下の画像をあぼ〜んする
+    enable_img_hash = cf.get_option_bool( "enable_img_hash", CONF_ENABLE_IMG_HASH );
+
     // NG 画像ハッシュの初期設定のしきい値
     img_hash_initial_threshold = cf.get_option_int( "img_hash_initial_threshold", CONF_IMG_HASH_INITIAL_THRESHOLD, -1, 128 );
 
@@ -781,6 +784,7 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "max_img_size", max_img_size );
     cf.update( "max_img_pixel", max_img_pixel );
     cf.update( "imgcache_size", imgcache_size );
+    cf.update( "enable_img_hash", enable_img_hash );
     cf.update( "img_hash_initial_threshold", img_hash_initial_threshold );
 
     cf.update( "cl_char", str_color[ COLOR_CHAR ] );

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -236,6 +236,9 @@ bool ConfigItems::load( const bool restore )
     // 画像のメモリキャッシュ枚数
     imgcache_size = cf.get_option_int( "imgcache_size", CONF_IMGCACHE_SIZE, 0, 20 );
 
+    // NG 画像ハッシュの初期設定のしきい値
+    img_hash_initial_threshold = cf.get_option_int( "img_hash_initial_threshold", CONF_IMG_HASH_INITIAL_THRESHOLD, -1, 128 );
+
     // JD ホームページのアドレス
     url_jdhp = cf.get_option_str( "url_jdhp", CONF_URL_JDHP );
 
@@ -778,6 +781,7 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "max_img_size", max_img_size );
     cf.update( "max_img_pixel", max_img_pixel );
     cf.update( "imgcache_size", imgcache_size );
+    cf.update( "img_hash_initial_threshold", img_hash_initial_threshold );
 
     cf.update( "cl_char", str_color[ COLOR_CHAR ] );
     cf.update( "cl_char_name", str_color[ COLOR_CHAR_NAME ] );

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -181,6 +181,9 @@ namespace CONFIG
         // 画像のメモリキャッシュ枚数
         int imgcache_size{};
 
+        /// @brief 画像のハッシュ値を計算してNG 画像ハッシュとの差がしきい値以下の画像をあぼ〜んする
+        bool enable_img_hash{};
+
         /// @brief NG 画像ハッシュの初期設定のしきい値
         int img_hash_initial_threshold{};
 

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -181,6 +181,9 @@ namespace CONFIG
         // 画像のメモリキャッシュ枚数
         int imgcache_size{};
 
+        /// @brief NG 画像ハッシュの初期設定のしきい値
+        int img_hash_initial_threshold{};
+
         // JD ホームページのアドレス
         std::string url_jdhp;
 

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -136,6 +136,7 @@ namespace CONFIG
         CONF_MAX_IMG_SIZE = 16,     // ダウンロードする画像の最大サイズ(Mbyte)
         CONF_MAX_IMG_PIXEL = 20,     // 画像の最大サイズ(Mピクセル)
         CONF_IMGCACHE_SIZE = 3,      // 画像のメモリキャッシュ枚数
+        CONF_IMG_HASH_INITIAL_THRESHOLD = 30, ///< NG 画像ハッシュの初期設定のしきい値
         CONF_USE_LINK_AS_BOARD = 0,     // bbsmenu.html内にあるリンクは全て板とみなす
         CONF_SHOW_MOVEDIAG = 1,    // 板移転時に確認ダイアログを表示する
         CONF_REMOVE_OLD_ABONE_THREAD = 0, // dat落ちしたスレをNGスレタイトルリストから取り除くか( 0: ダイアログ表示 1: 取り除く 2: 除かない )

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -136,6 +136,7 @@ namespace CONFIG
         CONF_MAX_IMG_SIZE = 16,     // ダウンロードする画像の最大サイズ(Mbyte)
         CONF_MAX_IMG_PIXEL = 20,     // 画像の最大サイズ(Mピクセル)
         CONF_IMGCACHE_SIZE = 3,      // 画像のメモリキャッシュ枚数
+        CONF_ENABLE_IMG_HASH = 0, ///< 画像のハッシュ値を計算してNG 画像ハッシュとの差がしきい値以下の画像をあぼ〜んする
         CONF_IMG_HASH_INITIAL_THRESHOLD = 30, ///< NG 画像ハッシュの初期設定のしきい値
         CONF_USE_LINK_AS_BOARD = 0,     // bbsmenu.html内にあるリンクは全て板とみなす
         CONF_SHOW_MOVEDIAG = 1,    // 板移転時に確認ダイアログを表示する

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -301,6 +301,9 @@ void CONFIG::set_del_imgabone_day( const int day ){ get_confitem()->del_imgabone
 int CONFIG::get_max_img_size(){ return get_confitem()->max_img_size; }
 int CONFIG::get_max_img_pixel(){ return get_confitem()->max_img_pixel; }
 int CONFIG::get_imgcache_size(){ return get_confitem()->imgcache_size; }
+
+bool CONFIG::get_enable_img_hash() { return get_confitem()->enable_img_hash; }
+void CONFIG::set_enable_img_hash( bool enabled ) { get_confitem()->enable_img_hash = enabled; }
 int CONFIG::get_img_hash_initial_threshold(){ return get_confitem()->img_hash_initial_threshold; }
 void CONFIG::set_img_hash_initial_threshold( int threshold ) { get_confitem()->img_hash_initial_threshold = threshold; }
 

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -301,6 +301,8 @@ void CONFIG::set_del_imgabone_day( const int day ){ get_confitem()->del_imgabone
 int CONFIG::get_max_img_size(){ return get_confitem()->max_img_size; }
 int CONFIG::get_max_img_pixel(){ return get_confitem()->max_img_pixel; }
 int CONFIG::get_imgcache_size(){ return get_confitem()->imgcache_size; }
+int CONFIG::get_img_hash_initial_threshold(){ return get_confitem()->img_hash_initial_threshold; }
+void CONFIG::set_img_hash_initial_threshold( int threshold ) { get_confitem()->img_hash_initial_threshold = threshold; }
 
 int CONFIG::get_newthread_hour(){ return get_confitem()->newthread_hour; }
 

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -304,6 +304,10 @@ namespace CONFIG
     // 画像のメモリキャッシュ枚数
     int get_imgcache_size();
 
+    // NG 画像ハッシュの初期設定のしきい値
+    int get_img_hash_initial_threshold();
+    void set_img_hash_initial_threshold( int threshold );
+
     // スレ一覧で指定した値(時間)よりも後に立てられたスレを新着とみなす
     int get_newthread_hour();
 

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -304,6 +304,10 @@ namespace CONFIG
     // 画像のメモリキャッシュ枚数
     int get_imgcache_size();
 
+    // 画像のハッシュ値を計算してNG 画像ハッシュとの差がしきい値以下の画像をあぼ〜んする
+    bool get_enable_img_hash();
+    void set_enable_img_hash( bool enabled );
+
     // NG 画像ハッシュの初期設定のしきい値
     int get_img_hash_initial_threshold();
     void set_img_hash_initial_threshold( int threshold );

--- a/src/dbimg/img.h
+++ b/src/dbimg/img.h
@@ -5,8 +5,11 @@
 #ifndef _IMG_H
 #define _IMG_H
 
+#include "imghash.h"
+
 #include "skeleton/loadable.h"
 
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -52,6 +55,8 @@ namespace DBIMG
 
         // 保存用ファイルハンドラ
         FILE* m_fout{};
+
+        std::optional<DHash> m_dhash{}; ///< 画像のハッシュ値
 
       public:
 
@@ -110,6 +115,9 @@ namespace DBIMG
 
         // 拡張子が偽装されているか
         bool is_fake() const;
+
+        void set_dhash( const DHash& dhash );
+        const std::optional<DHash>& get_dhash() const noexcept { return m_dhash; }
 
         // ロード開始
         // receive_data()　と receive_finish() がコールバックされる

--- a/src/dbimg/imghash.h
+++ b/src/dbimg/imghash.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef JDIM_DBIMG_IMGHASH_H
+#define JDIM_DBIMG_IMGHASH_H
+
+#include <cstdint>
+#include <ctime>
+#include <string>
+
+
+namespace DBIMG
+{
+
+/** @brief uint64_t のペアにハッシュ値を格納する */
+struct DHash
+{
+    std::uint64_t row_hash; ///< 行ハッシュ
+    std::uint64_t col_hash; ///< 列ハッシュ
+};
+
+/** @brief あぼーん処理で使うデータ */
+struct AboneImgHash
+{
+    DHash dhash;              ///< ハッシュ値
+    int threshold;            ///< あぼーん判定のしきい値
+    std::time_t last_matched; ///< 最後にマッチした日時
+    std::string source_url;   ///< ハッシュのソースURL
+};
+
+} // namespace DBIMG
+
+#endif // JDIM_DBIMG_IMGHASH_H

--- a/src/dbimg/imginterface.cpp
+++ b/src/dbimg/imginterface.cpp
@@ -103,6 +103,55 @@ std::string DBIMG::get_cache_path( const std::string& url )
 }
 
 
+std::optional<DBIMG::DHash> DBIMG::get_dhash( const std::string& url )
+{
+    const DBIMG::Img* img = DBIMG::get_img( url );
+    if( img ) return img->get_dhash();
+
+    return std::nullopt;
+}
+
+JDLIB::span<const DBIMG::AboneImgHash> DBIMG::get_span_abone_imghash()
+{
+    if( ! instance_dbimg_root ) return JDLIB::span<const DBIMG::AboneImgHash>{};
+
+    return instance_dbimg_root->get_vec_abone_imghash();
+}
+
+void DBIMG::push_abone_imghash( const std::string& url, const int threshold )
+{
+    if( ! instance_dbimg_root ) return;
+
+    instance_dbimg_root->push_abone_imghash( url, threshold );
+}
+
+bool DBIMG::test_imghash( DBIMG::Img& img )
+{
+    if( ! instance_dbimg_root ) return false;
+
+    return instance_dbimg_root->test_imghash( img );
+}
+
+void DBIMG::save_abone_imghash_list()
+{
+    if( ! instance_dbimg_root ) return;
+
+    instance_dbimg_root->save_abone_imghash_list();
+}
+
+void DBIMG::update_abone_imghash_list( JDLIB::span<DBIMG::AboneImgHash> span )
+{
+    if( ! instance_dbimg_root ) return;
+
+    instance_dbimg_root->update_abone_imghash_list( span );
+}
+
+DBIMG::DHash DBIMG::calc_dhash_from_pixbuf( const Gdk::Pixbuf& pixbuf )
+{
+    return DBIMG::ImgRoot::calc_dhash_from_pixbuf( pixbuf );
+}
+
+
 void DBIMG::download_img( const std::string& url, const std::string& refurl, const bool mosaic )
 {
     DBIMG::Img* img = DBIMG::get_img( url );

--- a/src/dbimg/imginterface.h
+++ b/src/dbimg/imginterface.h
@@ -7,7 +7,18 @@
 #ifndef _IMGINTERFACE_H
 #define _IMGINTERFACE_H
 
+#include "imghash.h"
+
+#include "jdlib/span.h"
+
+#include <optional>
 #include <string>
+
+
+namespace Gdk
+{
+    class Pixbuf;
+}
 
 namespace Gtk
 {
@@ -39,6 +50,8 @@ namespace DBIMG
         T_FORCEIMAGE, // 拡張子がなくても画像として扱う
     };
 
+    constexpr int kImgHashReserved = 0;
+
     class Img;
 
     void create_root();
@@ -69,6 +82,14 @@ namespace DBIMG
 
     DBIMG::Img* get_img( const std::string& url );
     std::string get_cache_path( const std::string& url );
+
+    std::optional<DBIMG::DHash> get_dhash( const std::string& url );
+    JDLIB::span<const AboneImgHash> get_span_abone_imghash();
+    void push_abone_imghash( const std::string& url, const int threshold );
+    bool test_imghash( DBIMG::Img& img );
+    void save_abone_imghash_list();
+    void update_abone_imghash_list( JDLIB::span<AboneImgHash> span );
+    DBIMG::DHash calc_dhash_from_pixbuf( const Gdk::Pixbuf& pixbuf );
 
     // ロード開始
     // refurl : 参照元のスレのアドレス

--- a/src/dbimg/imgroot.cpp
+++ b/src/dbimg/imgroot.cpp
@@ -33,6 +33,64 @@
 namespace DBIMG::ir {
 /// @brief NG 画像ハッシュの設定ファイル名
 constexpr const char* kDHashListFileName = "dhash_list.txt";
+
+/** @brief NG 画像ハッシュのデフォルト設定
+ *
+ * @details 最後にマッチした日時は 2000-01-01 (Sat) 09:00:00 JST に設定。
+ * ハッシュのソースURLはデフォルト設定の目印として U+2699 GEAR を追加した。
+ *
+ * NGの対象は大量にレスを投稿する荒らしが繰り返し書き込んでいたグロテスク・ゴア・残虐な画像。
+ */
+constexpr const char* kDefaultConfig =
+    "1028040033BF4F7C A2A430B1B070E1E 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/qsO20Gk.jpg\n"
+    "178FC74220E94A20 E8E8E86828694BDE 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/wzq202L.jpg\n"
+    "1CE2D3C1FF7E98 3B1D395D4D0F0F07 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/vjijPhf.jpg\n"
+    "1EFBFC7BF208E7FC 6F7BB63B524E774F 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/PgMJGnN.jpg\n"
+    "1F7CC23143F7CCBE 4D76B3B9EBADAEB5 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/WFteJZP.jpg\n"
+    "1FE7F321F079D 4D5D0D8990CC643D 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/0B8cU8D.jpg\n"
+    "23E0039D80C1633F B7E68A8E0E232317 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/Qwvsb6e.jpg\n"
+    "291A080018FF7F86 4D5E65771B3372F2 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/FYYmQwu.jpg\n"
+    "3882A2E73C4B04FF F6325450D4B2787 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/WJikloU.jpg\n"
+    "3F63030079FC3ECC 1371CDAC4C86A2EC 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/lSkTyBs.jpg\n"
+    "4343061C38B46C 636226A48C94F448 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/4EIF09A.gif\n"
+    "5540FBCF8974002 6D6AAB475536AE2 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/Eq8pFcA.gif\n"
+    "6378061381C4667D 73CFE3C1E474313D 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/iDOOCc5.jpg\n"
+    "79FFBF3EB1C0006C 18D5A0E0E0E0E424 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/OXQ59ju.jpg\n"
+    "7CB3772F0EC190AE 777367666E7C3E26 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/0pNEpr3.jpg\n"
+    "7E81C2A1703111C7 B2B8262446C746E7 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/IQRJ6Xq.jpg\n"
+    "801C308FFF0FBEFF B0F23C2C0E4F67C 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/Osuen0U.jpg\n"
+    "811D3E8AB74916FF D0E2B3B376F173A 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/fZRYVgw.jpg\n"
+    "833C6FCEC0BFFF3F 670663C3939112A2 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/8ftQr1w.jpg\n"
+    "837FFCF18000E 382C23474D0D5656 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/ZX5KXSN.jpg\n"
+    "923727080000C0E0 E9E5EC494C4C3D2D 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/7y8F03y.jpg\n"
+    "9D0100000000E1 BCD46033B038B030 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/L5teub6.jpg\n"
+    "A33F7A45411D7F01 333370507090F0F0 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/aZdlsbt.jpg\n"
+    "B1B1F74F7E0017F0 B838326A3C74612C 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/Y1jjgEE.jpg\n"
+    "BC3E3EC7420A9F01 E2373736A293931 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/31x4INT.jpg\n"
+    "BE367CF7C091C3E9 A6366AD1E9922A2E 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/eZb4Fc4.jpg\n"
+    "BEFF47593FFDC7FF 3371715D1B556727 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/wUyhJXD.jpg\n"
+    "BF7FE1C1FCBFCE43 8171F8E9CFC3C771 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/OIbTczq.jpg\n"
+    "C0841F8B3701F97C 20871131313D2D14 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/TUjtfzL.jpg\n"
+    "C0BE3C856FDF3649 6F3F3C7432143468 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/JR8NIaZ.jpg\n"
+    "C1EFA790F9B70E7 F0F8C0D8FC63667 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/Qw4FWRT.jpg\n"
+    "C2099C00FF7FC7C2 C8CC8E333B39735A 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/NElZob7.jpg\n"
+    "C2CCC0851116FBFE C7CF91041E022B27 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/ujTeALn.jpg\n"
+    "C563F0FEF736D10 437130F8F85868D0 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/t5hnSAS.jpg\n"
+    "C78038BF478E7B78 C68E8F6767EF3D7C 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/946sigr.jpg\n"
+    "CCC231839C1BFC61 C693AF2B1F4B6E63 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/VouEyc3.jpg\n"
+    "CD933744FCE0 9515173237658E9B 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/rWpzvPL.jpg\n"
+    "D8F7F6001BDDFF9 FCB636BFFDDF5B7B 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/RA9YiOK.jpg\n"
+    "DC1CFF37F3BD9D 70711B1A3830442 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/BPKDY3I.jpg\n"
+    "DFE3810D6C0E02B1 E824A406361B3B19 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/eaT3GmP.jpg\n"
+    "E3320C33CE3C0003 37364C594E3E7173 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/pe3oWus.jpg\n"
+    "E72C816360A4CCFE E3CD594946464A5A 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/WdpCuFp.jpg\n"
+    "F1E8CC20071F3FF7 ACCFC793C7C3B76E 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/ciXyCsx.jpg\n"
+    "F70000B070000B06 FCFC7CFB75F5F5F7 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/Vdjgk2P.jpg\n"
+    "F77980FE04000040 FA5C2E3E3C3C7C7E 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/nQoL19D.jpg\n"
+    "FC800461BFFF7C80 872323230B0E2CB1 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/8gJqNJM.jpg\n"
+    "FD811DF2DF7ED8C1 B070626A686870B0 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/GEswgVB.jpg\n"
+    "FEFE210104FF9D00 D2393868E43989B9 30 0 946684800 \xE2\x9A\x99+https://i.imgur.com/HRmhuay.jpg\n"
+    ;
 }
 
 
@@ -52,10 +110,15 @@ ImgRoot::ImgRoot()
     }
 
     const std::string img_abone_imghash_list = CACHE::path_img_abone_root() + ir::kDHashListFileName;
-    if( CACHE::file_exists( img_abone_imghash_list ) != CACHE::EXIST_FILE ) return;
-
     std::string contents;
-    if( ! CACHE::load_rawdata( img_abone_imghash_list, contents ) ) return;
+    if( CACHE::file_exists( img_abone_imghash_list ) == CACHE::EXIST_FILE ) {
+        // ファイルがあるときは内容の有無に関係なくデフォルト設定は使わない
+        if( ! CACHE::load_rawdata( img_abone_imghash_list, contents ) ) return;
+    }
+    else {
+        // 設定ファイルが見つからないときはデフォルト設定を読み込む
+        contents = ir::kDefaultConfig;
+    }
 
     load_imghash_list( contents );
 }

--- a/src/dbimg/imgroot.h
+++ b/src/dbimg/imgroot.h
@@ -5,11 +5,21 @@
 #ifndef _IMGROOT_H
 #define _IMGROOT_H
 
+#include "imghash.h"
+
+#include "jdlib/span.h"
+
 #include <list>
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
+
+namespace Gdk
+{
+    class Pixbuf;
+}
 
 namespace DBIMG
 {
@@ -18,6 +28,7 @@ namespace DBIMG
     class ImgRoot
     {
         std::map<std::string, std::unique_ptr<Img>> m_map_img;
+        std::vector<AboneImgHash> m_vec_abone_imghash;
         std::list< Img* > m_list_wait; // ロード待ち状態のImgクラス
         std::list< Img* > m_list_delwait; // ロード待ち状態のImgクラスを削除する時の一時変数
         bool m_webp_support{}; // WebP の読み込みに対応しているか
@@ -59,6 +70,19 @@ namespace DBIMG
 
         // 全キャッシュ削除
         void delete_all_files();
+
+        const std::vector<AboneImgHash>& get_vec_abone_imghash() const noexcept { return m_vec_abone_imghash; }
+        void push_abone_imghash( const std::string& url, const int threshold );
+        bool test_imghash( Img& img );
+        void load_imghash_list( const std::string& contents );
+        void save_abone_imghash_list();
+        void update_abone_imghash_list( JDLIB::span<AboneImgHash> span )
+        {
+            m_vec_abone_imghash.assign( span.begin(), span.end() );
+        }
+
+        static DBIMG::DHash calc_dhash_from_pixbuf( const Gdk::Pixbuf& pixbuf );
+        static int calc_hamming_distance( const DBIMG::DHash& a, const DBIMG::DHash& b ) noexcept;
 
       private:
 

--- a/src/globalabonepref.h
+++ b/src/globalabonepref.h
@@ -5,6 +5,8 @@
 #ifndef _GLOBALABONPREF_H
 #define _GLOBALABONPREF_H
 
+#include "imagehashtab.h"
+
 #include "skeleton/prefdiag.h"
 #include "skeleton/editview.h"
 
@@ -16,12 +18,15 @@
 
 #include "command.h"
 
+
+
 namespace CORE
 {
     class GlobalAbonePref : public SKELETON::PrefDiag
     {
         Gtk::Notebook m_notebook;
         SKELETON::EditView m_edit_name, m_edit_word, m_edit_regex;
+        ImageHashTab m_image_hash_tab;
         Gtk::Label m_label_warning;
 
         // OK押した
@@ -36,6 +41,7 @@ namespace CORE
             CONFIG::set_list_abone_name( list_name );
             CONFIG::set_list_abone_word( list_word );
             CONFIG::set_list_abone_regex( list_regex );
+            m_image_hash_tab.slot_ok_clicked();
 
             // あぼーん情報更新
             DBTREE::update_abone_all_article();
@@ -45,7 +51,8 @@ namespace CORE
       public:
 
         GlobalAbonePref( Gtk::Window* parent, const std::string& url )
-        : SKELETON::PrefDiag( parent, url )
+            : SKELETON::PrefDiag( parent, url )
+            , m_image_hash_tab{ this }
         {
             // name
             std::list< std::string > list_name = CONFIG::get_list_abone_name();
@@ -65,11 +72,13 @@ namespace CORE
             m_notebook.append_page( m_edit_name, "NG 名前" );
             m_notebook.append_page( m_edit_word, "NG ワード" );
             m_notebook.append_page( m_edit_regex, "NG 正規表現" );
+            m_notebook.append_page( m_image_hash_tab.get_widget(), "NG 画像ハッシュ" );
 
             get_content_area()->pack_start( m_notebook );
             set_title( "全体あぼ〜ん設定" );
             resize( 600, 400 );
             show_all_children();
+            m_notebook.set_current_page( 0 );
         }
 
         ~GlobalAbonePref() noexcept override = default;

--- a/src/image/preference.h
+++ b/src/image/preference.h
@@ -30,7 +30,11 @@ namespace IMAGE
         Gtk::Label m_label_size_value;
         Gtk::Label m_label_type;
         Gtk::Label m_label_type_value;
+        Gtk::Label m_label_imghash;
+        Gtk::Label m_label_imghash_value;
 
+        Gtk::Button* m_button_copy{};
+        Gtk::CheckButton* m_check_abone{};
         Gtk::CheckButton m_check_protect;
 
       public:
@@ -39,6 +43,9 @@ namespace IMAGE
       private:
         void slot_ok_clicked() override;
         void slot_open_ref();
+        void slot_copy_clicked();
+        void slot_button_icon_timeout();
+        void slot_toggled_protect();
     };
 
 }

--- a/src/imagehashtab.h
+++ b/src/imagehashtab.h
@@ -1,0 +1,499 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// 全体あぼーん設定のNG 画像ハッシュタブ
+
+#ifndef JDIM_IMAGEHASHTAB_H
+#define JDIM_IMAGEHASHTAB_H
+
+#include "config/defaultconf.h"
+#include "config/globalconf.h"
+#include "dbimg/imginterface.h"
+#include "jdlib/miscgtk.h"
+#include "jdlib/misctime.h"
+#include "skeleton/msgdiag.h"
+
+#include <gtkmm.h>
+
+#include <cinttypes>
+#include <cstdint>
+#include <cstdlib>
+#include <ios>
+
+
+namespace CORE
+{
+
+/** @brief NG 画像ハッシュを設定するタブ
+ *
+ * シグナルハンドラを安全に切断するため sigc::trackable を継承する
+ */
+class ImageHashTab : public sigc::trackable
+{
+    struct Columns : Gtk::TreeModel::ColumnRecord
+    {
+        Gtk::TreeModelColumn<std::uint64_t> m_col_hash_row; ///< ハッシュA
+        Gtk::TreeModelColumn<std::uint64_t> m_col_hash_col; ///< ハッシュB
+        Gtk::TreeModelColumn<int> m_col_threshold; ///< しきい値
+        Gtk::TreeModelColumn<Glib::ustring> m_col_last_matched; ///< 最後にマッチした日時
+        Gtk::TreeModelColumn<Glib::ustring> m_col_source_url; ///< ハッシュのソースURL
+        Gtk::TreeModelColumn<std::time_t> m_col_last_matched_time; ///< 最後にマッチした日時(time_t)
+
+        Columns()
+        {
+            add( m_col_hash_row );
+            add( m_col_hash_col );
+            add( m_col_threshold );
+            add( m_col_last_matched );
+            add( m_col_source_url );
+            add( m_col_last_matched_time );
+        }
+        ~Columns() noexcept override = default;
+    };
+
+    Gtk::Window* m_parent;
+    Gtk::Box m_box;
+
+    Gtk::Grid m_grid;
+
+    // NG 画像ハッシュの有効・無効切り替え
+    Gtk::ListBox m_listbox;
+    Gtk::Box m_hbox_check_enable_hash;
+    Gtk::Box m_vbox_check_enable_hash;
+    Gtk::Switch m_switch_enable_hash;
+    Gtk::Label m_label_enable_hash;
+
+    // 初期設定のしきい値
+    Gtk::Box m_hbox_initial_threshold;
+    Gtk::Label m_label_initial_threshold;
+    Gtk::SpinButton m_spin_initial_threshold;
+    Gtk::Button m_button_reset_initial_threshold;
+
+    // 選択した行に対する操作
+    Gtk::Box m_box_tool;
+    Gtk::Label m_label_tool;
+    Gtk::Button m_button_delete;
+    Gtk::MenuButton m_button_set_threshold;
+    Gtk::Button m_button_copy;
+    Glib::RefPtr<Gio::Menu> m_menu_set_threshold;
+    Glib::RefPtr<Gio::SimpleActionGroup> m_action_group;
+    Gtk::Label m_label_num_of_items;
+
+    // 注意事項
+    Glib::RefPtr<Glib::Binding> m_binding_notes; ///< ToggleButtonとRevealerをバインドする
+    Gtk::ToggleButton m_toggle_notes;
+    Gtk::Revealer m_revealer_notes;
+    Gtk::Label m_label_notes;
+
+    // NG 画像ハッシュのリスト
+    Gtk::ScrolledWindow m_scroll;
+    Gtk::TreeView m_treeview;
+    Glib::RefPtr<Gtk::ListStore> m_list_store;
+    Columns m_columns;
+    int m_col;
+    Gtk::SortType m_previous_sortmode{};
+
+public:
+
+    explicit ImageHashTab( Gtk::Window* parent )
+        : m_parent{ parent }
+        , m_box{ Gtk::ORIENTATION_VERTICAL, 8 }
+        , m_hbox_check_enable_hash{ Gtk::ORIENTATION_HORIZONTAL, 8 }
+        , m_vbox_check_enable_hash{ Gtk::ORIENTATION_VERTICAL, 0 }
+        , m_label_enable_hash{ "(実験的な機能) NG 画像ハッシュを有効にする(_A)", true }
+        , m_hbox_initial_threshold{ Gtk::ORIENTATION_HORIZONTAL, 8 }
+        , m_label_initial_threshold{ "初期設定のしきい値(_I):", true }
+        , m_button_reset_initial_threshold{ "リセット" }
+        , m_box_tool{ Gtk::ORIENTATION_HORIZONTAL, 0 }
+        , m_label_tool{ "選択した行に対する操作:" }
+        , m_button_delete{ "削除(_D)", true }
+        , m_menu_set_threshold{ Gio::Menu::create() }
+        , m_action_group{ Gio::SimpleActionGroup::create() }
+        , m_label_notes{ "・設定が無効のときはハッシュ値の計算やあぼ〜ん判定を行いません。\n"
+                         "・ハッシュ値を削除したりしきい値を変更してもあぼ〜んされた画像は解除されません。\n"
+                         "・判定基準のしきい値を大きくすると誤判定する可能性が高くなります。\n"
+                         "・マイナスのしきい値に設定したハッシュ値はあぼ〜んの判定を行いません。" }
+        , m_col{ -2 }
+    {
+        m_grid.set_row_spacing( 8 );
+        m_grid.set_column_spacing( 8 );
+        m_grid.attach( m_listbox, 0, 0, 2, 1 );
+        m_grid.attach( m_label_initial_threshold, 0, 1, 1, 1 );
+        m_grid.attach( m_hbox_initial_threshold, 1, 1, 1, 1 );
+        m_grid.attach( m_label_tool, 0, 2, 1, 1 );
+        m_grid.attach( m_box_tool, 1, 2, 1, 1 );
+
+        // 設定オプションのセットアップ
+        m_switch_enable_hash.set_active( CONFIG::get_enable_img_hash() );
+        m_switch_enable_hash.set_hexpand( false );
+        m_switch_enable_hash.set_valign( Gtk::ALIGN_CENTER );
+        m_switch_enable_hash.show();
+        m_label_enable_hash.set_halign( Gtk::ALIGN_START );
+        m_label_enable_hash.set_hexpand( true );
+        m_label_enable_hash.set_line_wrap( true );
+        m_label_enable_hash.set_mnemonic_widget( m_switch_enable_hash );
+        m_label_enable_hash.show();
+
+        m_label_enable_hash.set_ellipsize( Pango::ELLIPSIZE_END );
+
+        m_hbox_check_enable_hash.pack_start( m_label_enable_hash, Gtk::PACK_EXPAND_WIDGET );
+        m_hbox_check_enable_hash.pack_start( m_switch_enable_hash, Gtk::PACK_SHRINK );
+        m_hbox_check_enable_hash.pack_start( m_toggle_notes, Gtk::PACK_SHRINK );
+        m_hbox_check_enable_hash.show();
+
+        m_vbox_check_enable_hash.pack_start( m_hbox_check_enable_hash );
+        m_vbox_check_enable_hash.pack_start( m_revealer_notes );
+        m_vbox_check_enable_hash.show();
+        m_listbox.append( m_vbox_check_enable_hash );
+        m_listbox.set_selection_mode( Gtk::SELECTION_NONE );
+        m_listbox.signal_row_activated().connect( sigc::mem_fun( *this, &ImageHashTab::slot_listbox_row_activated ) );
+        m_listbox.show();
+
+        m_label_initial_threshold.set_halign( Gtk::ALIGN_START );
+        m_label_initial_threshold.set_ellipsize( Pango::ELLIPSIZE_END );
+        m_label_initial_threshold.set_mnemonic_widget( m_spin_initial_threshold );
+        m_label_initial_threshold.show();
+        m_spin_initial_threshold.set_increments( 1, 1 );
+        m_spin_initial_threshold.set_range( -1, 128 ); // -1: 判定しない、 128: 最大値
+        m_spin_initial_threshold.set_tooltip_text( "ハッシュ値を登録したとき設定する判定基準のしきい値" );
+        m_spin_initial_threshold.set_value( CONFIG::get_img_hash_initial_threshold() );
+        m_spin_initial_threshold.show();
+        m_button_reset_initial_threshold.show();
+        m_button_reset_initial_threshold.signal_clicked().connect(
+            sigc::mem_fun( *this, &ImageHashTab::slot_reset_initial_threshold ) );
+        m_hbox_initial_threshold.pack_start( m_spin_initial_threshold, Gtk::PACK_SHRINK );
+        m_hbox_initial_threshold.pack_start( m_button_reset_initial_threshold, Gtk::PACK_SHRINK );
+        m_hbox_initial_threshold.show();
+
+        m_label_tool.set_halign( Gtk::ALIGN_START );
+        m_label_tool.show();
+        m_button_delete.signal_clicked().connect( sigc::mem_fun( *this, &ImageHashTab::slot_delete ) );
+        m_button_delete.show();
+
+        m_action_group->add_action_with_parameter( "set-threshold", Glib::Variant<gint32>::variant_type(),
+                                                   sigc::mem_fun( *this, &ImageHashTab::slot_set_threshold ) );
+
+        // マジックナンバー 9999 は設定不可能な値で m_spin_initial_threshold が保持する値の代わり
+        m_menu_set_threshold->append( "初期設定", "image-hash.set-threshold(9999)" );
+        m_menu_set_threshold->append( "あぼ〜んしない(-1)", "image-hash.set-threshold(-1)" );
+        m_menu_set_threshold->append( "同一画像(0)", "image-hash.set-threshold(0)" );
+
+        m_button_set_threshold.set_label( "しきい値(_T)" );
+        m_button_set_threshold.set_use_underline( true );
+        m_button_set_threshold.set_menu_model( m_menu_set_threshold );
+        m_button_set_threshold.show();
+
+        m_button_copy.set_hexpand( false );
+        m_button_copy.set_image_from_icon_name( "edit-copy-symbolic" );
+        m_button_copy.set_tooltip_text( "選択した行をクリップボードにコピー" );
+        m_button_copy.signal_clicked().connect( sigc::mem_fun( *this, &ImageHashTab::slot_copy_clicked ) );
+        m_button_copy.show();
+
+        m_toggle_notes.set_label( "注意事項" );
+        m_toggle_notes.show();
+        m_label_notes.set_ellipsize( Pango::ELLIPSIZE_END );
+        m_label_notes.property_margin() = 4;
+        m_label_notes.show();
+        m_revealer_notes.add( m_label_notes );
+        m_revealer_notes.show();
+
+        m_binding_notes = Glib::Binding::bind_property( m_toggle_notes.property_active(),
+                                                        m_revealer_notes.property_reveal_child() );
+
+        m_label_num_of_items.set_ellipsize( Pango::ELLIPSIZE_END );
+        m_label_num_of_items.set_hexpand( false );
+        m_label_num_of_items.show();
+
+        m_box_tool.set_hexpand( true );
+        m_box_tool.pack_start( m_button_delete, Gtk::PACK_SHRINK );
+        m_box_tool.pack_start( m_button_set_threshold, Gtk::PACK_SHRINK );
+        m_box_tool.pack_start( m_button_copy, Gtk::PACK_SHRINK );
+        m_box_tool.pack_end( m_label_num_of_items, Gtk::PACK_SHRINK );
+        m_box_tool.show();
+
+        // あぼーん設定一覧のセットアップ
+        m_list_store = Gtk::ListStore::create( m_columns );
+        m_list_store->set_sort_column( Gtk::TreeSortable::DEFAULT_UNSORTED_COLUMN_ID,
+                                       Gtk::SortType::SORT_ASCENDING );
+        m_list_store->set_sort_func( 2, sigc::mem_fun( *this, &ImageHashTab::slot_compare_row_threshold ) );
+        m_list_store->set_sort_func( 3, sigc::mem_fun( *this, &ImageHashTab::slot_compare_row_last_matched ) );
+        m_list_store->set_sort_func( 4, sigc::mem_fun( *this, &ImageHashTab::slot_compare_row_source_url ) );
+        m_treeview.set_model( m_list_store );
+        m_treeview.get_selection()->set_mode( Gtk::SELECTION_MULTIPLE );
+
+        m_treeview.append_column_numeric( "ハッシュA", m_columns.m_col_hash_row, "%" PRIX64 );
+        m_treeview.append_column_numeric( "ハッシュB", m_columns.m_col_hash_col, "%" PRIX64 );
+        m_treeview.append_column_numeric_editable("しきい値", m_columns.m_col_threshold, "%d" );
+        m_treeview.append_column( "最後にマッチした日時", m_columns.m_col_last_matched );
+        m_treeview.append_column( "ハッシュのソースURL", m_columns.m_col_source_url );
+        const int num_column = m_treeview.append_column_numeric( "最後にマッチした日時(time_t)",
+                                                                 m_columns.m_col_last_matched_time, "%" PRId64 );
+        m_treeview.set_vexpand( true );
+        m_treeview.show();
+
+        Gtk::TreeView::Column* column = m_treeview.get_column( 2 );
+        column->set_clickable( true );
+        column->signal_clicked().connect( sigc::bind( sigc::mem_fun( *this, &ImageHashTab::slot_col_clicked ), 2 ) );
+        column = m_treeview.get_column( 3 );
+        column->set_clickable( true );
+        column->signal_clicked().connect( sigc::bind( sigc::mem_fun( *this, &ImageHashTab::slot_col_clicked ), 3 ) );
+        column = m_treeview.get_column( 4 );
+        column->set_clickable( true );
+        column->signal_clicked().connect( sigc::bind( sigc::mem_fun( *this, &ImageHashTab::slot_col_clicked ), 4 ) );
+
+        auto renderer = dynamic_cast<Gtk::CellRendererText*>( m_treeview.get_column_cell_renderer( 2 ) );
+        renderer->signal_edited().connect( sigc::mem_fun( *this, &ImageHashTab::slot_edited_threshold ) );
+
+        m_scroll.set_vexpand( true );
+        m_scroll.add( m_treeview );
+        m_scroll.show();
+
+        // 読み込んだあぼーん設定を一覧に追加
+        JDLIB::span<const DBIMG::AboneImgHash> span = DBIMG::get_span_abone_imghash();
+        for( const DBIMG::AboneImgHash& abone_imghash : span ) {
+            Gtk::TreeModel::Row row = *m_list_store->append();
+            row[ m_columns.m_col_hash_row ] = abone_imghash.dhash.row_hash;
+            row[ m_columns.m_col_hash_col ] = abone_imghash.dhash.col_hash;
+            row[ m_columns.m_col_threshold ] = abone_imghash.threshold;
+            row[ m_columns.m_col_last_matched ] = MISC::timettostr( abone_imghash.last_matched, MISC::TIME_WEEK );
+            row[ m_columns.m_col_source_url ] = abone_imghash.source_url;
+            row[ m_columns.m_col_last_matched_time ] = abone_imghash.last_matched;
+        }
+        m_label_num_of_items.set_text( Glib::ustring::compose( "設定数: %1", span.size() ) );
+        m_treeview.get_column( num_column - 1 )->set_visible( false );
+
+        m_box.set_hexpand( true );
+        m_box.set_vexpand( true );
+        m_box.property_margin() = 8;
+        m_box.insert_action_group( "image-hash", m_action_group );
+        m_box.pack_start( m_grid, Gtk::PACK_SHRINK );
+        m_box.pack_start( m_scroll, Gtk::PACK_EXPAND_WIDGET );
+        m_box.show();
+
+        m_treeview.grab_focus();
+    }
+
+    Gtk::Widget& get_widget() { return m_box; }
+
+    /**
+     * @brief ダイアログのOKボタンが押されたときに設定を反映する処理
+     */
+    void slot_ok_clicked()
+    {
+        CONFIG::set_enable_img_hash( m_switch_enable_hash.get_active() );
+        CONFIG::set_img_hash_initial_threshold( m_spin_initial_threshold.get_value_as_int() );
+        save_abone_imghash_list();
+    }
+
+private:
+
+    /**
+     * @brief 設定の状態をキャッシュに保存する
+     */
+    void save_abone_imghash_list()
+    {
+        Gtk::TreeModel::Children children = m_list_store->children();
+        std::vector<DBIMG::AboneImgHash> new_abone_imghash_list;
+        new_abone_imghash_list.reserve( children.size() );
+        for( const Gtk::TreeRow& row : children ) {
+            std::uint64_t row_hash = row[ m_columns.m_col_hash_row ];
+            std::uint64_t col_hash = row[ m_columns.m_col_hash_col ];
+            int threshold = row[ m_columns.m_col_threshold ];
+            Glib::ustring source_url = row[ m_columns.m_col_source_url ];
+            std::time_t last_matched = row[ m_columns.m_col_last_matched_time ];
+
+            new_abone_imghash_list.push_back(
+                DBIMG::AboneImgHash{ { row_hash, col_hash }, threshold, last_matched, source_url.raw() } );
+        }
+        DBIMG::update_abone_imghash_list( new_abone_imghash_list );
+        DBIMG::save_abone_imghash_list();
+    }
+
+    /**
+     * @brief ラベルをクリックしたときトグルボタンの状態を切り替える
+     */
+    void slot_listbox_row_activated( Gtk::ListBoxRow* )
+    {
+        m_switch_enable_hash.set_active( ! m_switch_enable_hash.get_active() );
+    }
+
+    /**
+     * @brief しきい値の初期設定をリセットする
+     */
+    void slot_reset_initial_threshold()
+    {
+        m_spin_initial_threshold.set_value( CONFIG::CONF_IMG_HASH_INITIAL_THRESHOLD );
+    }
+
+    /**
+     * @brief 選択された行の設定を取り除く
+     * @details ダイアログのOKボタンを押すまでキャッシュには反映されない。
+     */
+    void slot_delete()
+    {
+        std::vector<Gtk::TreeModel::Path> paths = m_treeview.get_selection()->get_selected_rows();
+        if( paths.empty() ) return;
+
+        SKELETON::MsgDiag mdiag( *m_parent, "削除しますか？", false, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO );
+        mdiag.set_secondary_text( "ハッシュ値を削除しても画像のあぼ〜んは維持されるため個別に解除する必要があります。" );
+        if( mdiag.run() != Gtk::RESPONSE_YES ) return;
+
+        // 先頭のiterから削除すると後続のイテレーターが指すiterがずれるため末尾のiterから削除していく
+        Gtk::TreeModel::iterator it_next = Gtk::TreeModel::const_iterator();
+        for( auto rit = paths.rbegin(); rit != paths.rend(); ++rit ) {
+            Gtk::TreeModel::iterator iter = m_list_store->get_iter( *rit );
+            if( ! iter ) continue;
+
+            it_next = m_list_store->erase( iter );
+        }
+
+        if( it_next ) {
+            m_treeview.get_selection()->select( it_next );
+        }
+        std::size_t n_children;
+        if( auto model = m_treeview.get_model(); model ) {
+            n_children = model->children().size();
+        }
+        else {
+            n_children = 0;
+        }
+        m_label_num_of_items.set_text( Glib::ustring::compose( "設定数: %1", n_children ) );
+    }
+
+    /**
+     * @brief 選択された行のしきい値に値をセットする
+     */
+    void slot_set_threshold( const Glib::VariantBase& threshold )
+    {
+        std::vector<Gtk::TreeModel::Path> paths = m_treeview.get_selection()->get_selected_rows();
+        if( paths.empty() ) return;
+
+        auto v = Glib::VariantBase::cast_dynamic<Glib::Variant<gint32>>( threshold );
+        gint32 value = v.get();
+        // マジックナンバー 9999 は設定不可能な値で m_spin_initial_threshold が保持する値の代わり
+        if( value == 9999 ) value = m_spin_initial_threshold.get_value_as_int();
+
+        for( Gtk::TreeModel::Path& path : paths ) {
+            Gtk::TreeModel::iterator it = m_list_store->get_iter( path );
+            if( ! it ) continue;
+
+            it->set_value( m_columns.m_col_threshold, value );
+        }
+    }
+
+    /**
+     * @brief 選択された行の設定をクリップボードにコピーする
+     */
+    void slot_copy_clicked()
+    {
+        std::vector<Gtk::TreeModel::Path> paths = m_treeview.get_selection()->get_selected_rows();
+        if( paths.empty() ) return;
+
+        Glib::ustring copied;
+
+        for( Gtk::TreeModel::Path& path : paths ) {
+            Gtk::TreeModel::iterator it = m_list_store->get_iter( path );
+            if( ! it ) continue;
+
+            Gtk::TreeModel::Row row = *it;
+            const std::uint64_t row_hash = row[ m_columns.m_col_hash_row ];
+            const std::uint64_t col_hash = row[ m_columns.m_col_hash_col ];
+            const int threshold = row[ m_columns.m_col_threshold ];
+            const std::size_t last_matched = row[ m_columns.m_col_last_matched_time ];
+            const Glib::ustring& source_url = row[ m_columns.m_col_source_url ];
+
+            copied.append( Glib::ustring::compose( "%1 %2 %3 %4 %5 %6\n",
+                                                   Glib::ustring::format(std::uppercase, std::hex, row_hash),
+                                                   Glib::ustring::format(std::uppercase, std::hex, col_hash),
+                                                   threshold, DBIMG::kImgHashReserved, last_matched, source_url ) );
+        }
+        MISC::CopyClipboard( copied.raw() );
+
+        // コピーしたことを表すためボタンのアイコンを2秒間チェックマークに変更する
+        constexpr int timeout_ms = 2000; // 単位はミリ秒
+        Glib::signal_timeout().connect_once( sigc::mem_fun( *this, &ImageHashTab::slot_button_timeout ), timeout_ms );
+        m_button_copy.set_image_from_icon_name( "object-select-symbolic" );
+    }
+
+    /**
+     * @brief コピーボタンのアイコンを元に戻す
+     */
+    void slot_button_timeout()
+    {
+        m_button_copy.set_image_from_icon_name( "edit-copy-symbolic" );
+    }
+
+    /**
+     * @brief 項目を比較するテンプレート関数
+     */
+    template<typename Col, typename T = typename Col::ElementType>
+    int slot_compare_row( const Gtk::TreeModel::iterator& a, const Gtk::TreeModel::iterator& b, const Col& col ) const
+    {
+        Gtk::TreeModel::Row row_a = *a;
+        Gtk::TreeModel::Row row_b = *b;
+        const T& value_a = row_a[ col ];
+        const T& value_b = row_b[ col ];
+        return value_a < value_b ? -1 : 1;
+    }
+
+    /**
+     * @brief 項目のしきい値を比較する
+     */
+    int slot_compare_row_threshold( const Gtk::TreeModel::iterator& a, const Gtk::TreeModel::iterator& b ) const
+    {
+        return slot_compare_row( a, b, m_columns.m_col_threshold );
+    }
+
+    /**
+     * @brief 項目の最後にマッチした日時を比較する
+     */
+    int slot_compare_row_last_matched( const Gtk::TreeModel::iterator& a, const Gtk::TreeModel::iterator& b ) const
+    {
+        return slot_compare_row( a, b, m_columns.m_col_last_matched_time );
+    }
+
+    /**
+     * @brief 項目のハッシュのソースURLを辞書順で比較する
+     */
+    int slot_compare_row_source_url( const Gtk::TreeModel::iterator& a, const Gtk::TreeModel::iterator& b ) const
+    {
+        return slot_compare_row( a, b, m_columns.m_col_source_url );
+    }
+
+    /**
+     * @brief 列の項目名をクリックしたときに一覧をソートする
+     */
+    void slot_col_clicked( const int col )
+    {
+        if( m_col != col ) {
+            m_list_store->set_sort_column( col, Gtk::SORT_ASCENDING );
+            m_previous_sortmode = Gtk::SORT_ASCENDING;
+        }
+        else if(  m_previous_sortmode == Gtk::SORT_ASCENDING ) {
+            m_list_store->set_sort_column( col, Gtk::SORT_DESCENDING );
+            m_previous_sortmode = Gtk::SORT_DESCENDING;
+        }
+        else {
+            m_list_store->set_sort_column( col, Gtk::SORT_ASCENDING );
+            m_previous_sortmode = Gtk::SORT_ASCENDING;
+        }
+        m_col = col;
+    }
+
+    /**
+     * @brief セルのしきい値を編集したときに値を正常な範囲に補正する
+     */
+    void slot_edited_threshold( const Glib::ustring& path, const Glib::ustring& new_text )
+    {
+        int new_value = std::atoi( new_text.c_str() );
+        if( new_value < -1 ) new_value = -1;
+        else if( new_value > 128 ) new_value = 128;
+        else return;
+
+        auto it = m_list_store->get_iter( path );
+        it->set_value( m_columns.m_col_threshold, new_value );
+    }
+};
+
+} // namespace CORE
+
+#endif // JDIM_IMAGEHASHTAB_H

--- a/src/jdlib/miscgtk.h
+++ b/src/jdlib/miscgtk.h
@@ -42,6 +42,9 @@ namespace MISC
 
     // ウィジェット左上隅を基準としたマウスポインターの座標を取得
     Glib::RefPtr<Gdk::Window> get_pointer_at_window( const Glib::RefPtr<const Gdk::Window>& window, int& x, int& y );
+
+    // 画像データをグレイスケール(白黒)画像に変換する
+    Glib::RefPtr<Gdk::Pixbuf> convert_to_grayscale( const Gdk::Pixbuf& pixbuf );
 }
 
 #endif


### PR DESCRIPTION
画像のハッシュ値を計算して類似する画像をあぼ〜んする機能を実装します。

関連のissue: #1388

### ConfigItems: Implement config for image hash initial threshold

NG 画像ハッシュの初期設定のしきい値を記憶する設定と値の取得・設定するインターフェース関数を実装します。
初期設定のデフォルト値は 30 です。

しきい値の取る範囲は 0 が最小(すべてのビットが一致する＝同一画像の判定)、128 が最大(すべてのビットが一致しない)となります。
また、マイナスの値は判定を行わない設定に使用します。

### ConfigItems: Implement boolean flag config for enabling image hash

NG 画像ハッシュが有効か否かを表す真偽値(有効・無効)の設定を実装します。
有効にすると、画像のハッシュ値を計算してNG 画像ハッシュとの差がしきい値以下の画像をあぼ〜んします。
また、値の取得・設定するインターフェース関数を実装します。
設定のデフォルト値は無効です。

### Implement MISC::convert_to_grayscale()

GdkPixbufの画像データをグレイスケール(白黒)画像に変換する関数を実装します。

### Implement base system of NG image hash

画像データクラス(`DBIMG::Img`)に画像のハッシュ値(dHash)を記憶するメンバー変数を追加します。
また、ハッシュ値の取得・設定を行う処理やキャッシュ情報ファイルの保存・読み込みを行う処理を実装します。

画像データベースのルートクラス(`DBIMG::ImgRoot`)にあぼーんした画像のハッシュ値(NG 画像ハッシュ)を記憶するメンバー変数を追加します。
また、以下の処理を実装しインターフェース関数を作成します。

- NG 画像ハッシュのリストを取得する
- 画像データベースにNG 画像ハッシュを登録、更新する
- NG 画像ハッシュの設定ファイルを保存・読み込む
- 画像のハッシュ値がNG 画像ハッシュとマッチするかテストする
  - NGのしきい値がマイナスの値ならテストしない
  - ハミング距離がしきい値以下のときはあぼーんする
  - あぼーんしたときは最後にマッチした日時を現在時刻に更新する
  - 画像のキャッシュが保護されているときはテストしない
- 画像データからハッシュ値を計算する
- 2つのハッシュ値からハミング距離を計算する

#### 背景事情
修正前でも画像URLを右クリックしてあぼーんすることができますが、一度表示しないとあぼーんの判別ができません。
また、同じ画像でもURLを変えて書き込まれているパターンだとURLのあぼ〜んでは対応が困難となっています。

そのため、画像の特徴をハッシュ値として計算してNG登録し、その後、登録したハッシュ値と比較を行い判定基準を超えた類似画像をあぼ〜んする機能を追加します。

#### 画像のハッシュ値を求めるアルゴリズム
dHashを利用しています。計算があまり複雑でなく他のアルゴリズムよりハッシュのデータが長いため判定基準のしきい値を大きくして許容範囲を広げても誤判定が増えにくいと判断しました。

### ImageAreaBase: Add dHash calculation and abone by NG image hash

画像クラスのベースクラス(`IMAGE::ImageAreaBase`)に画像のdHash計算とNG 画像ハッシュとマッチするかテストする処理を追加します。

画像のハッシュ値を有効にする設定(`CONFIG::get_enable_img_hash()`)がtrueのときは、画像を読み込んで表示する処理の中でハッシュ値を計算してNG 画像ハッシュとマッチするかテストします。

#### 画像のハッシュ値を計算してNGをチェックする場所、タイミングについて

画像のキャッシュ情報を扱う`DBIMG::Img`クラスは画像をダウンロードする機能がありますが、取得したバイナリデータはjpeg、png、gifなど各々の画像形式で圧縮されています。
ハッシュ値の計算を行うにはピクセル単位でアクセスできるフォーマットに変換する必要があるためImgクラスの中でハッシュ値の計算をするとクラスが肥大化します。

GTKで画像を扱うときはGdkPixbufを介して行います。
GdkPixbufはピクセル単位でアクセスするAPIが用意されているため、画像のバイナリデータからGdkPixbufを構築する処理がある画像を表示するクラスの処理の中でハッシュ値の計算を行うことにしました。

GdkPixbufを構築するタイミングは画像を表示する直前なので表示済みの画像はNG 画像ハッシュのチェックが発生しません。
画像をポップアップ表示する、画像を一度閉じて開き直す、JDimを再起動するなどGdkPixbufの構築を起こせばNGのチェックが発動します。

### IMAGE::Preferences: Add image hash property

画像のプロパティに画像のハッシュ値を表示するように修正します。
ハッシュ値が計算されていないときは空欄になります。

ハッシュ値に関して以下の操作を行うことができます。

- NG 画像ハッシュの設定をクリップボードにコピーしたい場合は、コピーボタンをクリックします。
- 画像をNG 画像ハッシュに追加したい場合は、NG 画像ハッシュに追加するチェックボックスを有効にしてダイアログのOKボタンを押します。

画像の右クリックメニューは項目が多くマウスポインターの移動距離が長くなっているためNG 画像ハッシュに追加する処理はプロパティの中に追加します。

### Implement CORE::ImageHashTab to display and modify image hash settings

全体あぼーん設定(対象: スレビュー)のダイアログに「NG 画像ハッシュ」のタブを追加します。
タブにはNG 画像ハッシュの一覧といくつかの設定があります。
ダイアログのOKボタンをクリックするとNG 画像ハッシュの設定が更新されます。

#### ユーザーインターフェース
- NG 画像ハッシュを有効にするスイッチ (デフォルト設定はoff)
- 初期設定のしきい値を設定するためのスピンボタンとリセットボタン
  しきい値の有効範囲は [-1, 128], リセットしたときの値は 30
- ハッシュ値を操作するためのボタン（削除、しきい値設定、コピー）
  項目の複数選択で一括操作が可能
- 注意事項を表示するトグルボタン
- NG 画像ハッシュ一覧を表示するツリービュー
  - ハッシュA、ハッシュB
  - しきい値 (クリックで編集可能、Enterキーで決定)
  - 最後にマッチした日時
  - ハッシュのソースURL
- ツリービューの列名をクリックすると項目をソートする
  しきい値、最後にマッチした日時、ハッシュのソースURLに対応

現状の実装ではNG 画像ハッシュでテストするときツリービューの上から順番に判定を行います。

### ImgRoot: Add default NG settings for image hash

NG 画像ハッシュのデフォルト設定を追加します。

デフォルト設定は設定ファイルが見つからないときに読み込まれます。
設定ファイルを初期状態に戻すときはキャッシュディレクトリの中にある `image_abone/dhash_list.txt` を削除してからJDimを起動してください。

- デフォルト設定の最後にマッチした日時は 2000-01-01 09:00:00 JST に設定
- デフォルト設定の目印としてハッシュのソースURLに U+2699 GEAR を追加

デフォルト設定でNGするのは大量にレスを投稿する荒らしが繰り返し書き込んでいたグロテスク・ゴア・残虐な画像です。
