### PR TITLE
JDWindow: Fix window resizing issue on Wayland

### DIFF
--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -1,6 +1,6 @@
 // ライセンス: GPL2
 
-//#define _DEBUG
+#define _DEBUG
 #include "jddebug.h"
 
 #include "window.h"
@@ -146,6 +146,8 @@ void JDWindow::init_win()
 
         Glib::signal_idle().connect( sigc::mem_fun( *this, &JDWindow::slot_idle ) );
     }
+
+    signal_realize().connect( sigc::mem_fun( *this, &JDWindow::slot_realize ) );
 }
 
 
@@ -173,6 +175,28 @@ bool JDWindow::slot_idle()
     }
 
     return false;
+}
+
+
+/** @brief ウインドウの初期設定サイズとrealizeしたときのサイズの差を計算して記憶します。
+ *
+ * @details Waylandでは、ウインドウがrealizeしたときに初期設定で指定したサイズより
+ * 大きく表示される環境があります。ウインドウの幅と高さは、デスクトップ環境やテーマごとに
+ * 異なる固定値で増えていきます。
+ *
+ * そのため、初期設定のサイズからウインドウがrealizeしたときのサイズの差を求め、
+ * サイズを保存する処理で差分を引いて補正を行うことでウインドウのサイズが拡大しないようにします。
+ */
+void JDWindow::slot_realize()
+{
+    m_offset_width = get_width_win() - get_width();
+    // 折り畳む場合はinit_win()のresizeで高さを1に指定するため0で処理する。
+    m_offset_height = ( m_fold_when_focusout ? 0 : get_height_win() ) - get_height();
+
+#ifdef _DEBUG
+    std::cout << "JDWindow::slot_realize offset_width = " << m_offset_width
+              << ", offset_height = " << m_offset_height << std::endl;
+#endif
 }
 
 
@@ -739,8 +763,10 @@ bool JDWindow::on_configure_event( GdkEventConfigure* event )
             if( ( ! m_fold_when_focusout || m_mode == JDWIN_NORMAL || m_mode == JDWIN_FOLD )
                     && height_new > min_height
                 ) {
-                set_width_win( width_new );
-                set_height_win( height_new );
+                // Waylandでは、eventでとれる値はinit_win()のresizeで指定したサイズより
+                // 大きくなる環境があるため計算した差分で打ち消す
+                set_width_win( width_new + m_offset_width );
+                set_height_win( height_new + m_offset_height );
             }
         }
 

--- a/src/skeleton/window.h
+++ b/src/skeleton/window.h
@@ -35,6 +35,9 @@ namespace SKELETON
         int m_counter{};
         int m_count_focusout{}; // フォーカス制御用カウンタ
 
+        int m_offset_width{}; ///< 初期設定と表示したときの幅の差
+        int m_offset_height{}; ///< 初期設定と表示したときの高さの差
+
         SKELETON::JDVBox m_vbox;
 
         std::unique_ptr<Gtk::ScrolledWindow> m_scrwin;
@@ -139,6 +142,7 @@ namespace SKELETON
       private:
 
         bool slot_idle();
+        void slot_realize();
 
         void move_win( const int x, const int y );
         void set_win_pos();


### PR DESCRIPTION
Wayland版GNOMEにおいて、メインウィンドウ、書き込みビューウィンドウ、画像ビューウィンドウを開く度にウィンドウが意図せず拡大する問題を修正します。

背景:
Wayland環境では、ウィンドウがrealizeされた際に、初期設定で指定したサイズよりも大きく表示されることがあります。ウィンドウの幅と高さは、デスクトップ環境やテーマによって異なる固定値で増加します。

この修正では、初期設定サイズとウィンドウがrealizeされた際のサイズの差分を算出し、サイズ保存処理でその差分を差し引くことで補正を行います。これにより、ウィンドウが不要に拡大するのを防ぎます。

パッチ作成にあたり、@feynoobs さんの[プルリクエスト][1]を参考にしました。
バグ報告とプルリクエストのご提供いただきありがとうございました。

Fixes an issue where the main window, write view window, and image view window would unintentionally increase in size each time they were opened in GNOME on Wayland.

Background:
In Wayland environments, windows may appear larger than their initially specified size when they are realized. The width and height of the window increase by fixed values that vary depending on the desktop environment and theme.

This fix calculates the difference between the initial size and the size when the window is realized, and then subtracts this difference in the size saving process for correction. This prevents the window from being unnecessarily enlarged.

This fix was created with reference to @feynoobs's pull request.
Thank you very much for the bug report and the pull request.

[1]: https://github.com/JDimproved/JDim/pull/1481
