### PR TITLE
Implement force mosaic mode for image abone

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -2740,13 +2740,34 @@ bool ArticleViewBase::click_url( std::string url, int res_number, GdkEventButton
         }
 
         else if( DBIMG::get_abone( url )){
-            SKELETON::MsgDiag mdiag( get_parent_win(), "あぼ〜んされています" );
+            SKELETON::MsgDiag mdiag( get_parent_win(), "あぼ〜んされています", false,
+                                     Gtk::MESSAGE_INFO, Gtk::BUTTONS_YES_NO );
             std::string abone_reason = DBIMG::get_img_abone_reason( url );
             if( ! abone_reason.empty() ) {
                 abone_reason = MISC::replace_str( abone_reason, "<br>", "\n" );
-                mdiag.set_secondary_text( abone_reason );
+                abone_reason.append( "\n\n" );
             }
-            mdiag.run();
+            abone_reason.append( DBIMG::kTemporaryMosaicQuestion );
+            mdiag.set_secondary_text( abone_reason );
+            const int response = mdiag.run();
+            if( response == Gtk::RESPONSE_YES ) {
+
+                const bool open_imageview{ ! sssp // sssp の時は画像ビューを開かない
+                                           && CONFIG::get_use_image_view()
+                                           && ( control.button_alloted( event, CONTROL::ClickButton )
+                                                || control.button_alloted( event, CONTROL::OpenBackImageButton ) ) };
+
+                const bool open_browser{ ! open_imageview
+                                         && control.button_alloted( event, CONTROL::ClickButton ) };
+
+                const bool mosaic{ ! sssp }; // sssp の時はモザイクをかけない
+
+                // 画像ビューに切り替える
+                const bool switch_image{ open_imageview
+                                         && ! control.button_alloted( event, CONTROL::OpenBackImageButton ) };
+
+                open_image( url, res_number, open_imageview, open_browser, mosaic, switch_image );
+            }
         }
 
         else if( DBIMG::get_type_real( url ) == DBIMG::T_LARGE ){

--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -2760,13 +2760,14 @@ bool ArticleViewBase::click_url( std::string url, int res_number, GdkEventButton
                 const bool open_browser{ ! open_imageview
                                          && control.button_alloted( event, CONTROL::ClickButton ) };
 
-                const bool mosaic{ ! sssp }; // sssp の時はモザイクをかけない
+                const int mosaic_mode{ sssp ? 0 // sssp の時はモザイクをかけない
+                                            : DBIMG::kForceMosaic };
 
                 // 画像ビューに切り替える
                 const bool switch_image{ open_imageview
                                          && ! control.button_alloted( event, CONTROL::OpenBackImageButton ) };
 
-                open_image( url, res_number, open_imageview, open_browser, mosaic, switch_image );
+                open_image( url, res_number, open_imageview, open_browser, mosaic_mode, switch_image );
             }
         }
 
@@ -2832,11 +2833,12 @@ bool ArticleViewBase::click_url( std::string url, int res_number, GdkEventButton
 // 画像表示
 //
 void ArticleViewBase::open_image( const std::string& url, const int res_number,
-                                  const bool open_imageview, const bool open_browser, const bool mosaic, const bool switch_image )
+                                  const bool open_imageview, const bool open_browser,
+                                  const int mosaic_mode, const bool switch_image )
 {
 #ifdef _DEBUG
     std::cout << "ArticleViewBase::open_image url = " << url << " num = " << res_number
-              << " open_view = " << open_imageview << " open_browser = " << open_browser << " mosaic = " << mosaic
+              << " open_view = " << open_imageview << " open_browser = " << open_browser << " mosaic = " << mosaic_mode
               << " switch_image = " << switch_image << std::endl;
 #endif
 
@@ -2845,7 +2847,7 @@ void ArticleViewBase::open_image( const std::string& url, const int res_number,
     // キャッシュに無かったらロード
     if( ! DBIMG::is_cached( url ) ){
 
-        DBIMG::download_img( url, DBTREE::url_readcgi( m_url_article, res_number, 0 ), mosaic );
+        DBIMG::download_img( url, DBTREE::url_readcgi( m_url_article, res_number, 0 ), mosaic_mode );
 
         // ポップアップ表示してダウンロードサイズを表示
         hide_popup();
@@ -2859,7 +2861,7 @@ void ArticleViewBase::open_image( const std::string& url, const int res_number,
     // 画像ビューを開く
     if( open_imageview ){
 
-        CORE::core_set_command( "open_image", url );
+        CORE::core_set_command( "open_image", url, mosaic_mode == DBIMG::kForceMosaic ? "force_mosaic" : "" );
         if( ! load && switch_image ) CORE::core_set_command( "switch_image" );
     }
 
@@ -4107,10 +4109,10 @@ void ArticleViewBase::slot_show_image_with_mosaic()
 
     const bool open_imageview = CONFIG::get_use_image_view();
     const bool open_browser = ! open_imageview;
-    const bool mosaic = true;
+    constexpr int mosaic_mode = DBIMG::kForceMosaic;
     const bool switch_image = open_imageview;
 
-    open_image( m_url_tmp, res_number, open_imageview, open_browser, mosaic, switch_image );
+    open_image( m_url_tmp, res_number, open_imageview, open_browser, mosaic_mode, switch_image );
 }
 
 

--- a/src/article/articleviewbase.h
+++ b/src/article/articleviewbase.h
@@ -340,7 +340,8 @@ namespace ARTICLE
         void slot_leave_url();
         bool click_url( std::string url, int res_number, GdkEventButton* event );
         void open_image( const std::string& url, const int res_number,
-                         const bool open_imageview, const bool open_browser, const bool mosaic, const bool switch_image );
+                         const bool open_imageview, const bool open_browser,
+                         const int mosaic_mode, const bool switch_image );
 
         // 画像ポップアップメニュー用
         void slot_cancel_mosaic();

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -2152,6 +2152,8 @@ bool BBSListViewBase::open_row( Gtk::TreePath& path, const bool tab )
 
     if( type != TYPE_DIR && url.empty() ) return false;
 
+    bool open_image = false;
+    std::string open_mode;
     switch( type ){
 
         case TYPE_BOARD:
@@ -2169,17 +2171,28 @@ bool BBSListViewBase::open_row( Gtk::TreePath& path, const bool tab )
 
         case TYPE_IMAGE:
 
-            if( DBIMG::get_abone( url )){
-                SKELETON::MsgDiag mdiag( get_parent_win(), "あぼ〜んされています" );
+            if( DBIMG::get_abone( url ) ) {
+                SKELETON::MsgDiag mdiag( get_parent_win(), "あぼ〜んされています", false,
+                                         Gtk::MESSAGE_INFO, Gtk::BUTTONS_YES_NO );
                 std::string abone_reason = DBIMG::get_img_abone_reason( url );
                 if( ! abone_reason.empty() ) {
                     abone_reason = MISC::replace_str( abone_reason, "<br>", "\n" );
-                    mdiag.set_secondary_text( abone_reason );
+                    abone_reason.append( "\n\n" );
                 }
-                mdiag.run();
+                abone_reason.append( DBIMG::kTemporaryMosaicQuestion );
+                mdiag.set_secondary_text( abone_reason );
+                const int response = mdiag.run();
+                if( response == Gtk::RESPONSE_YES ) {
+                    open_image = true;
+                    open_mode = "force_mosaic";
+                }
             }
-            else{
-                CORE::core_set_command( "open_image", url );
+            else {
+                open_image = true;
+            }
+
+            if( open_image ) {
+                CORE::core_set_command( "open_image", url, open_mode );
                 CORE::core_set_command( "switch_image" );
             }
             break;

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -2753,8 +2753,9 @@ void Core::set_command( const COMMAND_ARGS& command )
 
         // キャッシュに無かったらロード
         if( ! DBIMG::is_cached( command.url ) && ! DBIMG::is_loading( command.url ) && ! DBIMG::is_wait( command.url ) ){
-            const bool mosaic = CONFIG::get_use_mosaic();
-            DBIMG::download_img( command.url, std::string(), mosaic );
+            const int mosaic_mode = ( command.arg1 == "force_mosaic" ) ? DBIMG::kForceMosaic : CONFIG::get_use_mosaic();
+
+            DBIMG::download_img( command.url, std::string(), mosaic_mode );
         }
 
         IMAGE::get_admin()->set_command( "open_view", command.url );

--- a/src/dbimg/img.h
+++ b/src/dbimg/img.h
@@ -43,6 +43,7 @@ namespace DBIMG
         int m_height_mosaic;
 
         bool m_mosaic; // モザイクかける
+        bool m_force_mosaic{}; ///< true なら強制的にモザイク表示するモード
         bool m_zoom_to_fit; // windowにサイズをあわせる
         int m_size; // 画像の大きさ(パーセントで)
         bool m_protect; // true ならキャッシュを保護する( delete_cache()で削除しない )
@@ -99,6 +100,8 @@ namespace DBIMG
         bool get_mosaic() const { return m_mosaic; }
         void set_mosaic( const bool mosaic );
 
+        bool is_force_mosaic() const noexcept { return m_force_mosaic; }
+
         void show_large_img();
 
         bool is_zoom_to_fit() const { return m_zoom_to_fit; }
@@ -125,9 +128,10 @@ namespace DBIMG
         // ロード開始
         // receive_data()　と receive_finish() がコールバックされる
         // refurl : 参照元のスレのアドレス
-        // mosaic : モザイク表示するか
+        // mosaic_mode : モザイク表示するか
+        //               ( 0: モザイク表示しない, 1: モザイク表示する, 2: 強制的にモザイク表示する )
         // waitsec: 指定した秒数経過後にロード開始
-        void download_img( const std::string& refurl, const bool mosaic, const int waitsec );
+        void download_img( const std::string& refurl, const int mosaic_mode, const int waitsec );
 
         // ロード停止
         void stop_load() override;
@@ -140,7 +144,7 @@ namespace DBIMG
         void receive_finish() override;
 
         // ロード待ち状態セット/リセット
-        bool set_wait( const std::string& refurl, const bool mosaic, const int waitsec );
+        bool set_wait( const std::string& refurl, const int mosaic_mode, const int waitsec );
         void reset_wait();
 
         // 埋め込み画像のサイズを計算

--- a/src/dbimg/imginterface.cpp
+++ b/src/dbimg/imginterface.cpp
@@ -160,10 +160,10 @@ DBIMG::DHash DBIMG::calc_dhash_from_pixbuf( const Gdk::Pixbuf& pixbuf )
 }
 
 
-void DBIMG::download_img( const std::string& url, const std::string& refurl, const bool mosaic )
+void DBIMG::download_img( const std::string& url, const std::string& refurl, const int mosaic_mode )
 {
     DBIMG::Img* img = DBIMG::get_img( url );
-    if( img ) img->download_img( refurl, mosaic, 0 );
+    if( img ) img->download_img( refurl, mosaic_mode, 0 );
 }
 
 void DBIMG::download_img_wait( const std::string& url, const std::string& refurl, const bool mosaic, const int first )

--- a/src/dbimg/imginterface.h
+++ b/src/dbimg/imginterface.h
@@ -50,6 +50,10 @@ namespace DBIMG
         T_FORCEIMAGE, // 拡張子がなくても画像として扱う
     };
 
+    constexpr const char* kTemporaryMosaicQuestion =
+        "モザイクをかけて画像を表示しますか？「はい」を選択して画像を表示すると、JDimを再起動する、"
+        "あぼ〜んを解除する、またはモザイクを解除するまでNG 画像ハッシュは適用されません。";
+
     constexpr int kImgHashReserved = 0;
 
     class Img;

--- a/src/dbimg/imginterface.h
+++ b/src/dbimg/imginterface.h
@@ -50,6 +50,9 @@ namespace DBIMG
         T_FORCEIMAGE, // 拡張子がなくても画像として扱う
     };
 
+    // DBIMG::download_img( url, refurl, mosaic_mode ) の mosaic_mode に渡す定数
+    constexpr const int kForceMosaic = 2; ///< 強制的にモザイク表示する
+
     constexpr const char* kTemporaryMosaicQuestion =
         "モザイクをかけて画像を表示しますか？「はい」を選択して画像を表示すると、JDimを再起動する、"
         "あぼ〜んを解除する、またはモザイクを解除するまでNG 画像ハッシュは適用されません。";
@@ -98,8 +101,9 @@ namespace DBIMG
 
     // ロード開始
     // refurl : 参照元のスレのアドレス
-    // mosaic : モザイク表示するか
-    void download_img( const std::string& url, const std::string& refurl, const bool mosaic );
+    // mosaic_mode : モザイク表示するか
+    //               ( 0: モザイク表示しない, 1: モザイク表示する, 2: 強制的にモザイク表示する )
+    void download_img( const std::string& url, const std::string& refurl, const int mosaic_mode );
 
     // 時間差ロード
     // first : 一番最初の画像か

--- a/src/dbimg/imgroot.cpp
+++ b/src/dbimg/imgroot.cpp
@@ -505,7 +505,7 @@ bool ImgRoot::test_imghash( Img& img )
 #endif
         return false;
     }
-    if( img.is_protected() ) return false;
+    if( img.is_protected() || img.is_force_mosaic() ) return false;
 
     std::stringstream ss;
     for( auto& [abone_dhash, threshold, last_matched, source_url] : m_vec_abone_imghash ) {


### PR DESCRIPTION
### Implement force mosaic mode for image abone part1

あぼーんされた画像URLをクリックしたとき出る「あぼーんされています」のダイアログを修正して一時的にモザイクで表示する選択肢を追加します。

ダイアログの選択肢で「はい」を選択して画像を表示すると、JDimを再起動する、あぼ〜んを解除する、またはモザイクを解除するまでNG 画像ハッシュの適用外となります。

part1はGUIの修正で一時的にモザイクで表示する実処理はpart2で実装します。

#### Implement force mosaic mode for image abone part2

画像を表示するとき一時的にモザイクで表示するモードを実装します。

`DBIMG::download_img()`のモザイクで表示するかbool型で指定する引数をint型に変更してモザイク表示のモードを渡せるように変更します。

値  | モザイク表示のモード
--- | ---
0   | モザイク表示しない
1   | モザイク表示する
2   | 強制的にモザイク表示する

強制モザイクモードではJDimを終了する、あぼーんを解除する、またはモザイクを解除するまでNG 画像ハッシュの適用外となります。

関連のissue: #1388
