### PR TITLE
Implement grayscale display for mosaic images

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -2656,6 +2656,11 @@ bool DrawAreaBase::draw_one_img_node( LAYOUT* layout, const CLIPINFO& ci )
                     const int mosheight = img->get_height_mosaic();
 
                     if( moswidth && mosheight ){
+                        if( CONFIG::get_use_grayscale_mosaic() ) {
+                            // グレースケール化
+                            Glib::RefPtr<Gdk::Pixbuf> gray = MISC::convert_to_grayscale( *pixbuf.get() );
+                            pixbuf = std::move( gray );
+                        }
 
                         Glib::RefPtr< Gdk::Pixbuf > pixbuf2;
                         pixbuf2 = pixbuf->scale_simple( moswidth, mosheight, Gdk::INTERP_NEAREST );

--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -336,6 +336,7 @@ void AboutConfig::append_rows()
     append_row( "指定したサイズ(M byte)より大きい画像を表示するときに警告する", get_confitem()->max_img_size, CONF_MAX_IMG_SIZE );
     append_row( "指定した画素数(M pixel)より大きい画像を表示するときに警告する", get_confitem()->max_img_pixel, CONF_MAX_IMG_PIXEL );
     append_row( "モザイクのレベル", get_confitem()->mosaic_size, CONF_MOSAIC_SIZE );
+    append_row( "(実験的な機能) 画像をモザイクで開くときはグレースケール(白黒)で表示する", get_confitem()->use_grayscale_mosaic, CONF_USE_GRAYSCALE_MOSAIC );
     append_row( "画像ビューのスムージングレベル(0-2, 大きい程高画質で低速)", get_confitem()->imgmain_interp, CONF_IMGMAIN_INTERP );
     append_row( "インライン画像のスムージングレベル(0-2, 大きい程高画質で低速)", get_confitem()->imgemb_interp, CONF_IMGEMB_INTERP );
     append_row( "インライン画像の最大幅", get_confitem()->embimg_width, CONF_EMBIMG_WIDTH );

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -218,6 +218,9 @@ bool ConfigItems::load( const bool restore )
     // モザイクの大きさ
     mosaic_size = cf.get_option_int( "mosaic_size", CONF_MOSAIC_SIZE, 1, 1024 );
 
+    // 画像をモザイクで開くときはグレースケール(白黒)で表示する
+    use_grayscale_mosaic = cf.get_option_bool( "use_grayscale_mosaic", CONF_USE_GRAYSCALE_MOSAIC );
+
     // 画像をデフォルトでウィンドウサイズに合わせる
     zoom_to_fit = cf.get_option_bool( "zoom_to_fit", CONF_ZOOM_TO_FIT );
 
@@ -778,6 +781,7 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "show_delimgdiag", show_delimgdiag );
     cf.update( "use_mosaic", use_mosaic );
     cf.update( "mosaic_size", mosaic_size );
+    cf.update( "use_grayscale_mosaic", use_grayscale_mosaic );
     cf.update( "zoom_to_fit", zoom_to_fit );
     cf.update( "del_img_day", del_img_day );
     cf.update( "del_imgabone_day", del_imgabone_day );

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -163,6 +163,9 @@ namespace CONFIG
         // 画像のサイズがmosaic_sizeより小さい場合はモザイクをかけない
         int mosaic_size{};
 
+        /// @brief 画像をモザイクで開くときはグレースケール(白黒)で表示する
+        bool use_grayscale_mosaic{};
+
         // 画像をデフォルトでウィンドウサイズに合わせる
         bool zoom_to_fit{};
 

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -130,6 +130,7 @@ namespace CONFIG
         CONF_SHOW_DELIMGDIAG = 1 ,     // 画像ビューでdeleteを押したときに確認ダイアログを表示する
         CONF_USE_MOSAIC = 1,        // 画像にモザイクをかける
         CONF_MOSAIC_SIZE = 60,        // モザイクの大きさ
+        CONF_USE_GRAYSCALE_MOSAIC = 0, ///< 画像をモザイクで開くときはグレースケール(白黒)で表示する
         CONF_ZOOM_TO_FIT = 1,       // 画像をデフォルトでウィンドウサイズに合わせる
         CONF_DEL_IMG_DAY = 20,      // 画像キャッシュ削除の日数
         CONF_DEL_IMGABONE_DAY = 20, // 画像あぼーん削除の日数

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -292,6 +292,7 @@ void CONFIG::set_show_delimgdiag( const bool show ){ get_confitem()->show_delimg
 bool CONFIG::get_use_mosaic(){ return get_confitem()->use_mosaic; }
 void CONFIG::set_use_mosaic( const bool mosaic ) { get_confitem()->use_mosaic = mosaic; }
 int CONFIG::get_mosaic_size(){ return get_confitem()->mosaic_size; }
+bool CONFIG::get_use_grayscale_mosaic(){ return get_confitem()->use_grayscale_mosaic; }
 bool CONFIG::get_zoom_to_fit(){ return get_confitem()->zoom_to_fit; }
 void CONFIG::set_zoom_to_fit( const bool fit ){ get_confitem()->zoom_to_fit = fit; }
 int CONFIG::get_del_img_day(){ return get_confitem()->del_img_day; }

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -283,6 +283,9 @@ namespace CONFIG
     // モザイクの大きさ
     int get_mosaic_size();
 
+    /// @brief 画像をモザイクで開くときはグレースケール(白黒)で表示する
+    bool get_use_grayscale_mosaic();
+
     // 画像をデフォルトでウィンドウサイズに合わせる
     bool get_zoom_to_fit();
     void set_zoom_to_fit( const bool fit );

--- a/src/image/imageareabase.cpp
+++ b/src/image/imageareabase.cpp
@@ -5,6 +5,7 @@
 
 #include "imageareabase.h"
 
+#include "jdlib/miscgtk.h"
 #include "jdlib/miscmsg.h"
 
 #include "dbimg/imginterface.h"
@@ -267,6 +268,11 @@ void ImageAreaBase::set_mosaic( Glib::RefPtr< Gdk::Pixbuf > pixbuf )
     const int mosheight = get_img()->get_height_mosaic();
 
     if( moswidth && mosheight ){
+        if( CONFIG::get_use_grayscale_mosaic() ) {
+            // グレースケール化
+            Glib::RefPtr<Gdk::Pixbuf> gray = MISC::convert_to_grayscale( *pixbuf.get() );
+            pixbuf = std::move( gray );
+        }
 
         Glib::RefPtr< Gdk::Pixbuf > pixbuf2;
         pixbuf2 = pixbuf->scale_simple( moswidth, mosheight, Gdk::INTERP_NEAREST );

--- a/src/image/imageareaicon.h
+++ b/src/image/imageareaicon.h
@@ -22,6 +22,7 @@ namespace IMAGE
     class ImageAreaIcon : public ImageAreaBase
     {
         bool m_shown{};
+        bool m_use_grayscale_mosaic{};
         int m_imagetype{}; // dispatch()前に表示する画像を入れる
 
         Glib::RefPtr< Gdk::Pixbuf > m_pixbuf;


### PR DESCRIPTION
### Add "Use grayscale color scheme for mosaic image" to about:config

about:config に「画像をモザイクで開くときはグレースケール(白黒)で表示する」設定(はい・いいえ)を追加します。

- 「はい」は画像をモザイクで開くときはグレースケール(白黒)で表示する
- 「いいえ」は画像をモザイクで開くときはカラーで表示する(従来の動作)

デフォルト設定は「いいえ」(従来の動作)にします。

この機能は実験的なサポートとして追加します。
設定や動作は変更または廃止の可能性があります。

### Implement grayscale display for mosaic images

about:config の「画像をモザイクで開くときはグレースケール(白黒)で表示する」設定が"はい"のときに画像をグレースケール化する処理を実装します。

画像をモザイクで表示するとき元の画像の色彩の印象をそのまま受けます。
白黒で表示すると印象が和らぐかもしれません。

関連のissue: #1388
