### PR TITLE
Fix behavior of 'Go to previous response' shortcut in normal threads

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -3450,7 +3450,7 @@ void DrawAreaBase::goto_next_res()
 //
 void DrawAreaBase::goto_pre_res()
 {
-    if( m_seen_current == max_number() ) {
+    if( m_seen_current == 0 ) {
         goto_top();
         return;
     }


### PR DESCRIPTION
0.12.0-beta20240617 では通常のスレッドの画面一番下の書き込みに移動後ショートカットキー「前のレスに移動」を使うと画面一番上に移動するようになっていたため1つづつ前のレスに移動するように修正します。

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1640504277/827

Closes #1404
