### PR TITLE
Improve popup display handling for multi-monitor setups in X11

### DIFF
--- a/src/skeleton/popupwin.cpp
+++ b/src/skeleton/popupwin.cpp
@@ -86,16 +86,29 @@ void PopupWin::slot_realize()
  */
 void PopupWin::move_resize_conventional()
 {
-    // マウス座標
+    // ディスプレイの情報を取得する。
+    auto display = Gdk::Display::get_default();
+
+    // ディスプレイに対するマウス座標を取得する。
     int x_mouse, y_mouse;
-    Gdk::Display::get_default()->get_default_seat()->get_pointer()->get_position( x_mouse, y_mouse );
+    display->get_default_seat()->get_pointer()->get_position( x_mouse, y_mouse );
+
+    Gtk::Window* parent_win = get_transient_for();
+
+    // 以前は Gdk::Screen を使用してポップアップのサイズを計算していたが、
+    // Gdk::Screen は複数モニターを一つの画面領域として扱うため、
+    // マルチディスプレイ環境ではポップアップが画面を跨いで表示される問題があった。
+
+    // 親ウインドウが配置されている Gdk::Monitor の作業領域からポップアップのサイズと位置を計算する。
+    Gdk::Rectangle rect;
+    const auto monitor = display->get_monitor_at_window( parent_win->get_window() );
+    monitor->get_workarea( rect );
+    const int width_desktop = rect.get_width();
+    const int height_desktop = rect.get_height();
 
     // クライアントのサイズを取得
     const int width_client = m_view->width_client();
     const int height_client = m_view->height_client();
-
-    const int width_desktop = m_parent->get_screen()->get_width();
-    const int height_desktop = m_parent->get_screen()->get_height();
 
     // x 座標と幅
     const int width_popup = width_client;


### PR DESCRIPTION
ポップアップが親ウインドウの配置されているモニターの画面領域に収まるようにサイズを調整するよう変更します。

以前は [`Gdk::Screen`][1] を使用してポップアップのサイズを計算していましたが、 `Gdk::Screen` は複数モニターを一つの
画面領域として扱うため、マルチディスプレイ環境ではポップアップが画面を跨いで表示される問題がありました。

今回の変更では、親ウインドウが配置されているモニター(`Gdk::Monitor`)の作業領域を利用して、ポップアップのサイズと位置を計算します。
これにより、ポップアップがモニター内に収まるようになります。

Adjust the popup window's size to fit within the monitor where its parent window is located.

Previously, the popup size was calculated using [`Gdk::Screen`][1], which represents a single screen area combining multiple monitors.  This caused popups to span across screens in multi-monitor environments.

With this update, the popup's size and position are calculated based on the work area of the monitor (`Gdk::Monitor`) where the parent window resides. This ensures that the popup fits within the correct monitor.

[1]: https://docs.gtk.org/gdk3/class.Screen.html

修正にあたり不具合報告をしていただきありがとうございました。
https://next2ch.net/test/read.cgi/linux/1654053581/211
https://next2ch.net/test/read.cgi/linux/1654053581/213
