### PR TITLE
Modify char32_t output to Unicode format part2

### DIFF
--- a/src/jdlib/misccharcode.cpp
+++ b/src/jdlib/misccharcode.cpp
@@ -512,7 +512,7 @@ int MISC::utf32toutf8( const char32_t uch,  char* utf8str )
     }
 #ifdef _DEBUG
     else{
-        std::cout << "MISC::utf32toutf8 : invalid uch = " << uch << std::endl;
+        std::cout << "MISC::utf32toutf8 : invalid uch = " << MISC::utf32tostr( uch ) << std::endl;
     }
 #endif
 


### PR DESCRIPTION
char32_t (UTF-32) の値をデバッグやログ出力する際、Unicode の U+XXXX 形式にフォーマットするよう変更します。

以前は iostream で10進数や16進数の形式で出力していましたが、C++20で<<演算子のオーバーロードが削除されたため、これに対応するための修正です。

Change the output format of char32_t (UTF-32) values in debugging and logging to the Unicode U+XXXX format.

Previously, the values were output in decimal or hexadecimal using iostream, but this is no longer compatible with the new standard as the << operator overload was removed in C++20.

C++20モードでビルドしたときのエラーログ:
```
./src/jdlib/misccharcode.cpp: In function ‘int MISC::utf32toutf8(char32_t, char*)’:
../src/jdlib/misccharcode.cpp:515:62: error: use of deleted function ‘std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, char32_t) [with _Traits = char_traits<char>]’
  515 |         std::cout << "MISC::utf32toutf8 : invalid uch = " << uch << std::endl;
      |                                                              ^~~
In file included from /usr/include/c++/14/iostream:41,
                 from ../src/jddebug.h:9,
                 from ../src/jdlib/misccharcode.cpp:4:
/usr/include/c++/14/ostream:615:5: note: declared here
  615 |     operator<<(basic_ostream<char, _Traits>&, char32_t) = delete;
      |     ^~~~~~~~
../src/jdlib/misccharcode.cpp:515:62: note: use ‘-fdiagnostics-all-candidates’ to display considered candidates
  515 |         std::cout << "MISC::utf32toutf8 : invalid uch = " << uch << std::endl;
      |                                                              ^~~
```

関連のpull request: #1461
