### PR TITLE
Fix scan-build warnings for core.NonNullParamChecker

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -372,10 +372,10 @@ void App::slot_startup()
     if( logfile_mode && CACHE::mkdir_logroot() ){
         const std::string logfile = Glib::locale_from_utf8( CACHE::path_msglog() );
         m_redirect_stdout = std::freopen( logfile.c_str(), "ab", stdout );
-        std::setbuf( m_redirect_stdout, nullptr );
         m_redirect_stderr = std::freopen( logfile.c_str(), "ab", stderr );
-        std::setbuf( m_redirect_stderr, nullptr );
-        // tmp のクローズはプロセス終了にまかせる
+
+        if( m_redirect_stdout ) std::setbuf( m_redirect_stdout, nullptr );
+        if( m_redirect_stderr ) std::setbuf( m_redirect_stderr, nullptr );
     }
 
     /*--- IOMonitor -------------------------------------------------*/


### PR DESCRIPTION
関数の引数にnullポインターを渡しているとscan-buildに指摘されたため、nullチェックを追加します。

scan-build-19 のレポート
```
../../../src/main.cpp:375:9: warning: Null pointer passed to 1st parameter expecting 'nonnull' [core.NonNullParamChecker]
  375 |         std::setbuf( m_redirect_stdout, nullptr );
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../src/main.cpp:377:9: warning: Null pointer passed to 1st parameter expecting 'nonnull' [core.NonNullParamChecker]
  377 |         std::setbuf( m_redirect_stderr, nullptr );
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
