### PR TITLE
Weely CI: Use bootstrap.sh instead of meson for muon-master job

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -79,24 +79,23 @@ jobs:
       - name: dependencies installation
         run: |
           sudo apt update
-          sudo apt install git libgnutls28-dev libpkgconf-dev libgtest-dev libgtkmm-3.0-dev pkg-config zlib1g-dev g++-11
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-        # Since the muon revision on 2024-08-13, building muon requires Meson features up to version 1.3.0.
-      - name: meson installation
-        run: |
-          pip install meson==1.3.0 ninja
+          sudo apt install git libgnutls28-dev libpkgconf-dev libgtest-dev libgtkmm-3.0-dev zlib1g-dev g++-11
       - name: git clone muon
         run: |
           git clone --depth 1 https://git.sr.ht/~lattis/muon muon-src
         # Skip bootstrapping muon to do meson setup instead.
       - name: git log -n1 muon
         run: git -C muon-src log -n1
-      - name: build muon
+      - name: build muon stage1
         run: |
-          meson setup -Ddocs=disabled -Dlibarchive=disabled -Dlibcurl=disabled -Dlibpkgconf=enabled muon-build muon-src
-          ninja -C muon-build
+          cd muon-src
+          ./bootstrap.sh stage1
+          ./stage1/muon version
+      - name: build muon stage2
+        run: |
+          ./stage1/muon setup -Ddocs=disabled -Dlibarchive=disabled -Dlibcurl=disabled -Dlibpkgconf=enabled ../muon-build
+          ./stage1/muon samu -C ../muon-build
+          cd ..
       - name: muon version
         run: ./muon-build/muon version
       - name: muon setup builddir


### PR DESCRIPTION
python3.12 をセットアップしてインストールした meson と ninja を使うと gtkmm-3.0 パッケージの解決に失敗します。
そのため muon の bootstrap.sh を使って muon をビルドしてテストするように変更します。
