### PR TITLE
Bump version to 0.13.0-beta

### DIFF
--- a/docs/manual/2024.md
+++ b/docs/manual/2024.md
@@ -10,6 +10,110 @@ layout: default
 
 <a name="0.13.0-unreleased"></a>
 ### [0.13.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.12.0...master) (unreleased)
+- ([#1487](https://github.com/JDimproved/JDim/pull/1487))
+  Bump version to 0.13.0-beta
+- ([#1486](https://github.com/JDimproved/JDim/pull/1486))
+  `FontColorPref`: Add highlight text color settings to improve visibility
+- ([#1485](https://github.com/JDimproved/JDim/pull/1485))
+  Add GTK theme support for thread view text and background colors
+- ([#1482](https://github.com/JDimproved/JDim/pull/1482))
+  Improve popup display handling for multi-monitor setups in X11
+- ([#1480](https://github.com/JDimproved/JDim/pull/1480))
+  manual: Update "About Theme" page
+- ([#1479](https://github.com/JDimproved/JDim/pull/1479))
+  `FontColorPref`: Change mnemonic key to solve duplicate keys
+- ([#1478](https://github.com/JDimproved/JDim/pull/1478))
+  Fix preference dialog crashing on snap app
+- ([#1476](https://github.com/JDimproved/JDim/pull/1476))
+  `FontColorPref`: Add icon theme settings
+- ([#1475](https://github.com/JDimproved/JDim/pull/1475))
+  `FontColorPref`: Override check state if `GTK_THEME` defines light theme
+- ([#1474](https://github.com/JDimproved/JDim/pull/1474))
+  `FontColorPref`: Add GTK theme selection and dark theme settings
+- ([#1473](https://github.com/JDimproved/JDim/pull/1473))
+  Add notes for Wayland environment to README and online manual
+- ([#1472](https://github.com/JDimproved/JDim/pull/1472))
+  Fix popup position issue on Wayland and improve natural sizing
+- ([#1471](https://github.com/JDimproved/JDim/pull/1471))
+  Fix failing muon-master job in GitHub Actions Weekly CI
+- ([#1468](https://github.com/JDimproved/JDim/pull/1468))
+  Fix scan-build warning for unix.Stream
+- ([#1467](https://github.com/JDimproved/JDim/pull/1467))
+  Fix completion popup position on Wayland
+- ([#1465](https://github.com/JDimproved/JDim/pull/1465))
+  Fix scan-build warnings for core.NonNullParamChecker
+- ([#1464](https://github.com/JDimproved/JDim/pull/1464))
+  Fix issue where window size is not saved after unmaximizing in Wayland
+- ([#1462](https://github.com/JDimproved/JDim/pull/1462))
+  `NodeTree2ch`: Set `maybe_unused` attribute for class member
+- ([#1461](https://github.com/JDimproved/JDim/pull/1461))
+  Modify `char32_t` output to Unicode format and ensure C++20 compatibility
+- ([#1458](https://github.com/JDimproved/JDim/pull/1458))
+  meson: Fix unity build
+- ([#1456](https://github.com/JDimproved/JDim/pull/1456))
+  Fix compiler warnings for `-Wc++20-compat` part3,4,5
+- ([#1455](https://github.com/JDimproved/JDim/pull/1455))
+  environment: Add display server type for environment list
+- ([#1453](https://github.com/JDimproved/JDim/pull/1453))
+  Change `UNDO_BUFFER::set_item()` argument to pass by value
+- ([#1452](https://github.com/JDimproved/JDim/pull/1452))
+  `JDWindow`: Disable window movement handling in Wayland environment
+- ([#1451](https://github.com/JDimproved/JDim/pull/1451))
+  `Loader`: Get rid of anchor from path for HTTP request
+- ([#1448](https://github.com/JDimproved/JDim/pull/1448))
+  `ImgRoot`: Refactor image extension checks using `std::string_view`
+- ([#1447](https://github.com/JDimproved/JDim/pull/1447))
+  `ImgRoot`: Fix to avoid treating too short URLs as images
+- ([#1446](https://github.com/JDimproved/JDim/pull/1446))
+  `ImgRoot`: Ignore URL parameters and anchors in image format detection
+- ([#1445](https://github.com/JDimproved/JDim/pull/1445))
+  `ImgRoot`: Simplify `get_type_ext()` function by removing overloads
+- ([#1444](https://github.com/JDimproved/JDim/pull/1444))
+  Add test cases for `DBIMG::ImgRoot::get_type_ext()`
+- ([#1443](https://github.com/JDimproved/JDim/pull/1443))
+  Fix compiler warnings for `-Wc++20-compat` part3
+- ([#1442](https://github.com/JDimproved/JDim/pull/1442))
+  Fix compiler warnings for `-Wc++20-compat` part2
+- ([#1441](https://github.com/JDimproved/JDim/pull/1441))
+  `MouseKeyPref`: Implement search box on `MouseKeyPref` to filter rows
+- ([#1438](https://github.com/JDimproved/JDim/pull/1438))
+  Fix compiler warnings for `-Wc++20-compat` part1
+- ([#1437](https://github.com/JDimproved/JDim/pull/1437))
+  `PaneControl`: Get rid of member function unused parameters
+- ([#1436](https://github.com/JDimproved/JDim/pull/1436))
+  `MouseKeyPref`: Use `Gtk::TreeView` instead of `SKELETON::JDTreeViewBase`
+- ([#1434](https://github.com/JDimproved/JDim/pull/1434))
+  Img: Interrupt download for i.imgur.com/removed.png
+- ([#1432](https://github.com/JDimproved/JDim/pull/1432))
+  Weely CI: Use bootstrap.sh instead of meson for muon-master job
+- ([#1431](https://github.com/JDimproved/JDim/pull/1431))
+  Fix GitHub Actions workflow Weekly CI part2
+- ([#1430](https://github.com/JDimproved/JDim/pull/1430))
+  Fix GitHub Actions workflow Weekly CI
+- ([#1429](https://github.com/JDimproved/JDim/pull/1429))
+  Update GitHub Actions Weekly CI to solve Muon breaking changes
+- ([#1428](https://github.com/JDimproved/JDim/pull/1428))
+  control: Add shortcut key for "Go To Last Tab"
+- ([#1426](https://github.com/JDimproved/JDim/pull/1426))
+  Fix external BBSMENU loading
+- ([#1424](https://github.com/JDimproved/JDim/pull/1424))
+  Fix compiler warnings for `-Wold-style-cast` part12
+- ([#1423](https://github.com/JDimproved/JDim/pull/1423))
+  snap: Migrate base to core22
+- ([#1422](https://github.com/JDimproved/JDim/pull/1422))
+  tfidf: Rename local variable that has been typo
+- ([#1421](https://github.com/JDimproved/JDim/pull/1421))
+  Return class member const reference string instead of string value
+- ([#1419](https://github.com/JDimproved/JDim/pull/1419))
+  Deprecate platforms where gcc version less than 10
+- ([#1417](https://github.com/JDimproved/JDim/pull/1417))
+  Update documents
+- ([#1416](https://github.com/JDimproved/JDim/pull/1416))
+  Update documents
+- ([#1415](https://github.com/JDimproved/JDim/pull/1415))
+  readme: Update note about crypt(3) crash with AddressSanitizer
+- ([#1414](https://github.com/JDimproved/JDim/pull/1414))
+  Bump version to 0.13.0-alpha
 
 
 <a name="JDim-v0.12.0"></a>

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 
 project('jdim', 'cpp',
-        version : '0.13.0-alpha',
+        version : '0.13.0-beta',
         license : 'GPL2',
         meson_version : '>= 0.53.0',
         default_options : ['warning_level=3', 'cpp_std=c++17'])

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -17,8 +17,8 @@
 #define MAJORVERSION 0
 #define MINORVERSION 13
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20240713"
-#define JDTAG     "alpha"
+#define JDDATE_FALLBACK    "20241221"
+#define JDTAG     "beta"
 
 //---------------------------------
 


### PR DESCRIPTION
### Update histories

### Bump version to 0.13.0-beta

機能フリーズ期間に入るためバージョン番号をベータ版に更新します。

関連のissue: #1459
