### PR TITLE
Record abone reason for NG image hash and show it on dialog or popup

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -2240,6 +2240,11 @@ void ArticleViewBase::slot_on_url( const std::string& url, const std::string& im
         // あぼーん
         if( DBIMG::get_abone( imgurl ) ){
             args.arg1 = "あぼ〜んされています";
+            std::string abone_reason = DBIMG::get_img_abone_reason( imgurl );
+            if( ! abone_reason.empty() ) {
+                args.arg1.append( "<br>" );
+                args.arg1.append( MISC::replace_str( abone_reason, "://", "&#58;//" ) );
+            }
             view_popup = CORE::ViewFactory( CORE::VIEW_ARTICLEPOPUPHTML, m_url_article, args );
         }
 
@@ -2736,6 +2741,11 @@ bool ArticleViewBase::click_url( std::string url, int res_number, GdkEventButton
 
         else if( DBIMG::get_abone( url )){
             SKELETON::MsgDiag mdiag( get_parent_win(), "あぼ〜んされています" );
+            std::string abone_reason = DBIMG::get_img_abone_reason( url );
+            if( ! abone_reason.empty() ) {
+                abone_reason = MISC::replace_str( abone_reason, "<br>", "\n" );
+                mdiag.set_secondary_text( abone_reason );
+            }
             mdiag.run();
         }
 

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -2171,6 +2171,11 @@ bool BBSListViewBase::open_row( Gtk::TreePath& path, const bool tab )
 
             if( DBIMG::get_abone( url )){
                 SKELETON::MsgDiag mdiag( get_parent_win(), "あぼ〜んされています" );
+                std::string abone_reason = DBIMG::get_img_abone_reason( url );
+                if( ! abone_reason.empty() ) {
+                    abone_reason = MISC::replace_str( abone_reason, "<br>", "\n" );
+                    mdiag.set_secondary_text( abone_reason );
+                }
                 mdiag.run();
             }
             else{

--- a/src/dbimg/img.cpp
+++ b/src/dbimg/img.cpp
@@ -220,12 +220,13 @@ bool Img::is_cached() const
 }
 
 
-//
-// あぼーん状態セット
-//
-// キャッシュに無くてもinfoを作るので is_cached() でチェックしない
-//
-void Img::set_abone( bool abone )
+/** @brief あぼーん状態セット
+ *
+ * @details キャッシュに無くてもinfoを作るので is_cached() でチェックしない
+ * @param[in] abone        trueならあぼーんする, falseなら解除する
+ * @param[in] abone_reason あぼーんした理由のテキスト
+ */
+void Img::set_abone( bool abone, const std::string& abone_reason )
 {
     if( m_abone == abone ) return;
 
@@ -235,6 +236,7 @@ void Img::set_abone( bool abone )
 
     if( abone ) clear();
     m_abone = abone;
+    m_abone_reason = abone_reason;
     save_info();
 }
 
@@ -868,6 +870,16 @@ void Img::read_info()
         }
         set_current_length( total_length() );
     }
+    else if( m_abone ) {
+        std::string str_info;
+        CACHE::load_rawdata( path_info, str_info );
+
+        std::size_t i = str_info.find( "abone_reason = " );
+        if( i != std::string::npos ) {
+            i += 15;
+            m_abone_reason = str_info.substr( i, str_info.find( '\n', i ) - i );
+        }
+    }
 
 #ifdef _DEBUG
     std::cout << "path_info = " << path_info << std::endl;
@@ -927,7 +939,8 @@ void Img::save_info()
         << "height = " << m_height << std::endl
         << "dhash_row = " << std::uppercase << std::hex << (m_dhash.has_value() ? m_dhash->row_hash : 0) << std::endl
         << "dhash_col = " << std::uppercase << std::hex << (m_dhash.has_value() ? m_dhash->col_hash : 0)
-        << std::nouppercase << std::dec << std::endl;
+        << std::nouppercase << std::dec << std::endl
+        << "abone_reason = " << m_abone_reason << std::endl;
 
 #ifdef _DEBUG
     std::cout << "Img::save_info file = " << path_info << std::endl;

--- a/src/dbimg/img.h
+++ b/src/dbimg/img.h
@@ -57,6 +57,7 @@ namespace DBIMG
         FILE* m_fout{};
 
         std::optional<DHash> m_dhash{}; ///< 画像のハッシュ値
+        std::string m_abone_reason; ///< あぼーんした理由のテキスト
 
       public:
 
@@ -93,7 +94,7 @@ namespace DBIMG
         bool is_cached() const;
 
         bool get_abone() const { return m_abone; }
-        void set_abone( bool abone );
+        void set_abone( bool abone, const std::string& abone_reason = {} );
 
         bool get_mosaic() const { return m_mosaic; }
         void set_mosaic( const bool mosaic );
@@ -118,6 +119,8 @@ namespace DBIMG
 
         void set_dhash( const DHash& dhash );
         const std::optional<DHash>& get_dhash() const noexcept { return m_dhash; }
+
+        std::string get_abone_reason() const noexcept { return m_abone_reason; }
 
         // ロード開始
         // receive_data()　と receive_finish() がコールバックされる

--- a/src/dbimg/imginterface.cpp
+++ b/src/dbimg/imginterface.cpp
@@ -102,6 +102,14 @@ std::string DBIMG::get_cache_path( const std::string& url )
     return std::string();
 }
 
+std::string DBIMG::get_img_abone_reason( const std::string& url )
+{
+    const DBIMG::Img* img = DBIMG::get_img( url );
+    if( img ) return img->get_abone_reason();
+
+    return std::string{};
+}
+
 
 std::optional<DBIMG::DHash> DBIMG::get_dhash( const std::string& url )
 {

--- a/src/dbimg/imginterface.h
+++ b/src/dbimg/imginterface.h
@@ -82,6 +82,7 @@ namespace DBIMG
 
     DBIMG::Img* get_img( const std::string& url );
     std::string get_cache_path( const std::string& url );
+    std::string get_img_abone_reason( const std::string& url );
 
     std::optional<DBIMG::DHash> get_dhash( const std::string& url );
     JDLIB::span<const AboneImgHash> get_span_abone_imghash();

--- a/src/dbimg/imgroot.cpp
+++ b/src/dbimg/imgroot.cpp
@@ -511,7 +511,8 @@ bool ImgRoot::test_imghash( Img& img )
     for( auto& [abone_dhash, threshold, last_matched, source_url] : m_vec_abone_imghash ) {
         if( threshold < 0 ) continue;
 
-        if( calc_hamming_distance( abone_dhash, *dhash ) <= threshold ) {
+        const int distance = calc_hamming_distance( abone_dhash, *dhash );
+        if( distance <= threshold ) {
             last_matched = std::time( nullptr );
             std::string url = img.url();
             ss.str("");
@@ -523,6 +524,10 @@ bool ImgRoot::test_imghash( Img& img )
                << " (しきい値: " << threshold
                << ")<br>" << source_url
                << " の類似画像です。";
+#ifdef JDIM_DEVTOOLS
+            // 開発者向けの機能: あぼーん判定理由にハッシュ値を比較した計算結果を追加
+            ss << "(相違度: " << distance << ")";
+#endif
             img.set_abone( true, ss.str() );
             delete_cache( url );
 #ifdef _DEBUG

--- a/src/history/historysubmenu.cpp
+++ b/src/history/historysubmenu.cpp
@@ -170,6 +170,11 @@ bool HistorySubMenu::open_history( const unsigned int i )
 
                 if( DBIMG::get_abone( info_list[ i ].url )){
                     SKELETON::MsgDiag mdiag( nullptr, "あぼ〜んされています" );
+                    std::string abone_reason = DBIMG::get_img_abone_reason( info_list[i].url );
+                    if( ! abone_reason.empty() ) {
+                        abone_reason = MISC::replace_str( abone_reason, "<br>", "\n" );
+                        mdiag.set_secondary_text( abone_reason );
+                    }
                     mdiag.run();
                 }
                 else{


### PR DESCRIPTION
### Record abone reason for NG image hash and show it on dialog or popup

NG 画像ハッシュであぼーんされた画像は判定理由をキャッシュ情報ファイルに記録するように変更します。

また、NG 画像ハッシュであぼーんされた画像のURLをクリックしたときに出るダイアログボックスや、URLをマウスオーバーしたときに出るポップアップにあぼーんされた理由を表示するように変更します。

#### あぼーん理由の書式
`NG 画像ハッシュ XXX XXX (しきい値: NNN)<br>(URL) の類似画像です。`

修正前は画像URLをあぼーんしたのか、NG 画像ハッシュであぼーんしたのか判別が付かない状態でした。
NG 画像ハッシュの情報を記録することで画像やスレッドの状態が判断できるようにします。

### Add aboned image hash distance calculation when `JDIM_DEVTOOLS` is defined

JDimをビルドするときに`JDIM_DEVTOOLS`マクロを定義すると開発者向けの機能が有効にます。
有効にするとNG 画像ハッシュのあぼーん判定理由を記録するときにハッシュ値を比較した計算結果(相違度)が追加されます。

関連のissue: #1388
