### PR TITLE
Fix compiler warnings for -Wrange-loop-construct

### DIFF
--- a/src/article/font.cpp
+++ b/src/article/font.cpp
@@ -82,7 +82,7 @@ bool ARTICLE::get_width_of_char( const char32_t code, const char pre_char, int& 
             { 0x3099, 0x309A }, // COMBINING KATAKANA-HIRAGANA (SEMI-)VOICED SOUND MARK
             { 0xFE00, 0xFE0F }, // VS1-VS16
         };
-        for( const auto [start, end] : blocks ) {
+        for( const auto& [start, end] : blocks ) {
             for( int i = start; i <= end; ++i ) {
                 width_of_char[ mode ][ i ].width_wide = -1;
             }

--- a/test/gtest_dbtree_nodetreebase.cpp
+++ b/test/gtest_dbtree_nodetreebase.cpp
@@ -34,7 +34,7 @@ TEST_F(NodeTreeBase_RemoveImenuTest, not_remove)
     };
 
     std::string buffer;
-    for( auto [input, expect] : test_data ) {
+    for( auto& [input, expect] : test_data ) {
         buffer.assign( input );
         EXPECT_FALSE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
         EXPECT_EQ( expect, buffer );
@@ -50,7 +50,7 @@ TEST_F(NodeTreeBase_RemoveImenuTest, single_ime_nu)
     };
 
     std::string buffer;
-    for( auto [input, expect] : test_data ) {
+    for( auto& [input, expect] : test_data ) {
         buffer.assign( input );
         EXPECT_TRUE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
         EXPECT_EQ( expect, buffer );
@@ -66,7 +66,7 @@ TEST_F(NodeTreeBase_RemoveImenuTest, single_ime_st)
     };
 
     std::string buffer;
-    for( auto [input, expect] : test_data ) {
+    for( auto& [input, expect] : test_data ) {
         buffer.assign( input );
         EXPECT_TRUE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
         EXPECT_EQ( expect, buffer );
@@ -82,7 +82,7 @@ TEST_F(NodeTreeBase_RemoveImenuTest, single_nun_nu)
     };
 
     std::string buffer;
-    for( auto [input, expect] : test_data ) {
+    for( auto& [input, expect] : test_data ) {
         buffer.assign( input );
         EXPECT_TRUE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
         EXPECT_EQ( expect, buffer );
@@ -98,7 +98,7 @@ TEST_F(NodeTreeBase_RemoveImenuTest, single_pinktower_com)
     };
 
     std::string buffer;
-    for( auto [input, expect] : test_data ) {
+    for( auto& [input, expect] : test_data ) {
         buffer.assign( input );
         EXPECT_TRUE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
         EXPECT_EQ( expect, buffer );
@@ -114,7 +114,7 @@ TEST_F(NodeTreeBase_RemoveImenuTest, single_jump_5ch_net)
     };
 
     std::string buffer;
-    for( auto [input, expect] : test_data ) {
+    for( auto& [input, expect] : test_data ) {
         buffer.assign( input );
         EXPECT_TRUE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
         EXPECT_EQ( expect, buffer );
@@ -130,7 +130,7 @@ TEST_F(NodeTreeBase_RemoveImenuTest, single_jump_2ch_net)
     };
 
     std::string buffer;
-    for( auto [input, expect] : test_data ) {
+    for( auto& [input, expect] : test_data ) {
         buffer.assign( input );
         EXPECT_TRUE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
         EXPECT_EQ( expect, buffer );
@@ -146,7 +146,7 @@ TEST_F(NodeTreeBase_RemoveImenuTest, single_machi_to_bbs_link_cgi)
     };
 
     std::string buffer;
-    for( auto [input, expect] : test_data ) {
+    for( auto& [input, expect] : test_data ) {
         buffer.assign( input );
         EXPECT_TRUE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
         EXPECT_EQ( expect, buffer );


### PR DESCRIPTION
Fedora 42に投入されるgcc15開発版でcompileすると出る警告を解消します。
man gccによると、-Wrange-loop-construct は -Wall で有効になると書いてありますが、gcc14だとこの警告は出ません。

gcc15開発版のレポート(抜粋)
```
../src/article/font.cpp:85:25: warning: loop variable ‘<structured bindings>’ creates a copy from type ‘const int [2]’ [-Wrange-loop-construct]
../test/gtest_dbtree_nodetreebase.cpp:37:15: warning: loop variable ‘<structured bindings>’ creates a copy from type ‘const char* const [2]’ [-Wrange-loop-construct]
../test/gtest_dbtree_nodetreebase.cpp:53:15: warning: loop variable ‘<structured bindings>’ creates a copy from type ‘const char* const [2]’ [-Wrange-loop-construct]
../test/gtest_dbtree_nodetreebase.cpp:69:15: warning: loop variable ‘<structured bindings>’ creates a copy from type ‘const char* const [2]’ [-Wrange-loop-construct]
../test/gtest_dbtree_nodetreebase.cpp:85:15: warning: loop variable ‘<structured bindings>’ creates a copy from type ‘const char* const [2]’ [-Wrange-loop-construct]
../test/gtest_dbtree_nodetreebase.cpp:101:15: warning: loop variable ‘<structured bindings>’ creates a copy from type ‘const char* const [2]’ [-Wrange-loop-construct]
../test/gtest_dbtree_nodetreebase.cpp:117:15: warning: loop variable ‘<structured bindings>’ creates a copy from type ‘const char* const [2]’ [-Wrange-loop-construct]
../test/gtest_dbtree_nodetreebase.cpp:133:15: warning: loop variable ‘<structured bindings>’ creates a copy from type ‘const char* const [2]’ [-Wrange-loop-construct]
../test/gtest_dbtree_nodetreebase.cpp:149:15: warning: loop variable ‘<structured bindings>’ creates a copy from type ‘const char* const [2]’ [-Wrange-loop-construct]
```

パッチ作成の際に @mtasaka さんの[修正][1]を参考にしました。
バグ報告とパッチのご提供いただきまして、ありがとうございました。

[1] https://github.com/JDimproved/JDim/issues/1503#issuecomment-2590030926

Closes #1503
