### PR TITLE
Fix failing muon-master job in GitHub Actions Weekly CI

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -83,20 +83,20 @@ jobs:
       - name: git clone muon
         run: |
           git clone --depth 1 https://git.sr.ht/~lattis/muon muon-src
-        # Skip bootstrapping muon to do meson setup instead.
       - name: git log -n1 muon
         run: git -C muon-src log -n1
+        # Since 2024-11-03 07:27:25 -0500 (6ec469bb42), bootstrapping has used muon-bootstrap as exe name.
       - name: build muon stage1
         run: |
           cd muon-src
           ./bootstrap.sh stage1
-          ./stage1/muon version
+          ./stage1/muon-bootstrap version
           cd ..
       - name: build muon stage2
         run: |
           cd muon-src
-          ./stage1/muon setup -Ddocs=disabled -Dlibarchive=disabled -Dlibcurl=disabled -Dlibpkgconf=enabled ../muon-build
-          ./stage1/muon samu -C ../muon-build
+          ./stage1/muon-bootstrap setup -Ddocs=disabled -Dlibarchive=disabled -Dlibcurl=disabled -Dlibpkgconf=enabled ../muon-build
+          ./stage1/muon-bootstrap samu -C ../muon-build
           cd ..
       - name: muon version
         run: ./muon-build/muon version


### PR DESCRIPTION
GitHub Actions のWeekly CI で、muon-master ジョブが Muon リビジョン 6ec469bb42b28f3a1943d58c0e15a8493220c2f7（2024-11-03）以降の実行ファイル名変更の影響で失敗していたため、対応します。
この変更により、実行ファイル名を新しい `muon-bootstrap` に更新し、正常にジョブが完了するようにします。

Fixes the failure in the muon-master job of GitHub Actions Weekly CI, caused by a change in the Muon executable name to `muon-bootstrap` since revision 6ec469bb42b28f3a1943d58c0e15a8493220c2f7 (2024-11-03).  This update adjusts the job configuration to use the new executable name, ensuring successful completion of the job.

Closes #1469
