### PR TITLE
Tweak labels for 5ch donguri system mail login

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -319,7 +319,7 @@ void Core::run( const bool init, const bool skip_setupdiag )
                          sigc::mem_fun( *this, &Core::slot_toggle_login2ch ) );
     m_action_group->add( Gtk::ToggleAction::create( "LoginBe", "BEにログイン(_B)", std::string(), false ),
                         sigc::mem_fun( *this, &Core::slot_toggle_loginbe ) );
-    m_action_group->add( Gtk::ToggleAction::create( "LoginAcorn", "どんぐり警備員にログイン(_G)", {}, false ),
+    m_action_group->add( Gtk::ToggleAction::create( "LoginAcorn", "どんぐりシステムにGmail警備員●でログイン(_G)", {}, false ),
                          sigc::mem_fun( *this, &Core::slot_toggle_loginacorn ) );
     m_action_group->add( Gtk::Action::create( "ReloadList", "板一覧再読込(_R)"), sigc::mem_fun( *this, &Core::slot_reload_list ) );
 
@@ -1365,7 +1365,7 @@ void Core::set_maintitle()
 
     if( CORE::get_login2ch()->login_now() ) title +=" [ ● ]";
     if( CORE::get_loginbe()->login_now() ) title +=" [ BE ]";
-    if( CORE::get_loginacorn()->login_now() ) title +=" [ どんぐり警備員 ]";
+    if( CORE::get_loginacorn()->login_now() ) title +=" [ 警備員● ]";
     if( ! SESSION::is_online() ) title += " [ offline ]";
     m_win_main.set_title( title );
 }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -110,7 +110,7 @@ Core::Core( JDWinMain& win_main )
     // BEログインマネージャ作成
     CORE::get_loginbe();
 
-    // どんぐり警備員ログインマネージャ作成
+    // どんぐりシステム メールアドレス登録警備員のログインマネージャ作成
     CORE::get_loginacorn();
 
     // マウス、キー設定読み込み
@@ -228,7 +228,7 @@ Core::~Core()
     // BEログインマネージャ削除
     CORE::delete_loginbe();
 
-    // どんぐり警備員ログインマネージャ削除
+    // どんぐりシステム メールアドレス登録警備員のログインマネージャ削除
     CORE::delete_loginacorn();
 
     // データベース削除
@@ -1506,7 +1506,7 @@ void Core::slot_activate_menubar()
         else tact->set_active( false );
     }
 
-    // どんぐり警備員ログイン
+    // どんぐりシステム メールアドレス登録警備員のログイン
     act = m_action_group->get_action( "LoginAcorn" );
     tact = Glib::RefPtr<Gtk::ToggleAction>::cast_dynamic( act );
     if( tact ) {
@@ -3168,7 +3168,7 @@ void Core::exec_command()
     // BEへのログイン処理が完了した
     else if( command.command  == "loginbe_finished" ) set_maintitle();
 
-    // どんぐり警備員へのログイン処理が完了した
+    // どんぐりシステム メールアドレス登録警備員へのログイン処理が完了した
     else if( command.command  == "loginacorn_finished" ) set_maintitle();
 
     // あるadminのnotebookが空になった
@@ -3376,7 +3376,7 @@ void Core::exec_command_after_boot()
     // BEログイン
     if( SESSION::loginbe() ) slot_toggle_loginbe();
 
-    // どんぐり警備員ログイン
+    // どんぐりシステム メールアドレス登録警備員のログイン
     if( SESSION::loginacorn() ) slot_toggle_loginacorn();
 
     // タイトル表示

--- a/src/menuslots.cpp
+++ b/src/menuslots.cpp
@@ -118,7 +118,7 @@ void Core::slot_toggle_loginbe()
 
 
 /**
- * @brief どんぐり警備員にログイン
+ * @brief どんぐりシステム メールアドレス登録警備員にログイン
  */
 void Core::slot_toggle_loginacorn()
 {

--- a/src/passwdpref.h
+++ b/src/passwdpref.h
@@ -158,7 +158,7 @@ namespace CORE
         }
     };
 
-    // どんぐり警備員ログイン用
+    // どんぐりシステム メールアドレス登録警備員のログイン用
     class PasswdFrameAcorn : public Gtk::Grid
     {
         Gtk::Label m_label_account;
@@ -245,7 +245,7 @@ namespace CORE
             CORE::get_loginbe()->set_username( MISC::utf8_trim( m_frame_be.entry_id.get_text().raw() ) );
             CORE::get_loginbe()->set_passwd( MISC::utf8_trim( m_frame_be.entry_passwd.get_text().raw() ) );
 
-            // どんぐり警備員
+            // どんぐりシステム メールアドレス登録警備員
             CORE::get_loginacorn()->set_username( MISC::utf8_trim( m_frame_acorn.entry_id.get_text().raw() ) );
             CORE::get_loginacorn()->set_passwd( MISC::utf8_trim( m_frame_acorn.entry_passwd.get_text().raw() ) );
         }
@@ -269,7 +269,7 @@ namespace CORE
             set_activate_entry( m_frame_be.entry_id );
             set_activate_entry( m_frame_be.entry_passwd );
 
-            // どんぐり警備員用
+            // どんぐりシステム メールアドレス登録警備員
             m_frame_acorn.entry_id.set_text( CORE::get_loginacorn()->get_username() );
             m_frame_acorn.entry_passwd.set_text( CORE::get_loginacorn()->get_passwd() );
 

--- a/src/passwdpref.h
+++ b/src/passwdpref.h
@@ -182,11 +182,14 @@ namespace CORE
             , m_label_id{ "メールアドレス(_I):", true }
             , m_label_passwd{ "パスワード(_P):", true }
         {
+            constexpr const char* mail_addr_tooltip = "警備員アカウントを登録したGmailアドレスを設定してください。";
+
             property_margin() = 16;
             set_column_spacing( 10 );
             set_row_spacing( 8 );
 
             entry_id.set_hexpand( true );
+            entry_id.set_tooltip_text( mail_addr_tooltip );
             m_label_id.set_mnemonic_widget( entry_id );
 
             entry_passwd.set_hexpand( true );
@@ -194,6 +197,7 @@ namespace CORE
             m_label_passwd.set_mnemonic_widget( entry_passwd );
 
             m_label_id.set_halign( Gtk::ALIGN_START );
+            m_label_id.set_tooltip_text( mail_addr_tooltip );
             m_label_passwd.set_halign( Gtk::ALIGN_START );
             m_label_account.set_halign( Gtk::ALIGN_START );
             m_label_account_value.set_halign( Gtk::ALIGN_START );
@@ -274,7 +278,7 @@ namespace CORE
 
             m_notebook.append_page( m_frame_2ch, "2ch" );
             m_notebook.append_page( m_frame_be, "BE" );
-            m_notebook.append_page( m_frame_acorn, "どんぐり警備員" );
+            m_notebook.append_page( m_frame_acorn, "どんぐりシステム" );
             get_content_area()->pack_start( m_notebook );
 
             set_title( "パスワード設定" );

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -328,7 +328,7 @@ void SESSION::init_session()
     // beログイン
     mode_loginbe = cf.get_option_bool( "mode_loginbe", false );
 
-    // どんぐり警備員ログイン
+    // どんぐりシステム メールアドレス登録警備員のログイン
     mode_loginacorn = cf.get_option_bool( "mode_loginacorn", false );
 
     // paneのモード

--- a/src/session.h
+++ b/src/session.h
@@ -102,7 +102,7 @@ namespace SESSION
     bool loginbe();
     void set_loginbe( const bool login );
 
-    // どんぐり警備員ログイン中
+    // どんぐりシステム メールアドレス登録警備員にログイン中
     bool loginacorn();
     void set_loginacorn( const bool login );
 


### PR DESCRIPTION
### Core: Tweak labels for 5ch donguri system mail login

5ch.netどんぐりシステムのメールアドレス登録した警備員のログインを切り替えるメニューバーの項目は表現が分かりにくいと指摘があったため、Gmailのメールアドレスに登録された警備員アカウントを強調するテキストに変更します。

また、タイトルバーに表示するどんぐりシステムにログイン中であることを示すステータス表示のテキストが長いため、[どんぐりベース][1]の表現[^2]を使うように変更します。

修正にあたり報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1640504277/768

[1]: https://donguri.5ch.net/
[^2]: 「警備員」のテキストと黒丸(U+25CF BLACK CIRCLE)の組み合わせ

### passwdpref: Tweak label and tooltip for donguri system mail login

パスワード設定のタブのラベルは単純に「どんぐりシステム」へ変更します。
また、Gmail限定であることをラベルや入力欄のツールチップに表示します。

### Tweak source code comments for donguri system mail address login

ソースコードのコメントを編集してメールアドレスに登録した警備員のログイン処理であると明示します。
また、将来の仕様変更でGmail限定でなくなる場合を考えメールアドレス登録と書きます。
(ソースコードのコメント内容を更新していくのは忘れやすいです)

関連のissue: https://github.com/JDimproved/JDim/issues/1376
