### PR TITLE
BoardViewBase::slot_cell_data: Fix segfault

### DIFF
--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -893,7 +893,10 @@ void BoardViewBase::slot_cell_data_markup( Gtk::CellRenderer* cell, const Gtk::T
         rentext->property_cell_background_set() = true;
     }
 
-    else m_treeview.slot_cell_data( cell, it );
+    else {
+        rentext->property_foreground_set() = false;
+        m_treeview.slot_cell_data( cell, it );
+    }
 
     rentext->property_text() = "";
     rentext->property_markup() = row[ m_columns.m_col_subject ];
@@ -906,18 +909,30 @@ void BoardViewBase::slot_cell_data_markup( Gtk::CellRenderer* cell, const Gtk::T
 //
 void BoardViewBase::slot_cell_data( Gtk::CellRenderer* cell, const Gtk::TreeModel::iterator& it )
 {
+    // scanbuild-19 のレポートを抑制するためnullチェックする
+    // warning: Called C++ object pointer is null [core.CallAndMessage]
+    if( ! cell ) return;
+
     Gtk::TreeModel::Row row = *it;
+    // Gio::Icon を表示するcell (ITEM_MARK)は CellRendererText にキャストできない、nullptr が返る
+    Gtk::CellRendererText* rentext = dynamic_cast<Gtk::CellRendererText*>( cell );
 
     // ハイライト色 ( 抽出状態 )
     if( row[ m_columns.m_col_drawbg ] ){
-        Gtk::CellRendererText* rentext = dynamic_cast<Gtk::CellRendererText*>( cell );
-        rentext->property_foreground() = CONFIG::get_color( COLOR_CHAR_HIGHLIGHT_TREE );
-        rentext->property_foreground_set() = true;
-        rentext->property_cell_background() = CONFIG::get_color( COLOR_BACK_HIGHLIGHT_TREE );
-        rentext->property_cell_background_set() = true;
+        if( rentext ) {
+            rentext->property_foreground() = CONFIG::get_color( COLOR_CHAR_HIGHLIGHT_TREE );
+            rentext->property_foreground_set() = true;
+        }
+        cell->property_cell_background() = CONFIG::get_color( COLOR_BACK_HIGHLIGHT_TREE );
+        cell->property_cell_background_set() = true;
     }
 
-    else m_treeview.slot_cell_data( cell, it );
+    else {
+        if( rentext ) {
+            rentext->property_foreground_set() = false;
+        }
+        m_treeview.slot_cell_data( cell, it );
+    }
 }
 
 


### PR DESCRIPTION
スレ一覧で検索を実行するとJDimが異常終了する不具合を修正します。

Issue #1486 の修正で、スレ一覧の項目にハイライトの文字色と背景色を設定するため Gtk::CellRenderer を Gtk::CellRendererText にキャストする
処理が追加されました。しかし、スレ一覧にはアイコン(Gtk::CellRendererPixbuf を利用)の項目があるため、アイコンの文字色と背景色の設定でキャストに失敗して nullptr が返りそのまま続行した結果、Segmentation fault が発生しました。

Segmentation faultのレポート
```
Thread 1 "jdim" received signal SIGSEGV, Segmentation fault.
0x00007ffff7a56507 in Gtk::CellRendererText::property_foreground() ()
   from /lib/x86_64-linux-gnu/libgtkmm-3.0.so.1
(gdb) frame 1
    this=0x55555b0be7c0, cell=<optimized out>, it=...)
    at ../src/board/boardviewbase.cpp:914
914             rentext->property_foreground() = CONFIG::get_color( COLOR_CHAR_HIGHLIGHT_TREE );
(gdb) p rentext
$4 = (Gtk::CellRendererText *) 0x0
```

他の修正:

- スレタイトルのハイライトを解除するとき、文字色のリセットを追加します。
- scanbuild-19 のレポートを抑制するためnullチェックを追加します。
  `warning: Called C++ object pointer is null [core.CallAndMessage]`

scanbuild-19 のレポート
```
[96/287] Compiling C++ object src/board/libboard.a.p/boardviewbase.cpp.o
../../../src/board/boardviewbase.cpp:918:9: warning: Called C++ object pointer is null [core.CallAndMessage]
  918 |         cell->property_cell_background() = CONFIG::get_color( COLOR_BACK_HIGHLIGHT_TREE );
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../src/board/boardviewbase.cpp:925:9: warning: Called C++ object pointer is null [core.CallAndMessage]
  925 |         cell->property_cell_background_set() = false;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
```

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1722942440/451

Closes #1488
