### PR TITLE
control: Add shortcut key for "Go To Last Tab"

### DIFF
--- a/docs/manual/operation.md
+++ b/docs/manual/operation.md
@@ -50,6 +50,8 @@ layout: default
 
   <dt>Alt+1 〜 Alt+9</dt>
   <dd>左からn番目(1〜9)のタブへ移動</dd>
+  <dt>(デフォルト無し)</dt>
+  <dd>最後(右端)のタブへ移動 <small>( v0.13.0-alpha20240810 から追加 )</small></dd>
   <dt>Alt+&#x1f870;</dt>
   <dd>同じタブで直前に開いていた内容に戻る</dd>
   <dt>Alt+&#x1f872;</dt>

--- a/src/control/controlid.h
+++ b/src/control/controlid.h
@@ -62,6 +62,7 @@ namespace CONTROL
         TabNum7,
         TabNum8,
         TabNum9,
+        TabLast,
 
         CloseAllTabs,
         CloseOtherTabs,

--- a/src/control/controllabel.h
+++ b/src/control/controllabel.h
@@ -68,6 +68,7 @@ namespace CONTROL
         { "TabNum7", "タブ7に移動" },
         { "TabNum8", "タブ8に移動" },
         { "TabNum9", "タブ9に移動" },
+        { "TabLast", "最後のタブに移動" },
 
         { "CloseAllTabs", "全てのタブを閉じる" },
         { "CloseOtherTabs", "他のタブを閉じる" },

--- a/src/control/controlutil.cpp
+++ b/src/control/controlutil.cpp
@@ -640,6 +640,11 @@ bool CONTROL::operate_common( const int control, const std::string& url, SKELETO
             if( admin ) admin->set_command( "tab_num", "", "9" );
             break;
 
+        case CONTROL::TabLast:
+            // GtkNotebook の API はマイナスの値で最後のタブを指定する
+            if( admin ) admin->set_command( "tab_num", "", "-1" );
+            break;
+
             // サイドバー表示/非表示
         case CONTROL::ShowSideBar:
             CORE::core_set_command( "toggle_sidebar" );

--- a/src/control/defaultconf.h
+++ b/src/control/defaultconf.h
@@ -37,6 +37,7 @@ namespace CONTROL
 #define KEYCONF_TabNum7 "Alt+7"
 #define KEYCONF_TabNum8 "Alt+8"
 #define KEYCONF_TabNum9 "Alt+9"
+#define KEYCONF_TabLast ""
 
 #define KEYCONF_RestoreLastTab "Ctrl+T"
 

--- a/src/control/keyconfig.cpp
+++ b/src/control/keyconfig.cpp
@@ -56,6 +56,7 @@ void KeyConfig::load_conf()
     load_keymotions( cf, "TabNum7", KEYCONF_TabNum7 );
     load_keymotions( cf, "TabNum8", KEYCONF_TabNum8 );
     load_keymotions( cf, "TabNum9", KEYCONF_TabNum9 );
+    load_keymotions( cf, "TabLast", KEYCONF_TabLast );
 
     load_keymotions( cf, "RestoreLastTab", KEYCONF_RestoreLastTab );
 

--- a/src/control/keypref.cpp
+++ b/src/control/keypref.cpp
@@ -90,6 +90,7 @@ KeyPref::KeyPref( Gtk::Window* parent, const std::string& url )
     append_row( CONTROL::TabNum7 );
     append_row( CONTROL::TabNum8 );
     append_row( CONTROL::TabNum9 );
+    append_row( CONTROL::TabLast );
 
     append_row( CONTROL::RestoreLastTab );
 

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -1372,6 +1372,13 @@ void Admin::tab_num( const std::string& str_num )
 
     const int num = strtol( str_num.c_str(), nullptr, 10 );
 
+    // 最後のタブに移動
+    if( num == -1 ) {
+        // GtkNotebook の API はマイナスの値で最後のタブを指定する
+        set_current_page( -1 );
+        return;
+    }
+
     // Firefoxの動作に合わせた
     // 0 → 無視
     // 8以下で存在する数より多い → 無視


### PR DESCRIPTION
ショートカットキー設定に「最後のタブに移動」機能を追加します。

「最後のタブに移動」を実行すると一番最後(右端)のタブに表示を切り替えます。

デフォルト設定は無しとし、各ユーザーが設定できるようにします。
これは、新規ショートカットキーや既存のショートカットキーの変更は既存のユーザー設定と衝突する可能性があり、混乱を避けるためです。

#### 背景や動機

10個以上タブを開いた際、ショートカットキーで最後(右端)のタブに移動する方法は以下の通りですが手間がかかります。

- (a) 「タブ1に移動」して「左のタブに移動」する
- (b) 「タブ9に移動」して「右のタブに移動」を繰り返す

Google ChromeやFirefoxなどのwebブラウザはショートカットキーAlt+9に「最後のタブに選択(移動)」が割り当てられており、同様の機能があれば便利です。

Closes #1427
