### PR TITLE
Add GTK theme support for thread view text and background colors

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -321,14 +321,17 @@ void DrawAreaBase::init_color()
         m_color[ i ] = Gdk::RGBA( CONFIG::get_color( i ) );
     }
 
-    // スレビューの選択色でgtkrcの設定を使用
+    // スレビューの文字色、背景色、選択色でGTKテーマの設定を使用する
     if( CONFIG::get_use_select_gtkrc() ){
-        const bool fg_ok = context->lookup_color( "theme_selected_fg_color", m_color[ COLOR_CHAR_SELECTION ] );
-        const bool bg_ok = context->lookup_color( "theme_selected_bg_color", m_color[ COLOR_BACK_SELECTION ] );
+        bool fg_ok = context->lookup_color( "theme_text_color", m_color[ COLOR_CHAR ] );
+        bool bg_ok = context->lookup_color( "theme_base_color", m_color[ COLOR_BACK ] );
         if( !fg_ok || !bg_ok ) {
-#ifdef _DEBUG
-            std::cout << "ERROR:DrawAreaBase::init_color lookup theme color failed." << std::endl;
-#endif
+            MISC::ERRMSG( "DrawAreaBase::init_color: Failed to retrieve GTK theme char colors." );
+        }
+        fg_ok = context->lookup_color( "theme_selected_fg_color", m_color[ COLOR_CHAR_SELECTION ] );
+        bg_ok = context->lookup_color( "theme_selected_bg_color", m_color[ COLOR_BACK_SELECTION ] );
+        if( !fg_ok || !bg_ok ) {
+            MISC::ERRMSG( "DrawAreaBase::init_color: Failed to retrieve GTK theme selected color." );
         }
     }
 

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -295,7 +295,7 @@ bool ConfigItems::load( const bool restore )
     // ツリービューでgtkrcの設定を使用するか
     use_tree_gtkrc = cf.get_option_bool( "use_tree_gtkrc", CONF_USE_TREE_GTKRC );
 
-    // スレビューの選択色でgtkrcの設定を使用するか
+    // スレビューの文字色、背景色、選択色でGTKテーマの設定を使用するか
     use_select_gtkrc = cf.get_option_bool( "use_select_gtkrc", CONF_USE_SELECT_GTKRC );
 
     // スレビューでHTMLタグ指定の色を使用するか

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -248,7 +248,7 @@ namespace CONFIG
         // ツリービューでgtkrcの設定を使用するか
         bool use_tree_gtkrc{};
 
-        // スレビューの選択色でgtkrcの設定を使用するか
+        /// @brief スレビューの文字色、背景色、選択色でGTKテーマの設定を使用するか
         bool use_select_gtkrc{};
 
         /// スレビューでHTMLタグ指定の色を使用するか

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -46,7 +46,7 @@ namespace CONFIG
         CONF_USE_SYMBOLIC_ICON = 1, ///< @brief シンボリックアイコンを使用するか
         CONF_USE_MESSAGE_GTKTHEME = 0, // 書き込みビューでGTKテーマの設定を使用するか (GTK3版のみ)
         CONF_USE_TREE_GTKRC = 0,    // ツリービューでgtkrcの設定を使用するか
-        CONF_USE_SELECT_GTKRC = 0,  // スレビューの選択色でgtkrcの設定を使用するか
+        CONF_USE_SELECT_GTKRC = 0,  ///< @brief スレビューの文字色、背景色、選択色でGTKテーマの設定を使用するか
         CONF_USE_COLOR_HTML = 1,    ///< スレビューでHTMLタグ指定の色を使用するか
         CONF_TREE_YPAD = 1,         // ツリービューの行間スペース
         CONF_TREE_SHOW_EXPANDERS = 1, // ツリービューにエクスパンダを表示

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -72,7 +72,7 @@ namespace CONFIG
     bool get_use_tree_gtkrc();
     void set_use_tree_gtkrc( const bool use );
 
-    // スレビューの選択色でgtkrcの設定を使用するか
+    // スレビューの文字色、背景色、選択色でGTKテーマの設定を使用するか
     bool get_use_select_gtkrc();
     void set_use_select_gtkrc( const bool use );
 

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -329,7 +329,7 @@ void FontColorPref::pack_widget()
     m_chk_use_gtkrc_tree.set_active( CONFIG::get_use_tree_gtkrc() );
     m_vbox_color.pack_start( m_chk_use_gtkrc_tree, Gtk::PACK_SHRINK );
 
-    m_chk_use_gtkrc_selection.add_label( "スレビューの選択範囲の色設定に GTKテーマ を用いる(_E)", true ),
+    m_chk_use_gtkrc_selection.add_label( "スレビューの文字色、背景色、選択範囲の色設定に GTKテーマ を用いる(_E)", true ),
     m_chk_use_gtkrc_selection.set_active( CONFIG::get_use_select_gtkrc() );
     m_vbox_color.pack_start( m_chk_use_gtkrc_selection, Gtk::PACK_SHRINK );
 


### PR DESCRIPTION
フォントと色の詳細設定の「スレビューの選択範囲の色設定にGTKテーマを用いる(E)」設定を「スレビューの文字色、背景色、選択範囲の色設定にGTKテーマを用いる(E)」に拡張します。

この変更により、設定を有効にした場合、選択範囲だけでなく、通常のテキストの文字色と背景色にもGTKテーマが提供する定義済みカラーが適用されます。これにより、スレビューの配色をGTKテーマに合わせる際の設定作業が簡単になります。

詳細:
スレビューの配色とGTKテーマの定義済みカラーの対応は以下の通りです。

- 文字色: `@theme_text_color`
- 背景色: `@theme_base_color`
- 選択範囲の文字色: `@theme_selected_fg_color`
- 選択範囲の背景色: `@theme_selected_bg_color`

変更内容:
- `init_color`メソッドに文字色と背景色の設定を追加
- 関連コメントと設定項目の表記を更新
- エラーメッセージを明確化

設定内容の一貫性を高め、ユーザー体験の向上を図ります。

The font and color settings option "Use GTK theme for thread view selection colors (E)" has been extended to "Use GTK theme for thread view text, background, and selection colors (E)".

With this change, when the setting is enabled, not only the selection colors but also the text and background colors will use the predefined GTK theme colors. This simplifies the configuration process when aligning thread view's color scheme with the GTK theme.

Details:
The correspondence between the thread view colors and the predefined colors of the GTK theme is as follows:

- Text color: `@theme_text_color`
- Background color: `@theme_base_color`
- Selection text color: `@theme_selected_fg_color`
- Selection background color: `@theme_selected_bg_color`

Changes:
- Added text and background color settings to the `init_color` method
- Updated related comments and configuration labels
- Improved clarity of error messages

This enhancement improves consistency in configuration and user experience.

Closes #1483
