### PR TITLE
MouseKeyPref: Use Gtk::TreeView instead of SKELETON::JDTreeViewBase

### DIFF
--- a/src/control/mousekeypref.h
+++ b/src/control/mousekeypref.h
@@ -7,7 +7,6 @@
 #define _MOUSEKEYPREFPREF_H
 
 #include "skeleton/prefdiag.h"
-#include "skeleton/treeviewbase.h"
 
 #include "control.h"
 
@@ -89,7 +88,7 @@ namespace CONTROL
         int m_controlmode;
         bool m_single{};
 
-        SKELETON::JDTreeViewBase m_treeview;
+        Gtk::TreeView m_treeview;
         Glib::RefPtr< Gtk::ListStore > m_liststore;
         MouseKeyDiagColumn m_columns;
         Gtk::ScrolledWindow m_scrollwin;
@@ -171,7 +170,7 @@ namespace CONTROL
     //
     class MouseKeyPref : public SKELETON::PrefDiag
     {
-        SKELETON::JDTreeViewBase m_treeview;
+        Gtk::TreeView m_treeview;
         Glib::RefPtr< Gtk::ListStore > m_liststore;
         MouseKeyTreeColumn m_columns;
         Gtk::ScrolledWindow m_scrollwin;


### PR DESCRIPTION
ショートカットキー設定ダイアログの設定一覧で上下の矢印キーを押しても選択項目が切り替わらない不具合を修正します。
マウスジェスチャ設定とマウスボタン設定のダイアログも同じ不具合がありましたので修正します。

修正前は、設定一覧の実装に独自にカスタマイズした`SKELETON::JDTreeViewBase`を使っていました。
このウィジェットは矢印キーなどの入力イベントを上書きしているためシグナルハンドラの接続で処理する必要があります。
しかし、設定ダイアログは`SKELETON::JDTreeViewBase`のカスタマイズ機能を使っていないため必要以上に複雑な実装になっています。
そこで`Gtk::TreeView`に戻して余計な機能を外し、デフォルトの入力イベントを復活させます。

Closes #1435
