### PR TITLE
Implement 5ch donguri system guard account login

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -240,6 +240,7 @@ namespace CORE
         void slot_toggle_online();
         void slot_toggle_login2ch();
         void slot_toggle_loginbe();
+        void slot_toggle_loginacorn();
         void slot_reload_list();
         void slot_quit();
         ///

--- a/src/global.h
+++ b/src/global.h
@@ -269,6 +269,7 @@ enum
 
 #define URL_LOGIN2CH "jdlogin://login2ch"
 #define URL_LOGINBE "jdlogin://loginbe"
+#define URL_LOGINACORN "jdlogin://loginacorn"
 
 #define URL_BBSLISTADMIN "jdadmin://bbslist"
 #define URL_BOARDADMIN "jdadmin://board"

--- a/src/loginacorn.cpp
+++ b/src/loginacorn.cpp
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//#define _DEBUG
+#include "jddebug.h"
+
+#include "loginacorn.h"
+
+#include "command.h"
+#include "global.h"
+#include "httpcode.h"
+#include "session.h"
+
+#include "config/globalconf.h"
+#include "jdlib/cookiemanager.h"
+#include "jdlib/jdregex.h"
+#include "jdlib/loaderdata.h"
+#include "jdlib/miscutil.h"
+#include "skeleton/msgdiag.h"
+
+
+namespace CORE::ac {
+constexpr std::size_t kSizeOfRawData = 64 * 1024;
+
+constexpr const char* kHostDonguri = "donguri.5ch.net";
+constexpr const char* kOriginDonguri = "https://donguri.5ch.net";
+}
+
+
+static CORE::LoginAcorn* instance_loginacorn = nullptr;
+
+
+CORE::LoginAcorn* CORE::get_loginacorn()
+{
+    if( ! instance_loginacorn ) instance_loginacorn = new CORE::LoginAcorn();
+    assert( instance_loginacorn );
+
+    return instance_loginacorn;
+}
+
+
+void CORE::delete_loginacorn()
+{
+    if( instance_loginacorn ){
+        instance_loginacorn->terminate_load();
+        delete instance_loginacorn;
+    }
+    instance_loginacorn = nullptr;
+}
+
+
+using namespace CORE;
+
+
+LoginAcorn::LoginAcorn()
+    : SKELETON::Login( URL_LOGINACORN )
+{
+}
+
+
+/**
+ * @brief ログイン状態をリセットする
+ */
+void LoginAcorn::reset()
+{
+    SKELETON::Login::set_login_now( false );
+    SKELETON::Login::set_sessionid( std::string() );
+    SKELETON::Login::set_sessiondata( std::string() );
+    SESSION::set_loginacorn( false );
+}
+
+/**
+ * @brief ログアウト
+ */
+void LoginAcorn::logout()
+{
+#ifdef _DEBUG
+    std::cout << "LoginAcorn::logout\n";
+#endif
+    if( is_loading() ) return;
+
+    reset();
+
+    JDLIB::LOADERDATA data;
+    data.init_for_data();
+    data.url = std::string{ ac::kOriginDonguri } + "/logout";
+    data.referer = std::string{ ac::kOriginDonguri } + "/";
+    data.agent = CONFIG::get_agent_for2ch();
+
+    const JDLIB::CookieManager* cookie_manager = JDLIB::get_cookie_manager();
+    data.cookie_for_request = cookie_manager->get_cookie_by_host( ac::kHostDonguri );
+
+    m_rawdata.clear();
+    m_operation = Operation::logout;
+
+    start_load( data );
+}
+
+
+/**
+ * @brief ログイン開始
+ */
+void LoginAcorn::start_login()
+{
+    if( is_loading() ) return;
+
+    std::string login_url = std::string{ ac::kOriginDonguri } + "/login";
+#ifdef _DEBUG
+    std::cout << "LoginAcorn::start_login  url = " << login_url << std::endl;
+#endif
+
+    set_str_code( "" );
+
+    if( ! SESSION::is_online() ){
+        SKELETON::MsgDiag mdiag( nullptr, "オフラインです" );
+        mdiag.run();
+        return;
+    }
+
+    if( get_username().empty() || get_passwd().empty() ){
+        SKELETON::MsgDiag mdiag( nullptr, "メールアドレスまたはパスワードが設定されていません\n\n"
+                                 "設定→ネットワーク→パスワードで設定してください" );
+        mdiag.run();
+        return;
+    }
+
+    reset();
+
+    JDLIB::LOADERDATA data;
+    data.init_for_data();
+    data.url = std::move( login_url );
+    data.origin = ac::kOriginDonguri;
+    data.referer = std::string{ ac::kOriginDonguri } + "/";
+    data.agent = CONFIG::get_agent_for2ch();
+
+    data.contenttype = "application/x-www-form-urlencoded";
+    data.str_post = "email=" + MISC::url_encode_plus( get_username() );
+    data.str_post += "&pass=" + MISC::url_encode_plus( get_passwd() );
+
+    if( m_rawdata.capacity() < ac::kSizeOfRawData ) m_rawdata.reserve( ac::kSizeOfRawData );
+    m_rawdata.clear();
+    m_operation = Operation::login;
+
+    start_load( data );
+}
+
+
+/**
+ * @brief データ受信
+ */
+void LoginAcorn::receive_data( std::string_view buf )
+{
+    m_rawdata.append( buf );
+}
+
+
+/**
+ * @brief データ受信完了
+ */
+void LoginAcorn::receive_finish()
+{
+#ifdef _DEBUG
+    std::cout << "LoginAcorn::receive_finish code = " << get_code() << std::endl;
+    std::cout << "rawdata size = " << m_rawdata.size() << std::endl;
+#endif
+
+    // ログイン、ログアウトでクッキーを更新する
+    if( get_code() == HTTP_REDIRECT ) {
+
+        receive_finish_redirect();
+    }
+    // どんぐりベースからアカウント名とIDを取得する
+    else if( get_code() == HTTP_OK ) {
+
+        receive_finish_ok();
+        return;
+    }
+
+    if( m_operation != Operation::login ) return;
+
+    std::string str_err = "ログインに失敗しました。\n\nどんぐりシステムの"
+                          "認証サーバのアドレスやメールアドレス、パスワード等を確認して下さい。\n\n";
+    str_err += get_str_code();
+    SKELETON::MsgDiag mdiag( nullptr, str_err );
+    mdiag.run();
+}
+
+
+/**
+ * @brief データ受信完了 (リダイレクト)
+ *
+ * @details ログインとログアウト時にHTTPクッキーを更新する。
+ */
+void LoginAcorn::receive_finish_redirect()
+{
+    std::string acorn;
+
+    JDLIB::Regex regex;
+    constexpr std::size_t offset = 0;
+    constexpr bool icase = false;
+    constexpr bool newline = true;
+    constexpr bool usemigemo = false;
+    constexpr bool wchar = false;
+
+    for( const std::string& cookie : cookies() ) {
+
+        const std::string pattern = "acorn=([^;]*)";
+        if( regex.exec( pattern, cookie, offset, icase, newline, usemigemo, wchar ) ) {
+            acorn = regex.str( 1 );
+
+            JDLIB::CookieManager* cookie_manager = JDLIB::get_cookie_manager();
+            cookie_manager->feed( ac::kHostDonguri, MISC::utf8_trim( cookie ) );
+        }
+    }
+
+    if( acorn.empty() ) return;
+
+    set_login_now( true );
+    set_sessiondata( acorn );
+    SESSION::set_loginacorn( true );
+
+    CORE::core_set_command( "loginacorn_finished", "" );
+
+    // どんぐりベースにアクセスしてアカウント名とIDを取得する
+    JDLIB::LOADERDATA data;
+    data.init_for_data();
+    data.url = std::string{ ac::kOriginDonguri } + "/";
+    data.referer = data.url;
+    data.agent = CONFIG::get_agent_for2ch();
+
+    const JDLIB::CookieManager* cookie_manager = JDLIB::get_cookie_manager();
+    data.cookie_for_request = cookie_manager->get_cookie_by_host( ac::kHostDonguri );
+
+    m_rawdata.clear();
+    m_operation = Operation::status;
+
+    start_load( data );
+}
+
+
+/**
+ * @brief データ受信完了 (200 OK)
+ *
+ * @details どんぐりベースからアカウント名とIDを取得する。
+ */
+void LoginAcorn::receive_finish_ok()
+{
+    std::string name_and_id;
+
+    const std::size_t offset = m_rawdata.find( "<div" );
+    if( offset != std::string::npos ) {
+
+        JDLIB::Regex regex;
+        constexpr bool icase = false;
+        constexpr bool newline = true;
+        constexpr bool usemigemo = false;
+        constexpr bool wchar = false;
+        const std::string pattern = ">([^<]+)</div><div>(警備員[^<]+)</div>";
+        if( regex.exec( pattern, m_rawdata, offset, icase, newline, usemigemo, wchar ) ) {
+            name_and_id = regex.replace( "\\1 / \\2" );
+        }
+    }
+
+    set_sessionid( name_and_id );
+}

--- a/src/loginacorn.h
+++ b/src/loginacorn.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/** @file loginacorn.h
+ *
+ * @brief どんぐりシステムの警備員ログイン(メールアドレス認証)管理クラス
+ * @details セッション管理やログイン、パスワードの保存などを行う
+ */
+
+#ifndef JDIM_LOGINACORN_H
+#define JDIM_LOGINACORN_H
+
+#include "skeleton/login.h"
+
+#include <string>
+#include <string_view>
+
+
+namespace CORE
+{
+
+class LoginAcorn : public SKELETON::Login
+{
+    enum class Operation
+    {
+        login, ///< ログイン操作
+        status, ///< アカウント名とIDを取得
+        logout, ///< ログアウト操作
+    };
+
+    std::string m_rawdata;
+    Operation m_operation{};
+
+  public:
+
+    LoginAcorn();
+    ~LoginAcorn() override = default;
+
+    void start_login() override;
+    void logout() override;
+
+  private:
+
+    void reset();
+    void receive_data( std::string_view buf ) override;
+    void receive_finish() override;
+    void receive_finish_redirect();
+    void receive_finish_ok();
+};
+
+LoginAcorn* get_loginacorn();
+void delete_loginacorn();
+
+}
+
+#endif // JDIM_LOGINACORN_H

--- a/src/menuslots.cpp
+++ b/src/menuslots.cpp
@@ -11,6 +11,7 @@
 #include "session.h"
 #include "login2ch.h"
 #include "loginbe.h"
+#include "loginacorn.h"
 #include "winmain.h"
 #include "fontid.h"
 #include "colorid.h"
@@ -111,6 +112,27 @@ void Core::slot_toggle_loginbe()
 
     // ログオフ中ならログイン開始
     else CORE::get_loginbe()->start_login();
+
+    set_maintitle();
+}
+
+
+/**
+ * @brief どんぐり警備員にログイン
+ */
+void Core::slot_toggle_loginacorn()
+{
+    if( ! m_enable_menuslot ) return;
+
+#ifdef _DEBUG
+    std::cout << "Core::slot_toggle_loginacorn\n";
+#endif
+
+    // ログイン中ならログアウト
+    if( CORE::get_loginacorn()->login_now() ) CORE::get_loginacorn()->logout();
+
+    // ログオフ中ならログイン開始
+    else CORE::get_loginacorn()->start_login();
 
     set_maintitle();
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -54,6 +54,7 @@ core_sources = files(
   'livepref.cpp',
   'login2ch.cpp',
   'loginbe.cpp',
+  'loginacorn.cpp',
   'mainitempref.cpp',
   'maintoolbar.cpp',
   'menuslots.cpp',

--- a/src/passwdpref.h
+++ b/src/passwdpref.h
@@ -279,6 +279,7 @@ namespace CORE
 
             set_title( "パスワード設定" );
             show_all_children();
+            set_default_size( 450, -1 );
         }
 
         ~PasswdPref() noexcept override = default;

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -714,6 +714,8 @@ void SESSION::set_login2ch( const bool login ){ mode_login2ch = login; }
 bool SESSION::loginbe(){ return mode_loginbe; }
 void SESSION::set_loginbe( const bool login ){ mode_loginbe = login; }
 
+void SESSION::set_loginacorn( const bool login ){ }
+
 bool SESSION::show_sidebar(){ return win_show_sidebar; }
 
 bool SESSION::show_menubar(){ return win_show_menubar; }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -29,6 +29,7 @@ bool mode_online;
 bool mode_login2ch;
 bool mode_loginbe;
 enum { mode_loginp2 }; // Removed in v0.3.0 (2020-05)
+static bool mode_loginacorn;
 
 int win_hpane_main_pos;
 int win_vpane_main_pos;
@@ -327,6 +328,9 @@ void SESSION::init_session()
     // beログイン
     mode_loginbe = cf.get_option_bool( "mode_loginbe", false );
 
+    // どんぐり警備員ログイン
+    mode_loginacorn = cf.get_option_bool( "mode_loginacorn", false );
+
     // paneのモード
     mode_pane = cf.get_option_int( "mode_pane", MODE_2PANE, 0, MODE_PANE_NUM -1 );
 
@@ -580,6 +584,7 @@ void SESSION::save_session()
         << "mode_online = " << mode_online << std::endl
         << "mode_login2ch = " << mode_login2ch << std::endl
         << "mode_loginbe = " << mode_loginbe << std::endl
+        << "mode_loginacorn = " << mode_loginacorn << std::endl
         << "x = " << x_win_main << std::endl
         << "y = " << y_win_main << std::endl
         << "width = " << width_win_main << std::endl
@@ -714,7 +719,8 @@ void SESSION::set_login2ch( const bool login ){ mode_login2ch = login; }
 bool SESSION::loginbe(){ return mode_loginbe; }
 void SESSION::set_loginbe( const bool login ){ mode_loginbe = login; }
 
-void SESSION::set_loginacorn( const bool login ){ }
+bool SESSION::loginacorn(){ return mode_loginacorn; }
+void SESSION::set_loginacorn( const bool login ){ mode_loginacorn = login; }
 
 bool SESSION::show_sidebar(){ return win_show_sidebar; }
 

--- a/src/session.h
+++ b/src/session.h
@@ -102,6 +102,8 @@ namespace SESSION
     bool loginbe();
     void set_loginbe( const bool login );
 
+    void set_loginacorn( const bool login );
+
     bool loginp2() = delete; // Removed in v0.3.0 (2020-05)
     void set_loginp2( const bool login ) = delete; // Removed in v0.3.0 (2020-05)
 

--- a/src/session.h
+++ b/src/session.h
@@ -102,6 +102,8 @@ namespace SESSION
     bool loginbe();
     void set_loginbe( const bool login );
 
+    // どんぐり警備員ログイン中
+    bool loginacorn();
     void set_loginacorn( const bool login );
 
     bool loginp2() = delete; // Removed in v0.3.0 (2020-05)


### PR DESCRIPTION
### Implement LoginAcorn class for 5ch donguri system guard account

5ch.netのどんぐりシステムをサポートするためメールアドレスとパスワードで登録した警備員アカウントにログイン、ログアウトする処理と実装します。

また、ログインした後にアカウントの名前やIDを取得する処理を実装してどのアカウントでログインしたのか識別できるようにします。

今回の修正では警備員の登録はサポートしません。

### Implement PasswdFrameAcorn class for 5ch donguri system guard account

パスワード設定のダイアログに「どんぐり警備員」のタブを実装します。
メールアドレスとパスワードを入力してOKを押してダイアログを閉じ、メニューバーからログインします。

また、ログイン中はアカウントの名前とID、HTTPクッキー(acorn)をタブに表示することでどのアカウントにログインしているのか判別できるようにします。

### PasswdPref: Set dialog default size

パスワード設定のダイアログの幅サイズにデフォルトの値を設定します。
修正前はラベルのテキストに合わせてダイアログのサイズが引き伸ばされて表示されていました。

### Core: Implement menubar button for 5ch donguri system guard login/logout

メニューバーに5ch.netどんぐりシステムの警備員アカウントにログインするボタンを実装します。
また、ログインしている状態でJDimを終了したときは次回起動時に自動でログインするように処理を実装します。

ログイン中はメインウィンドウのタイトルバーに`[ どんぐり警備員 ]`と表示します。

この機能は実験的なサポートとして追加します。
設定や動作は変更または廃止の可能性があります。

関連のissue: #1376
