### PR TITLE
Update year to 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ JDimで追加された不具合や機能の修正については[Pull requests][
 ## 著作権
 
 © 2017-2019 yama-natuki [https://github.com/yama-natuki/JD]  
-© 2019-2024 JDimproved project [https://github.com/JDimproved/JDim]
+© 2019-2025 JDimproved project [https://github.com/JDimproved/JDim]
 
 パッチやファイルを取り込んだ場合、それらのコピーライトは「JDimproved project」に統一します。
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ layout: default
 - [JDim 0.2.0-20190720](./link-20190720)
 - [JDim 0.1.0-20190122](./link-20190122)
 
-© 2019-2024 JDimproved project
+© 2019-2025 JDimproved project
 
 [dis592]: https://github.com/JDimproved/JDim/discussions/592
 [wiki-faq]: https://ja.osdn.net/projects/jd4linux/wiki/FAQ

--- a/docs/manual/2024.md
+++ b/docs/manual/2024.md
@@ -8,8 +8,8 @@ layout: default
 
 ## {{ page.title }}
 
-<a name="0.13.0-unreleased"></a>
-### [0.13.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.12.0...master) (unreleased)
+<a name="0.13.0-beta20241221"></a>
+### [0.13.0-beta2024](https://github.com/JDimproved/JDim/compare/JDim-v0.12.0...056d34bf3a9) (2024-12-21)
 - ([#1487](https://github.com/JDimproved/JDim/pull/1487))
   Bump version to 0.13.0-beta
 - ([#1486](https://github.com/JDimproved/JDim/pull/1486))

--- a/docs/manual/2025.md
+++ b/docs/manual/2025.md
@@ -1,0 +1,24 @@
+---
+title: 更新履歴(2025年)
+layout: default
+---
+<!-- SPDX-License-Identifier: FSFAP OR GPL-2.0-or-later -->
+
+&gt; [Top](../) &gt; [更新履歴]({{ site.baseurl }}/history/) &gt; {{ page.title }}
+
+## {{ page.title }}
+
+<a name="0.13.0-unreleased"></a>
+### [0.13.0-unreleased](https://github.com/JDimproved/JDim/compare/056d34bf3a9...master) (unreleased)
+- ([#1496](https://github.com/JDimproved/JDim/pull/1496))
+  Update year to 2025
+- ([#1495](https://github.com/JDimproved/JDim/pull/1495))
+  `JDWindow`: Fix window resizing issue on Wayland
+- ([#1494](https://github.com/JDimproved/JDim/pull/1494))
+  `NodeTree2ch`: Update kako log dat URL
+- ([#1492](https://github.com/JDimproved/JDim/pull/1492))
+  Modify `char32_t` output to Unicode format part2
+- ([#1491](https://github.com/JDimproved/JDim/pull/1491))
+  Apply Wayland popup positioning logic to X11
+- ([#1490](https://github.com/JDimproved/JDim/pull/1490))
+  `BoardViewBase::slot_cell_data`: Fix segfault

--- a/docs/manual/about.md
+++ b/docs/manual/about.md
@@ -29,7 +29,7 @@ JDimはGPLv2の下で公開されている [JD][] からforkしたソフトウ�
 <a name="copyright"></a>
 ### 著作権
 © 2017-2019 [yama-natuki][]  
-© 2019-2024 [JDimproved project][repository]
+© 2019-2025 [JDimproved project][repository]
 
 パッチやファイルを取り込んだ場合、それらのコピーライトは「JDimproved project」に統一します。
 

--- a/docs/manual/history.md
+++ b/docs/manual/history.md
@@ -7,6 +7,7 @@ layout: default
 
 ## {{ page.title }}
 
+- [2025年]({{ site.baseurl }}/2025/)
 - [2024年]({{ site.baseurl }}/2024/)
 - [2023年]({{ site.baseurl }}/2023/)
 - [2022年]({{ site.baseurl }}/2022/)

--- a/jdim.metainfo.xml
+++ b/jdim.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- SPDX-License-Identifier: FSFAP -->
-<!-- Copyright (c) 2019-2024 JDimproved project -->
+<!-- Copyright (c) 2019-2025 JDimproved project -->
 <component type="desktop-application">
   <id>com.github.jdimproved.jdim</id>
   <metadata_license>FSFAP</metadata_license>

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -17,7 +17,7 @@
 #define MAJORVERSION 0
 #define MINORVERSION 13
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20241221"
+#define JDDATE_FALLBACK    "20250104"
 #define JDTAG     "beta"
 
 //---------------------------------
@@ -25,7 +25,7 @@
 #define JDCOMMENT "JDim (JD improved) は gtkmm/GTK+ を用いた2chブラウザです。"
 #define JDCOPYRIGHT "(c) 2006-2015 JD project" "\n" \
                     "(c) 2017-2019 yama-natuki" "\n" \
-                    "(c) 2019-2024 JDimproved project"
+                    "(c) 2019-2025 JDimproved project"
 #define JDBBS CONFIG::get_url_jdhp()+"cgi-bin/bbs/support/"
 #define JD2CHLOG CONFIG::get_url_jdhp()+"old2ch/"
 #define JDHELP "https://jdimproved.github.io/JDim/"


### PR DESCRIPTION
- copyrightの表示を2025年に更新する
- オンラインマニュアルに更新履歴(2025年)のページを作成し未リリースの変更を移動する
