### PR TITLE
PaneControl: Get rid of member function unused parameters

### DIFF
--- a/src/skeleton/panecontrol.cpp
+++ b/src/skeleton/panecontrol.cpp
@@ -172,7 +172,7 @@ void PaneControl::button_press_event( GdkEventButton* event )
 }
 
 
-void PaneControl::button_release_event( GdkEventButton* event )
+void PaneControl::button_release_event( GdkEventButton* )
 {
 #ifdef _DEBUG
     std::cout << "PaneControl::butoon_release_event clicked = " << m_clicked << " drag = " << m_drag << std::endl;
@@ -217,7 +217,7 @@ void PaneControl::button_release_event( GdkEventButton* event )
 
 
 
-void PaneControl::motion_notify_event( GdkEventMotion* event )
+void PaneControl::motion_notify_event( GdkEventMotion* )
 {
 #ifdef _DEBUG
 //    std::cout << "PaneControl::motion_notify_event\n";
@@ -227,7 +227,7 @@ void PaneControl::motion_notify_event( GdkEventMotion* event )
 }
 
 
-void PaneControl::enter_notify_event( GdkEventCrossing* event )
+void PaneControl::enter_notify_event( GdkEventCrossing* )
 {
 #ifdef _DEBUG
     std::cout << "PaneControl::enter_notify_event\n";
@@ -237,7 +237,7 @@ void PaneControl::enter_notify_event( GdkEventCrossing* event )
 }
 
 
-void PaneControl::leave_notify_event( GdkEventCrossing* event )
+void PaneControl::leave_notify_event( GdkEventCrossing* )
 {
 #ifdef _DEBUG
     std::cout << "PaneControl::leave_notify_event\n";

--- a/src/skeleton/panecontrol.h
+++ b/src/skeleton/panecontrol.h
@@ -79,10 +79,10 @@ namespace SKELETON
         void add_remove2( bool unpack, Gtk::Widget& child );
 
         void button_press_event( GdkEventButton* event );
-        void button_release_event( GdkEventButton* event );
-        void motion_notify_event( GdkEventMotion* event );
-        void enter_notify_event( GdkEventCrossing* event );
-        void leave_notify_event( GdkEventCrossing* event );
+        void button_release_event( GdkEventButton* );
+        void motion_notify_event( GdkEventMotion* );
+        void enter_notify_event( GdkEventCrossing* );
+        void leave_notify_event( GdkEventCrossing* );
 
       protected:
 


### PR DESCRIPTION
メンバー関数の仮引数`event`にconst修飾子をつけることができるとcppcheckに指摘されました。
この`event`は未使用変数なので関数の宣言や定義から取り除いてレポートを抑制します。
同様に他のメンバー関数のうち未使用の`event`を取り除きます。

cppcheck 2.14.2のレポート
```
src/skeleton/panecontrol.cpp:220:56: style: Parameter 'event' can be declared as pointer to const [constParameterPointer]
void PaneControl::motion_notify_event( GdkEventMotion* event )
                                                       ^
```
