### PR TITLE
Apply Wayland popup positioning logic to X11

### DIFF
--- a/src/skeleton/popupwin.cpp
+++ b/src/skeleton/popupwin.cpp
@@ -51,12 +51,7 @@ void PopupWin::slot_resize_popup()
 {
     if( ! m_view ) return;
 
-    if( m_running_on_wayland ) {
-        move_resize_wayland();
-    }
-    else {
-        move_resize_conventional();
-    }
+    move_resize();
     show_all();
 }
 
@@ -70,86 +65,14 @@ void PopupWin::slot_realize()
 {
     if( ! m_view ) return;
 
-    if( m_running_on_wayland ) {
-        move_resize_wayland();
-    }
-    else {
-        move_resize_conventional();
-    }
+    move_resize();
 }
 
 
-/**
- * @brief ポップアップウィンドウの座標と幅と高さを計算してリサイズと移動する (従来方式)
+/** @brief ポップアップウィンドウの座標と幅と高さを計算してリサイズと移動する
  *
- * @details X11で gdk_window_move_to_rect() を使うと挙動が変わるため従来の方法を使う。
- */
-void PopupWin::move_resize_conventional()
-{
-    // ディスプレイの情報を取得する。
-    auto display = Gdk::Display::get_default();
-
-    // ディスプレイに対するマウス座標を取得する。
-    int x_mouse, y_mouse;
-    display->get_default_seat()->get_pointer()->get_position( x_mouse, y_mouse );
-
-    Gtk::Window* parent_win = get_transient_for();
-
-    // 以前は Gdk::Screen を使用してポップアップのサイズを計算していたが、
-    // Gdk::Screen は複数モニターを一つの画面領域として扱うため、
-    // マルチディスプレイ環境ではポップアップが画面を跨いで表示される問題があった。
-
-    // 親ウインドウが配置されている Gdk::Monitor の作業領域からポップアップのサイズと位置を計算する。
-    Gdk::Rectangle rect;
-    const auto monitor = display->get_monitor_at_window( parent_win->get_window() );
-    monitor->get_workarea( rect );
-    const int width_desktop = rect.get_width();
-    const int height_desktop = rect.get_height();
-
-    // クライアントのサイズを取得
-    const int width_client = m_view->width_client();
-    const int height_client = m_view->height_client();
-
-    // x 座標と幅
-    const int width_popup = width_client;
-    int x_popup;
-    if( x_mouse + m_mrg_x + width_popup <= width_desktop ) x_popup = x_mouse + m_mrg_x;
-    else x_popup = MAX( 0, width_desktop - width_popup );
-
-    // y 座標と高さ
-    int y_popup;  
-    int height_popup;
-    if( y_mouse - ( height_client + m_mrg_y ) >= 0 ){  // 上にスペースがある
-        y_popup = y_mouse - height_client - m_mrg_y;
-        height_popup = height_client;
-    }
-    else if( y_mouse + m_mrg_y + height_client <= height_desktop ){ // 下にスペースがある
-        y_popup = y_mouse + m_mrg_y;
-        height_popup = height_client;
-    }
-    else if( m_view->get_popup_upside() || y_mouse > height_desktop/2 ){ // スペースは無いが上に表示
-        y_popup = MAX( 0, y_mouse - ( height_client + m_mrg_y ) );
-        height_popup = y_mouse - ( y_popup + m_mrg_y );
-    }
-    else{ // 下
-        y_popup = y_mouse + m_mrg_y;
-        height_popup = height_desktop - y_popup;
-    }
-
-#ifdef _DEBUG
-    std::cout << "PopupWin::slot_resize_popup : x = " << x_popup << " y = " << y_popup
-              << " w = " << width_popup << " h = " << height_popup << std::endl;
-#endif
-    move( x_popup, y_popup );
-    resize( width_popup,  height_popup );
-}
-
-
-/** @brief ポップアップウィンドウの座標と幅と高さを計算してリサイズと移動する (Wayland)
- *
- * @details Waylandでポップアップを表示するときの動作を説明します。
- * GTK 3.24から導入された [`gdk_window_move_to_rect()`] を使用してWaylandでの配置を改善します。
- * X11環境では従来の `Gtk::Window::move()` による方法を維持します。
+ * @details ポップアップを表示するときの動作を説明します。
+ * GTK 3.24から導入された [`gdk_window_move_to_rect()`] を使用して配置を改善します。
  *
  * ポップアップを表示するには `SKELETON::PopupWin` と `Gdk::Window` が関連づけられている必要があります。
  * Waylandでは、 `PopupWin` のコンストラクタを実行している間は `Gdk::Window` が関連付けされていないため、
@@ -174,7 +97,7 @@ void PopupWin::move_resize_conventional()
  * [`gdk_window_move_to_rect()`]: https://docs.gtk.org/gdk3/method.Window.move_to_rect.html
  * [`GdkAnchorHints`]: https://docs.gtk.org/gdk3/flags.AnchorHints.html
  */
-void PopupWin::move_resize_wayland()
+void PopupWin::move_resize()
 {
     // 1. ディスプレイの情報を取得する
 
@@ -247,6 +170,11 @@ void PopupWin::move_resize_wayland()
         // ウインドウを非表示にして呼び出さないと期待通り動作しない環境がある
         // https://gitlab.gnome.org/GNOME/gtk/-/issues/1986
         hide();
+    }
+    else if( ! m_running_on_wayland ) {
+        // X11環境では、viewの自然なサイズからウインドウの幅と高さを計算すると、
+        // 高さが大きい場合に期待通り動作しないことがあるため、幅と高さを明示的に指定します。
+        set_default_size( width_client, height_popup );
     }
     gdk_window_move_to_rect( get_window()->gobj(), &rect_dest, rect_anchor, window_anchor, anchor_hints,
                              rect_anchor_dx, rect_anchor_dy );

--- a/src/skeleton/popupwin.cpp
+++ b/src/skeleton/popupwin.cpp
@@ -115,6 +115,10 @@ void PopupWin::move_resize()
     monitor->get_workarea( rect );
     const int height_desktop = rect.get_height();
 
+    // 作業領域上のマウス座標を計算する。
+    const int y_desktop = rect.get_y();
+    const int y_mouse_local = y_mouse - y_desktop;
+
     // クライアントのサイズを取得
     const int height_client = m_view->height_client();
     const int width_client = m_view->width_client();
@@ -127,27 +131,26 @@ void PopupWin::move_resize()
     GdkGravity rect_anchor; // 表示位置の角
     GdkGravity window_anchor; // ポップアップの角
     int height_popup; // ポップアップ表示中にリサイズするとき使う
-    if( y_mouse - ( height_client + m_mrg_y ) >= 0 ) { // 上にスペースがある
+    if( y_mouse_local - ( height_client + m_mrg_y ) >= 0 ) { // 上にスペースがある
         rect_anchor = GDK_GRAVITY_NORTH_WEST;
         window_anchor = GDK_GRAVITY_SOUTH_WEST;
         height_popup = height_client;
     }
-    else if( y_mouse + m_mrg_y + height_client <= height_desktop ) { // 下にスペースがある
+    else if( y_mouse_local + m_mrg_y + height_client <= height_desktop ) { // 下にスペースがある
         rect_anchor = GDK_GRAVITY_SOUTH_WEST;
         window_anchor = GDK_GRAVITY_NORTH_WEST;
         height_popup = height_client;
     }
-    else if( m_view->get_popup_upside() || y_mouse > height_desktop / 2 ) { // スペースは無いが上に表示
+    else if( m_view->get_popup_upside() || y_mouse_local > height_desktop / 2 ) { // スペースは無いが上に表示
         rect_anchor = GDK_GRAVITY_NORTH_WEST;
         window_anchor = GDK_GRAVITY_SOUTH_WEST;
-        const int y_popup = (std::max)( 0, y_mouse - ( height_client + m_mrg_y ) );
-        height_popup = y_mouse - ( y_popup + m_mrg_y );
+        const int y_popup = y_desktop + (std::max)( 0, y_mouse_local - ( height_client + m_mrg_y ) );
+        height_popup = y_mouse_local - ( y_popup - y_desktop + m_mrg_y );
     }
     else { // スペースは無いが下に表示
         rect_anchor = GDK_GRAVITY_SOUTH_WEST;
         window_anchor = GDK_GRAVITY_NORTH_WEST;
-        const int y_popup = y_mouse + m_mrg_y;
-        height_popup = height_desktop - y_popup;
+        height_popup = height_desktop - ( y_mouse_local + m_mrg_y );
     }
 
     // 3. リサイズと移動を行う

--- a/src/skeleton/popupwin.h
+++ b/src/skeleton/popupwin.h
@@ -46,8 +46,7 @@ namespace SKELETON
 
         void slot_realize();
 
-        void move_resize_conventional();
-        void move_resize_wayland();
+        void move_resize();
     };
 }
 


### PR DESCRIPTION
### Apply Wayland popup positioning logic to X11

Wayland環境のポップアップ配置ロジックをX11環境にも適用します。

このパッチは親ウィンドウの左上を原点としてポップアップの位置を決定し、2つのウィンドウの相対的な座標で配置します。これにより、モニターの画面領域を考慮した座標計算がY方向のみで済むようになります(マウスポインターの上と下どちらにポップアップを配置するかの判断など)。

Waylandでは、SKELETON::Viewの自然な幅・高さを基にGTK/GDKがポップアップサイズを計算しますが、X11環境では高さが大きい場合に期待通りに動作しないことがあります。このため、X11環境では`Gtk::Window::set_default_size()`を使ってポップアップの幅と高さを明示的に指定するよう変更しました。

配置処理の統合により使わなくなった`PopupWin::move_resize_conventional()`を削除して、`PopupWin::move_resize_wayland()`の名前を`move_resize()`に変更します。

### ポップアップの位置判定に使用するマウス座標を作業領域上の座標に変換するように修正

マルチディスプレイ環境でX11を使用し、モニタの位置にオフセットがある場合、ポップアップがマウスからずれて表示される問題を直します。

パッチ作成の際に @mokeke-maru さんの[修正][1]を参考にしました。
バグ報告とパッチのご提供いただきまして、ありがとうございました。

[1]: https://github.com/mokeke-maru/JDim/commit/b6563e5dcfdfa5f13f4c6cd30e236c4f5c6e0262
