### PR TITLE
Modify char32_t output to Unicode format and ensure C++20 compatibility

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -1646,7 +1646,7 @@ int DrawAreaBase::get_width_of_one_char( const char* utfstr, int& byte, char& pr
 #ifdef _DEBUG
             std::cout << "DrawAreaBase::get_width_of_one_char "
                       << "byte = " << byte
-                      << " code = " << code
+                      << " code = " << MISC::utf32tostr( code )
                       << " [" << tmpchar << "]\n";
 #endif
 
@@ -1654,7 +1654,8 @@ int DrawAreaBase::get_width_of_one_char( const char* utfstr, int& byte, char& pr
                 && ( code < 0xF0000 || code > 0x10FFFF ) // 私用面ではない
               ){
                 std::stringstream ss_err;
-                ss_err << "unknown font byte = " << byte << " ucs = " << code << " width = " << width;
+                ss_err << "unknown font byte = " << byte << " utf32 = " << MISC::utf32tostr( code )
+                       << " width = " << width;
 
                 MISC::ERRMSG( ss_err.str() );
             }
@@ -4203,7 +4204,7 @@ bool DrawAreaBase::set_carets_dclick( CARET_POSITION& caret_left, CARET_POSITION
                 const char32_t uch_pointer = MISC::utf8toutf32( layout->text + pos, byte_char_pointer );
                 const MISC::UnicodeBlock block_pointer = MISC::get_unicodeblock( uch_pointer );
 #ifdef _DEBUG
-                std::cout << "utf32 = " << std::hex << uch_pointer << std::dec
+                std::cout << "utf32 = " << MISC::utf32tostr( uch_pointer )
                           << " type = " << static_cast<int>( block_pointer ) << " pos = " << pos << std::endl;
 #endif
 

--- a/src/jdlib/jdiconv.cpp
+++ b/src/jdlib/jdiconv.cpp
@@ -287,7 +287,7 @@ std::string& Iconv::convert( char* str_in, std::size_t size_in, std::string& out
 
                         const std::string uni_str = std::to_string( unich );
 #ifdef _DEBUG
-                        std::cout << "utf32 = " << unich << " byte = " << byte << std::endl;
+                        std::cout << "utf32 = " << MISC::utf32tostr( unich ) << " byte = " << byte << std::endl;
 #endif
                         buf_in_tmp += byte;
 

--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -521,6 +521,21 @@ int MISC::utf32toutf8( const char32_t uch,  char* utf8str )
 }
 
 
+/** @brief UTF-32 の値から Unicode のコードポイントを表す文字列("U+XXXX")を返す
+ *
+ * @param[in] uch Unicodeコードポイント
+ * @return "U+" プレフィックスを付けた 4〜6 桁の16進数値 (A〜F は大文字)。
+ * U+10000 未満の値は 4 桁にゼロ埋めする。
+ */
+std::string MISC::utf32tostr( const char32_t uch )
+{
+    std::string str( 11u, '\0' );
+    const auto length = std::snprintf( str.data(), 11u, "U+%04X", uch );
+    str.resize( length );
+    return str;
+}
+
+
 /** @brief 特定のUnicodeブロックかコードポイントを調べる
  *
  * @param[in] unich Unicodeコードポイント

--- a/src/jdlib/misccharcode.h
+++ b/src/jdlib/misccharcode.h
@@ -55,6 +55,9 @@ namespace MISC
     // 戻り値 : バイト数
     int utf32toutf8( const char32_t uch, char* utf8str );
 
+    // UTF-32 の値から Unicode のコードポイントを表す文字列("U+XXXX")を返す
+    std::string utf32tostr( const char32_t uch );
+
     /// 特定のUnicodeブロックかコードポイントを調べる
     UnicodeBlock get_unicodeblock( const char32_t unich );
 

--- a/test/gtest_jdlib_misccharcode.cpp
+++ b/test/gtest_jdlib_misccharcode.cpp
@@ -793,6 +793,51 @@ TEST_F(Utf32ToUtf8Test, out_of_range)
 }
 
 
+class MISC_Utf32ToStrTest : public ::testing::Test {};
+
+TEST_F(MISC_Utf32ToStrTest, u_0000)
+{
+    constexpr char32_t ch = U'\u0000';
+    EXPECT_EQ( "U+0000", MISC::utf32tostr( ch ) );
+}
+
+TEST_F(MISC_Utf32ToStrTest, u_0041)
+{
+    constexpr char32_t ch = U'\u0041';
+    EXPECT_EQ( "U+0041", MISC::utf32tostr( ch ) );
+}
+
+TEST_F(MISC_Utf32ToStrTest, u_1000)
+{
+    constexpr char32_t ch = U'\uabcd';
+    EXPECT_EQ( "U+ABCD", MISC::utf32tostr( ch ) );
+}
+
+TEST_F(MISC_Utf32ToStrTest, u_10000)
+{
+    constexpr char32_t ch = U'\U0001fe00';
+    EXPECT_EQ( "U+1FE00", MISC::utf32tostr( ch ) );
+}
+
+TEST_F(MISC_Utf32ToStrTest, u_10FFFF)
+{
+    constexpr char32_t ch = U'\U0010ffff';
+    EXPECT_EQ( "U+10FFFF", MISC::utf32tostr( ch ) );
+}
+
+TEST_F(MISC_Utf32ToStrTest, out_of_range)
+{
+    char32_t ch = 0x110000;
+    EXPECT_EQ( "U+110000", MISC::utf32tostr( ch ) );
+
+    ch = 0x7FFF'FFFF;
+    EXPECT_EQ( "U+7FFFFFFF", MISC::utf32tostr( ch ) );
+
+    ch = static_cast<char32_t>( -1 );
+    EXPECT_EQ( "U+FFFFFFFF", MISC::utf32tostr( ch ) );
+}
+
+
 class GetUnicodeBlockTest : public ::testing::Test {};
 
 TEST_F(GetUnicodeBlockTest, basic_latin)


### PR DESCRIPTION
### Implement function to convert UTF-32 to Unicode code point string

UTF-32の値からUnicodeのコードポイントを表す文字列("U+XXXX")を返す関数を追加します。

- 返り値は"U+"プレフィックスを付けた4〜6桁の16進数値（A〜Fは大文字）。
- U+10000未満の値は4桁にゼロ埋めします。

テストケースも合わせて追加し、異常値の処理も含めたケースをカバーしています。

Add a function that returns a string representing the Unicode code point from a UTF-32 value ("U+XXXX").

- The return value is a 4-6 digit hexadecimal number with a "U+"
  prefix (A-F are uppercase).
- Values below U+10000 are zero-padded to 4 digits.

Test cases are added, covering cases including out-of-range values.

### Modify `char32_t` output to Unicode format and ensure C++20 compatibility

`char32_t` (UTF-32) の値をデバッグやログ出力する際、Unicode の U+XXXX 形式にフォーマットするよう変更します。

以前は iostream で10進数や16進数の形式で出力していましたが、C++20で<<演算子のオーバーロードが削除されたため、これに対応するための修正です。

Change the output format of `char32_t` (UTF-32) values in debugging and logging to the Unicode U+XXXX format.

Previously, the values were output in decimal or hexadecimal using iostream, but this is no longer compatible with the new standard as the << operator overload was removed in C++20.

