### PR TITLE
Add context menu display via menu key in Image View

### DIFF
--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -352,6 +352,12 @@ void ImageAdmin::open_view( const COMMAND_ARGS& command )
         // view作成
         auto view = std::unique_ptr<SKELETON::View>( CORE::ViewFactory( CORE::VIEW_IMAGEVIEW, command.url ) );
         if( view ){
+            // 画像ビューはタブにフォーカスが当たる仕組みになっているため、
+            // 画像ビュー内でメニューキーを押すとタブの画像アイコン(icon)でキー入力が処理されます。
+            // そのため、 view に対してメニューキーを押してコンテキストメニューを表示する処理を追加しても
+            // キー入力を受け取れず動作しません。 (`ImageAdmin::focus_view()`を参照)
+            // そこで、 icon に view のシグナルハンドラを接続して、 icon のキー入力イベントを view に伝達します。
+            icon->signal_key_press_event().connect( sigc::mem_fun( *view, &SKELETON::View::slot_key_press ) );
             view->show_view();
             m_list_view.push_back( std::move( view ) );
         }

--- a/src/image/imageview.cpp
+++ b/src/image/imageview.cpp
@@ -569,5 +569,11 @@ bool ImageViewMain::operate_view( const int control )
         else cntl = CONTROL::OrgSizeImage;
     }
 
+    if( cntl == CONTROL::ShowPopupMenu ) {
+        // ポップアップメニュー表示
+        show_popupmenu( "", true );
+        return true;
+    }
+
     return ImageViewBase::operate_view( cntl );
 }

--- a/src/image/imageviewbase.cpp
+++ b/src/image/imageviewbase.cpp
@@ -624,9 +624,13 @@ void ImageViewBase::clicked()
 
 
 
-//
-// viewの操作
-//
+/** @brief viewの操作
+ *
+ * @param[in] control GdkEvent 構造体を解析して取得したコントロールID
+ * @return true ならイベントの伝播を止めて他のハンドラーを呼び出さない
+ * @note ImageViewMain でも呼び出されるので、動作の重複を避けるため
+ * 処理を行ったときは true を返してイベントが伝播しないようにします。
+ */
 bool ImageViewBase::operate_view( const int control )
 {
     if( CONTROL::operate_common( control, get_url(), IMAGE::get_admin() ) ) return true;


### PR DESCRIPTION
画像ビューにおいて、メニューキー（または `Shift + F10` キー）によるコンテキストメニュー表示機能を追加します。これにより、スレビュー、スレ一覧、サイドバー、および画像ビューでのキーボード操作の一貫性が向上し、操作の利便性が高まります。

**背景:**

キーボードのメニューキー（メニューとその上にカーソルが描かれているキー）や `Shift + F10` は、フォーカスされているUIのコンテキストメニューを開く機能があります。JDim では、GTK が提供するデフォルトのコンテキストメニューがメニューキーに対応しているだけでなく、スレビュー、スレ一覧、サイドバーでも使用できます。しかし、画像ビューではメニューキーが機能しないため、キーボード操作の一貫性が損なわれていました。

画像ビューはタブにフォーカスが当たる仕組みのため(`ImageAdmin::focus_view()`を参照)、画像ビュー内でメニューキーを押すと、タブの画像アイコン (`ImageViewIcon`) でキー入力が処理されます。
そのため、`ImageViewMain` にメニューキーの入力処理を追加しても、キー入力を受け取れず動作しません。

**修正内容:**

この問題を解決するため、`ImageViewIcon` に `ImageViewMain` の `key_press_event` を処理するシグナルハンドラを接続し、キー入力イベントを `ImageViewMain` に伝達するようにしました。
`ImageViewMain::operate_view()` で `CONTROL::ShowPopupMenu` を処理し、`show_popupmenu("", true)` を呼び出すことで、メニューキーと `Shift + F10` の両方でコンテキストメニューを表示します。

---

This commit adds support for displaying the context menu in the Image View using the menu key (or `Shift + F10`). With this change, keyboard operation consistency is improved across the thread view, thread list, sidebar, and Image View, enhancing usability.

**Background:**

The menu key (a key with a menu icon and a cursor) and `Shift + F10` are commonly used to open the context menu for the focused UI.  JDim already supports this functionality in the thread view, thread list, and sidebar. However, the menu key did not function in the Image View, breaking keyboard operation consistency.

Because the image view is designed to focus on the tab (see `ImageAdmin::focus_view()`), pressing the menu key within the image view causes the key input to be processed by the tab's image icon (`ImageViewIcon`). Therefore, adding menu key input handling to `ImageViewMain` does not work because it cannot receive the key input.

**Fix Details:**

To resolve this, we connect a signal handler in `ImageViewIcon` to forward the `key_press_event` to `ImageViewMain`, ensuring that the menu key functions correctly. By handling `CONTROL::ShowPopupMenu` in `ImageViewMain::operate_view()` and calling `show_popupmenu("", true)`, the context menu is displayed for both the menu key and `Shift + F10`.

Closes #1515
