### PR TITLE
Fix: Incorrect thread title matching when aboning threads with emojis

### DIFF
--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -3047,9 +3047,10 @@ void BoardViewBase::slot_search_next()
 }
 
 
-//
-// 選択したスレをあぼーん
-//
+/** @brief 選択したスレをあぼーん
+ *
+ * @details NG スレタイトルは未変換のスレタイトルで比較します。
+ */
 void BoardViewBase::slot_abone_thread()
 {
     std::list< Gtk::TreeModel::iterator > list_it = m_treeview.get_selected_iterators();
@@ -3059,8 +3060,9 @@ void BoardViewBase::slot_abone_thread()
 
     for( const Gtk::TreeModel::iterator& iter : list_it ) {
         Gtk::TreeModel::Row row = *iter;
-        Glib::ustring subject = row[ m_columns.m_col_subject ];
-        threads.push_back( subject );
+        if( const DBTREE::ArticleBase* art = row[ m_columns.m_col_article ]; art ) {
+            threads.push_back( art->get_subject() );
+        }
     }
 
     // あぼーん情報更新

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1555,7 +1555,7 @@ bool BoardBase::is_abone_thread( ArticleBase* article )
     // スレ立てからの時間であぼーん
     if( check_hour ) if( article->get_hour() >= check_hour ) return true;
     
-    // スレあぼーん
+    // スレあぼーんは、未変換のスレタイトルで完全一致するかチェックします。
     if( check_thread ){
         auto it = std::find_if( m_list_abone_thread.cbegin(), m_list_abone_thread.cend(),
                                 [a = article](const std::string& subj) { return a->get_subject() == subj; } );


### PR DESCRIPTION
スレ一覧でスレをあぼ〜んする際、スレタイトルに絵文字が含まれていると、正しく処理されない問題を修正します。

背景:

これまで、あぼ〜ん判定に使用するスレッド情報のスレタイトルは`DBTREE::ArticleBase::get_subject()` から取得していました。
このメンバー関数は、スレタイトルを表示用に変換する処理を行っていません。

一方で、NG スレタイトルに登録されるスレタイトルはスレ一覧の表示用スレタイトルを基にしており、以下の変換が適用されていました：

- `DBTREE::ArticleBase::get_modified_subject(true)` による置換処理
- `MISC::to_markup()` による Pango Markup 変換

この違いにより、あぼ〜ん判定時にスレッド情報のスレタイトルと NG スレタイトルが一致せず、絵文字を含むスレタイトルが正しく処理されない問題が発生していました。

修正内容:

この修正では、NG スレタイトルに登録されるスレタイトルを、表示用に変換されたものではなく、未変換のものに変更します。
これにより、あぼ〜ん判定時のスレタイトルの変換状態を統一し、処理の実行性能を維持します。

影響:

- NG スレタイトルに登録されるスレタイトルが未変換のものになるため、手動で編集する際の可読性が低下する可能性があります。
- ただし、スレあぼ〜んの操作は主に GUI を通じて行われるため、実際の運用では問題にならないと考えられます。

---

Fixes an issue where aboning a thread from the thread list does not work correctly if the thread title contains emojis.

Background:

Previously, the thread title used for abone judgment was obtained from `DBTREE::ArticleBase::get_subject()`, which does not apply any display transformations.

On the other hand, the thread title registered in the NG thread title list was derived from the display title in the thread list, which had the following transformations applied:

- Substitution processing via `DBTREE::ArticleBase::get_modified_subject(true)`
- Conversion to Pango Markup via `MISC::to_markup()`

Due to this inconsistency, the abone judgment failed when comparing the NG thread title with the actual thread title, causing the issue where threads with emojis were not properly aboned.

Fix Details:

This fix changes the NG thread title registration process to store unprocessed thread titles instead of display-transformed ones.  This ensures that both the thread title used in abone judgment and the NG thread title remain in the same transformation state, improving processing efficiency.

Impact:

- NG thread titles will now be stored in an unprocessed state, which may reduce readability when manually editing the NG list.
- However, since thread aboning is typically performed through the GUI, this change is not expected to cause usability issues.

Closes #1511
