### PR TITLE
Fix compiler warnings for -Wc++20-compat part2

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -2404,7 +2404,7 @@ create_multispace:
                 ){
 
                 pos += 4;
-                m_parsed_text.append( u8"\u30FB" ); // KATAKANA MIDDLE DOT
+                m_parsed_text.append( "\u30FB" ); // KATAKANA MIDDLE DOT
             }
 
             // 水平線 <HR>

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -116,7 +116,7 @@ std::list< std::string > MISC::get_elisp_lists( const std::string& str )
 //
 std::list< std::string > MISC::split_line( const std::string& str )
 {
-    constexpr const char* str_space = u8"\u3000"; // "\xE3\x80\x80" 全角スペース
+    constexpr const char* str_space = "\u3000"; // "\xE3\x80\x80" 全角スペース
     constexpr size_t lng_space = 3;
 
     std::list< std::string > list_str;

--- a/test/gtest_jdlib_misctrip.cpp
+++ b/test/gtest_jdlib_misctrip.cpp
@@ -22,74 +22,74 @@ inline static std::string get_trip_sjis( std::string u8key )
 
 TEST_F(GetTripTest, trip8_sjis_empty)
 {
-    EXPECT_EQ( "", get_trip_sjis( u8"" ) );
+    EXPECT_EQ( "", get_trip_sjis( "" ) );
 }
 
 TEST_F(GetTripTest, trip8_sjis_A)
 {
-    EXPECT_EQ( "hRJ9Ya./t.", get_trip_sjis( u8"A" ) );
+    EXPECT_EQ( "hRJ9Ya./t.", get_trip_sjis( "A" ) );
 }
 
 TEST_F(GetTripTest, trip8_sjis_hello7)
 {
-    EXPECT_EQ( "/wfpxFEFeQ", get_trip_sjis( u8"hellowo" ) );
+    EXPECT_EQ( "/wfpxFEFeQ", get_trip_sjis( "hellowo" ) );
 }
 
 TEST_F(GetTripTest, trip8_sjis_hello8)
 {
-    EXPECT_EQ( "d75etXAowg", get_trip_sjis( u8"hellowor" ) );
+    EXPECT_EQ( "d75etXAowg", get_trip_sjis( "hellowor" ) );
 }
 
 TEST_F(GetTripTest, trip8_sjis_hello11)
 {
     // 11バイトまでは従来の方式(9〜11バイト目は無視される)
-    EXPECT_EQ( "d75etXAowg", get_trip_sjis( u8"helloworld!" ) );
+    EXPECT_EQ( "d75etXAowg", get_trip_sjis( "helloworld!" ) );
 }
 
 TEST_F(GetTripTest, trip8_sjis_yojijukugo)
 {
-    EXPECT_EQ( "sX.SlNvMe.", get_trip_sjis( u8"四字熟語" ) );
+    EXPECT_EQ( "sX.SlNvMe.", get_trip_sjis( "四字熟語" ) );
 }
 
 TEST_F(GetTripTest, trip8_sjis_hex_less_12)
 {
     // シャープで始まる16進数キーでも12バイト未満なら従来の方式
-    EXPECT_EQ( "RTDIJZhD3g", get_trip_sjis( u8"#0123456789" ) );
+    EXPECT_EQ( "RTDIJZhD3g", get_trip_sjis( "#0123456789" ) );
 }
 
 TEST_F(GetTripTest, trip8_sjis_dollar_less_12)
 {
     // ドル記号で始まるキーでも12バイト未満なら従来の方式
-    EXPECT_EQ( "46g6cHndYk", get_trip_sjis( u8"$0123456789" ) );
+    EXPECT_EQ( "46g6cHndYk", get_trip_sjis( "$0123456789" ) );
 }
 
 TEST_F(GetTripTest, trip12_sjis_hello12)
 {
     // 12バイト以上は新方式
-    EXPECT_EQ( "xwumaTFfu1OK", get_trip_sjis( u8"helloworld!?" ) );
+    EXPECT_EQ( "xwumaTFfu1OK", get_trip_sjis( "helloworld!?" ) );
 }
 
 TEST_F(GetTripTest, trip12_sjis_jdimprovedproject)
 {
     // 新方式の+は.に変換される
-    EXPECT_EQ( "Y7G9gYfXrr6.", get_trip_sjis( u8"jdimprovedproject" ) );
+    EXPECT_EQ( "Y7G9gYfXrr6.", get_trip_sjis( "jdimprovedproject" ) );
 }
 
 TEST_F(GetTripTest, trip12_sjis_hex)
 {
     // 新方式 16進数のキー
-    EXPECT_EQ( "ClNHFHdYIw", get_trip_sjis( u8"#0123456789abcdef" ) );
+    EXPECT_EQ( "ClNHFHdYIw", get_trip_sjis( "#0123456789abcdef" ) );
 }
 
 TEST_F(GetTripTest, trip12_sjis_non_hex)
 {
     // 念の為トライグラフ対策としてエスケープ
-    EXPECT_EQ( "\?\?\?", get_trip_sjis( u8"#あいうえおか" ) );
+    EXPECT_EQ( "\?\?\?", get_trip_sjis( "#あいうえおか" ) );
 }
 
 TEST_F(GetTripTest, trip12_sjis_dollar)
 {
-    EXPECT_EQ( "\?\?\?", get_trip_sjis( u8"$将来の拡張用" ) );
+    EXPECT_EQ( "\?\?\?", get_trip_sjis( "$将来の拡張用" ) );
 }
 
 } // namespace


### PR DESCRIPTION
C++20からUTF-8文字列リテラルの型が`char8_t`の配列に変更されるとclangに指摘されたためu8プレフィックスを外してコンパイラー警告を抑制します。
JDimのソースコードのエンコーディングはUTF-8なので影響はありません。

clang-18のレポート (file pathを一部省略)
```
src/dbtree/nodetreebase.cpp:2407:39: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
src/jdlib/miscutil.cpp:119:39: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_misctrip.cpp:25:35: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_misctrip.cpp:30:45: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_misctrip.cpp:35:45: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_misctrip.cpp:40:45: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_misctrip.cpp:46:45: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_misctrip.cpp:51:45: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_misctrip.cpp:57:45: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_misctrip.cpp:63:45: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_misctrip.cpp:69:47: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_misctrip.cpp:75:47: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_misctrip.cpp:81:45: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_misctrip.cpp:87:41: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_misctrip.cpp:92:41: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
```

関連のpull request: #1438
