### PR TITLE
ImgRoot: Fix to avoid treating too short URLs as images

### DIFF
--- a/src/dbimg/imgroot.cpp
+++ b/src/dbimg/imgroot.cpp
@@ -261,6 +261,9 @@ int ImgRoot::get_image_type( const unsigned char *sign ) const
 //
 int ImgRoot::get_type_ext( const std::string& url ) const
 {
+    // is_xxx() を安全に実行できない短すぎるURLはタイプを判定せず T_UNKNOWN を返す
+    if( url.size() < 5 ) return T_UNKNOWN;
+
     // Urlreplaceによる画像コントロールを取得する
     int imgctrl = CORE::get_urlreplace_manager()->get_imgctrl( url );
 

--- a/test/gtest_dbimg_imgroot.cpp
+++ b/test/gtest_dbimg_imgroot.cpp
@@ -29,6 +29,13 @@ TEST_F(DBIMG_ImgRoot_GetTypeExtTest, not_url)
     EXPECT_EQ( DBIMG::T_UNKNOWN, imgroot.get_type_ext( "test-invalid" ) );
 }
 
+TEST_F(DBIMG_ImgRoot_GetTypeExtTest, too_short_string)
+{
+    DBIMG::ImgRoot imgroot;
+    EXPECT_EQ( DBIMG::T_UNKNOWN, imgroot.get_type_ext( ".jpg" ) );
+    EXPECT_EQ( DBIMG::T_JPG, imgroot.get_type_ext( ".jpeg" ) );
+}
+
 TEST_F(DBIMG_ImgRoot_GetTypeExtTest, not_image_url)
 {
     DBIMG::ImgRoot imgroot;


### PR DESCRIPTION
URLの画像拡張子を安全にチェックできない短すぎるURLに対して、画像タイプを判定せず`T_UNKNOWN`を返すようにしました。
これにより、誤ったURLが画像として認識されるのを防ぎます。
また、新しいテストケースを追加して、短すぎるURLが正しく`T_UNKNOWN`を返すことを確認します。

Updated the logic to return `T_UNKNOWN` for URLs that are too short to safely check for image extensions. This prevents incorrect URLs from being recognized as images.  Additionally, a new test case was added to ensure that short URLs correctly return `T_UNKNOWN`.

関連のissue: #1440
