### PR TITLE
Allow specifying search start position in thread view by mouse click

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -4273,6 +4273,8 @@ void ArticleViewBase::exec_search()
     std::string query = get_search_query();
     if( query.empty() ){
         clear_highlight();
+        // 検索entryが空欄の状態で検索したときは、キャレット（検索開始位置）を一番上に移動します。
+        m_drawarea->reset_caret_position();
         focus_view();
         CORE::core_set_command( "set_info", "", "" );
         return;

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -3866,6 +3866,17 @@ void DrawAreaBase::clear_highlight()
 }
 
 
+/**
+ * @brief キャレットの位置をリセットします。
+ */
+void DrawAreaBase::reset_caret_position()
+{
+    m_caret_pos = CARET_POSITION();
+    m_caret_pos_pre = CARET_POSITION();
+    m_caret_pos_dragstart = CARET_POSITION();
+}
+
+
 //
 // 実況開始
 //

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -49,7 +49,17 @@ namespace ARTICLE
     // 範囲選択用
     struct SELECTION
     {
+        /// @brief クリックして選択を変更したときの位置情報
+        enum class ClickPosition : char
+        {
+            unknown,          ///< @brief クリックした位置を記憶していない
+            before_first_hit, ///< @brief クリックした位置が先頭のヒットより前
+            between_hits,     ///< @brief クリックした位置がヒットとヒットの間
+            on_hit,           ///< @brief クリックした位置がヒットの上
+        };
+
         bool select;
+        ClickPosition click_pos;
         CARET_POSITION caret_from;
         CARET_POSITION caret_to;
         std::string str;      // 現在の選択文字列
@@ -473,6 +483,8 @@ namespace ARTICLE
         bool set_selection_str();
         bool is_caret_on_selection( const CARET_POSITION& caret_pos ) const;
         std::string get_selection_as_url( const CARET_POSITION& caret_pos ) const;
+
+        void update_search_start_position( const CARET_POSITION& caret_pos );
 
         // マウスが動いた時の処理
         bool motion_mouse();

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -377,6 +377,7 @@ namespace ARTICLE
         int search( const std::list< std::string >& list_query, const bool reverse );
         int search_move( const bool reverse );
         void clear_highlight();
+        void reset_caret_position();
 
         // 実況モード
         void live_start();


### PR DESCRIPTION
### Allow specifying search start position in thread view by mouse click

スレッドビューの検索開始位置をマウスクリックで指定可能にします。
これにより、検索開始位置を直感的に設定できます。

**背景:**

JDimの検索機能では、「次検索」や「前検索」を使用する際、検索開始位置が自動的に決まり、ユーザーが手動で変更することはできません。他の一般的なテキストエディタやWebブラウザでは、マウスクリックで検索の開始位置を指定する仕様が多く、JDimの操作性向上のためにこの機能を導入します。

**機能追加:**

スレッドビュー内でマウスクリックした位置を基準に「次検索」「前検索」の動作を調整します。

**マウスのクリック位置と検索の動作ルール:**

| マウスのクリック位置          | 次検索の動作        | 前検索の動作        |
| :---                          | :---                | :---                |
| 先頭のヒットより前をクリック  | 先頭のヒットを選択  | 末尾のヒットを選択  |
| ヒットの1文字目をクリック     | そのヒットを選択    | 1つ前のヒットを選択 |
| ヒットの2文字目以降をクリック | 1つ次のヒットを選択 | 1つ前のヒットを選択 |
| ヒットとヒットの間をクリック  | 1つ次のヒットを選択 | 1つ前のヒットを選択 |
| 末尾のヒットより後をクリック  | 先頭のヒットを選択  | 末尾のヒットを選択  |

---

Allow specifying the search start position in the thread view by mouse click.  This allows you to intuitively set the search start position.

**Background:**

In JDim's search functionality, the search start position is automatically determined when using "Next Search" or "Previous Search," and users cannot manually change it. Many text editors and web browsers allow users to specify the search start position by clicking. To improve usability, we are introducing this feature in JDim.

**Feature addition:**

Adjust the behavior of "search next" and "search previous" based on the position clicked in the thread view.

**Mouse click position and search operation rules:**

| Mouse click position                              | Search next behavior | Search previous behavior |
| :---                                              | :---                 | :---                     |
| Click before the first hit                        | Select the first hit | Select the last hit      |
| Click on the first character of a hit             | Select that hit      | Select the previous hit  |
| Click on the 2nd or subsequent character of a hit | Select the next hit  | Select the previous hit  |
| Click between hits                                | Select the next hit  | Select the previous hit  |
| Click after the last hit                          | Select the first hit | Select the last hit      |

### Add feature to reset search start position when search box is empty

検索ボックスを空の状態にして検索したとき、検索開始位置をスレビューの先頭に設定します。これにより、検索開始位置を直感的にリセットできます。

**背景:**

JDimの検索機能では、「次検索」や「前検索」を使用する際、検索開始位置は自動的に決定され、ユーザーが手動で変更することはできません。
他の一般的なテキストエディタやWebブラウザでは、検索ボックスを空の状態で検索を実行すると、検索開始位置がリセットされる仕様が多く、JDimの操作性向上のためにこの機能を導入します。

**変更点:**

- 検索ボックスが空の状態で検索を実行した際、検索開始位置をスレビューの先頭に設定する
- `DrawAreaBase::reset_caret_position()` を追加し、検索開始位置をリセットできるようにする

**検討したが採用しなかったアイデア:**

- 検索キーワードを変更した際に検索開始位置をリセットする
- 検索結果のハイライトを解除すると検索開始位置をリセットする
  → これらは今回の提案の趣旨とは異なるため、含めませんでした。

---

When searching with an empty search box, the search start position is set to the beginning of the thread view. This allows users to intuitively reset the search start position.

**Background:**

In JDim's search functionality, the search start position is automatically determined when using "Next Search" or "Previous Search," and users cannot manually change it. Many text editors and web browsers reset the search start position when executing a search with an empty search box. To improve usability, we are introducing this feature in JDim.

**Changes:**

- When executing a search with an empty search box, the search start position is set to the top of the thread view.
- Added `DrawAreaBase::reset_caret_position()` to enable resetting the search start position.

**Ideas Considered but Not Adopted:**

- Resetting the search start position when modifying the search keyword.
- Resetting the search start position when clearing the search highlight.
  → These behaviors differ from the intent of this proposal and were not included.

Closes #1513
