### PR TITLE
ImgRoot: Ignore URL parameters and anchors in image format detection

### DIFF
--- a/src/dbimg/imgroot.cpp
+++ b/src/dbimg/imgroot.cpp
@@ -267,7 +267,9 @@ int ImgRoot::get_type_ext( const std::string& url ) const
     // URLに拡張子があっても画像として扱わない
     if( imgctrl & CORE::IMGCTRL_FORCEBROWSER ) return T_UNKNOWN;
 
-    const int n = static_cast<int>(url.size());
+    // URLの引数とアンカー(フラグメント)を除外して判定する
+    const auto found = url.find_first_of( "#?" );
+    const int n = static_cast<int>( found != std::string::npos ? found : url.size() );
 
     if( is_jpg( url.c_str(), n ) ) return T_JPG;
     if( is_png( url.c_str(), n ) ) return T_PNG;

--- a/test/gtest_dbimg_imgroot.cpp
+++ b/test/gtest_dbimg_imgroot.cpp
@@ -102,4 +102,22 @@ TEST_F(DBIMG_ImgRoot_GetTypeExtTest, url_mixcase)
     EXPECT_EQ( DBIMG::T_UNKNOWN, imgroot.get_type_ext( "http://jdim.test/image.avIf" ) );
 }
 
+TEST_F(DBIMG_ImgRoot_GetTypeExtTest, url_with_parameters)
+{
+    DBIMG::ImgRoot imgroot;
+    EXPECT_EQ( DBIMG::T_JPG, imgroot.get_type_ext( "http://jdim.test/image.jpg?" ) );
+    EXPECT_EQ( DBIMG::T_JPG, imgroot.get_type_ext( "http://jdim.test/image.jpeg?foo=bar" ) );
+    EXPECT_EQ( DBIMG::T_PNG, imgroot.get_type_ext( "http://jdim.test/image.png?hoge=1&moge=2" ) );
+    EXPECT_EQ( DBIMG::T_GIF, imgroot.get_type_ext( "http://jdim.test/image.gif?a=b.jpg" ) );
+}
+
+TEST_F(DBIMG_ImgRoot_GetTypeExtTest, url_with_anchor)
+{
+    DBIMG::ImgRoot imgroot;
+    EXPECT_EQ( DBIMG::T_JPG, imgroot.get_type_ext( "http://jdim.test/image.jpg#" ) );
+    EXPECT_EQ( DBIMG::T_JPG, imgroot.get_type_ext( "http://jdim.test/image.jpeg#foo" ) );
+    EXPECT_EQ( DBIMG::T_PNG, imgroot.get_type_ext( "http://jdim.test/image.png?hoge=1#moge" ) );
+    EXPECT_EQ( DBIMG::T_GIF, imgroot.get_type_ext( "http://jdim.test/image.gif#b.jpg" ) );
+}
+
 } // namespace


### PR DESCRIPTION
画像URLの種類を判定する関数を修正し、URLの引数とアンカー(フラグメント) 部分を無視して正確に画像形式を判定できるようにしました。

修正前は引数とアンカーの部分まで含めてチェックしていたため、例えば`http://example.com/image.jpg?foo=bar`のようなURLの場合、`.jpg?foo=bar`という拡張子として判定され、画像URLを正しく判定できない状態でした。

この修正により、引数やアンカーが付与された画像URLでも正しく判定できるようになります。 テストケースも追加し、引数やアンカーが含まれるURLに対して正しい判定が行われることを確認しました。

Modified the function that detects the type of image URL to ignore the query parameters and anchor (fragment) parts, allowing for more accurate image format detection.

Previously, the entire URL including parameters and anchors was checked.  For example, a URL like `http://example.com/image.jpg?foo=bar` would be incorrectly judged as having the extension .jpg?foo=bar, preventing correct identification of image URLs.

This fix ensures that image URLs with parameters and anchors are correctly identified.  Test cases were added to verify that URLs containing parameters or anchors are correctly handled.

Fixes #1440
