### PR TITLE
NodeTree2ch: Update kako log dat URL

### DIFF
--- a/src/dbtree/nodetree2ch.cpp
+++ b/src/dbtree/nodetree2ch.cpp
@@ -135,14 +135,14 @@ void NodeTree2ch::create_loaderdata( JDLIB::LOADERDATA& data )
         const std::string& url = ( m_mode == MODE_OLDURL ) ? m_org_url : get_url();
 
         if( ! regex.exec( "(https?://[^/]*)(/.*)/dat(/.*)\\.dat$", url, offset, icase, newline, usemigemo, wchar ) ) return;
-        const int id = std::atoi( regex.str( 3 ).c_str() + 1 );
 
         std::ostringstream ss;
 
-        // 過去ログURLの構築
+        // 過去ログURLの構築 (9桁のURLは2024年2月頃から上位4桁に移行しています)
         // スレIDが10桁の場合 -> https://サーバ/板ID/oyster/IDの上位4桁/ID.dat
-        // スレIDが 9桁の場合 -> https://サーバ/板ID/oyster/IDの上位3桁/ID.dat
-        ss << regex.str( 1 ) << regex.str( 2 ) << "/oyster/" << ( id / 1000000 ) << regex.str( 3 ) << ".dat";
+        // スレIDが 9桁の場合 -> https://サーバ/板ID/oyster/IDの上位4桁/ID.dat
+        const std::string id_high4 = regex.str( 3 ).substr( 1, 4 );
+        ss << regex.str( 1 ) << regex.str( 2 ) << "/oyster/" << id_high4 << regex.str( 3 ) << ".dat";
 
         // レジューム設定
         // DATを読み込んでいた場合はレジュームを有りにして、DATの未取得部分を追加するように処理する


### PR DESCRIPTION
5ch.netの過去ログdatのうち、現役サーバーに収容されている番号9桁のスレッドを読み込むことができるように修正します。番号9桁のdat URLは、oyster下のサブディレクトリ名に番号上位3桁を使用していましたが、2024年2月頃から上位4桁を使うように変更されています。

- 変更前: https://kizuna.5ch.net/event/oyster/980/980934474.dat
- 変更後: https://kizuna.5ch.net/event/oyster/9809/980934474.dat

注意:
過去ログdatは現役サーバーに収容されているスレッドに限り取得できます。

過去ログサーバーに収容されているスレッドは、read.cgiにアクセスすると、`kako.5ch.net`にHTTPリダイレクトして開きます。
過去ログのdatにアクセスするときも同様にリダイレクトしますが、この修正を行った時点では404 Not Foundが返ってきてdatを取得することができません。

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1722942440/181

Closes #1493
