### PR TITLE
MouseKeyPref: Implement search box on MouseKeyPref to filter rows

### DIFF
--- a/src/control/mousekeypref.h
+++ b/src/control/mousekeypref.h
@@ -170,8 +170,14 @@ namespace CONTROL
     //
     class MouseKeyPref : public SKELETON::PrefDiag
     {
+        Gtk::Box m_hbox_search;
+        Gtk::ToggleButton m_toggle_search;
+        Glib::RefPtr<Glib::Binding> m_binding_search; ///< ToggleButtonとSearchBarをバインドする
+        Gtk::SearchBar m_search_bar;
+        Gtk::SearchEntry m_search_entry;
         Gtk::TreeView m_treeview;
         Glib::RefPtr< Gtk::ListStore > m_liststore;
+        Glib::RefPtr<Gtk::TreeModelFilter> m_model_filter;
         MouseKeyTreeColumn m_columns;
         Gtk::ScrolledWindow m_scrollwin;
 
@@ -203,6 +209,9 @@ namespace CONTROL
         void slot_reset();
         void slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::TreeViewColumn* column );
         void slot_cell_data( Gtk::CellRenderer* cell, const Gtk::TreeModel::iterator& it );
+        bool slot_key_press_event( GdkEventKey* event );
+        void slot_entry_changed();
+        bool slot_visible_func( const Gtk::TreeModel::const_iterator& iter );
     };
 
 }


### PR DESCRIPTION
ショートカットキー設定とマウスジェスチャ設定とマウスボタン設定のダイアログに設定項目をキーワードでフィルタリングする検索ボックスとボックスを開閉するトグルボタンを追加します。
また、検索ボックスを開くキーボードショートカットキー(Ctrl+F)も実装します。

検索ボックスに入力したキーワードで設定項目のフィルタリングを行います。
設定項目のラベルにキーワードが含まれていればその項目を表示します。
検索ボックスを閉じたりキーワードが空欄のときはフィルタリングが解除されます。

検索はキーワードの前後にある空白を取り除いて単純な比較で実行するため正規表現や大文字小文字の無視、migemoを使ってローマ字から日本語の検索
などは行いません。
また、キーワードの中に空白が含まれていても全体を1つのキーワードとして検索します。

Closes #1439
