### PR TITLE
waylandだとポップアップウィンドウがだんだん大きくなる件の暫定的な対応

### DIFF
--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -739,8 +739,11 @@ bool JDWindow::on_configure_event( GdkEventConfigure* event )
             if( ( ! m_fold_when_focusout || m_mode == JDWIN_NORMAL || m_mode == JDWIN_FOLD )
                     && height_new > min_height
                 ) {
-                set_width_win( width_new );
-                set_height_win( height_new );
+                // eventでとれる値は
+                // resizeで指定したサイズより横約51 縦約89大きくなるため
+                // 打ち消すwaylandだから？
+                set_width_win( width_new - 51 );
+                set_height_win( height_new - 89 );
             }
         }
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: FSFAP -->
<!--
Pull request(PR)の作成ありがとうございます！
このコメントやテンプレートは変形・削除しても問題ありません。

PRの説明はレビューの手掛かり・助けになりますので記入をお願いいたします。
大抵のケースではgitコミットメッセージをコピーして貼り付ければOKです。
コミットメッセージだけでは説明が不十分と判断したときはテンプレートをご利用ください。

RFC 0013[1] が承認されてPRで取り込む修正のライセンスが GPL-2.0-or-later に変更されました。
また、寛容なライセンスが使われているファイルを修正するときはそのライセンスが適用されます。

ファイルを新しく作成するときはファイルの冒頭にライセンスを表示するSPDX形式のコメントを追加していただけると幸いです。
詳しくは CONTRIBUTING.md または RFC 0013 を参照してください。

[1]: https://github.com/JDimproved/rfcs/tree/master/docs/0013-introduce-license-gpl-2.0-or-later.md
-->

#### 変更の概要
waylandでポップアップウィンドウを開く度に大きくなる件の解消
ポップアップウィンドウを開くたび幅51、高さ89大きくなるのを補正

#### 背景や動機
waylandのjdimでウィンドウサイズが段々でかくなる

#### 変更内容
waylandのとき保存する幅、高さをそれぞれ51、89引く

#### やらないこと
waylandが一律51、89大きくなるか不明。
俺環かもしれない。

#### レビューしてほしいポイント
特にない。
場当たり的だしマージするか含めておまかせします。

#### 補足
特にない。