### PR TITLE
Update CI settings (2025-01)

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -11,11 +11,11 @@ on:
 
 jobs:
 
-  ASan-22:
-    runs-on: ubuntu-22.04
+  ASan-24:
+    runs-on: ubuntu-24.04
     env:
-      CC: gcc-11
-      CXX: g++-11
+      CC: gcc-13
+      CXX: g++-13
       # Avoid crash for calling crypt_r() that is pointing invalid address.
       # https://github.com/JDimproved/JDim/issues/943
       AVOID_CRASH: -Wl,--push-state,--no-as-needed -lcrypt -Wl,--pop-state
@@ -24,55 +24,13 @@ jobs:
       - name: dependencies installation
         run: |
           sudo apt update
-          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev g++-11
-      - name: meson setup builddir -Db_sanitize=address,undefined -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dcpp_link_args="${AVOID_CRASH}"
-        run: meson setup builddir -Db_sanitize=address,undefined -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dcpp_link_args="${AVOID_CRASH}"
+          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev g++-13
+      - run: meson setup builddir -Db_sanitize=address,undefined -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dcpp_link_args="${AVOID_CRASH}"
         # `compile` subcommand requires Meson 0.54 or later.
-      - name: ninja -C builddir
-        run: ninja -C builddir
+      - run: ninja -C builddir
         # Since Meson 0.57, `test` subcommand will only rebuild test program.
-      - name: meson test -v -C builddir
-        run: meson test -v -C builddir
-      - name: ./builddir/src/jdim -V
-        run: ./builddir/src/jdim -V
-
-  compiler-20:
-    runs-on: ubuntu-20.04
-    env:
-      CC: ${{ matrix.sets.cc }}
-      CXX: ${{ matrix.sets.cxx }}
-    strategy:
-      matrix:
-        sets:
-          - cc: gcc-9
-            cxx: g++-9
-            package: g++-9
-          - cc: gcc-10
-            cxx: g++-10
-            package: g++-10
-          - cc: clang-10
-            cxx: clang++-10
-            package: clang-10
-          - cc: clang-11
-            cxx: clang++-11
-            package: clang-11
-          - cc: clang-12
-            cxx: clang++-12
-            package: clang-12
-    steps:
-      - uses: actions/checkout@v4
-      - name: dependencies installation
-        run: |
-          sudo apt update
-          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev ${{ matrix.sets.package }}
-      - name: meson setup builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
-        run: meson setup builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
-      - name: ninja -C builddir
-        run: ninja -C builddir
-      - name: meson test -v -C builddir
-        run: meson test -v -C builddir
-      - name: ./builddir/src/jdim -V
-        run: ./builddir/src/jdim -V
+      - run: meson test -v -C builddir
+      - run: ./builddir/src/jdim -V
 
   compiler-22:
     runs-on: ubuntu-22.04
@@ -82,6 +40,9 @@ jobs:
     strategy:
       matrix:
         sets:
+          - cc: gcc-10
+            cxx: g++-10
+            package: g++-10
           - cc: gcc-11
             cxx: g++-11
             package: g++-11
@@ -109,47 +70,46 @@ jobs:
         run: |
           sudo apt update
           sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev ${{ matrix.sets.package }}
-      - name: meson setup builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
-        run: meson setup builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
-      - name: ninja -C builddir
-        run: ninja -C builddir
-      - name: meson test -v -C builddir
-        run: meson test -v -C builddir
-      - name: ./builddir/src/jdim -V
-        run: ./builddir/src/jdim -V
+      - run: meson setup builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
+      - run: ninja -C builddir
+      - run: meson test -v -C builddir
+      - run: ./builddir/src/jdim -V
 
-  library-20:
-
-    runs-on: ubuntu-20.04
+  compiler-24:
+    runs-on: ubuntu-24.04
     env:
-      CC: gcc-9
-      CXX: g++-9
+      CC: ${{ matrix.sets.cc }}
+      CXX: ${{ matrix.sets.cxx }}
     strategy:
       matrix:
-        deps:
-          - config_args: -Dtls=gnutls -Dsessionlib=xsmp -Dmigemo=enabled -Dalsa=enabled -Dpangolayout=enabled
-            packages: libgnutls28-dev libmigemo-dev libasound2-dev
-          - config_args: -Dtls=openssl -Dsessionlib=no -Dmigemo=enabled -Dcompat_cache_dir=disabled
-            packages: libssl-dev libmigemo-dev
-          - config_args: -Dtls=openssl -Dsessionlib=xsmp -Dalsa=enabled -Dpangolayout=enabled
-            packages: libssl-dev libasound2-dev
+        sets:
+          - cc: gcc-13
+            cxx: g++-13
+            package: g++-13
+          - cc: gcc-14
+            cxx: g++-14
+            package: g++-14
+          - cc: clang-16
+            cxx: clang++-16
+            package: clang-16
+          - cc: clang-17
+            cxx: clang++-17
+            package: clang-17
+          - cc: clang-18
+            cxx: clang++-18
+            package: clang-18
     steps:
       - uses: actions/checkout@v4
-      - name: dependencies installation (${{ matrix.deps.packages }})
+      - name: dependencies installation
         run: |
           sudo apt update
-          sudo apt install meson libgtest-dev libgtkmm-3.0-dev ${{ matrix.deps.packages }} g++-9
-      - name: meson setup builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG" ${{ matrix.deps.config_args }}
-        run: meson setup builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG" ${{ matrix.deps.config_args }}
-      - name: ninja -C builddir
-        run: ninja -C builddir
-      - name: meson test -v -C builddir
-        run: meson test -v -C builddir
-      - name: ./builddir/src/jdim -V
-        run: ./builddir/src/jdim -V
+          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev ${{ matrix.sets.package }}
+      - run: meson setup builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
+      - run: ninja -C builddir
+      - run: meson test -v -C builddir
+      - run: ./builddir/src/jdim -V
 
   library-22:
-
     runs-on: ubuntu-22.04
     env:
       CC: gcc-11
@@ -169,17 +129,37 @@ jobs:
         run: |
           sudo apt update
           sudo apt install meson libgtest-dev libgtkmm-3.0-dev ${{ matrix.deps.packages }} g++-11
-      - name: meson setup builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG" ${{ matrix.deps.config_args }}
-        run: meson setup builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG" ${{ matrix.deps.config_args }}
-      - name: ninja -C builddir
-        run: ninja -C builddir
-      - name: meson test -v -C builddir
-        run: meson test -v -C builddir
-      - name: ./builddir/src/jdim -V
-        run: ./builddir/src/jdim -V
+      - run: meson setup builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG" ${{ matrix.deps.config_args }}
+      - run: ninja -C builddir
+      - run: meson test -v -C builddir
+      - run: ./builddir/src/jdim -V
+
+  library-24:
+    runs-on: ubuntu-24.04
+    env:
+      CC: gcc-13
+      CXX: g++-13
+    strategy:
+      matrix:
+        deps:
+          - config_args: -Dtls=gnutls -Dsessionlib=xsmp -Dmigemo=enabled -Dalsa=enabled -Dpangolayout=enabled
+            packages: libgnutls28-dev libmigemo-dev libasound2-dev
+          - config_args: -Dtls=openssl -Dsessionlib=no -Dmigemo=enabled -Dcompat_cache_dir=disabled
+            packages: libssl-dev libmigemo-dev
+          - config_args: -Dtls=openssl -Dsessionlib=xsmp -Dalsa=enabled -Dpangolayout=enabled
+            packages: libssl-dev libasound2-dev
+    steps:
+      - uses: actions/checkout@v4
+      - name: dependencies installation (${{ matrix.deps.packages }})
+        run: |
+          sudo apt update
+          sudo apt install meson libgtest-dev libgtkmm-3.0-dev ${{ matrix.deps.packages }} g++-13
+      - run: meson setup builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG" ${{ matrix.deps.config_args }}
+      - run: ninja -C builddir
+      - run: meson test -v -C builddir
+      - run: ./builddir/src/jdim -V
 
   manual-build:
-
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -9,82 +9,68 @@ on:
 
 jobs:
 
-  Unity-build-gcc12-Werror:
-    runs-on: ubuntu-22.04
+  Unity-build-gcc14-Werror:
+    runs-on: ubuntu-24.04
     env:
-      CC: gcc-12
-      CXX: g++-12
+      CC: gcc-14
+      CXX: g++-14
     steps:
       - uses: actions/checkout@v4
       - name: dependencies installation
         run: |
           sudo apt update
-          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev g++-12
-      - name: meson setup builddir -Dunity=on -Dunity_size=1000 -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dwerror=true
-        run: meson setup builddir -Dunity=on -Dunity_size=1000 -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dwerror=true
-      - name: ninja -C builddir -k0
-        run: ninja -C builddir -k0
-      - name: meson test -v -C builddir
-        run: meson test -v -C builddir
-      - name: ./builddir/src/jdim -V
-        run: ./builddir/src/jdim -V
+          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev g++-14
+      - run: meson setup builddir -Dunity=on -Dunity_size=1000 -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dwerror=true
+      - run: ninja -C builddir -k0
+      - run: meson test -v -C builddir
+      - run: ./builddir/src/jdim -V
 
-  Unity-build-clang15-Werror:
-    runs-on: ubuntu-22.04
+  Unity-build-clang18-Werror:
+    runs-on: ubuntu-24.04
     env:
-      CC: clang-15
-      CXX: clang++-15
+      CC: clang-18
+      CXX: clang++-18
     steps:
       - uses: actions/checkout@v4
       - name: dependencies installation
         run: |
           sudo apt update
-          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev clang-15
-      - name: meson setup builddir -Dunity=on -Dunity_size=1000 -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dwerror=true
-        run: meson setup builddir -Dunity=on -Dunity_size=1000 -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dwerror=true
-      - name: ninja -C builddir -k0
-        run: ninja -C builddir -k0
-      - name: meson test -v -C builddir
-        run: meson test -v -C builddir
-      - name: ./builddir/src/jdim -V
-        run: ./builddir/src/jdim -V
+          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev clang-18
+      - run: meson setup builddir -Dunity=on -Dunity_size=1000 -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dwerror=true
+      - run: ninja -C builddir -k0
+      - run: meson test -v -C builddir
+      - run: ./builddir/src/jdim -V
 
-  Unity-build-gcc12-with-options-Werror:
-    runs-on: ubuntu-22.04
+  Unity-build-gcc14-with-options-Werror:
+    runs-on: ubuntu-24.04
     env:
-      CC: gcc-12
-      CXX: g++-12
+      CC: gcc-14
+      CXX: g++-14
     steps:
       - uses: actions/checkout@v4
       - name: dependencies installation
         run: |
           sudo apt update
-          sudo apt install g++-12 libasound2-dev libgtest-dev libgtkmm-3.0-dev libmigemo-dev libssl-dev meson zlib1g-dev
-      - name: meson setup builddir -Dunity=on -Dunity_size=1000 -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dalsa=enabled -Dmigemo=enabled -Dtls=openssl -Dcompat_cache_dir=disabled -Dsessionlib=no -Dwerror=true
-        run: meson setup builddir -Dunity=on -Dunity_size=1000 -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dalsa=enabled -Dmigemo=enabled -Dtls=openssl -Dcompat_cache_dir=disabled -Dsessionlib=no -Dwerror=true
-      - name: ninja -C builddir -k0
-        run: ninja -C builddir -k0
-      - name: meson test -v -C builddir
-        run: meson test -v -C builddir
-      - name: ./builddir/src/jdim -V
-        run: ./builddir/src/jdim -V
+          sudo apt install g++-14 libasound2-dev libgtest-dev libgtkmm-3.0-dev libmigemo-dev libssl-dev meson zlib1g-dev
+      - run: meson setup builddir -Dunity=on -Dunity_size=1000 -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dalsa=enabled -Dmigemo=enabled -Dtls=openssl -Dcompat_cache_dir=disabled -Dsessionlib=no -Dwerror=true
+      - run: ninja -C builddir -k0
+      - run: meson test -v -C builddir
+      - run: ./builddir/src/jdim -V
 
   muon-master:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
-      CC: gcc-11
-      CXX: g++-11
+      CC: gcc-13
+      CXX: g++-13
     steps:
       - uses: actions/checkout@v4
       - name: dependencies installation
         run: |
           sudo apt update
-          sudo apt install git libgnutls28-dev libpkgconf-dev libgtest-dev libgtkmm-3.0-dev zlib1g-dev g++-11
-      - name: git clone muon
-        run: |
+          sudo apt install git libgnutls28-dev libpkgconf-dev libgtest-dev libgtkmm-3.0-dev zlib1g-dev g++-13
+      - run: |
           git clone --depth 1 https://git.sr.ht/~lattis/muon muon-src
-      - name: git log -n1 muon
-        run: git -C muon-src log -n1
+      - run: git -C muon-src log -n1
         # Since 2024-11-03 07:27:25 -0500 (6ec469bb42), bootstrapping has used muon-bootstrap as exe name.
       - name: build muon stage1
         run: |
@@ -98,10 +84,8 @@ jobs:
           ./stage1/muon-bootstrap setup -Ddocs=disabled -Dlibarchive=disabled -Dlibcurl=disabled -Dlibpkgconf=enabled ../muon-build
           ./stage1/muon-bootstrap samu -C ../muon-build
           cd ..
-      - name: muon version
-        run: ./muon-build/muon version
-      - name: muon setup builddir
-        run: ./muon-build/muon setup -Dcompat_cache_dir=disabled jdim-build
+      - run: ./muon-build/muon version
+      - run: ./muon-build/muon setup -Dcompat_cache_dir=disabled jdim-build
         # Use embedded samurai instead of ninja
       - run: ./muon-build/muon samu -C jdim-build -k0
       - name: muon test
@@ -109,5 +93,4 @@ jobs:
           cd jdim-build
           ../muon-build/muon test -v
           cd ..
-      - name: ./jdim-build/src/jdim -V
-        run: ./jdim-build/src/jdim -V
+      - run: ./jdim-build/src/jdim -V


### PR DESCRIPTION
### Update CI settings

コンパイラ対応とオプションのライブラリを確認するためGitHub Actionsを利用してCI設定を構成します。[20 jobs][*]を超えると実行待機が発生するため廃止予定オプションとコンパイラオプションはテストから除外しています。
ディストロとツールチェーンの組み合わせも網羅していません。

コンパイラ: gcc-10 ~ gcc-13, clang-11 ~ clang-18
ディストロ: Ubuntu22.04, Ubuntu24.04
ビルドツール: Meson

AddressSanitizerを有効にしたビルド (1 job)
Ubuntu24.04
- gcc-13

コンパイラーを変更するビルド (13 jobs)
Ubuntu22.04
- gcc-10
- gcc-11
- gcc-12
- clang-11
- clang-12
- clang-13
- clang-14
- clang-15

Ubuntu24.04
- gcc-13
- gcc-14
- clang-16
- clang-17
- clang-18

オプションのビルド (6 jobs)
Ubuntu22.04
- gnutls, oniguruma, xsmp, migemo, alsa, pangolayout
- openssl, gregex, migemo, sessionlib=no, compat_cache_dir=disabled
- openssl, oniguruma, xsmp, alsa, pangolayout

Ubuntu24.04
- gnutls, oniguruma, xsmp, migemo, alsa, pangolayout
- openssl, gregex, migemo, sessionlib=no, compat_cache_dir=disabled
- openssl, oniguruma, xsmp, alsa, pangolayout

マニュアルのビルド (1 job)

[*]: https://docs.github.com/en/free-pro-team@latest/actions/reference/usage-limits-billing-and-administration#usage-limits

### CI: Update weekly jobs

GitHub ActionsのWeekly CIで利用するディストロとコンパイラーを更新します。

jobの構成

スケジュール: 毎週月曜日 00:00 UTC

Ubuntu | Compiler | Unity size | Notes
---    | ---      | ---        | ---
24.04  | gcc 14   | 1000       | -Dwerror=true
24.04  | clang 18 | 1000       | -Dwerror=true
24.04  | gcc 14   | 1000       | -Dwerror=true and project options
24.04  | gcc 13   | n/a        | use muon master instead of meson

Closes ma8ma/JDim#89