### PR TITLE
Loader: Get rid of anchor from path for HTTP request

### DIFF
--- a/src/jdlib/loader.cpp
+++ b/src/jdlib/loader.cpp
@@ -604,6 +604,10 @@ bool Loader::run( SKELETON::Loadable* cb, const LOADERDATA& data_in )
     
     m_data.host = m_data.url.substr( i, i2 - i );
     m_data.path = m_data.url.substr( i2 );
+    // HTTPやURLの仕様に基づいて、リクエストで送信するパスからアンカー(`#`以降の部分)を取り除く
+    if( const auto anchor = m_data.path.find( '#' ); anchor != std::string::npos ) {
+        m_data.path.erase( anchor );
+    }
 
     // ポートセット
     // ホスト名の後に指定されている


### PR DESCRIPTION
HTTPやURLの仕様に基づいて、リクエストで送信するパスからアンカー(`#`以降の部分)を取り除きます。

修正前はアンカーを含めてパスを送信していたため、間違ったリクエストとしてサーバーからエラーを返されることがありました。

Based on the specifications of HTTP and URL, remove the anchor (the part after `#`) from the path sent in the request.

Before the fix, the path was sent including the anchor, which sometimes resulted in receiving an error from the server as an incorrect request.

Closes #1449
