### PR TITLE
FontColorPref: Add highlight text color settings to improve visibility

### DIFF
--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -883,15 +883,18 @@ void BoardViewBase::slot_cell_data_markup( Gtk::CellRenderer* cell, const Gtk::T
 {
     Gtk::TreeModel::Row row = *it;
 
+    Gtk::CellRendererText* rentext = dynamic_cast<Gtk::CellRendererText*>( cell );
+
     // ハイライト色 ( 抽出状態 )
     if( row[ m_columns.m_col_drawbg ] ){
-        cell->property_cell_background() = CONFIG::get_color( COLOR_BACK_HIGHLIGHT_TREE );
-        cell->property_cell_background_set() = true;
+        rentext->property_foreground() = CONFIG::get_color( COLOR_CHAR_HIGHLIGHT_TREE );
+        rentext->property_foreground_set() = true;
+        rentext->property_cell_background() = CONFIG::get_color( COLOR_BACK_HIGHLIGHT_TREE );
+        rentext->property_cell_background_set() = true;
     }
 
     else m_treeview.slot_cell_data( cell, it );
 
-    Gtk::CellRendererText* rentext = dynamic_cast<Gtk::CellRendererText*>( cell );
     rentext->property_text() = "";
     rentext->property_markup() = row[ m_columns.m_col_subject ];
 }
@@ -907,8 +910,11 @@ void BoardViewBase::slot_cell_data( Gtk::CellRenderer* cell, const Gtk::TreeMode
 
     // ハイライト色 ( 抽出状態 )
     if( row[ m_columns.m_col_drawbg ] ){
-        cell->property_cell_background() = CONFIG::get_color( COLOR_BACK_HIGHLIGHT_TREE );
-        cell->property_cell_background_set() = true;
+        Gtk::CellRendererText* rentext = dynamic_cast<Gtk::CellRendererText*>( cell );
+        rentext->property_foreground() = CONFIG::get_color( COLOR_CHAR_HIGHLIGHT_TREE );
+        rentext->property_foreground_set() = true;
+        rentext->property_cell_background() = CONFIG::get_color( COLOR_BACK_HIGHLIGHT_TREE );
+        rentext->property_cell_background_set() = true;
     }
 
     else m_treeview.slot_cell_data( cell, it );

--- a/src/colorid.h
+++ b/src/colorid.h
@@ -18,6 +18,7 @@ enum
     COLOR_CHAR_AGE,         // 非sageのメール欄
     COLOR_CHAR_SELECTION,   // 選択範囲の文字
     COLOR_CHAR_HIGHLIGHT,   // ハイライトの文字
+    COLOR_CHAR_HIGHLIGHT_TREE, ///< @brief ツリー表示における検索結果や抽出項目のハイライト文字色
     COLOR_CHAR_LINK,        // 通常のリンクの文字色
     COLOR_CHAR_LINK_ID_LOW, // 複数発言したIDの文字色
     COLOR_CHAR_LINK_ID_HIGH,// 多く発言したIDの文字色

--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -197,12 +197,18 @@ bool AboutConfig::slot_visible_func( const Gtk::TreeModel::const_iterator& iter 
 void AboutConfig::slot_cell_data( Gtk::CellRenderer* cell, const Gtk::TreeModel::iterator& it )
 {
     Gtk::TreeModel::Row row = *it;
+    Gtk::CellRendererText* rentext = dynamic_cast<Gtk::CellRendererText*>( cell );
 
     if( row[ m_columns.m_col_drawbg ] ){
-        cell->property_cell_background() = CONFIG::get_color( COLOR_BACK_HIGHLIGHT_TREE );
-        cell->property_cell_background_set() = true;
+        rentext->property_foreground() = CONFIG::get_color( COLOR_CHAR_HIGHLIGHT_TREE );
+        rentext->property_foreground_set() = true;
+        rentext->property_cell_background() = CONFIG::get_color( COLOR_BACK_HIGHLIGHT_TREE );
+        rentext->property_cell_background_set() = true;
     }
-    else cell->property_cell_background_set() = false;
+    else {
+        rentext->property_foreground_set() = false;
+        rentext->property_cell_background_set() = false;
+    }
 }
 
 

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -810,6 +810,7 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "cl_char_age", str_color[ COLOR_CHAR_AGE ] );
     cf.update( "cl_char_selection", str_color[ COLOR_CHAR_SELECTION ] );
     cf.update( "cl_char_highlight", str_color[ COLOR_CHAR_HIGHLIGHT ] );
+    cf.update( "cl_char_highlight_tree", str_color[ COLOR_CHAR_HIGHLIGHT_TREE ] );
     cf.update( "cl_char_link", str_color[ COLOR_CHAR_LINK ] );
     cf.update( "cl_char_link_id_low", str_color[ COLOR_CHAR_LINK_ID_LOW ] );
     cf.update( "cl_char_link_id_high", str_color[ COLOR_CHAR_LINK_ID_HIGH ] );
@@ -1082,6 +1083,9 @@ void ConfigItems::set_colors( JDLIB::ConfLoader& cf )
 
     // ハイライトの文字色
     str_color[ COLOR_CHAR_HIGHLIGHT ] = cf.get_option_str( "cl_char_highlight", CONF_COLOR_CHAR_HIGHLIGHT, 13 );
+
+    // ハイライトの文字色(ツリー用)
+    str_color[ COLOR_CHAR_HIGHLIGHT_TREE ] = cf.get_option_str( "cl_char_highlight_tree", CONF_COLOR_CHAR_HIGHLIGHT_TREE, 13 );
 
     // 通常のリンクの文字色
     str_color[ COLOR_CHAR_LINK ] = cf.get_option_str( "cl_char_link", CONF_COLOR_CHAR_LINK, 13 );

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -257,6 +257,7 @@ namespace CONFIG
 #define CONF_COLOR_CHAR_AGE "#fde800000000"    // ageの時のメール欄の文字色
 #define CONF_COLOR_CHAR_SELECTION "#ffffffffffff"  // 選択範囲の文字色
 #define CONF_COLOR_CHAR_HIGHLIGHT CONF_COLOR_CHAR  // ハイライトの文字色
+#define CONF_COLOR_CHAR_HIGHLIGHT_TREE CONF_COLOR_CHAR  // ハイライトの文字色
 #define CONF_COLOR_CHAR_LINK "#00000000ffff" //通常のリンクの文字色
 #define CONF_COLOR_CHAR_LINK_ID_LOW  CONF_COLOR_CHAR_LINK // 複数発言したIDの文字色
 #define CONF_COLOR_CHAR_LINK_ID_HIGH CONF_COLOR_CHAR_AGE // 多く発言したIDの文字色

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -665,12 +665,18 @@ void MouseKeyPref::slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::Tr
 void MouseKeyPref::slot_cell_data( Gtk::CellRenderer* cell, const Gtk::TreeModel::iterator& it )
 {
     Gtk::TreeModel::Row row = *it;
+    Gtk::CellRendererText* rentext = dynamic_cast<Gtk::CellRendererText*>( cell );
 
     if( row[ m_columns.m_col_drawbg ] ){
-        cell->property_cell_background() = CONFIG::get_color( COLOR_BACK_HIGHLIGHT_TREE );
-        cell->property_cell_background_set() = true;
+        rentext->property_foreground() = CONFIG::get_color( COLOR_CHAR_HIGHLIGHT_TREE );
+        rentext->property_foreground_set() = true;
+        rentext->property_cell_background() = CONFIG::get_color( COLOR_BACK_HIGHLIGHT_TREE );
+        rentext->property_cell_background_set() = true;
     }
-    else cell->property_cell_background_set() = false;
+    else {
+        rentext->property_foreground_set() = false;
+        rentext->property_cell_background_set() = false;
+    }
 }
 
 

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -75,6 +75,7 @@ FontColorPref::FontColorPref( Gtk::Window* parent, const std::string& url )
 
     // 色設定をセット
     set_color_settings( COLOR_NONE, "■ " + CONTROL::get_mode_label( CONTROL::MODE_COMMON ), "" );
+    set_color_settings( COLOR_CHAR_HIGHLIGHT_TREE, "板、スレ一覧での検索結果などのハイライトの文字色", CONF_COLOR_CHAR_HIGHLIGHT_TREE );
     set_color_settings( COLOR_BACK_HIGHLIGHT_TREE, "板、スレ一覧での検索結果などのハイライトの背景色", CONF_COLOR_BACK_HIGHLIGHT_TREE );
 
     set_color_settings( COLOR_NONE, "", "" );
@@ -590,11 +591,17 @@ void FontColorPref::slot_cell_data_name( Gtk::CellRenderer* cell, const Gtk::Tre
 
     const int colorid = row[ m_columns_color.m_col_colorid ];
     const std::string defaultcolor = row[ m_columns_color.m_col_default ];
+    Gtk::CellRendererText* rentext = dynamic_cast<Gtk::CellRendererText*>( cell );
     if( colorid != COLOR_NONE && CONFIG::get_color( colorid ) != defaultcolor ){
-        cell->property_cell_background() = CONFIG::get_color( COLOR_BACK_HIGHLIGHT_TREE );
-        cell->property_cell_background_set() = true;
+        rentext->property_foreground() = CONFIG::get_color( COLOR_CHAR_HIGHLIGHT_TREE );
+        rentext->property_foreground_set() = true;
+        rentext->property_cell_background() = CONFIG::get_color( COLOR_BACK_HIGHLIGHT_TREE );
+        rentext->property_cell_background_set() = true;
     }
-    else cell->property_cell_background_set() = false;
+    else {
+        rentext->property_foreground_set() = false;
+        rentext->property_cell_background_set() = false;
+    }
 }
 
 


### PR DESCRIPTION
フォントと色の詳細設定に、スレ一覧や設定画面(about:config など)におけるハイライト表示の文字色の設定を追加します。これにより、ユーザーは背景色と文字色を自由にカスタマイズできるようになり、特にダークテーマ使用時の視認性低下を防ぐ効果が期待できます。

詳細:

- 新たに追加された設定項目：`COLOR_CHAR_HIGHLIGHT_TREE`
  - スレ一覧や設定画面でのハイライト文字色を制御
- 設定変更に伴い、以下のソースコードを修正
  - `BoardViewBase`, `AboutConfig`, `FontColorPref`などのハイライト関連ロジックを更新
  - 設定保存とデフォルト値の管理に関する修正を反映

この機能追加により、テーマの視覚的な一貫性とカスタマイズ性が向上します。

Add a new font and color setting to customize the highlight text color in thread lists and configuration screens (e.g., about:config).  This feature allows users to freely adjust both background and text colors, addressing visibility issues, especially when using dark themes.

Details:

- Newly added setting: `COLOR_CHAR_HIGHLIGHT_TREE`
  - Controls highlight text color in thread lists and configuration screens
- Updated source code logic for highlight functionality
  - Modified related methods in `BoardViewBase`, `AboutConfig`, `FontColorPref`, etc.
  - Reflected changes in setting persistence and default value management

This enhancement improves visual consistency and customization for theme alignment.

Closes #1484
