### PR TITLE
DrawAreaBase: Fix busy loop issue in go to previouse response command

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -3450,11 +3450,16 @@ void DrawAreaBase::goto_next_res()
 //
 void DrawAreaBase::goto_pre_res()
 {
+    if( m_seen_current == max_number() ) {
+        goto_top();
+        return;
+    }
+
     // 表示するレスを検索
     const LAYOUT* header;
     int num = m_seen_current;
     int pos_y = get_vscr_val();
-    do{ header = m_layout_tree->get_header_of_res_const( --num ); } while( num && ( ! header || header->rect->y >= pos_y ) );
+    do{ header = m_layout_tree->get_header_of_res_const( --num ); } while( 0 < num && ( ! header || header->rect->y >= pos_y ) );
     goto_num( num );
 }
 


### PR DESCRIPTION
書き込みログを開いて「前のレスに移動」するショートカットキーを使うと一時的にウインドウが固まる(ハングアップ)不具合を修正します。

また、書き込みログでは「次のレスに移動」する機能が一番下にスクロールする挙動なので「前のレスに移動」の機能を一番上にスクロールするように変更することで上下対称にします。

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1640504277/800-809n

Thanks @mtasaka for reporting the issue.

Closes #1404
