### PR TITLE
Fix popup position issue on Wayland and improve natural sizing

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -2908,6 +2908,7 @@ void ArticleViewBase::show_popup( SKELETON::View* view, const int mrg_x, const i
     m_popup_win = std::make_unique<SKELETON::PopupWin>( this, view, mrg_x, mrg_y );
     m_popup_win->signal_leave_notify_event().connect( sigc::mem_fun( *this, &ArticleViewBase::slot_popup_leave_notify_event ) );
     m_popup_win->sig_hide_popup().connect( sigc::mem_fun( *this, &ArticleViewBase::slot_hide_popup ) );
+    m_popup_win->show_all();
     m_popup_shown = true;
 }
 

--- a/src/image/imageviewpopup.cpp
+++ b/src/image/imageviewpopup.cpp
@@ -141,6 +141,30 @@ void ImageViewPopup::remove_label()
 
 
 
+/** @brief ウィジェットの自然な幅と高さを使用してビューのサイズを調整する
+ *
+ * @details 取得した自然なサイズが現在の値より大きい場合は更新する。
+ * @param[in] widget 自然な幅と高さを取得する対象
+ */
+void ImageViewPopup::adjust_client_size( Gtk::Widget& widget )
+{
+    [[maybe_unused]] int unused_value;
+    int natural_width = 0;
+    int natural_height = 0;
+
+    widget.get_preferred_width( unused_value, natural_width );
+    widget.get_preferred_height( unused_value, natural_height );
+
+    if( width_client() < natural_width ) {
+        set_width_client( natural_width );
+    }
+    if( height_client() < natural_height ) {
+        set_height_client( natural_height );
+    }
+}
+
+
+
 //
 // 表示
 //
@@ -257,6 +281,8 @@ void ImageViewPopup::show_view_impl()
             else{
                 set_label( "" );
                 m_label->set_text( imagearea->get_errmsg() );
+
+                adjust_client_size( *m_label );
             }
         }
 
@@ -265,6 +291,8 @@ void ImageViewPopup::show_view_impl()
             set_label( "" );
             if( get_img()->get_str_code( ).empty() ) m_label->set_text( "キャッシュが存在しません" );
             else m_label->set_text( get_img()->get_str_code( ) );
+
+            adjust_client_size( *m_label );
         }
     }
 

--- a/src/image/imageviewpopup.h
+++ b/src/image/imageviewpopup.h
@@ -51,6 +51,8 @@ namespace IMAGE
         void update_label();
         void set_label( const std::string& status );
         void remove_label();
+
+        void adjust_client_size( Gtk::Widget& widget );
     };
 
 }

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -198,6 +198,7 @@ void DragTreeView::show_popup( const std::string& url, View* view )
     m_popup_win->sig_hide_popup().connect( sigc::mem_fun( *this, &DragTreeView::hide_popup ) );
 
     m_pre_popup_url = url;
+    m_popup_win->show_all();
     m_popup_shown = true;
 }
 

--- a/src/skeleton/popupwin.cpp
+++ b/src/skeleton/popupwin.cpp
@@ -5,6 +5,15 @@
 
 #include "popupwin.h"
 
+#include "jdlib/miscgtk.h"
+
+#ifdef GDK_WINDOWING_WAYLAND
+#include <gdk/gdkwayland.h>
+#endif
+
+#include <algorithm>
+
+
 using namespace SKELETON;
 
 
@@ -18,6 +27,7 @@ PopupWin::PopupWin( Gtk::Widget* parent, SKELETON::View* view, const int mrg_x, 
 #ifdef _DEBUG
     std::cout << "PopupWin::PopupWin\n";
 #endif
+    signal_realize().connect( sigc::mem_fun( *this, &PopupWin::slot_realize ) );
 
     m_view->sig_resize_popup().connect( sigc::mem_fun( *this, &PopupWin::slot_resize_popup ) );
     add( *m_view );
@@ -27,8 +37,10 @@ PopupWin::PopupWin( Gtk::Widget* parent, SKELETON::View* view, const int mrg_x, 
     Gtk::Widget* toplevel = m_parent->get_toplevel();
     if( toplevel->get_is_toplevel() ) {
         set_transient_for( *dynamic_cast< Gtk::Window* >( toplevel ) );
+#ifdef GDK_WINDOWING_WAYLAND
+        m_running_on_wayland = GDK_IS_WAYLAND_DISPLAY( toplevel->get_window()->get_display()->gobj() );
+#endif
     }
-    slot_resize_popup();
 }
 
 
@@ -39,6 +51,41 @@ void PopupWin::slot_resize_popup()
 {
     if( ! m_view ) return;
 
+    if( m_running_on_wayland ) {
+        move_resize_wayland();
+    }
+    else {
+        move_resize_conventional();
+    }
+    show_all();
+}
+
+
+/** @brief realize したときにポップアップの座標と幅と高さを計算してリサイズと移動を行う
+ *
+ * @details Wayland では realize すると GdkWindow が関連付けされて
+ * gdk_window_move_to_rect() が実行できるようになる。
+ */
+void PopupWin::slot_realize()
+{
+    if( ! m_view ) return;
+
+    if( m_running_on_wayland ) {
+        move_resize_wayland();
+    }
+    else {
+        move_resize_conventional();
+    }
+}
+
+
+/**
+ * @brief ポップアップウィンドウの座標と幅と高さを計算してリサイズと移動する (従来方式)
+ *
+ * @details X11で gdk_window_move_to_rect() を使うと挙動が変わるため従来の方法を使う。
+ */
+void PopupWin::move_resize_conventional()
+{
     // マウス座標
     int x_mouse, y_mouse;
     Gdk::Display::get_default()->get_default_seat()->get_pointer()->get_position( x_mouse, y_mouse );
@@ -64,7 +111,7 @@ void PopupWin::slot_resize_popup()
         height_popup = height_client;
     }
     else if( y_mouse + m_mrg_y + height_client <= height_desktop ){ // 下にスペースがある
-        y_popup = y_mouse + m_mrg_y;        
+        y_popup = y_mouse + m_mrg_y;
         height_popup = height_client;
     }
     else if( m_view->get_popup_upside() || y_mouse > height_desktop/2 ){ // スペースは無いが上に表示
@@ -72,7 +119,7 @@ void PopupWin::slot_resize_popup()
         height_popup = y_mouse - ( y_popup + m_mrg_y );
     }
     else{ // 下
-        y_popup = y_mouse + m_mrg_y;        
+        y_popup = y_mouse + m_mrg_y;
         height_popup = height_desktop - y_popup;
     }
 
@@ -82,5 +129,112 @@ void PopupWin::slot_resize_popup()
 #endif
     move( x_popup, y_popup );
     resize( width_popup,  height_popup );
-    show_all();
+}
+
+
+/** @brief ポップアップウィンドウの座標と幅と高さを計算してリサイズと移動する (Wayland)
+ *
+ * @details Waylandでポップアップを表示するときの動作を説明します。
+ * GTK 3.24から導入された [`gdk_window_move_to_rect()`] を使用してWaylandでの配置を改善します。
+ * X11環境では従来の `Gtk::Window::move()` による方法を維持します。
+ *
+ * ポップアップを表示するには `SKELETON::PopupWin` と `Gdk::Window` が関連づけられている必要があります。
+ * Waylandでは、 `PopupWin` のコンストラクタを実行している間は `Gdk::Window` が関連付けされていないため、
+ * `show_all()` をはじめ、 `Gdk::Window` が必要な操作が期待通りに動作しません。
+ * そのため、 `Gdk::Window` が関連付けされたときに発行される `realize` シグナルに接続したシグナルハンドラで
+ * ウインドウの操作を行うように修正します。 また、ポップアップの表示はコンストラクタを呼び出した後に行います。
+ *
+ * - `gdk_window_move_to_rect()` は [`GdkAnchorHints`] を使ってウインドウのサイズと配置を決定します。
+ *   - 水平方向(X軸)はポップアップの幅を変えずディスプレイに収まるようにずらします。
+ *   - 垂直方向(Y軸)はポップアップの高さをディスプレイに収まるようにサイズ調整します。
+ *   デフォルトの動作では垂直方向が期待した位置に配置されないことがあるため、
+ *   ディスプレイのサイズとマウスポインターの座標から手動で配置を指定します。
+ *
+ * - `gdk_window_move_to_rect()` はウインドウに追加された子要素のサイズからウインドウの表示サイズを算出します。
+ *   ポップアップを自然なサイズで表示するため `SKELETON::View` にウィジェットの最小サイズと自然なサイズを返す
+ *   virtual method を実装します。
+ *
+ * - `gdk_window_move_to_rect()` はウインドウが表示された状態では効果がありません。
+ *   表示されているウインドウの移動を行うときは一度閉じます。
+ *   また、サイズ変更するときは `Gtk::Window::resize()` を使います。
+ *
+ * [`gdk_window_move_to_rect()`]: https://docs.gtk.org/gdk3/method.Window.move_to_rect.html
+ * [`GdkAnchorHints`]: https://docs.gtk.org/gdk3/flags.AnchorHints.html
+ */
+void PopupWin::move_resize_wayland()
+{
+    // 1. ディスプレイの情報を取得する
+
+    auto display = Gdk::Display::get_default();
+
+    // ディスプレイに対するマウス座標
+    int x_mouse, y_mouse;
+    display->get_default_seat()->get_pointer()->get_position( x_mouse, y_mouse );
+
+    Gtk::Window* parent = get_transient_for();
+
+    // ディスプレイのサイズ
+    Gdk::Rectangle rect;
+    const auto monitor = display->get_monitor_at_window( parent->get_window() );
+    monitor->get_workarea( rect );
+    const int height_desktop = rect.get_height();
+
+    // クライアントのサイズを取得
+    const int height_client = m_view->height_client();
+    const int width_client = m_view->width_client();
+
+    // 2. 環境の情報から方向と高さを計算する
+
+    // GdkAnchorHints に GDK_ANCHOR_RESIZE_Y と GDK_ANCHOR_FLIP_Y を一緒に指定して
+    // gdk_window_move_to_rect() に配置を任せると下の条件通りには動作しないため
+    // ディスプレイのサイズとマウス座標から計算して GdkGravity を設定する
+    GdkGravity rect_anchor; // 表示位置の角
+    GdkGravity window_anchor; // ポップアップの角
+    int height_popup; // ポップアップ表示中にリサイズするとき使う
+    if( y_mouse - ( height_client + m_mrg_y ) >= 0 ) { // 上にスペースがある
+        rect_anchor = GDK_GRAVITY_NORTH_WEST;
+        window_anchor = GDK_GRAVITY_SOUTH_WEST;
+        height_popup = height_client;
+    }
+    else if( y_mouse + m_mrg_y + height_client <= height_desktop ) { // 下にスペースがある
+        rect_anchor = GDK_GRAVITY_SOUTH_WEST;
+        window_anchor = GDK_GRAVITY_NORTH_WEST;
+        height_popup = height_client;
+    }
+    else if( m_view->get_popup_upside() || y_mouse > height_desktop / 2 ) { // スペースは無いが上に表示
+        rect_anchor = GDK_GRAVITY_NORTH_WEST;
+        window_anchor = GDK_GRAVITY_SOUTH_WEST;
+        const int y_popup = (std::max)( 0, y_mouse - ( height_client + m_mrg_y ) );
+        height_popup = y_mouse - ( y_popup + m_mrg_y );
+    }
+    else { // スペースは無いが下に表示
+        rect_anchor = GDK_GRAVITY_SOUTH_WEST;
+        window_anchor = GDK_GRAVITY_NORTH_WEST;
+        const int y_popup = y_mouse + m_mrg_y;
+        height_popup = height_desktop - y_popup;
+    }
+
+    // 3. リサイズと移動を行う
+
+    // ポップアップ表示位置を取得 (親ウインドウのマウス座標)
+    MISC::get_pointer_at_window( parent->get_window(), x_mouse, y_mouse );
+    // 表示位置を垂直に伸びる矩形で指定して、ポップアップとマウスポインターの間のマージンを作る
+    const GdkRectangle rect_dest = { x_mouse, y_mouse - m_mrg_y, 1, m_mrg_y * 2 + 1 };
+
+    // 水平方向(X軸)は、ディスプレイに収まるようにスライドさせる。
+    // 垂直方向(Y軸)は、ウインドウ配置の方向と初期サイズを計算して調整する。
+    constexpr GdkAnchorHints anchor_hints = GdkAnchorHints( GDK_ANCHOR_SLIDE_X | GDK_ANCHOR_RESIZE_Y );
+    const int rect_anchor_dx = m_mrg_x;
+    constexpr int rect_anchor_dy = 0;
+
+    if( get_mapped() ) {
+        // gdk_window_move_to_rect() は表示したポップアップのサイズ変更を無視するため resize() を使う
+        resize( width_client, height_popup );
+
+        // ウインドウを非表示にして呼び出さないと期待通り動作しない環境がある
+        // https://gitlab.gnome.org/GNOME/gtk/-/issues/1986
+        hide();
+    }
+    gdk_window_move_to_rect( get_window()->gobj(), &rect_dest, rect_anchor, window_anchor, anchor_hints,
+                             rect_anchor_dx, rect_anchor_dy );
 }

--- a/src/skeleton/popupwin.h
+++ b/src/skeleton/popupwin.h
@@ -26,6 +26,7 @@ namespace SKELETON
         std::unique_ptr<SKELETON::View> m_view;
         int m_mrg_x;  // ポップアップとマウスカーソルの間のマージン(水平方向)
         int m_mrg_y;  // ポップアップとマウスカーソルの間のマージン(垂直方向)
+        bool m_running_on_wayland{};
 
     public:
 
@@ -40,6 +41,13 @@ namespace SKELETON
 
         // ポップアップウィンドウの座標と幅と高さを計算して移動とリサイズ
         void slot_resize_popup();
+
+    private:
+
+        void slot_realize();
+
+        void move_resize_conventional();
+        void move_resize_wayland();
     };
 }
 

--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -264,3 +264,27 @@ std::string View::get_color() const
 
     return "";
 }
+
+
+/** @brief 最小の幅と自然な幅の初期値を取得する
+ *
+ * @param[out] minimum_width ウィジェットの最小の幅
+ * @param[out] natural_width ウィジェットの自然な幅
+ */
+void View::get_preferred_width_vfunc( int& minimum_width, int& natural_width ) const
+{
+    minimum_width = 0;
+    natural_width = width_client();
+}
+
+
+/** @brief 最小の高さと自然な高さの初期値を取得する
+ *
+ * @param[out] minimum_width ウィジェットの最小の高さ
+ * @param[out] natural_width ウィジェットの自然な高さ
+ */
+void View::get_preferred_height_vfunc( int& minimum_height, int& natural_height ) const
+{
+    minimum_height = 0;
+    natural_height = height_client();
+}

--- a/src/skeleton/view.h
+++ b/src/skeleton/view.h
@@ -171,6 +171,9 @@ namespace SKELETON
         //  ポップアップメニュー取得
         virtual Gtk::Menu* get_popupmenu( const std::string& url ){ return nullptr; }
 
+        void get_preferred_width_vfunc( int& minimum_width, int& natural_width ) const override;
+        void get_preferred_height_vfunc( int& minimum_height, int& natural_height ) const override;
+
     public:
 
         SIG_HIDE_POPUP sig_hide_popup(){ return m_sig_hide_popup; }


### PR DESCRIPTION
### Fix popup position issue on Wayland and improve natural sizing

Wayland環境で多段ポップアップがマウスポインターから離れて表示される問題を修正します。

`PopupWin`コンストラクタの中では`Gdk::Window`が関連付けされないため、`realize`シグナルでウィンドウ操作を行います。
また、ポップアップ表示に`gdk_window_move_to_rect()`を使用し、表示サイズを自動調整するため`SKELETON::View`に自然サイズ用メソッドを追加しました。X11では従来の方法を維持し、適切な表示動作を実現します。

This commit fixes the issue where multi-level popups appear away from the mouse pointer on Wayland.

It adjusts `PopupWin` behavior by handling window operations on the `realize` signal, as `Gdk::Window` is not linked in the constructor.  Popups now use `gdk_window_move_to_rect()` for automatic resizing, and `SKELETON::View` has added methods for natural sizing. On X11, the previous method remains in use, ensuring correct display behavior.

### Adjust error message display size automatically in image popup

エラーメッセージを表示する際に固定サイズ(200x50)で表示される問題を修正します。
`Gtk::Label`ウィジェットから取得した自然なサイズ(natural size)を使用して、ビューの表示領域を適切なサイズに自動調整します。

- `adjust_client_size()`メソッドを追加して自然なサイズを取得
- エラーメッセージ表示時にウィジェットサイズを更新

Fix the issue where error messages are displayed with fixed size (200x50). Use the natural size obtained from Gtk::Label widget to automatically adjust the view area to an appropriate size.

- Add `update_client_size()` method to get natural size
- Update widget size when displaying error messages

Closes #1470
