### PR TITLE
tfidf: Rename local variable that has been typo

### DIFF
--- a/src/jdlib/tfidf.cpp
+++ b/src/jdlib/tfidf.cpp
@@ -117,7 +117,7 @@ double MISC::tfidf_cos_similarity( const VEC_TFIDF& vec_tfidf1, const VEC_TFIDF&
     std::cout << "MISC::tfidf_cos_similarity n = " << n << std::endl;
 #endif
 
-    if( ! n || n != vec_tfidf1.size() ) return 0;
+    if( ! n || n != vec_tfidf2.size() ) return 0;
 
     double product = 0;
     double lng1 = 0;


### PR DESCRIPTION
演算子の両側に同じ式が見つかったとcppcheckに指摘されたためチェックしたところ、変数名の誤りが見つかったため修正します。

関数の2つの引数の名前が似ていたため同じ引数に由来する数値で比較していました。

cppcheck 2.14.2のレポート
```
src/jdlib/tfidf.cpp:120:18: style: Finding the same expression on both sides of an operator is suspicious and might indicate a cut and paste or logic error. Please examine this code carefully to determine if it is correct. [knownConditionTrueFalse]
    if( ! n || n != vec_tfidf1.size() ) return 0;
                 ^
src/jdlib/tfidf.cpp:114:42: note: 'n' is assigned value 'vec_tfidf1.size()' here.
    const std::size_t n = vec_tfidf1.size();
                                         ^
src/jdlib/tfidf.cpp:120:18: note: The comparison 'n != vec_tfidf1.size()' is always false because 'n' and 'vec_tfidf1.size()' represent the same value.
    if( ! n || n != vec_tfidf1.size() ) return 0;
                 ^
```
