### PR TITLE
Fix image view window folding not working on Wayland

### DIFF
--- a/src/skeleton/window.h
+++ b/src/skeleton/window.h
@@ -35,9 +35,6 @@ namespace SKELETON
         int m_counter{};
         int m_count_focusout{}; // フォーカス制御用カウンタ
 
-        int m_offset_width{}; ///< 初期設定と表示したときの幅の差
-        int m_offset_height{}; ///< 初期設定と表示したときの高さの差
-
         SKELETON::JDVBox m_vbox;
 
         std::unique_ptr<Gtk::ScrolledWindow> m_scrwin;
@@ -142,7 +139,6 @@ namespace SKELETON
       private:
 
         bool slot_idle();
-        void slot_realize();
 
         void move_win( const int x, const int y );
         void set_win_pos();


### PR DESCRIPTION
ウインドウ（メイン、書き込みビュー、画像ビュー）のサイズ変更イベント処理を修正し、画像ビューの折りたたむ機能がWayland環境でも正常に動作するよう対応します。

背景:
一部のウィンドウマネージャーでは、 `event->width/height` の値にClient-side decoration (CSD)などの装飾が含まれている可能性があります。
`Gtk::Window::resize()`はウィンドウのコンテンツ領域（クライアント領域）を指定したサイズに変更するため、装飾が含まれたサイズを渡すと、保存したサイズに正しく復元しません。代わりに、コンテンツ領域のサイズ保存に適している `Gtk::Window::get_size()` を使用します。

修正内容:
サイズ変更イベント処理において、 `event->width` および `event->height` からウィンドウサイズを取得する代わりに、 `get_size()` を使用するように変更しました。
また、この変更に伴い、不要になった `slot_realize()` 関数を削除しました。

This commit modifies the window resize event handling for the main, write, and image view windows to ensure the fold functionality in the image view works correctly in Wayland environments.

Background:
In some window managers, the values of `event->width/height` may include decorations such as Client-side decorations (CSD).  `Gtk::Window::resize()` changes the size of the window's content area (client area) to the specified size. Passing a size that includes decorations will prevent it from being restored to the saved size correctly. Instead, `Gtk::Window::get_size()`, which is suitable for saving the content area size, is used.

Details of the fix:
In the resize event handling, the code is changed to use `get_size()` to obtain the window size instead of relying on `event->width` and `event->height`.  Additionally, the `slot_realize()` function, which is no longer needed due to this change, has been removed.
