### PR TITLE
FontColorPref: Add dark theme color preset

### DIFF
--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -1204,6 +1204,20 @@ void ConfigItems::reset_colors_dark_theme()
         }
     }
 
+    update_view_colors();
+}
+
+
+/** @brief ビューで使用する文字色と背景色を更新する
+ *
+ * @details ビューで使用する文字色と背景色はフォントと色の詳細設定ダイアログにある
+ * 「色の設定を全てデフォルトに戻す」ボタンで更新されますが、JDimを起動した直後や
+ * フォントと色の詳細設定ダイアログで「OK」ボタンを押した際も更新する必要があります。
+ * そのため、 `ConfigItems::reset_colors_dark_theme()` から処理を抽出して関数にまとめ、
+ * 更新が必要な箇所で呼び出しできるようにします。
+ */
+void ConfigItems::update_view_colors()
+{
     // Gtk::Entryのデフォルトの文字色
     str_color[ COLOR_CHAR_ENTRY_DEFAULT ] = MISC::get_entry_color_text();
 

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -1193,6 +1193,25 @@ void ConfigItems::reset_colors()
 }
 
 
+/**
+ * @brief 色をダークテーマ用のデフォルト値にリセット
+ */
+void ConfigItems::reset_colors_dark_theme()
+{
+    for( unsigned int i = COLOR_CHAR; i != COLOR_NUM; ++i ) {
+        if( const char* dark = CONFIG::kDarkColors[i]; dark && dark[0] != '\0' ) {
+            str_color[i] = dark;
+        }
+    }
+
+    // Gtk::Entryのデフォルトの文字色
+    str_color[ COLOR_CHAR_ENTRY_DEFAULT ] = MISC::get_entry_color_text();
+
+    // Gtk::Entryのデフォルトの背景色
+    str_color[ COLOR_BACK_ENTRY_DEFAULT ] = MISC::get_entry_color_base();
+}
+
+
 //
 // プロクシ設定
 //

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -610,6 +610,7 @@ namespace CONFIG
 
         // 色のリセット
         void reset_colors();
+        void reset_colors_dark_theme();
 
         // プロクシ設定
         void set_proxy_for2ch( const std::string& proxy );

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -611,6 +611,7 @@ namespace CONFIG
         // 色のリセット
         void reset_colors();
         void reset_colors_dark_theme();
+        void update_view_colors();
 
         // プロクシ設定
         void set_proxy_for2ch( const std::string& proxy );

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -296,6 +296,52 @@ namespace CONFIG
 #define CONF_COLOR_BACK_BOARD CONF_COLOR_BACK  // スレ一覧の背景色
 #define CONF_COLOR_BACK_BOARD_EVEN CONF_COLOR_BACK_BOARD  // スレ一覧の背景色(偶数行)
 
+/// @brief ダークテーマ用のプリセット
+constexpr const char* kDarkColors[] = {
+    "",        // COLOR_NONE
+    "#DCDCDC", // COLOR_CHAR  スレの文字
+    "#ADDAA0", // COLOR_CHAR_NAME  名前欄の文字色
+    "#89B4FA", // COLOR_CHAR_NAME_B  トリップや fusianasan 等、<b>が含まれている名前欄
+    "#ADDAA0", // COLOR_CHAR_NAME_NOMAIL  メールが無いときの名前欄
+    "#F08080", // COLOR_CHAR_AGE  非sageのメール欄
+    "#F0F0F0", // COLOR_CHAR_SELECTION  選択範囲の文字
+    "#222222", // COLOR_CHAR_HIGHLIGHT  ハイライトの文字
+    "#222222", // COLOR_CHAR_HIGHLIGHT_TREE  ツリー表示における検索結果や抽出項目のハイライト文字色
+    "#89B4FA", // COLOR_CHAR_LINK  通常のリンクの文字色
+    "#89B4FA", // COLOR_CHAR_LINK_ID_LOW  複数発言したIDの文字色
+    "#F08080", // COLOR_CHAR_LINK_ID_HIGH  多く発言したIDの文字色
+    "#89B4FA", // COLOR_CHAR_LINK_RES  参照されていないレス番号の文字色
+    "#EE82EE", // COLOR_CHAR_LINK_LOW  他のレスから参照されたレス番号の文字色
+    "#F08080", // COLOR_CHAR_LINK_HIGH  参照された数が多いレス番号の文字色
+    "#F0F0F0", // COLOR_CHAR_MESSAGE  メッセージビューの文字
+    "#F0F0F0", // COLOR_CHAR_MESSAGE_SELECTION  メッセージビュー(選択範囲)の文字
+    "#F0F0F0", // COLOR_CHAR_ENTRY_DEFAULT  Gtk::Entryのデフォルトの文字色
+    "#FFA07A", // COLOR_IMG_NOCACHE  画像のリンク(キャッシュ無)
+    "#66CDAA", // COLOR_IMG_CACHED  画像のリンク(キャッシュ有)
+    "#FF8C00", // COLOR_IMG_LOADING  画像のリンク(ロード中)
+    "#F08080", // COLOR_IMG_ERR  画像のリンク(エラー)
+    "#323234", // COLOR_BACK  スレビューなど基本の背景
+    "#38383A", // COLOR_BACK_POPUP  ポップアップの背景
+    "#14539E", // COLOR_BACK_SELECTION  選択範囲
+    "#F0E68C", // COLOR_BACK_HIGHLIGHT  ハイライト文字の背景色
+    "#F0E68C", // COLOR_BACK_HIGHLIGHT_TREE  ハイライト文字の背景色(ツリー用)
+    "#2C2C2C", // COLOR_BACK_MESSAGE  メッセージビューの背景色
+    "#14539E", // COLOR_BACK_MESSAGE_SELECTION  メッセージビュー(選択範囲)の背景色
+    "#38383A", // COLOR_BACK_ENTRY_DEFAULT  Gtk::Entryのデフォルトの背景色
+    "#D0D0C0", // COLOR_SEPARATOR_NEW  新着セパレータ
+    "#F0F0F0", // COLOR_FRAME  ポップアップフレーム色
+    "#F0F0F0", // COLOR_MARKER  オートスクロールのマーク色
+    "",        // USRCOLOR_BASE = END_COLOR_FOR_THREAD  cssで使用する色番号のベース
+    "#F0F0F0", // COLOR_CHAR_BBS  板一覧の文字
+    "#F0F0F0", // COLOR_CHAR_BBS_COMMENT  板一覧のコメント
+    "#F0F0F0", // COLOR_CHAR_BOARD  スレ一覧の文字
+    "#38383A", // COLOR_BACK_BBS  板一覧の背景
+    "#38383A", // COLOR_BACK_BBS_EVEN  板一覧の背景(偶数行)
+    "#38383A", // COLOR_BACK_BOARD  スレ一覧の背景
+    "#38383A", // COLOR_BACK_BOARD_EVEN  スレ一覧の背景(偶数行)
+    "",        // COLOR_NUM
+};
+
 #define CONF_WRITE_NAME ""  // デフォルトの書き込み名
 #define CONF_WRITE_MAIL "sage"  // デフォルトのメールアドレス
 

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -87,6 +87,7 @@ void CONFIG::set_color( const int id, const std::string& color )
 }
 
 void CONFIG::reset_colors(){ get_confitem()->reset_colors(); }
+void CONFIG::reset_colors_dark_theme(){ get_confitem()->reset_colors_dark_theme(); }
 
 const std::string& CONFIG::get_gtk_theme_name() { return get_confitem()->gtk_theme_name; }
 void CONFIG::set_gtk_theme_name( const std::string& name ) { get_confitem()->gtk_theme_name = name; }

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -88,6 +88,7 @@ void CONFIG::set_color( const int id, const std::string& color )
 
 void CONFIG::reset_colors(){ get_confitem()->reset_colors(); }
 void CONFIG::reset_colors_dark_theme(){ get_confitem()->reset_colors_dark_theme(); }
+void CONFIG::update_view_colors(){ get_confitem()->update_view_colors(); }
 
 const std::string& CONFIG::get_gtk_theme_name() { return get_confitem()->gtk_theme_name; }
 void CONFIG::set_gtk_theme_name( const std::string& name ) { get_confitem()->gtk_theme_name = name; }

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -47,6 +47,7 @@ namespace CONFIG
     const std::string& get_color( const int id );
     void set_color( const int id, const std::string& color );
     void reset_colors();
+    void reset_colors_dark_theme();
 
     // GTKテーマの名前
     const std::string& get_gtk_theme_name();

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -48,6 +48,7 @@ namespace CONFIG
     void set_color( const int id, const std::string& color );
     void reset_colors();
     void reset_colors_dark_theme();
+    void update_view_colors();
 
     // GTKテーマの名前
     const std::string& get_gtk_theme_name();

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -102,6 +102,8 @@ Core::Core( JDWinMain& win_main )
     }
     // property_gtk_application_prefer_dark_theme() に値を設定しても同期は維持される
     Gtk::Settings::get_default()->property_gtk_application_prefer_dark_theme() = CONFIG::get_use_dark_theme();
+    // 色のセットアップが済んだのでビューで使う文字色と背景色を取得する
+    CONFIG::update_view_colors();
 
     if( auto icon_theme = CONFIG::get_gtk_icon_theme_name(); ! icon_theme.empty() ) {
         // GTKの仕様により property_gtk_icon_theme_name() に値を設定すると

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -36,7 +36,10 @@ FontColorPref::FontColorPref( Gtk::Window* parent, const std::string& url )
     , m_bt_change_color{ "選択行の色を設定する(_S)", true }
     , m_bt_reset_color{ "ライト(_R)", true }
     , m_bt_reset_color_dark{ "ダーク(_A)", true }
-    , m_bt_reset_all_colors{ "色の設定を全てデフォルトに戻す(_D)", true }
+    , m_hbox_reset_all_colors{ Gtk::ORIENTATION_HORIZONTAL, 8 }
+    , m_label_reset_all_colors{ "色の設定を全てデフォルトに戻す:", false }
+    , m_bt_reset_all_colors{ "ライトテーマ(_D)", true }
+    , m_bt_reset_all_colors_dark{ "ダークテーマ(_K)", true }
 
     , m_label_gtk_theme{ "GTKテーマ(_T):", true }
     , m_check_system_theme{ "システム設定のGTKテーマを使う(_S)（再起動後に有効になります）", true }
@@ -344,7 +347,17 @@ void FontColorPref::pack_widget()
     m_vbox_color.pack_start( m_chk_use_html_color, Gtk::PACK_SHRINK );
 
     m_bt_reset_all_colors.signal_clicked().connect( sigc::mem_fun( *this, &FontColorPref::slot_reset_all_colors ) );
-    m_vbox_color.pack_end( m_bt_reset_all_colors, Gtk::PACK_SHRINK );
+    m_bt_reset_all_colors_dark.signal_clicked().connect( sigc::mem_fun( *this, &FontColorPref::slot_reset_all_colors_dark ) );
+    m_label_reset_all_colors.set_xalign( Gtk::ALIGN_END );
+    m_bt_reset_all_colors.set_hexpand( false );
+    m_bt_reset_all_colors_dark.set_hexpand( false );
+    m_bt_reset_all_colors_dark.set_tooltip_text(
+        "HTMLタグで指定された文字色は、ダークテーマでは視認性が低下する可能性があるため、無効にします。" );
+
+    m_hbox_reset_all_colors.pack_end( m_bt_reset_all_colors_dark, Gtk::PACK_SHRINK );
+    m_hbox_reset_all_colors.pack_end( m_bt_reset_all_colors, Gtk::PACK_SHRINK );
+    m_hbox_reset_all_colors.pack_end( m_label_reset_all_colors, Gtk::PACK_SHRINK );
+    m_vbox_color.pack_end( m_hbox_reset_all_colors, Gtk::PACK_SHRINK );
 
     // ディスプレイ解像度が小さい環境で表示できるようにスクロール可能にする
     m_scroll_color.add( m_vbox_color );
@@ -726,6 +739,23 @@ void FontColorPref::slot_reset_all_colors()
     m_chk_use_html_color.set_active( CONFIG::CONF_USE_COLOR_HTML );
 
     CONFIG::reset_colors();
+
+    m_treeview_color.queue_draw();
+}
+
+
+/** @brief 全ての色をダークテーマ用のデフォルト値にリセット
+ *
+ * @details HTMLタグで指定された文字色は、ダークテーマでは視認性が低下する可能性があるため、無効にします。
+ */
+void FontColorPref::slot_reset_all_colors_dark()
+{
+    m_chk_use_gtktheme_message.set_active( CONFIG::CONF_USE_MESSAGE_GTKTHEME );
+    m_chk_use_gtkrc_tree.set_active( CONFIG::CONF_USE_TREE_GTKRC );
+    m_chk_use_gtkrc_selection.set_active( CONFIG::CONF_USE_SELECT_GTKRC );
+    m_chk_use_html_color.set_active( false );
+
+    CONFIG::reset_colors_dark_theme();
 
     m_treeview_color.queue_draw();
 }

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -454,6 +454,8 @@ void FontColorPref::slot_ok_clicked()
         }
     }
     CONFIG::set_use_dark_theme( m_check_dark_theme.get_active() );
+    // GTKテーマを変更したときは、ビューで使用する文字色と背景色を更新する必要がある
+    CONFIG::update_view_colors();
 
     if( m_check_system_icon.get_active() ) {
         // システム設定のアイコンテーマを使うため、空文字列をセットする

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -32,8 +32,10 @@ FontColorPref::FontColorPref( Gtk::Window* parent, const std::string& url )
     , m_label_aafont{ "AAレスと判定する正規表現(_R):", true }
     , m_bt_reset_font{ "フォントの設定を全てデフォルトに戻す(_F)", true }
 
+    , m_label_reset_color{ "選択行の色をデフォルトに戻す:", false }
     , m_bt_change_color{ "選択行の色を設定する(_S)", true }
-    , m_bt_reset_color{ "選択行の色をデフォルトに戻す(_R)", true }
+    , m_bt_reset_color{ "ライト(_R)", true }
+    , m_bt_reset_color_dark{ "ダーク(_A)", true }
     , m_bt_reset_all_colors{ "色の設定を全てデフォルトに戻す(_D)", true }
 
     , m_label_gtk_theme{ "GTKテーマ(_T):", true }
@@ -316,9 +318,12 @@ void FontColorPref::pack_widget()
 
     m_bt_change_color.signal_clicked().connect( sigc::mem_fun( *this, &FontColorPref::slot_change_color ) );
     m_bt_reset_color.signal_clicked().connect( sigc::mem_fun( *this, &FontColorPref::slot_reset_color ) );
+    m_bt_reset_color_dark.signal_clicked().connect( sigc::mem_fun( *this, &FontColorPref::slot_reset_color_dark ) );
 
     m_hbox_change_color.set_spacing( mrg );
+    m_hbox_change_color.pack_end( m_bt_reset_color_dark, Gtk::PACK_SHRINK );
     m_hbox_change_color.pack_end( m_bt_reset_color, Gtk::PACK_SHRINK );
+    m_hbox_change_color.pack_end( m_label_reset_color, Gtk::PACK_SHRINK );
     m_hbox_change_color.pack_end( m_bt_change_color , Gtk::PACK_SHRINK );
     m_vbox_color.pack_start( m_hbox_change_color, Gtk::PACK_SHRINK );
 
@@ -680,6 +685,30 @@ void FontColorPref::slot_reset_color()
 
             const std::string defaultcolor = row[ m_columns_color.m_col_default ];
             CONFIG::set_color( colorid , defaultcolor );
+            m_treeview_color.queue_draw();
+        }
+    }
+}
+
+
+/**
+ * @brief 選択行の色をダークテーマ用のデフォルト値にリセット
+ */
+void FontColorPref::slot_reset_color_dark()
+{
+    std::vector<Gtk::TreePath> selection_paths = m_treeview_color.get_selection()->get_selected_rows();
+    if( selection_paths.empty() ) return;
+
+    for( const Gtk::TreePath& path : selection_paths ) {
+
+        Gtk::TreeRow row = *m_liststore_color->get_iter( path );
+        if( ! row ) continue;
+
+        const int colorid = row[ m_columns_color.m_col_colorid ];
+        if( colorid != COLOR_NONE ) {
+
+            const std::string default_dark = CONFIG::kDarkColors[ colorid ];
+            CONFIG::set_color( colorid, default_dark );
             m_treeview_color.queue_draw();
         }
     }

--- a/src/fontcolorpref.h
+++ b/src/fontcolorpref.h
@@ -72,8 +72,10 @@ namespace CORE
         CORE::ColorTreeColumn m_columns_color;
         Gtk::ScrolledWindow m_scrollwin_color;
         Gtk::HBox m_hbox_change_color;
+        Gtk::Label m_label_reset_color;
         Gtk::Button m_bt_change_color;
         Gtk::Button m_bt_reset_color;
+        Gtk::Button m_bt_reset_color_dark;
         Gtk::Button m_bt_reset_all_colors;
 
         // テーマの設定
@@ -124,6 +126,7 @@ namespace CORE
         void slot_cell_data_color( Gtk::CellRenderer* cell, const Gtk::TreeModel::iterator& it );
         void slot_change_color();
         void slot_reset_color();
+        void slot_reset_color_dark();
         void slot_reset_all_colors();
         void slot_toggled_symbolic();
 

--- a/src/fontcolorpref.h
+++ b/src/fontcolorpref.h
@@ -76,7 +76,10 @@ namespace CORE
         Gtk::Button m_bt_change_color;
         Gtk::Button m_bt_reset_color;
         Gtk::Button m_bt_reset_color_dark;
+        Gtk::Box m_hbox_reset_all_colors;
+        Gtk::Label m_label_reset_all_colors;
         Gtk::Button m_bt_reset_all_colors;
+        Gtk::Button m_bt_reset_all_colors_dark;
 
         // テーマの設定
         Gtk::Grid m_grid_theme;
@@ -128,6 +131,7 @@ namespace CORE
         void slot_reset_color();
         void slot_reset_color_dark();
         void slot_reset_all_colors();
+        void slot_reset_all_colors_dark();
         void slot_toggled_symbolic();
 
         // OK,cancel,apply が押された


### PR DESCRIPTION
### config: Add dark theme color preset

`src/colorid.h` で定義されている列挙値を参考に、ダークテーマの配色を配列 `kDarkColors` として定義します。配色はGTK3デフォルトテーマのAdwaita-darkを元にカスタマイズしています。これにより、ダークテーマを使用する際の色彩設定が統一され、視認性が向上します。

Define color scheme for dark theme as array `kDarkColors` referring to enum values defined in `src/colorid.h`.  The color scheme is customized based on GTK3 default theme Adwaita-dark.  This improves consistency in color settings and enhances visibility when using the dark theme.

### FontColorPref: Add selected row reset button that sets dark theme color

フォントと色の詳細設定ダイアログの「色の設定」タブにある既存の「選択行の色をデフォルトに戻す」ボタンのラベルを「ライト」に変更し、代わりにライトテーマのデフォルト色を適用するボタンとします。
そして、選択行の色をダークテーマのデフォルト色に戻す「ダーク」ボタンを追加します。

この修正により、色の設定をデフォルト色にリセットする際に、ライトテーマだけでなくダークテーマにも対応可能になります。
これにより、ダークテーマ利用時の設定操作性が向上します。

Modify the existing "Reset selected row color to default" button in the "Color Settings" tab of the font and color detail settings dialog, changing its label to "Light" and making it apply the default colors for the light theme.  Then, add a "Dark" button to reset the selected row color to the default colors of the dark theme.

With this change, it is now possible to reset the selection row color to default for both light and dark themes. This improves usability when operating under the dark theme.

### FontColorPref: Add dark theme reset functionality to color settings

フォントと色の詳細設定ダイアログの「色の設定」タブにある既存の「色の設定を全てデフォルトに戻す」ボタンのラベルを「ライトテーマ」に変更し、ライトテーマのデフォルト色を適用するボタンにします。そして、ダークテーマのデフォルト配色を適用する「ダークテーマ」ボタンを追加します。

さらに、HTMLタグで指定された文字色はダークテーマでは視認性が低下する可能性があるため、ダークテーマ適用時には無効化する仕様を追加します。

背景として、バージョン0.13.0でディストリビューションにインストールされたGTKテーマをJDimの外観に反映する機能が追加されましたが、必要な配色をカバーできない問題がありました。この修正により、色設定ダイアログから簡単にダークテーマ用の配色を適用できるようになり、より直感的な操作性を提供します。

Modify the existing "Reset all colors to default" button in the "Color Settings" tab of the font and color detail settings dialog, changing its label to "Light Theme" and making it a button to apply the default colors for the light theme.  Then, add a "Dark Theme" button to apply the default color scheme for the dark theme.

Furthermore, HTML tag-specified text colors are now disabled in dark themes to avoid potential visibility issues.

As background, version 0.13.0 introduced the ability to reflect GTK themes installed in the distribution on JDim's appearance. However, this feature was incomplete as the required color schemes were not fully covered. This update allows users to easily apply dark theme color schemes from the settings dialog, improving usability and intuitive control.

### Add functionality to update text and background colors when changing themes

JDimを起動した直後やフォントと色の詳細設定ダイアログで「OK」ボタンを押した際に、ビューで使用する文字色と背景色を更新する処理を追加します。

修正前は、「色の設定を全てデフォルトに戻す」ボタンを操作しなければ文字色と背景色が更新されませんでした。このため、GTKテーマやダークテーマの切り替え後に、板のプロパティのローカルルールなどが周囲と異なる配色で表示される問題が発生していました。

今回の修正でテーマ変更時に文字色と背景色が自動的に更新されるようになり、ユーザー体験を向上させます。

**制限:**
アプリケーション外でGTKテーマを変更した場合、色が自動的に更新されない問題は残っています。この問題は、時間帯に応じてGTKテーマを切り替えるデスクトップ環境や、アプリケーション起動中にテーマを変更する状況で発生します。この場合は、フォントと色の詳細設定ダイアログから「色の設定を全てデフォルトに戻す」を選択し、手動で色を更新してください。

Add functionality to update the text and background colors used in views upon JDim startup or after pressing the "OK" button in the Font and Color Preferences dialog.

Previously, text and background colors were only updated by manually using the "Reset all color settings to default" button. As a result, issues arose where elements like local board rule properties were displayed in color schemes inconsistent with the surrounding theme after switching between GTK or dark themes.

With this update, text and background colors are now automatically updated when themes are changed, improving the user experience.

**Limitations:**
Colors are not automatically updated when changing GTK themes outside the application. This issue may occur in desktop environments that switch GTK themes based on time or when themes are changed while the application is running. In such cases, use the Font and Color Preferences dialog to manually update colors by selecting "Reset all color settings to default."

関連のissue: #1508
