### PR TITLE
Remove support code for GTK versions older than 3.24.6

### DIFF
--- a/src/history/historysubmenu.cpp
+++ b/src/history/historysubmenu.cpp
@@ -231,12 +231,7 @@ bool HistorySubMenu::slot_button_press( GdkEventButton* event, unsigned int i )
     // ポップアップメニュー表示
     if( event->button == 3 )
     {
-#if GTK_CHECK_VERSION(3,24,6)
         m_popupmenu.popup_at_pointer( reinterpret_cast<GdkEvent*>( event ) );
-#else
-        // GTK 3.24.5 以下のバージョンではメニューのスクロールが出来なくなることがあるため廃止予定APIを使う
-        m_popupmenu.popup( 0, gtk_get_current_event_time() );
-#endif
     }
 
     return true;

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -2296,12 +2296,7 @@ void Admin::slot_tab_menu( int page, int x, int y )
             m_prev_n_pages = n_pages;
         }
 
-#if GTK_CHECK_VERSION(3,24,6)
         m_tablabel_menu.popup_at_pointer( nullptr ); // current event
-#else
-        // GTK 3.24.5 以下のバージョンではメニューのスクロールが出来なくなることがあるため廃止予定APIを使う
-        m_tablabel_menu.popup( 0, gtk_get_current_event_time() );
-#endif
     }
 }
 
@@ -2326,40 +2321,10 @@ void Admin::slot_show_tabswitchmenu()
         m_tabswitchmenu.signal_deactivate().connect( sigc::mem_fun( *this, &Admin::slot_popupmenu_deactivate ) );
     }
 
-#if GTK_CHECK_VERSION(3,24,6)
     // Specify the current event by nullptr.
     m_tabswitchmenu.popup_at_widget( &( m_notebook->get_tabswitch_button() ),
                                      Gdk::GRAVITY_SOUTH_EAST, Gdk::GRAVITY_NORTH_EAST, nullptr );
-#else
-    // GTK 3.24.5 以下のバージョンではメニューのスクロールが出来なくなることがあるため廃止予定APIを使う
-    m_tabswitchmenu.popup( Gtk::Menu::SlotPositionCalc( sigc::mem_fun( *this, &Admin::slot_popup_pos ) ),
-                           0, gtk_get_current_event_time() );
-#endif
 }
-
-
-#if ! GTK_CHECK_VERSION(3,24,6)
-/**
- * @brief タブ切り替えメニューの位置決め
- */
-void Admin::slot_popup_pos( int& x, int& y, bool& push_in )
-{
-    if( ! m_model_tabswitch ) return;
-
-    const int mrg = 16;
-
-    m_notebook->get_tabswitch_button().get_pointer( x, y );
-
-    int ox, oy;
-    m_notebook->get_tabswitch_button().get_window()->get_origin( ox, oy );
-    const Gdk::Rectangle rect = m_notebook->get_tabswitch_button().get_allocation();
-
-    x += ox + rect.get_x() - mrg;
-    y = oy + rect.get_y() + rect.get_height();
-
-    push_in = false;
-}
-#endif
 
 
 //

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -294,11 +294,6 @@ namespace SKELETON
         // タブ切り替えメニュー表示
         void slot_show_tabswitchmenu();
 
-#if ! GTK_CHECK_VERSION(3,24,6)
-        /// タブ切り替えメニューの位置決め
-        void slot_popup_pos( int& x, int& y, bool& push_in );
-#endif
-
         // 右クリックメニュー
         virtual void slot_close_tab();
         virtual void slot_lock();

--- a/src/skeleton/menubutton.cpp
+++ b/src/skeleton/menubutton.cpp
@@ -2,7 +2,6 @@
 
 //#define _DEBUG
 #include "jddebug.h"
-#include "gtkmmversion.h"
 
 #include "menubutton.h"
 
@@ -127,14 +126,8 @@ void MenuButton::show_popupmenu()
 {
     if( ! m_popupmenu ) return;
 
-#if GTK_CHECK_VERSION(3,24,6)
     // Specify the current event by nullptr.
     m_popupmenu->popup_at_widget( this, Gdk::GRAVITY_SOUTH_WEST, Gdk::GRAVITY_NORTH_WEST, nullptr );
-#else
-    // GTK 3.24.5 以下のバージョンではメニューのスクロールが出来なくなることがあるため廃止予定APIを使う
-    m_popupmenu->popup( Gtk::Menu::SlotPositionCalc( sigc::mem_fun( *this, &MenuButton::slot_popup_pos ) ),
-                        0, gtk_get_current_event_time() );
-#endif
 }
 
 
@@ -163,22 +156,6 @@ void MenuButton::on_clicked()
     if( ! m_enable_sig_clicked || m_on_arrow ) show_popupmenu();
     else m_sig_clicked.emit();
 }
-
-
-#if ! GTK_CHECK_VERSION(3,24,6)
-/**
- * @brief ポップアップメニューの位置決め
- */
-void MenuButton::slot_popup_pos( int& x, int& y, bool& push_in )
-{
-    int ox, oy;
-    get_window()->get_origin( ox, oy );
-    Gdk::Rectangle rect = get_allocation();
-    x = ox + rect.get_x();
-    y = oy + rect.get_y() + rect.get_height();
-    push_in = false;
-}
-#endif
 
 
 bool MenuButton::slot_enter( GdkEventCrossing* event )

--- a/src/skeleton/menubutton.h
+++ b/src/skeleton/menubutton.h
@@ -70,11 +70,6 @@ namespace SKELETON
 
       void slot_menu_selected( int i );
 
-#if ! GTK_CHECK_VERSION(3,24,6)
-        /// ポップアップメニューの位置決め
-        void slot_popup_pos( int& x, int& y, bool& push_in );
-#endif
-
       bool slot_enter( GdkEventCrossing* event );
       bool slot_leave( GdkEventCrossing* event );
       bool slot_motion( GdkEventMotion* event );

--- a/src/usrcmdpref.cpp
+++ b/src/usrcmdpref.cpp
@@ -2,7 +2,6 @@
 
 //#define _DEBUG
 #include "jddebug.h"
-#include "gtkmmversion.h"
 
 #include "usrcmdpref.h"
 #include "usrcmdmanager.h"
@@ -242,12 +241,8 @@ void UsrCmdPref::show_popupmenu()
         act_delete->set_enabled( true );
     }
 
-#if GTK_CHECK_VERSION(3,24,6)
     // Specify the current event by nullptr.
     m_treeview_menu.popup_at_pointer( nullptr );
-#else
-    m_treeview_menu.popup( 0, gtk_get_current_event_time() );
-#endif
 }
 
 


### PR DESCRIPTION
JDimの動作環境が更新され、GTK 3.24.6 未満のサポートが不要になったため、該当するソースコードを整理します。

プロジェクトのドキュメントには、GTKのバージョン要件を明確に記述していませんが、サポート対象としている Debian bullseye に収録されているGTK3のバージョンが 3.24.24 なので、削除してもサポートに影響がないと判断しました。

---

As the operating environment of JDim has been updated, support for GTK versions below 3.24.6 is no longer necessary, so the corresponding source code has been removed.

The project documentation does not explicitly state the GTK version requirements, but the GTK3 version included in Debian bullseye, which is a supported environment, is 3.24.24. Therefore, it was determined that removing this code would not affect support.

関連のissue: #1515, #1516
