### PR TITLE
Fix preference dialog crashing on snap app

### DIFF
--- a/src/icons/iconmanager.cpp
+++ b/src/icons/iconmanager.cpp
@@ -197,8 +197,14 @@ std::vector<std::string> ICON::get_installed_icon_theme_names()
     fill_icon( Glib::get_user_data_dir() + "/icons" );
     fill_icon( Glib::get_home_dir() + "/.icons" );
 
+    const bool running_on_snap{ ! Glib::getenv( "SNAP_DESKTOP_RUNTIME" ).empty()
+                                && Glib::getenv( "GTK_USE_PORTAL" ) == "1" };
+
     auto data_dirs = Glib::get_system_data_dirs();
     for( auto& data_dir : data_dirs ) {
+        // Snapで実行しているときは以下のディレクトリにアクセスすると Permission denied が発生する
+        if( running_on_snap && data_dir == "/var/lib/snapd/desktop" ) continue;
+
         data_dir += "/icons";
         fill_icon( data_dir );
     }


### PR DESCRIPTION
インストールされているアイコンテーマを探すとき、環境変数を調べてSnap環境で実行されているかチェックします。Snapで実行されているときはアクセス権限がないファイルを調べないようにします。

この修正よって、Snap版でフォントと色の詳細設定が開けない問題を修正します。(下記エラーメッセージ)

環境変数:
https://snapcraft.io/docs/gnome-extension#p-113162-runtime-variables

- SNAP_DESKTOP_RUNTIME: $SNAP/gnome-platform
- GTK_USE_PORTAL: '1'

エラーメッセージ:
```
unhandled exception (type Glib::Error) in signal handler:
domain: g-file-error-quark
code  : 2
what  : ディレクトリ“/var/lib/snapd/desktop/icons”を開くときにエラーが発生しました: Permission denied
```

関連のpull request: https://github.com/JDimproved/JDim/issues/1476

Closes #1477
