### PR TITLE
Bump version to 0.14.0-alpha

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 
 project('jdim', 'cpp',
-        version : '0.13.0',
+        version : '0.14.0-alpha',
         license : 'GPL2',
         meson_version : '>= 0.53.0',
         default_options : ['warning_level=3', 'cpp_std=c++17'])

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -15,10 +15,10 @@
 // SEE ALSO: ENVIRONMENT::get_jdversion()
 
 #define MAJORVERSION 0
-#define MINORVERSION 13
+#define MINORVERSION 14
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20250111"
-#define JDTAG     ""
+#define JDDATE_FALLBACK    "20250118"
+#define JDTAG     "alpha"
 
 //---------------------------------
 


### PR DESCRIPTION
開発中のバージョンであることを明らかにするためalpha版に更新します。
