### PR TITLE
ConfigItems: Fix a loading error in the thread hiding settings

### DIFF
--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -527,9 +527,9 @@ bool ConfigItems::load( const bool restore )
     // スレ あぼーん( レス数 )
     // abone_number_thread は変数や関数と名前が異なるが互換性のため維持する
     abone_low_number_thread = cf.get_option_int( "abone_low_number_thread", CONF_ABONE_LOW_NUMBER_THREAD, 0,
-                                                 CONFIG::get_max_resnumber() );
+                                                 std::numeric_limits<int>::max() - 1 );
     abone_high_number_thread = cf.get_option_int( "abone_number_thread", CONF_ABONE_HIGH_NUMBER_THREAD, 0,
-                                                  CONFIG::get_max_resnumber() );
+                                                  std::numeric_limits<int>::max() - 1 );
 
     // スレ あぼーん( スレ立てからの経過時間 )
     abone_hour_thread = cf.get_option_int( "abone_hour_thread", CONF_ABONE_HOUR_THREAD, 0, 9999 );


### PR DESCRIPTION
全体スレあぼ～ん設定(対象：スレ一覧)において、「xレス以下のスレをあぼ～ん」に1以上の値を設定すると、JDim起動時に読み込みエラーが発生する不具合を修正します。この修正により、起動時の読み込みエラーが解消され、「xレス以下のスレをあぼ～ん」「xレス以上のスレをあぼ～ん」の機能が正常に動作するようになります。

**背景:**

`CONFIG::ConfigItems::load()` で `abone_low_number_thread` と`abone_high_number_thread` を読み込む際、`CONFIG::get_max_resnumber()`を使用していました。しかし、`abone_low_number_thread` の読み込み段階では `max_resnumber` がまだロードされていないため、`CONFIG::get_max_resnumber()` が初期値 0 を返していました。
これにより、設定値の判定が正常に行われず、スレッド非表示機能が正しく動作しない状態でした。

**修正内容:**

設定値を読み込む際に、他の設定値に依存するのではなく、定数`std::numeric_limits<int>::max() - 1` を使用するように修正しました。
これにより、設定値の上限を適切に設定し、初期値による誤判定を防ぎます。

----

Fix a bug where a loading error occurs when JDim starts if a value of 1 or more is set for "Hide threads with x or fewer responses" in the overall thread hiding settings (target: thread list). This fix resolves the loading error at startup and enables the "Hide threads with x or fewer responses" and "Hide threads with x or more responses" functions to work correctly.

**Background:**

When loading `abone_low_number_thread` and `abone_high_number_thread` in `CONFIG::ConfigItems::load()`, `CONFIG::get_max_resnumber()` was used. However, since `max_resnumber` has not yet been loaded at the stage of loading `abone_low_number_thread`, `CONFIG::get_max_resnumber()` was returning the initial value of 0.  As a result, the setting value was not judged correctly, and the thread hiding function was not working properly.

As a result, when setting `abone_low_number_thread`, calling `CONFIG::get_max_resnumber()` returned the initial value of 0 instead of the actual value, leading to incorrect value validation.

**Fix details:**

Modified to use the constant `std::numeric_limits<int>::max() - 1` instead of relying on other setting values when loading setting values. This properly sets the upper limit of the setting value and prevents misjudgment due to initial values.

Closes #1517
