### PR TITLE
Img: Interrupt download for i.imgur.com/removed.png

### DIFF
--- a/src/dbimg/img.cpp
+++ b/src/dbimg/img.cpp
@@ -574,6 +574,10 @@ void Img::receive_finish()
         std::string url_tmp = MISC::tolower_str( location() );
         if( url_tmp.find( "404" ) != std::string::npos && url_tmp.find( ".htm" ) != std::string::npos ) m_type = T_NOT_FOUND;
 
+        // 画像共有サービスimgurの削除された画像のURLは削除済みを示す画像へリダイレクトする
+        // 不要な通信やキャッシュを回避するため404 Not Foundにする。
+        else if( url_tmp == "https://i.imgur.com/removed.png" ) m_type = T_NOT_FOUND;
+
         else if( ! location().empty() && m_count_redirect < MAX_REDIRECT ){
 
 #ifdef _DEBUG


### PR DESCRIPTION
imgurの画像にアクセスした際に`https://i.imgur.com/removed.png`へのHTTPリダイレクトが発生した場合、ダウンロードをキャンセルし、HTTP 404 Not Foundとして処理します。

#### 背景や動機

画像共有サービスimgurにアップロードされた画像には、個別のURLが割り当てられます。
投稿者や運営が削除した画像のURLにアクセスすると、削除済みを示す画像へのHTTPリダイレクトが行われます。
削除済みを示す画像はサイズが小さいものの、HTTP通信に時間がかかり不要な画像データがキャッシュに残ってしまうため 404 Not Found にして通信やキャッシュを回避します。

Closes #1433
