### PR TITLE
ImgRoot: Simplify `get_type_ext()` function by removing overloads

### DIFF
--- a/src/dbimg/imginterface.cpp
+++ b/src/dbimg/imginterface.cpp
@@ -70,12 +70,6 @@ int DBIMG::get_image_type( const unsigned char *sign )
     return T_UNKNOWN;
 }
 
-int DBIMG::get_type_ext( const char* url, int n )
-{
-    if( instance_dbimg_root )  return instance_dbimg_root->get_type_ext( url, n );
-    return T_UNKNOWN;
-}
-
 
 int DBIMG::get_type_real( const std::string& url )
 {

--- a/src/dbimg/imginterface.h
+++ b/src/dbimg/imginterface.h
@@ -81,7 +81,6 @@ namespace DBIMG
     // キャッシュに無くても判断可能
     // 画像ではない場合は T_UNKNOWN を返す
     int get_type_ext( const std::string& url );
-    int get_type_ext( const char* url, int n );
 
     // 実際の画像ファイルの種類を判断
     // 画像がキャッシュに無いときは判断不能( T_UNKNOWN を返す )

--- a/src/dbimg/imgroot.cpp
+++ b/src/dbimg/imgroot.cpp
@@ -261,24 +261,20 @@ int ImgRoot::get_image_type( const unsigned char *sign ) const
 //
 int ImgRoot::get_type_ext( const std::string& url ) const
 {
-    return get_type_ext( url.c_str(), url.length() );
-}
-
-
-int ImgRoot::get_type_ext( const char* url, int n ) const
-{
     // Urlreplaceによる画像コントロールを取得する
     int imgctrl = CORE::get_urlreplace_manager()->get_imgctrl( url );
 
     // URLに拡張子があっても画像として扱わない
     if( imgctrl & CORE::IMGCTRL_FORCEBROWSER ) return T_UNKNOWN;
 
-    if( is_jpg( url, n ) ) return T_JPG;
-    if( is_png( url, n ) ) return T_PNG;
-    if( is_gif( url, n ) ) return T_GIF;
-    if( is_bmp( url, n ) ) return T_BMP;
-    if( m_webp_support && is_webp( url, n ) ) return T_WEBP;
-    if( m_avif_support && is_avif( url, n ) ) return T_AVIF;
+    const int n = static_cast<int>(url.size());
+
+    if( is_jpg( url.c_str(), n ) ) return T_JPG;
+    if( is_png( url.c_str(), n ) ) return T_PNG;
+    if( is_gif( url.c_str(), n ) ) return T_GIF;
+    if( is_bmp( url.c_str(), n ) ) return T_BMP;
+    if( m_webp_support && is_webp( url.c_str(), n ) ) return T_WEBP;
+    if( m_avif_support && is_avif( url.c_str(), n ) ) return T_AVIF;
 
     // URLに拡張子がない場合でも画像として扱うか
     if( imgctrl & CORE::IMGCTRL_FORCEIMAGE ) return T_FORCEIMAGE;

--- a/src/dbimg/imgroot.h
+++ b/src/dbimg/imgroot.h
@@ -63,7 +63,6 @@ namespace DBIMG
         // 拡張子から画像タイプを取得
         // 画像ではない場合は T_UNKNOWN を返す
         int get_type_ext( const std::string& url ) const;
-        int get_type_ext( const char* url, int n ) const;
 
         // キャッシュ削除
         void delete_cache( const std::string& url );


### PR DESCRIPTION
`get_type_ext()` 関数の `const char*` と `int` を引数に取るオーバーロードを削除し、`const std::string&` を引数に取る形に統一しました。
これにより、コードの重複を削減し、メンテナンス性を向上させました。
`Urlreplace_Manager::get_imgctrl()` の関数呼び出しにおいて、ヌル終端文字列が必要なため、`std::string_view` ではなく`const std::string&` を引き続き使用します。

Removed the overload of the `get_type_ext()` function that takes `const char*` and `int` as arguments, consolidating it to use `const std::string&`.  This change reduces code duplication and improves maintainability.  The `Urlreplace_Manager::get_imgctrl()` call requires a null-terminated string, so we continue using `const std::string&` instead of `std::string_view`.

関連のissue: #1440
