### PR TITLE
ImageHashTab: Add online manual link button

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -37,6 +37,7 @@ std::string ENVIRONMENT::get_jd2chlog(){ return JD2CHLOG; }
 std::string ENVIRONMENT::get_jdhelp(){ return JDHELP; }
 std::string ENVIRONMENT::get_jdhelpcmd(){ return JDHELPCMD; }
 std::string ENVIRONMENT::get_jdhelpreplstr() { return JDHELPREPLSTR; }
+std::string ENVIRONMENT::get_jdhelpimghash() { return JDHELPIMGHASH; }
 std::string ENVIRONMENT::get_jdlicense(){ return JDLICENSE; }
 
 

--- a/src/environment.h
+++ b/src/environment.h
@@ -40,6 +40,7 @@ namespace ENVIRONMENT
 	std::string get_jdhelp();
 	std::string get_jdhelpcmd();
 	std::string get_jdhelpreplstr();
+	std::string get_jdhelpimghash();
     std::string get_jdlicense();
     std::string get_configure_args( const int mode = CONFIGURE_OMITTED );
 

--- a/src/imagehashtab.h
+++ b/src/imagehashtab.h
@@ -12,6 +12,8 @@
 #include "jdlib/misctime.h"
 #include "skeleton/msgdiag.h"
 
+#include "environment.h"
+
 #include <gtkmm.h>
 
 #include <cinttypes>
@@ -84,6 +86,8 @@ class ImageHashTab : public sigc::trackable
     Gtk::Revealer m_revealer_notes;
     Gtk::Label m_label_notes;
 
+    Gtk::LinkButton m_link_manual;
+
     // NG 画像ハッシュのリスト
     Gtk::ScrolledWindow m_scroll;
     Gtk::TreeView m_treeview;
@@ -112,6 +116,7 @@ public:
                          "・ハッシュ値を削除したりしきい値を変更してもあぼ〜んされた画像は解除されません。\n"
                          "・判定基準のしきい値を大きくすると誤判定する可能性が高くなります。\n"
                          "・マイナスのしきい値に設定したハッシュ値はあぼ〜んの判定を行いません。" }
+        , m_link_manual{ ENVIRONMENT::get_jdhelpimghash(), "オンラインマニュアル(_M)" }
         , m_col{ -2 }
     {
         m_grid.set_row_spacing( 8 );
@@ -160,8 +165,12 @@ public:
         m_button_reset_initial_threshold.show();
         m_button_reset_initial_threshold.signal_clicked().connect(
             sigc::mem_fun( *this, &ImageHashTab::slot_reset_initial_threshold ) );
+        m_link_manual.set_halign( Gtk::ALIGN_END );
+        m_link_manual.set_use_underline( true );
+        m_link_manual.show();
         m_hbox_initial_threshold.pack_start( m_spin_initial_threshold, Gtk::PACK_SHRINK );
         m_hbox_initial_threshold.pack_start( m_button_reset_initial_threshold, Gtk::PACK_SHRINK );
+        m_hbox_initial_threshold.pack_end( m_link_manual, Gtk::PACK_SHRINK );
         m_hbox_initial_threshold.show();
 
         m_label_tool.set_halign( Gtk::ALIGN_START );

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -31,6 +31,7 @@
 #define JDHELP "https://jdimproved.github.io/JDim/"
 #define JDHELPCMD JDHELP "usrcmd/"
 #define JDHELPREPLSTR JDHELP "replacestr/"
+#define JDHELPIMGHASH JDHELP "imghash/"
 
 // [ ライセンス表記 ]
 //


### PR DESCRIPTION
`全体あぼ〜ん設定(対象: スレビュー)`ダイアログの`NG 画像ハッシュ`タブにオンラインマニュアルのNG 画像ハッシュの設定についてまとめたページを開くリンクボタンを追加します。

関連のissue: https://github.com/JDimproved/JDim/issues/1388, https://github.com/JDimproved/JDim/pull/1409
