### PR TITLE
NodeTree2ch: Set maybe_unused attribute for class member

### DIFF
--- a/src/dbtree/nodetree2ch.h
+++ b/src/dbtree/nodetree2ch.h
@@ -15,7 +15,7 @@ namespace DBTREE
     class NodeTree2ch : public NodeTree2chCompati
     {
         std::string m_org_url;  // 移転前のオリジナルURL
-        time_t m_since_time; // スレが立った時刻
+        [[maybe_unused]] std::time_t m_since_time; // スレが立った時刻
         int m_mode; // 読み込みモード
         int m_res_number_max; // 最大レス数
         std::size_t m_dat_volume_max{}; // 最大DATサイズ(KB)


### PR DESCRIPTION
クラスのプライベートメンバー変数が使われていないとclangに指摘されたため`[[maybe_unused]]`を付与して警告を抑制します。

clang-18の警告
```
In file included from ../src/dbtree/nodetree2ch.cpp:6:
../src/dbtree/nodetree2ch.h:18:16: warning: private field 'm_since_time' is not used [-Wunused-private-field]
   18 |         time_t m_since_time; // スレが立った時刻
      |                ^
1 warning generated.
```

修正にあたり報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1722942440/267
