### PR TITLE
Fix context menu is displayed at an incorrect position

### DIFF
--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -204,22 +204,12 @@ void View::show_popupmenu( const std::string& url, bool use_slot )
             popupmenu->signal_hide().connect( sigc::mem_fun( *this, &View::slot_hide_popupmenu ) );
         }
 
-        if( use_slot ) popupmenu->popup( sigc::mem_fun( *this, &View::slot_popup_menu_position ), 0, gtk_get_current_event_time() );
+        if( use_slot ) {
+            // viewと左上とメニューの左上を揃える
+            popupmenu->popup_at_widget( this, Gdk::GRAVITY_NORTH_WEST, Gdk::GRAVITY_NORTH_WEST, nullptr );
+        }
         else popupmenu->popup( 0, gtk_get_current_event_time() );
     }
-}
-
-
-// ポップアップメニュー表示時に表示位置を決めるスロット
-void View::slot_popup_menu_position( int& x, int& y, bool& push_in)
-{
-    // viewの左上の座標をセットする
-    int x2, y2;
-    get_window()->get_position( x, y );
-    translate_coordinates( *dynamic_cast< Gtk::Widget* >( get_toplevel() ), 0, 0, x2, y2 );
-    x += x2;
-    y += y2;
-    push_in = false;
 }
 
 

--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -204,11 +204,14 @@ void View::show_popupmenu( const std::string& url, bool use_slot )
             popupmenu->signal_hide().connect( sigc::mem_fun( *this, &View::slot_hide_popupmenu ) );
         }
 
+        // メニューのサイズが大きく、ディスプレイの外にはみ出す場合でも、
+        // 自動的に画面内に収まるように調整します。
         if( use_slot ) {
-            // viewと左上とメニューの左上を揃える
+            // viewの左上とメニューの左上を揃える
             popupmenu->popup_at_widget( this, Gdk::GRAVITY_NORTH_WEST, Gdk::GRAVITY_NORTH_WEST, nullptr );
         }
-        else popupmenu->popup( 0, gtk_get_current_event_time() );
+        // 現在のイベントに関連するマウスポインターの位置にメニューを表示する
+        else popupmenu->popup_at_pointer( nullptr );
     }
 }
 

--- a/src/skeleton/view.h
+++ b/src/skeleton/view.h
@@ -156,9 +156,6 @@ namespace SKELETON
         // ポップアップメニュー表示
         void show_popupmenu( const std::string& url, bool use_slot = false );
 
-        // ポップアップメニュー表示時に表示位置を決めるスロット
-        void slot_popup_menu_position( int& x, int& y, bool& push_in );
-
         // ポップアップメニューがmapした時に呼び出されるスロット
         void slot_map_popupmenu();
 


### PR DESCRIPTION
### Fix context menu via menu key is displayed at an incorrect position

スレッドビュー、スレッド一覧、サイドバーにおいて、メニューキーで開くコンテキストメニューが意図しない位置に表示される問題を修正します。

従来、メニューキーを押すとコンテキストメニューはビューの左上に表示される想定でしたが、実際にはビューの種類や環境によって異なる位置に表示されていました。今回の修正により、メニューキーで開いたコンテキストメニューが常にビューの左上に表示されるようになります。
これにより、コンテキストメニューの表示位置が一貫し、ユーザーは予測どおりの位置にメニューを表示させることができるため、操作性が向上します。

この修正では、`popup_at_widget()` を使用し、ビューの左上にメニューの左上が一致するよう調整します。また、今回の修正では、ポップアップメニューの表示位置を調整するために使用していた `slot_popup_menu_position()` 関数を削除しました。これにより、メニュー表示位置の一貫性を確保し、意図した動作を実現します。

**注意:**

コンテキストメニューのサイズが大きく、ビューの左上に揃えるとディスプレイからはみ出す場合、メニューは画面内に収まるように自動調整されることがあります。これにより、環境によってはメニューが完全に左上に配置されない場合があります。

**背景:**

スレッドビュー、スレッド一覧、サイドバーでは、メニューキー（メニューとその上にカーソルが描かれているキー）や `Shift + F10` を押すと、フォーカスされているUIのコンテキストメニューを開く機能があります。

ソースコードの[コメント][1]には、メニューキーを押した際のコンテキストメニューの表示位置は「viewの左上の座標をセットする」と記載されています。しかし、実際の動作では意図した位置に表示されない場合があり、ビューの種類やディスプレイサーバーによって表示位置が異なることを確認しました。

---

In thread view, thread list, and sidebar, this commit fixes the issue where the context menu opened by the menu key is displayed at an unintended position.

Previously, it was expected that pressing the menu key would display the context menu at the top-left of the view. However, in reality, it was displayed at different positions depending on the view type and environment. With this correction, the context menu opened by the menu key will always be displayed at the top-left of the view. This ensures consistency in the display position of the context menu, and users can display the menu at the expected position, thereby improving operability.

This fix replaces the previous method with `popup_at_widget()`, ensuring that the menu aligns correctly with the top-left of the view.  In addition, this correction removes the `slot_popup_menu_position()` function, which was used to adjust the display position of the popup menu. These change improves consistency in menu display positioning and ensures expected behavior.

**Note:**

If the context menu is too large and aligning it to the top-left of the view would cause it to overflow beyond the display, the menu may be automatically adjusted to fit within the screen. As a result, the menu may not always be positioned exactly at the top-left, depending on the environment.

**Background:**

In thread view, thread list, and sidebar, there is a function to open the context menu of the focused UI by pressing the menu key (the key with a menu and a cursor drawn on it) or `Shift + F10`.

The source code [comment][1] states that the display position of the context menu when the menu key is pressed is "set at the top-left coordinate of the view.".  However, in actual operation, it was not always displayed at the intended position, and we confirmed that the display position varied depending on the view type and display server.

[1]: https://github.com/JDimproved/JDim/blob/525b8b29b8f1e5310daaf86549f7c98fd0b812f8/src/skeleton/view.cpp#L206-L223


### View: Adjust context menu position to prevent it from going off-screen

板一覧、スレッド一覧、スレッドビュー、画像ビューでマウスクリックしたときに表示するコンテキストメニューの表示APIを`Gtk::Menu::popup_at_pointer()`を使うように更新します。

従来の実装では、メニューのサイズが大きい場合にディスプレイ外にはみ出し、メニュー項目が一部見えなくなることがありました。
この修正により、メニューがディスプレイの外にはみ出す場合でも、自動的に画面内に収まるよう調整されます。

---

Update the context menu display API for board list, thread list, thread view, and image view to use `Gtk::Menu::popup_at_pointer()` when triggered by mouse clicks.

Previously, if the menu was too large, it could extend beyond the display, making some menu items inaccessible. This fix ensures that the menu is automatically adjusted to stay within the screen when necessary.

Closes #1516
