### PR TITLE
Fix processing of subject with full-width spaces in thread list abone

### DIFF
--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -57,7 +57,8 @@ namespace DBTREE
         // 詳しくはコンストラクタの説明を参照せよ
         std::string m_org_host;
 
-        std::string m_subject;           // サブジェクト
+        std::string m_subject;           ///< サブジェクト(スレタイトル)。先頭と末尾のASCII空白文字は削除される。
+
         std::string m_modified_subject;  // 置換で変更されたサブジェクト
         int m_number{};                  // サーバ上にあるレスの数
         int m_number_diff{};             // レス増分( subject.txt をロードした時の m_number の増分 )

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -1775,8 +1775,12 @@ void BoardBase::reset_abone_thread( const std::list< std::string >& threads,
 
     // 前後の空白と空白行を除く
 
-    m_list_abone_thread = MISC::remove_space_from_list( threads );
-    m_list_abone_thread = MISC::remove_nullline_from_list( m_list_abone_thread );
+    m_list_abone_thread.clear();
+    for( const std::string& th : threads ) {
+        // NG スレタイトルの登録時に、先頭と末尾のASCIIの空白文字のみ削除し、全角空白は保持する。`
+        std::string tmp_th = MISC::ascii_trim( th );
+        if( ! tmp_th.empty() ) m_list_abone_thread.push_back( std::move( tmp_th ) );
+    }
 
     m_list_abone_word_thread = MISC::remove_space_from_list( words );
     m_list_abone_word_thread = MISC::remove_nullline_from_list( m_list_abone_word_thread );


### PR DESCRIPTION
スレ一覧でスレッドをあぼ〜んする際、スレタイトルの先頭または末尾に全角空白が含まれていると、正しく処理されない問題を修正します。

背景:

これまでは、あぼ〜ん判定を行うスレタイトルと、 NG スレタイトルで、空白文字の処理方法が異なっていました。
スレタイトルは半角空白のみ削除していましたが、 NG スレタイトルは半角空白と全角空白の両方を削除していました。
このため、先頭または末尾に全角空白を含むスレタイトルがNG スレタイトルに登録されていても、正しくあぼ〜んできませんでした。

修正内容:

本修正では、NG スレタイトルの登録時に、先頭と末尾の半角空白のみ削除し、全角空白はそのまま残すように修正しました。
これにより、スレタイトルと NG スレタイトルの空白処理が統一され、正しくあぼ〜んされるようになります。

備考:

なお、既に登録されている NG スレタイトルは変更されません。
全角空白を含むスレタイトルを正しくあぼ〜んするには、NG スレタイトル設定から一度削除し、再登録する必要があります。

---

Fix an issue where threads could not be properly aboned when their titles contained full-width spaces (U+3000: IDEOGRAPHIC SPACE) at the beginning or end.

Background:

Previously, the handling of whitespace differed between the thread title used for abone judgment and the NG thread title.  The thread title only removed leading and trailing half-width spaces, whereas the NG thread title removed both half-width and full-width spaces. As a result, even if an NG thread title was registered with a full-width space at the beginning or end, it was not correctly aboned.

Changes:

This fix modifies the NG thread title registration process to remove only leading and trailing half-width spaces while keeping full-width spaces intact. By unifying the whitespace handling between the thread title and NG thread title, abone judgment will now work correctly.

Note:

Note that existing NG thread titles will not be modified.  To apply NG thread titles correctly for thread titles containing full-width spaces, users must manually delete and re-register them in the NG settings.

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1722942440/549

Closes #1524
