### PR TITLE
Bump version to 0.12.0-beta

### DIFF
--- a/docs/manual/2024.md
+++ b/docs/manual/2024.md
@@ -11,6 +11,46 @@ layout: default
 
 <a name="0.12.0-unreleased"></a>
 ### [0.12.0-unreleased](https://github.com/JDimproved/JDim/compare/bbf9902ee62...master) (unreleased)
+- ([#1403](https://github.com/JDimproved/JDim/pull/1403))
+  Bump version to 0.12.0-beta
+- ([#1402](https://github.com/JDimproved/JDim/pull/1402))
+  Implement 5ch donguri system guard account login
+- ([#1401](https://github.com/JDimproved/JDim/pull/1401))
+  font: Convert signedness for integer type to compare ASCII character
+- ([#1400](https://github.com/JDimproved/JDim/pull/1400))
+  `IMAGE::Preferences`: Add note property for abone reason
+- ([#1399](https://github.com/JDimproved/JDim/pull/1399))
+  Implement force mosaic mode for image abone
+- ([#1398](https://github.com/JDimproved/JDim/pull/1398))
+  Implement grayscale display for mosaic images
+- ([#1397](https://github.com/JDimproved/JDim/pull/1397))
+  Record abone reason for NG image hash and show it on dialog or popup
+- ([#1396](https://github.com/JDimproved/JDim/pull/1396))
+  Implement base system of the NG image hash
+- ([#1395](https://github.com/JDimproved/JDim/pull/1395))
+  Update CI (gcc >= 9, clang >= 10)
+- ([#1393](https://github.com/JDimproved/JDim/pull/1393))
+  `DrawAreaBase`: Fix crash if scroll thumb maximized
+- ([#1391](https://github.com/JDimproved/JDim/pull/1391))
+  @DrawAreaBase@: Fix crash for mouse wheel scrolling to upper
+- ([#1389](https://github.com/JDimproved/JDim/pull/1389))
+  Fix compiler warnings for `-Wold-style-cast` part9,10,11
+- ([#1387](https://github.com/JDimproved/JDim/pull/1387))
+  Fix compiler warnings for `-Wold-style-cast` part4,5,6,7,8
+- ([#1386](https://github.com/JDimproved/JDim/pull/1386))
+  Fix compiler warnings for `-Wold-style-cast` part1,2,3
+- ([#1385](https://github.com/JDimproved/JDim/pull/1385))
+  Fix compiler warning for `-Wmissing-variable-declarations` part2
+- ([#1384](https://github.com/JDimproved/JDim/pull/1384))
+  Fix compiler warnings for `-Wimplicit-int-conversion` part2
+- ([#1383](https://github.com/JDimproved/JDim/pull/1383))
+  `Board2ch::update_hap()`: Fix cookie retrieval method
+- ([#1382](https://github.com/JDimproved/JDim/pull/1382))
+  Improve date string parsing to handle 5ch.net's date format
+- ([#1381](https://github.com/JDimproved/JDim/pull/1381))
+  `SimpleCookieManager`: Update Cookie management to remove expired Cookies
+- ([#1379](https://github.com/JDimproved/JDim/pull/1379))
+  Update histories
 
 
 <a name="0.11.0-20240406"></a>

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 
 project('jdim', 'cpp',
-        version : '0.11.0',
+        version : '0.12.0-beta',
         license : 'GPL2',
         meson_version : '>= 0.53.0',
         default_options : ['warning_level=3', 'cpp_std=c++17'])

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -15,10 +15,10 @@
 // SEE ALSO: ENVIRONMENT::get_jdversion()
 
 #define MAJORVERSION 0
-#define MINORVERSION 11
+#define MINORVERSION 12
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20240406"
-#define JDTAG     ""
+#define JDDATE_FALLBACK    "20240616"
+#define JDTAG     "beta"
 
 //---------------------------------
 


### PR DESCRIPTION
### Update histories

### Bump version to 0.12.0-beta

機能フリーズ期間に入るためバージョン番号をベータ版に更新します。

関連のissue: https://github.com/JDimproved/JDim/issues/1380
