### PR TITLE
Fix dialog width issue when toggling list in Wayland GNOME

### DIFF
--- a/src/bbslist/selectdialog.cpp
+++ b/src/bbslist/selectdialog.cpp
@@ -158,7 +158,11 @@ void SelectListDialog::slot_show_tree()
     }
     else if( m_selectview ){
         get_content_area()->remove( *m_selectview );
-        resize( get_width(), 1 );
+        // CSDによる装飾を含まないコンテンツ領域の幅を取得し、
+        // resize()に指定することで、意図したサイズ変更を実現します。
+        int width = 1;
+        gtk_window_get_size( static_cast<Gtk::Window*>(this)->gobj(), &width, nullptr );
+        resize( width, 1 );
         m_selectview.reset();
     }
 }


### PR DESCRIPTION
Wayland版GNOMEにおいて、お気に入り追加先選択ダイアログの詳細ボタンを押してリストを折り畳んだ際に、ダイアログの幅が不適切に拡大される問題を修正します。

背景:
一部のウインドウマネージャーでは、`Gtk::Widget::get_width()`が返す幅にClient-side decoration (CSD)などの装飾が含まれる場合があります。この幅をそのまま`Gtk::Window::resize()`に渡すと、ウインドウのコンテンツ領域（クライアント領域）が保存したサイズに復元されません。

修正内容:
この問題を解決するため、ウインドウのコンテンツ領域サイズを取得する`gtk_window_get_size()`を使用して正しい幅を取得し、`resize()`に指定するよう変更しました。

This commit fixes an issue in Wayland GNOME where the width of the "Add to Favorites" selection dialog expands unexpectedly when the "Details" button is pressed and the list is collapsed.

Background:
In some window managers, `Gtk::Widget::get_width()` includes decorations such as client-side decorations (CSD).  Passing this width directly to `Gtk::Window::resize()` causes the content area of the window to fail to restore to its saved size.

Details of the fix:
To resolve this, the code now uses `gtk_window_get_size()` to obtain the correct width of the content area before calling `resize()`.
