### PR TITLE
Return class member const reference string instead of string value

### DIFF
--- a/src/dbimg/img.h
+++ b/src/dbimg/img.h
@@ -123,7 +123,7 @@ namespace DBIMG
         void set_dhash( const DHash& dhash );
         const std::optional<DHash>& get_dhash() const noexcept { return m_dhash; }
 
-        std::string get_abone_reason() const noexcept { return m_abone_reason; }
+        const std::string& get_abone_reason() const noexcept { return m_abone_reason; }
 
         // ロード開始
         // receive_data()　と receive_finish() がコールバックされる

--- a/src/skeleton/window.h
+++ b/src/skeleton/window.h
@@ -80,7 +80,7 @@ namespace SKELETON
         void set_status( const std::string& stat );
         void set_status_temporary( const std::string& stat );
         void restore_status();
-        std::string get_status() const { return m_status; }
+        const std::string& get_status() const noexcept { return m_status; }
         void set_mginfo( const std::string& mginfo );
 
         // ステータスの色を変える

--- a/src/xml/dom.h
+++ b/src/xml/dom.h
@@ -97,8 +97,8 @@ namespace XML
 
         // プロパティを扱うアクセッサ
         int nodeType() const noexcept { return m_nodeType; }
-        std::string nodeName() const { return m_nodeName; }
-        std::string nodeValue() const { return m_nodeValue; }
+        const std::string& nodeName() const noexcept { return m_nodeName; }
+        const std::string& nodeValue() const noexcept { return m_nodeValue; }
         void nodeValue( const std::string& value ) { m_nodeValue = value; }
 
         // ノード


### PR DESCRIPTION
クラスメンバー変数の文字列をコピーして返すメンバー関数はconst参照を返すべきとcppcheckに指摘されたため修正します。

cppcheck 2.14.2のレポート
```
src/xml/dom.h:100:21: performance: Function 'nodeName()' should return member 'm_nodeName' by const reference. [returnByReference]
        std::string nodeName() const { return m_nodeName; }
                    ^
src/xml/dom.h:101:21: performance: Function 'nodeValue()' should return member 'm_nodeValue' by const reference. [returnByReference]
        std::string nodeValue() const { return m_nodeValue; }
                    ^
src/dbimg/img.h:126:21: performance: Function 'get_abone_reason()' should return member 'm_abone_reason' by const reference. [returnByReference]
        std::string get_abone_reason() const noexcept { return m_abone_reason; }
                    ^
src/skeleton/window.h:83:21: performance: Function 'get_status()' should return member 'm_status' by const reference. [returnByReference]
        std::string get_status() const { return m_status; }
                    ^
```
