### PR TITLE
Fix compiler warnings for -Wc++20-compat part3

### DIFF
--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -14,34 +14,34 @@ class SplitLineTest : public ::testing::Test {};
 TEST_F(SplitLineTest, split_empty)
 {
     std::list< std::string > expect = {};
-    EXPECT_EQ( expect, MISC::split_line( u8"" ) );
+    EXPECT_EQ( expect, MISC::split_line( "" ) );
 }
 
 TEST_F(SplitLineTest, split_U_0020)
 {
     std::list< std::string > expect = {};
-    EXPECT_EQ( expect, MISC::split_line( u8"    " ) );
+    EXPECT_EQ( expect, MISC::split_line( "    " ) );
 
-    expect.assign( { u8"the", u8"quick", u8"brown", u8"fox" } );
-    EXPECT_EQ( expect, MISC::split_line( u8" the quick  brown   fox  " ) );
+    expect.assign( { "the", "quick", "brown", "fox" } );
+    EXPECT_EQ( expect, MISC::split_line( " the quick  brown   fox  " ) );
 }
 
 TEST_F(SplitLineTest, split_U_3000)
 {
     std::list< std::string > expect = {};
-    EXPECT_EQ( expect, MISC::split_line( u8"\u3000 \u3000 " ) );
+    EXPECT_EQ( expect, MISC::split_line( "\u3000 \u3000 " ) );
 
-    expect.assign( { u8"the", u8"quick", u8"brown", u8"fox" } );
-    EXPECT_EQ( expect, MISC::split_line( u8"\u3000the\u3000quick \u3000brown\u3000 \u3000fox\u3000 " ) );
+    expect.assign( { "the", "quick", "brown", "fox" } );
+    EXPECT_EQ( expect, MISC::split_line( "\u3000the\u3000quick \u3000brown\u3000 \u3000fox\u3000 " ) );
 }
 
 TEST_F(SplitLineTest, split_doublequote_U_0020)
 {
     std::list< std::string > expect = {};
-    EXPECT_EQ( expect, MISC::split_line( u8"  \"\"  " ) );
+    EXPECT_EQ( expect, MISC::split_line( "  \"\"  " ) );
 
-    expect.assign( { u8"the quick", u8" ", u8" brown   fox " } );
-    EXPECT_EQ( expect, MISC::split_line( u8" \"the quick\" \" \" \" brown   fox \" " ) );
+    expect.assign( { "the quick", " ", " brown   fox " } );
+    EXPECT_EQ( expect, MISC::split_line( " \"the quick\" \" \" \" brown   fox \" " ) );
 }
 
 TEST_F(SplitLineTest, split_doublequote_U_3000)


### PR DESCRIPTION
C++20からUTF-8文字列リテラルの型がchar8_tの配列に変更されるとclangに指摘されたためu8プレフィックスを外してコンパイラー警告を抑制します。
JDimのソースコードのエンコーディングはUTF-8なので影響はありません。

clang-18のレポート (file pathを一部省略)
```
test/gtest_jdlib_miscutil.cpp:17:42: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:23:42: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:25:22: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:25:31: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:25:42: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:25:53: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:26:42: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:32:42: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:34:22: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:34:31: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:34:42: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:34:53: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:35:42: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:41:42: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:43:22: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:43:37: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:43:44: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
test/gtest_jdlib_miscutil.cpp:44:42: warning: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Wc++20-compat]
```

関連のpull request: #1438
