### PR TITLE
Fix completion popup position on Wayland

### DIFF
--- a/src/skeleton/compentry.h
+++ b/src/skeleton/compentry.h
@@ -67,6 +67,9 @@ namespace SKELETON
 
       private:
 
+        // 入力補完のポップアップを配置する
+        void place_popup();
+
         // ポップアップ表示
         // show_all == true なら候補を全て表示する
         void show_popup( const bool show_all );


### PR DESCRIPTION
Wayland環境で書き込みビューをウインドウ表示すると、名前欄とメール欄の入力補完ポップアップが正しい位置に表示されない問題を修正します。

以前は、入力補完のポップアップを`Gtk::Window::move()`を使って入力欄の下に配置していましたが、Wayland環境では期待通りに動作しませんでした。
その代わりに`gdk_window_move_to_rect()`を使用して配置するようにします。

Fix the issue where the completion popup for the name and email fields does not appear in the correct position when displaying the entry view window on Wayland.

Previously, the completion popup was positioned under the input field using `Gtk::Window::move()`, but it did not work as expected on Wayland. Instead, it is now positioned using `gdk_window_move_to_rect()`.

Closes #1466
