### PR TITLE
Fix compiler warnings for -Wc++20-compat part1

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -323,8 +323,8 @@ void DrawAreaBase::init_color()
 
     // スレビューの選択色でgtkrcの設定を使用
     if( CONFIG::get_use_select_gtkrc() ){
-        const bool fg_ok = context->lookup_color( u8"theme_selected_fg_color", m_color[ COLOR_CHAR_SELECTION ] );
-        const bool bg_ok = context->lookup_color( u8"theme_selected_bg_color", m_color[ COLOR_BACK_SELECTION ] );
+        const bool fg_ok = context->lookup_color( "theme_selected_fg_color", m_color[ COLOR_CHAR_SELECTION ] );
+        const bool bg_ok = context->lookup_color( "theme_selected_bg_color", m_color[ COLOR_BACK_SELECTION ] );
         if( !fg_ok || !bg_ok ) {
 #ifdef _DEBUG
             std::cout << "ERROR:DrawAreaBase::init_color lookup theme color failed." << std::endl;

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -216,7 +216,7 @@ void MessageViewBase::init_color()
     if( m_text_message ){
 
         if( CONFIG::get_use_message_gtktheme() ) {
-            m_text_message->update_style( u8"" );
+            m_text_message->update_style( "" );
         }
         else {
             const char* const classname = m_text_message->get_css_classname();
@@ -225,7 +225,7 @@ void MessageViewBase::init_color()
             const auto sel_fg = Gdk::RGBA( CONFIG::get_color( COLOR_CHAR_MESSAGE_SELECTION ) ).to_string();
             const auto sel_bg = Gdk::RGBA( CONFIG::get_color( COLOR_BACK_MESSAGE_SELECTION ) ).to_string();
             m_text_message->update_style( Glib::ustring::compose(
-                u8R"(
+                R"(
                     .%1, .%1 text { color: %2; background-color: %3; caret-color: %2; }
                     .%1:selected, .%1:selected:focus,
                     .%1 text:selected, .%1 text:selected:focus,

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -114,7 +114,7 @@ void DragTreeView::init_color( const int colorid_text, const int colorid_bg, con
 {
     if( CONFIG::get_use_tree_gtkrc() ) {
         m_use_bg_even = false;
-        m_provider->load_from_data( u8"" );
+        m_provider->load_from_data( "" );
         return;
     }
 
@@ -131,7 +131,7 @@ void DragTreeView::init_color( const int colorid_text, const int colorid_bg, con
     // https://gitlab.gnome.org/GNOME/gtk/issues/581
     try {
         m_provider->load_from_data( Glib::ustring::compose(
-            u8".%1.view:not(:selected) { color: %2; background-color: %3; }",
+            ".%1.view:not(:selected) { color: %2; background-color: %3; }",
             s_css_classname, m_color_text.to_string(), m_color_bg.to_string() ) );
     }
     catch( Gtk::CssProviderError& err ) {

--- a/src/skeleton/dragtreeview.h
+++ b/src/skeleton/dragtreeview.h
@@ -41,7 +41,7 @@ namespace SKELETON
         Gtk::TreeModel::Path m_path_dragstart;
         Gtk::TreeModel::Path m_path_dragpre;
 
-        static constexpr const char* s_css_classname = u8"jd-dragtreeview";
+        static constexpr const char* s_css_classname = "jd-dragtreeview";
         Glib::RefPtr< Gtk::CssProvider > m_provider = Gtk::CssProvider::create();
 
         // 色

--- a/src/skeleton/editview.h
+++ b/src/skeleton/editview.h
@@ -123,7 +123,7 @@ namespace SKELETON
     class EditView : public Gtk::ScrolledWindow
     {
         EditTextView m_textview;
-        static constexpr const char* s_css_classname = u8"jd-editview";
+        static constexpr const char* s_css_classname = "jd-editview";
         Glib::RefPtr< Gtk::CssProvider > m_provider = Gtk::CssProvider::create();
 
     public:

--- a/src/skeleton/toolbar.h
+++ b/src/skeleton/toolbar.h
@@ -69,7 +69,7 @@ namespace SKELETON
         SKELETON::ToolBackForwardButton* m_button_back{};
         SKELETON::ToolBackForwardButton* m_button_forward{};
 
-        static constexpr const char* s_css_label = u8"jd-toolbar-label";
+        static constexpr const char* s_css_label = "jd-toolbar-label";
         Glib::RefPtr< Gtk::CssProvider > m_label_provider = Gtk::CssProvider::create();
 
       public:

--- a/src/skeleton/window.h
+++ b/src/skeleton/window.h
@@ -49,7 +49,7 @@ namespace SKELETON
         Gtk::EventBox m_mginfo_ebox;
         Gtk::Label m_mginfo;
 
-        static constexpr const char* s_css_stat_label = u8"jd-stat-label";
+        static constexpr const char* s_css_stat_label = "jd-stat-label";
         Glib::RefPtr< Gtk::CssProvider > m_stat_provider = Gtk::CssProvider::create();
 
       public:


### PR DESCRIPTION
C++20からUTF-8文字列リテラルの型がchar8_tの配列に変更されるとclangに指摘されたためu8プレフィックスを外してコンパイラー警告を抑制します。
JDimのソースコードのエンコーディングはUTF-8なので影響はありません。

clang-18のレポート (file pathを一部省略)
```
src/article/drawareabase.cpp:326:51: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
src/article/drawareabase.cpp:327:51: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
src/message/messageviewbase.cpp:219:43: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
src/message/messageviewbase.cpp:228:17: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
src/skeleton/dragtreeview.cpp:117:37: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
src/skeleton/dragtreeview.cpp:134:13: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
src/skeleton/dragtreeview.h:44:56: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
src/skeleton/editview.h:126:56: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
src/skeleton/toolbar.h:72:52: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
src/skeleton/window.h:52:57: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
```
