### PR TITLE
Fix GitHub Actions workflow Weekly CI

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -86,7 +86,7 @@ jobs:
         # Since the muon revision on 2024-08-13, building muon requires Meson features up to version 1.3.0.
       - name: meson installation
         run: |
-          pip install meson==1.3.0
+          pip install meson==1.3.0 ninja
       - name: git clone muon
         run: |
           git clone --depth 1 https://git.sr.ht/~lattis/muon muon-src


### PR DESCRIPTION
muon-master の job を実行したとき ninja build が見つからず失敗する設定ミスを修正します。

関連のaction:
https://github.com/JDimproved/JDim/actions/runs/10429894791
