### PR TITLE
Revert "View: Adjust context menu position to prevent it from going off-screen"

### DIFF
--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -204,14 +204,13 @@ void View::show_popupmenu( const std::string& url, bool use_slot )
             popupmenu->signal_hide().connect( sigc::mem_fun( *this, &View::slot_hide_popupmenu ) );
         }
 
-        // メニューのサイズが大きく、ディスプレイの外にはみ出す場合でも、
-        // 自動的に画面内に収まるように調整します。
         if( use_slot ) {
             // viewの左上とメニューの左上を揃える
+            // メニューのサイズが大きく、ディスプレイの外にはみ出す場合でも、
+            // 自動的に画面内に収まるように調整します。
             popupmenu->popup_at_widget( this, Gdk::GRAVITY_NORTH_WEST, Gdk::GRAVITY_NORTH_WEST, nullptr );
         }
-        // 現在のイベントに関連するマウスポインターの位置にメニューを表示する
-        else popupmenu->popup_at_pointer( nullptr );
+        else popupmenu->popup( 0, gtk_get_current_event_time() );
     }
 }
 


### PR DESCRIPTION
This reverts commit d34fc3bbcee32f9195c1ddf1f49b247bd2c5f518.

ツールバーボタンを押して表示するポップアップメニューが出ないと報告がありましたので一度変更を取り消します。

影響を受けるツールバーボタンを確認したところ、以下のボタンでポップアップメニューが表示されませんでした。

- スレ一覧
  - お気に入り追加
  - 削除
- スレビュー
  - 削除

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1722942440/537-538n

関連のissue: #1516
