### PR TITLE
meson: Fix unity build

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -1039,7 +1039,7 @@ bool ArticleViewBase::operate_view( const int control )
 
     if( CONTROL::operate_common( control, get_url(), ARTICLE::get_admin() ) ) return true;
 
-    if( control == CONTROL::None ) return false;
+    if( control == CONTROL::NoOperation ) return false;
 
     // スクロール系操作
     if( m_drawarea->set_scroll( control ) ) return true;
@@ -2090,7 +2090,7 @@ bool ArticleViewBase::slot_button_release( std::string url, int res_number, GdkE
         if( ! is_mouse_on_popup() ){
 
             // マウスジェスチャ
-            if( mg != CONTROL::None && enable_mg() ){
+            if( mg != CONTROL::NoOperation && enable_mg() ){
                 hide_popup();
                 operate_view( mg );
             }
@@ -2154,7 +2154,7 @@ bool ArticleViewBase::slot_key_press( GdkEventKey* event )
 
     int key = get_control().key_press( event );
 
-    if( key != CONTROL::None ){
+    if( key != CONTROL::NoOperation ){
         if( operate_view( key ) ) return true;
     }
     else if( release_keyjump_key( event->keyval ) ) return true;
@@ -2195,7 +2195,7 @@ bool ArticleViewBase::slot_scroll_event( GdkEventScroll* event )
 
     // ホイールマウスジェスチャ
     int control = get_control().MG_wheel_scroll( event );
-    if( enable_mg() && control != CONTROL::None ){
+    if( enable_mg() && control != CONTROL::NoOperation ){
         operate_view( control );
         return true;
     }

--- a/src/article/articleviewpreview.cpp
+++ b/src/article/articleviewpreview.cpp
@@ -54,7 +54,7 @@ ArticleViewPreview::~ArticleViewPreview()
 //
 bool ArticleViewPreview::operate_view( const int control )
 {
-    if( control == CONTROL::None ) return false;
+    if( control == CONTROL::NoOperation ) return false;
 
     // スクロール系操作
     if( drawarea()->set_scroll( control ) ) return true;

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -1200,7 +1200,7 @@ bool BBSListViewBase::slot_button_release( GdkEventButton* event )
     // 実行された場合は何もしない
     if( get_control().MG_wheel_end( event ) ) return true;
 
-    if( mg != CONTROL::None && enable_mg() ){
+    if( mg != CONTROL::NoOperation && enable_mg() ){
         operate_view( mg );
         return true;
     }
@@ -1336,7 +1336,7 @@ bool BBSListViewBase::slot_scroll_event( GdkEventScroll* event )
 {
     // ホイールマウスジェスチャ
     int control = get_control().MG_wheel_scroll( event );
-    if( enable_mg() && control != CONTROL::None ){
+    if( enable_mg() && control != CONTROL::NoOperation ){
         operate_view( control );
         return true;
     }

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -2131,7 +2131,7 @@ bool BoardViewBase::slot_button_release( GdkEventButton* event )
     // 実行された場合は何もしない
     if( get_control().MG_wheel_end( event ) ) return true;
 
-    if( mg != CONTROL::None && enable_mg() ){
+    if( mg != CONTROL::NoOperation && enable_mg() ){
         operate_view( mg );
         return true;
     }
@@ -2216,7 +2216,7 @@ bool BoardViewBase::slot_key_press( GdkEventKey* event )
 {
     m_pressed_key = get_control().key_press( event );
 
-    if( m_pressed_key != CONTROL::None ){
+    if( m_pressed_key != CONTROL::NoOperation ){
 
         // キー入力でスレを開くとkey_releaseイベントがboadviewが画面から
         // 消えてから送られてWIDGET_REALIZED_FOR_EVENT assertionが出るので
@@ -2261,7 +2261,7 @@ bool BoardViewBase::slot_scroll_event( GdkEventScroll* event )
 {
     // ホイールマウスジェスチャ
     const int control = get_control().MG_wheel_scroll( event );
-    if( enable_mg() && control != CONTROL::None ){
+    if( enable_mg() && control != CONTROL::NoOperation ){
         operate_view( control );
         return true;
     }

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -93,10 +93,10 @@ int Control::key_press( const GdkEventKey* event )
     std::cout << "\n";
 #endif    
 
-    int control = CONTROL::None;
+    int control = CONTROL::NoOperation;
     for( const int mode : m_mode ) {
         control = CONTROL::get_keyconfig()->get_id( mode, key, ctrl, shift, alt, dblclick, trpclick );
-        if( control != CONTROL::None ) break;
+        if( control != CONTROL::NoOperation ) break;
     }
 
     return control;
@@ -119,10 +119,10 @@ int Control::button_press( const GdkEventButton* event )
     const bool dblclick = ( event->type == GDK_2BUTTON_PRESS );
     const bool trpclick = ( event->type == GDK_3BUTTON_PRESS );
 
-    int control = CONTROL::None;
+    int control = CONTROL::NoOperation;
     for( const int mode : m_mode ) {
         control = CONTROL::get_buttonconfig()->get_id( mode, button, ctrl, shift, alt, dblclick, trpclick );
-        if( control != CONTROL::None ) break;
+        if( control != CONTROL::NoOperation ) break;
     }
 
     return control;
@@ -266,10 +266,10 @@ bool Control::MG_motion( const GdkEventMotion* event )
             const bool dblclick = false;
             const bool trpclick = false;
 
-            int control = CONTROL::None;
+            int control = CONTROL::NoOperation;
             for( const int mode : m_mode ) {
                 control = CONTROL::get_mouseconfig()->get_id( mode, m_mg_value, ctrl, shift, alt, dblclick, trpclick );
-                if( control != CONTROL::None ) break;
+                if( control != CONTROL::NoOperation ) break;
             }
 
             if( m_send_mg_info ) CORE::core_set_command( "set_mginfo", "", "■" + m_mg_direction + CONTROL::get_label( control ) );
@@ -288,7 +288,7 @@ bool Control::MG_motion( const GdkEventMotion* event )
 // 戻り値はコントロールID
 int Control::MG_end( const GdkEventButton* event )
 {
-    if( ! m_mg ) return None;
+    if( ! m_mg ) return CONTROL::NoOperation;
 
 #ifdef _DEBUG
     std::cout << "Control::MG_end val = " << m_mg_value << std::endl;
@@ -300,17 +300,17 @@ int Control::MG_end( const GdkEventButton* event )
     const bool dblclick = false;
     const bool trpclick = false;
 
-    int control = CONTROL::None;
+    int control = CONTROL::NoOperation;
     for( const int mode : m_mode ) {
         control = CONTROL::get_mouseconfig()->get_id( mode, m_mg_value, ctrl, shift, alt, dblclick, trpclick );
-        if( control != CONTROL::None ) break;
+        if( control != CONTROL::NoOperation ) break;
     }
 
     std::string str_command = CONTROL::get_label( control );
 
     if( m_mg_lng ){
 
-        if( control == CONTROL::None ){
+        if( control == CONTROL::NoOperation ){
             str_command = "Cancel";
             control = CONTROL::CancelMG;
         }
@@ -355,7 +355,7 @@ bool Control::MG_wheel_start( const GdkEventButton* event )
 // ホイールマウスジェスチャ。 戻り値はコントロールID
 int Control::MG_wheel_scroll( const GdkEventScroll* event )
 {
-    int control = CONTROL::None;
+    int control = CONTROL::NoOperation;
 
     const guint direction = event->direction;
 
@@ -387,7 +387,7 @@ int Control::MG_wheel_scroll( const GdkEventScroll* event )
 
         for( const int mode : m_mode ) {
             control = CONTROL::get_buttonconfig()->get_id( mode, button, ctrl, shift, alt, dblclick, trpclick );
-            if( control != CONTROL::None ) break;
+            if( control != CONTROL::NoOperation ) break;
         }
     }
 
@@ -396,7 +396,7 @@ int Control::MG_wheel_scroll( const GdkEventScroll* event )
 
         for( const int mode : m_mode ) {
             control = CONTROL::get_buttonconfig()->get_id( mode, button, ctrl, shift, alt, dblclick, trpclick );
-            if( control != CONTROL::None ) break;
+            if( control != CONTROL::NoOperation ) break;
         }
     }
 
@@ -417,7 +417,7 @@ int Control::MG_wheel_scroll( const GdkEventScroll* event )
     std::cout << "Control::MG_wheel_scroll control = " << control << std::endl;
 #endif
 
-    if( control != CONTROL::None ){
+    if( control != CONTROL::NoOperation ){
         if( m_send_mg_info ) CORE::core_set_command( "set_mginfo", "", CONTROL::get_label( control ) );
         mg_wheel_done = true;
     }

--- a/src/control/controlid.h
+++ b/src/control/controlid.h
@@ -316,7 +316,7 @@ namespace CONTROL
 
         // その他
         CancelMG,
-        None,
+        NoOperation,
 
         CONTROL_END
     };

--- a/src/control/controlutil.cpp
+++ b/src/control/controlutil.cpp
@@ -135,7 +135,7 @@ static void slot_set_menu_motion( Gtk::Widget& widget )
         std::cout << label->get_text() << std::endl;
 #endif
         const int id = CONTROL::get_id( label->get_text() );
-        if( id != CONTROL::None ) {
+        if( id != CONTROL::NoOperation ) {
             const std::string str_label = CONTROL::get_label_with_mnemonic( id );
             std::string str_motions;
 
@@ -306,7 +306,7 @@ int CONTROL::get_id( const std::string& name )
         if( name == CONTROL::control_label[ id ][0] ) return id;
     }
 
-    return CONTROL::None;
+    return CONTROL::NoOperation;
 }
 
 
@@ -554,7 +554,7 @@ std::string CONTROL::get_label_motions( const int id )
 // 共通操作
 bool CONTROL::operate_common( const int control, const std::string& url, SKELETON::Admin* admin )
 {
-    if( control == CONTROL::None ) return false;
+    if( control == CONTROL::NoOperation ) return false;
 
     switch( control ){
             

--- a/src/control/mousekeyconf.cpp
+++ b/src/control/mousekeyconf.cpp
@@ -61,11 +61,11 @@ int MouseKeyConf::get_id( const int mode,
                           const guint motion, const bool ctrl, const bool shift, const bool alt,
                           const bool dblclick, const bool trpclick ) const
 {
-    int id = CONTROL::None;
+    int id = CONTROL::NoOperation;
     for( const MouseKeyItem& item : m_vec_items ) {
 
         id = item.is_activated( mode, motion, ctrl, shift, alt, dblclick, trpclick );
-        if( id != CONTROL::None ) break;
+        if( id != CONTROL::NoOperation ) break;
     }
 
 #ifdef _DEBUG
@@ -124,7 +124,7 @@ std::vector< int > MouseKeyConf::check_conflict( const int mode, const std::stri
     for( const MouseKeyItem& item : m_vec_items ) {
 
         const int id = item.is_activated( mode, str_motion );
-        if( id != CONTROL::None ) vec_ids.push_back( id );
+        if( id != CONTROL::NoOperation ) vec_ids.push_back( id );
     }
 
     return vec_ids;
@@ -185,7 +185,7 @@ void MouseKeyConf::load_keymotions( JDLIB::ConfLoader& cf, const std::string& na
 // スペースで区切られた複数の操作をデータベースに登録
 void MouseKeyConf::set_motions( const int id, const std::string& str_motions )
 {
-    if( id == CONTROL::None ) return;
+    if( id == CONTROL::NoOperation ) return;
 
     const std::string name = CONTROL::get_name( id );
     if( name.empty() ) return;
@@ -201,7 +201,7 @@ void MouseKeyConf::set_motions( const int id, const std::string& str_motions )
 // デフォルト操作を登録
 void MouseKeyConf::set_default_motions( const int id, const std::string& default_motions )
 {
-    if( id == CONTROL::None ) return;
+    if( id == CONTROL::NoOperation ) return;
 
     m_map_default_motions.insert( make_pair( id, default_motions ) );
 }
@@ -211,7 +211,7 @@ void MouseKeyConf::set_default_motions( const int id, const std::string& default
 void MouseKeyConf::set_one_motion( const std::string& name, const std::string& str_motion )
 {
     const int id = CONTROL::get_id( name );
-    if( id == CONTROL::None ) return;
+    if( id == CONTROL::NoOperation ) return;
 
     const int mode = CONTROL::get_mode( id );
     if( mode == CONTROL::MODE_ERROR ) return;

--- a/src/control/mousekeyitem.h
+++ b/src/control/mousekeyitem.h
@@ -58,7 +58,7 @@ namespace CONTROL
         int equal( const std::string& str_motion ) const
         {
             if( str_motion == m_str_motion ) return m_id;
-            return CONTROL::None;
+            return CONTROL::NoOperation;
         }
 
         // モード無視
@@ -67,20 +67,20 @@ namespace CONTROL
         {
             if( motion == m_motion && ctrl == m_ctrl && shift == m_shift && alt == m_alt && dblclick == m_dblclick
                     && trpclick == m_trpclick ) return m_id;
-            return CONTROL::None;
+            return CONTROL::NoOperation;
         }
 
         int is_activated( const int mode, const std::string& str_motion ) const
         {
             if( mode == m_mode ) return equal( str_motion );
-            return CONTROL::None;
+            return CONTROL::NoOperation;
         }
 
         int is_activated( const int mode, const guint motion, const bool ctrl, const bool shift, const bool alt,
                           const bool dblclick, const bool trpclick ) const
         {
             if( mode == m_mode ) return equal( motion, ctrl, shift, alt, dblclick, trpclick );
-            return CONTROL::None;
+            return CONTROL::NoOperation;
         }
     };
 }

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -373,7 +373,7 @@ std::string MouseKeyDiag::show_inputdiag( bool is_append )
         bool conflict = false;
         const std::vector< int > vec_ids = check_conflict( m_controlmode, diag->get_str_motion() );
         auto it = std::find_if( vec_ids.cbegin(), vec_ids.cend(),
-                                [this]( int id ) { return id != CONTROL::None && id != m_id; } );
+                                [this]( int id ) { return id != CONTROL::NoOperation && id != m_id; } );
         if( it != vec_ids.cend() ) {
             const std::string label = CONTROL::get_label( *it );
             SKELETON::MsgDiag mdiag( nullptr, diag->get_str_motion() + "\n\nは「" + label + "」で使用されています" );
@@ -475,7 +475,7 @@ void MouseKeyDiag::slot_reset()
         bool conflict = false;
         const std::vector< int > vec_ids = check_conflict( m_controlmode, motion );
         auto it = std::find_if( vec_ids.cbegin(), vec_ids.cend(),
-                                [this]( int id ) { return id != CONTROL::None && id != m_id; } );
+                                [this]( int id ) { return id != CONTROL::NoOperation && id != m_id; } );
         if( it != vec_ids.cend() ) {
             const std::string label = CONTROL::get_label( *it );
             SKELETON::MsgDiag mdiag( nullptr, motion + "\n\nは「" + label + "」で使用されています" );
@@ -599,7 +599,7 @@ void MouseKeyPref::append_comment_row( const std::string& comment )
     if( row ){
         row[ m_columns.m_col_label ] = comment;
         row[ m_columns.m_col_motions ] = std::string();
-        row[ m_columns.m_col_id ] = CONTROL::None;
+        row[ m_columns.m_col_id ] = CONTROL::NoOperation;
         row[ m_columns.m_col_drawbg ] = false;
         static_cast<void>( row ); // cppcheck: unreadVariable
     }
@@ -615,7 +615,7 @@ void MouseKeyPref::slot_reset()
     for( Gtk::TreeRow row : children ) {
         if( row ){
             const int id = row[ get_colums().m_col_id ];
-            if( id != CONTROL::None ){
+            if( id != CONTROL::NoOperation ){
 
                 const std::string str_motions = get_default_motions( id );
 
@@ -643,7 +643,7 @@ void MouseKeyPref::slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::Tr
     if( ! row ) return;
 
     const int id = row[ get_colums().m_col_id ];
-    if( id == CONTROL::None ) return;
+    if( id == CONTROL::NoOperation ) return;
 
     std::unique_ptr<MouseKeyDiag> diag = create_setting_diag( id, row[ get_colums().m_col_motions ] );
     if( diag->run() == Gtk::RESPONSE_OK ){
@@ -721,7 +721,7 @@ bool MouseKeyPref::slot_visible_func( const Gtk::TreeModel::const_iterator& iter
 
     const Gtk::TreeModel::Row& row = *iter;
     // 検索中は設定カテゴリの名前や空行を取り除く
-    if( row[ m_columns.m_col_id ] == CONTROL::None ) return false;
+    if( row[ m_columns.m_col_id ] == CONTROL::NoOperation ) return false;
 
     // 検索クエリの前後にある空白文字は無視する
     constexpr auto is_not_space = []( gunichar uc ) { return uc != U' ' && uc != U'\u3000'; };

--- a/src/image/imageviewbase.cpp
+++ b/src/image/imageviewbase.cpp
@@ -784,7 +784,7 @@ bool ImageViewBase::slot_button_release( GdkEventButton* event )
     // 実行された場合は何もしない 
     if( get_control().MG_wheel_end( event ) ) return true;
 
-    if( mg != CONTROL::None && enable_mg() ){
+    if( mg != CONTROL::NoOperation && enable_mg() ){
         operate_view( mg );
         return true;
     }
@@ -828,7 +828,7 @@ bool ImageViewBase::slot_scroll_event( GdkEventScroll* event )
 {
     // ホイールマウスジェスチャ
     int control = get_control().MG_wheel_scroll( event );
-    if( enable_mg() && control != CONTROL::None ){
+    if( enable_mg() && control != CONTROL::NoOperation ){
         operate_view( control );
         return true;
     }

--- a/src/jdlib/meson.build
+++ b/src/jdlib/meson.build
@@ -28,6 +28,7 @@ deps = [
   socket_dep,
   tls_dep,
   x11_dep,
+  zlib_dep,
 ]
 
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -31,8 +31,7 @@ subdir('sound')
 subdir('xml')
 
 
-# テストプログラムのビルドで利用するため files() でまとめる
-core_sources = files(
+core_sources = [
   'aamanager.cpp',
   'articleitemmenupref.cpp',
   'articleitempref.cpp',
@@ -76,7 +75,15 @@ core_sources = files(
   'usrcmdpref.cpp',
   'viewfactory.cpp',
   'winmain.cpp',
+]
+
+# テストプログラムのビルドで利用するためライブラリにまとめる
+core_lib = static_library(
+  'core', core_sources,
+  dependencies : [config_h_dep, gtkmm_dep, tls_dep],
+  include_directories : include_directories('.'),
 )
+
 
 sources = [
   'main.cpp',
@@ -104,6 +111,7 @@ jdim_libs = [
   board_lib,
   config_lib,
   control_lib,
+  core_lib,
   dbimg_lib,
   dbtree_lib,
   history_lib,
@@ -118,7 +126,7 @@ jdim_libs = [
 
 
 jdim_exe = executable(
-  'jdim', [core_sources, sources, buildinfo_h],
+  'jdim', [sources, buildinfo_h],
   dependencies : [config_h_dep, jdim_deps],
   include_directories : jdim_incs,
   link_with : jdim_libs,

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -525,7 +525,7 @@ void MessageViewBase::focus_view()
 //
 bool MessageViewBase::operate_view( const int control )
 {
-    if( control == CONTROL::None ) return false;
+    if( control == CONTROL::NoOperation ) return false;
 
     switch( control ){
 

--- a/src/skeleton/entry.cpp
+++ b/src/skeleton/entry.cpp
@@ -34,7 +34,7 @@ bool JDEntry::on_key_press_event( GdkEventKey* event )
     std::cout << "JDEntry::on_key_press_event key = " << event->keyval << std::endl;
 #endif
 
-    m_controlid = CONTROL::None;
+    m_controlid = CONTROL::NoOperation;
 
     const guint key = event->keyval;
     const bool ctrl = ( event->state ) & GDK_CONTROL_MASK;
@@ -86,7 +86,7 @@ bool JDEntry::on_key_release_event( GdkEventKey* event )
             break;
     }
 
-    m_controlid = CONTROL::None;
+    m_controlid = CONTROL::NoOperation;
 
     return ret;
 }

--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -307,7 +307,7 @@ bool JDWinMain::on_button_release_event( GdkEventButton* event )
     const int mg = m_control.MG_end( event );
 
     // マウスジェスチャ
-    if( mg != CONTROL::None ) operate_win( mg );
+    if( mg != CONTROL::NoOperation ) operate_win( mg );
 
     return ret;
 }

--- a/test/meson.build
+++ b/test/meson.build
@@ -27,7 +27,7 @@ deps = [
 
 
 test_exe = executable(
-  'gtest_jdim', [buildinfo_h, core_sources, sources],
+  'gtest_jdim', [buildinfo_h, sources],
   dependencies : deps,
   include_directories : jdim_incs,
   link_with : jdim_libs,


### PR DESCRIPTION
### controlid: Fix Unity build failure by renaming enum identifier `None`

コントロールIDのenum識別子`None`を`NoOperation`に変更し、MesonのUnity buildが失敗する不具合を修正します。

修正前は、X11ライブラリのヘッダーファイル`/usr/include/X11/X.h`で定義された`None`マクロが、JDimの`src/control/controlid.h`で定義されたenum識別子`None`を上書きし、コンパイルエラーが発生していました。

Change the control ID enum identifier from `None` to `NoOperation` and fix the issue causing the meson Unity build to fail.

Before this change, the `None` macro defined in the X11 library header `/usr/include/X11/X.h` was overwriting the `None` enum identifier defined in `src/control/controlid.h` of JDim, causing a compilation error.

### meson: Improve JDim build configuration and fix library conflict issue

Meson の構成を更新し、JDim のコア部分(src/ にあるソースファイル)を静的ライブラリにまとめました。
この静的ライブラリを、JDim の実行ファイルとテストプログラムにリンクさせます。
この変更前は、2つのビルドターゲットに対してソースファイルを別々にコンパイルし、リンクしていました。

また、Meson の Unity build の block size を大きくすると、 X11 ライブラリのヘッダーファイルで定義されたマクロ(Bool, None)が Google Test の識別子と競合し、コンパイルエラーが発生する問題がありました。
この修正によって、2つのライブラリを同時に使用する箇所が無くなるため、この問題は解消されます。

gccのコンパイルエラー
```
/usr/include/gtest/internal/gtest-type-util.h:138:8: error: expected identifier before numeric constant
  138 | struct None {};
      |        ^~~~
/usr/include/gtest/gtest-param-test.h:359:44: error: expected unqualified-id before ‘)’ token
  359 | inline internal::ParamGenerator<bool> Bool() { return Values(false, true); }
      |                                            ^
```

最後に、src/jdlib のビルド構成に欠けていた zlib_dep を追加しました。
Linux 環境では、zlib_dep が無くてもビルドは可能でしたが、他の環境では依存関係が必要になります。

The Meson configuration has been updated to group the core part of JDim (source files in the src/ directory) into a static library.  This static library is linked to both the JDim executable and the test program. Before this change, the source files were compiled and linked separately for the two build targets.

Additionally, increasing the block size of Meson's Unity build caused a compile error due to conflicts between macros (Bool, None) defined in the X11 library headers and identifiers in Google Test. This issue is resolved by this fix, as the parts where both libraries are used together are eliminated.

Lastly, zlib_dep, which was missing from the build configuration of src/jdlib, has been added. While zlib_dep wasn't required for building in Linux environments, it is necessary for other environments.

Closes #1457
