### PR TITLE
font: Convert signedness for integer type to compare ASCII character

### DIFF
--- a/src/article/font.cpp
+++ b/src/article/font.cpp
@@ -105,7 +105,10 @@ bool ARTICLE::get_width_of_char( const char32_t code, const char pre_char, int& 
                 width_of_char[ mode ][ code ].width = new unsigned int[ 128 ]{};
             }
 
-            const int pre_char_num = ( int ) pre_char;
+            // ここの比較はASCIIの範囲 [0, 127] を想定しているが、
+            // char型はCPUアーキテクチャによって符号の有無が変わるので、
+            // 明示的にunsigned char型へ変換して比較する。
+            const auto pre_char_num = static_cast<unsigned char>(pre_char);
             if( pre_char_num < 128 ) width = width_of_char[ mode ][ code ].width[ pre_char_num ];
         }
     }
@@ -146,7 +149,10 @@ void ARTICLE::set_width_of_char( const char32_t code, const char pre_char, const
     // 半角モードの幅を厳密に求める場合
     if( code < 128 && strict_of_char ){
 
-        const int pre_char_num = pre_char;
+        // ここの比較はASCIIの範囲 [0, 127] を想定しているが、
+        // char型はCPUアーキテクチャによって符号の有無が変わるので、
+        // 明示的にunsigned char型へ変換して比較する。
+        const auto pre_char_num = static_cast<unsigned char>(pre_char);
         if( pre_char_num < 128 ) width_of_char[ mode ][ code ].width[ pre_char_num ] = width;
     }
 


### PR DESCRIPTION
条件文の比較はASCIIの範囲`[0, 127]`を想定しているが、char型はCPUアーキテクチャによって符号の有無が変わるので明示的にunsigned char型へ変換して比較します。

また、C言語スタイルのキャストを使用しているとclangに指摘されたためC++スタイルのキャスト`static_cast<...>(value)`に変更してコンパイラー警告を修正します。

clang-17のレポート (file pathを一部省略)
```
src/article/font.cpp:108:38: warning: use of old-style cast [-Wold-style-cast]
  108 |             const int pre_char_num = ( int ) pre_char;
      |                                      ^       ~~~~~~~~
```
