### PR TITLE
Fix toolbar button menu display and apply `popup_at_pointer()`

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -956,7 +956,7 @@ void ArticleViewBase::close_view()
 //
 void ArticleViewBase::delete_view()
 {
-    show_popupmenu( "popup_menu_delete", false );
+    show_popupmenu( "popup_menu_delete", SKELETON::PopupMenuPosition::mouse_pointer );
 }
 
 
@@ -1159,9 +1159,9 @@ bool ArticleViewBase::operate_view( const int control )
             forward_viewhistory( 1 );
             break;
 
-        // ポップアップメニュー表示
+        // ポップアップメニューをビューの左上に表示
         case CONTROL::ShowPopupMenu:
-            show_popupmenu( "", true );
+            show_popupmenu( "", SKELETON::PopupMenuPosition::view_top_left );
             break;
 
             // ブックマーク移動
@@ -2098,8 +2098,10 @@ bool ArticleViewBase::slot_button_release( std::string url, int res_number, GdkE
             // リンクをクリック
             else if( click_url( url, res_number, event ) );
 
-            // コンテキストメニュー表示
-            else if( get_control().button_alloted( event, CONTROL::PopupmenuButton ) ) show_popupmenu( url, false );
+            // コンテキストメニューをマウスポインターの位置に表示
+            else if( get_control().button_alloted( event, CONTROL::PopupmenuButton ) ) {
+                show_popupmenu( url, SKELETON::PopupMenuPosition::mouse_pointer );
+            }
 
             // 実況中の場合は停止
             else if( get_control().button_alloted( event, CONTROL::ClickButton ) && get_live() )
@@ -2529,7 +2531,7 @@ bool ArticleViewBase::click_url( std::string url, int res_number, GdkEventButton
             }
             else if( control.button_alloted( event, CONTROL::DrawoutIDButton ) ) slot_drawout_id();
             else if( control.button_alloted( event, CONTROL::PopupmenuIDButton ) ){
-                show_popupmenu( url, false );
+                show_popupmenu( url, SKELETON::PopupMenuPosition::mouse_pointer );
             }
         }
     }
@@ -2560,7 +2562,7 @@ bool ArticleViewBase::click_url( std::string url, int res_number, GdkEventButton
             }
             else if( control.button_alloted( event, CONTROL::DrawoutIDButton ) ) slot_drawout_name();
             else if( control.button_alloted( event, CONTROL::PopupmenuIDButton ) ){
-                show_popupmenu( url, false );
+                show_popupmenu( url, SKELETON::PopupMenuPosition::mouse_pointer );
             }
         }
     }
@@ -2572,7 +2574,7 @@ bool ArticleViewBase::click_url( std::string url, int res_number, GdkEventButton
         hide_popup();
 
         if( control.button_alloted( event, CONTROL::PopupmenuAncButton ) ){
-            show_popupmenu( url, false );
+            show_popupmenu( url, SKELETON::PopupMenuPosition::mouse_pointer );
         }
     }
 
@@ -2583,7 +2585,7 @@ bool ArticleViewBase::click_url( std::string url, int res_number, GdkEventButton
         hide_popup();
 
         if( control.button_alloted( event, CONTROL::PopupmenuAncButton ) ){
-            show_popupmenu( url, false );
+            show_popupmenu( url, SKELETON::PopupMenuPosition::mouse_pointer );
         }
     }
 
@@ -2619,7 +2621,7 @@ bool ArticleViewBase::click_url( std::string url, int res_number, GdkEventButton
 #endif
         if( control.button_alloted( event, CONTROL::OpenBeButton ) ) CORE::core_set_command( "open_url_browser", openurl );
         else if( control.button_alloted( event, CONTROL::PopupmenuBeButton ) ){
-            show_popupmenu( openurl, false );
+            show_popupmenu( openurl, SKELETON::PopupMenuPosition::mouse_pointer );
         }
     }
 
@@ -2643,7 +2645,9 @@ bool ArticleViewBase::click_url( std::string url, int res_number, GdkEventButton
             hide_popup();
 
             if( control.button_alloted( event, CONTROL::JumpAncButton ) ) slot_jump();
-            else if( control.button_alloted( event, CONTROL::PopupmenuAncButton ) ) show_popupmenu( url, false );
+            else if( control.button_alloted( event, CONTROL::PopupmenuAncButton ) ) {
+                show_popupmenu( url, SKELETON::PopupMenuPosition::mouse_pointer );
+            }
             else if( control.button_alloted( event, CONTROL::DrawoutAncButton ) ) slot_drawout_around();
         }
     }
@@ -2667,7 +2671,9 @@ bool ArticleViewBase::click_url( std::string url, int res_number, GdkEventButton
             m_jump_to = m_str_num;
             m_jump_from = m_str_num;
 
-            if( control.button_alloted( event, CONTROL::PopupmenuResButton ) ) show_popupmenu( url, false );
+            if( control.button_alloted( event, CONTROL::PopupmenuResButton ) ) {
+                show_popupmenu( url, SKELETON::PopupMenuPosition::mouse_pointer );
+            }
 
             // ブックマークセット
             else if( control.button_alloted( event, CONTROL::BmResButton ) ) slot_bookmark();
@@ -2731,7 +2737,7 @@ bool ArticleViewBase::click_url( std::string url, int res_number, GdkEventButton
 
         if( control.button_alloted( event, CONTROL::PopupmenuImageButton ) ){
             m_str_num = std::to_string( res_number );
-            show_popupmenu( url, false );
+            show_popupmenu( url, SKELETON::PopupMenuPosition::mouse_pointer );
         }
 
         else if( ! DBIMG::is_cached( url ) && ! SESSION::is_online() ){

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -61,11 +61,11 @@ enum
 #define GET_PATH( row ) m_treestore->get_path( row )
 
 
-// ポップアップメニュー表示
-#define SHOW_POPUPMENU(slot) do{\
+/// @brief ポップアップメニューを指定位置に表示
+#define SHOW_POPUPMENU(position) do{\
 std::string url = path2url( m_path_selected ); \
 if( ! m_path_selected.empty() && url.empty() ) url = "dummy_url"; \
-show_popupmenu( url, slot ); \
+show_popupmenu( url, position ); \
 }while(0)
 
 
@@ -943,7 +943,7 @@ bool BBSListViewBase::operate_view( const int control )
             if( m_treeview.get_selection()->get_selected_rows().size() >= 1 ){
                 m_path_selected = * (m_treeview.get_selection()->get_selected_rows().begin() );
             }
-            SHOW_POPUPMENU(true);
+            SHOW_POPUPMENU( SKELETON::PopupMenuPosition::view_top_left );
             break;
         }
 
@@ -1220,7 +1220,9 @@ bool BBSListViewBase::slot_button_release( GdkEventButton* event )
     else if( get_control().button_alloted( event, CONTROL::OpenBoardTabButton ) ) operate_view( CONTROL::OpenBoardTabButton );
 
     // ポップアップメニューボタン
-    else if( get_control().button_alloted( event, CONTROL::PopupmenuButton ) ) SHOW_POPUPMENU( false );
+    else if( get_control().button_alloted( event, CONTROL::PopupmenuButton ) ) {
+        SHOW_POPUPMENU( SKELETON::PopupMenuPosition::mouse_pointer );
+    }
 
     // その他の操作
     else operate_view( get_control().button_press( event ) );

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -1609,9 +1609,9 @@ bool BoardViewBase::operate_view( const int control )
             break;
         }
 
-        // ポップアップメニュー表示
+        // ポップアップメニューをビューの左上に表示
         case CONTROL::ShowPopupMenu:
-            show_popupmenu( "", true );
+            show_popupmenu( "", SKELETON::PopupMenuPosition::view_top_left );
             break;
 
         // 検索
@@ -2212,7 +2212,7 @@ bool BoardViewBase::slot_button_release( GdkEventButton* event )
         // ポップアップメニューボタン
         else if( get_control().button_alloted( event, CONTROL::PopupmenuButton ) ){
 
-            show_popupmenu( "", false );
+            show_popupmenu( "", SKELETON::PopupMenuPosition::mouse_pointer );
         }
 
         else operate_view( get_control().button_press( event ) );
@@ -2476,7 +2476,7 @@ void BoardViewBase::write()
 //
 void BoardViewBase::delete_view()
 {
-    show_popupmenu( "popup_menu_delete", false );
+    show_popupmenu( "popup_menu_delete", SKELETON::PopupMenuPosition::mouse_pointer );
 }
 
 
@@ -2485,7 +2485,7 @@ void BoardViewBase::delete_view()
 //
 void BoardViewBase::set_favorite()
 {
-    show_popupmenu( "popup_menu_favorite", false );
+    show_popupmenu( "popup_menu_favorite", SKELETON::PopupMenuPosition::mouse_pointer );
 }
 
 

--- a/src/image/imageview.cpp
+++ b/src/image/imageview.cpp
@@ -570,8 +570,8 @@ bool ImageViewMain::operate_view( const int control )
     }
 
     if( cntl == CONTROL::ShowPopupMenu ) {
-        // ポップアップメニュー表示
-        show_popupmenu( "", true );
+        // ポップアップメニューをビューの左上に表示
+        show_popupmenu( "", SKELETON::PopupMenuPosition::view_top_left );
         return true;
     }
 

--- a/src/image/imageviewbase.cpp
+++ b/src/image/imageviewbase.cpp
@@ -800,7 +800,7 @@ bool ImageViewBase::slot_button_release( GdkEventButton* event )
     // ポップアップメニュー
     if( get_control().button_alloted( event, CONTROL::PopupmenuButton ) ){
 
-        show_popupmenu( "", false );
+        show_popupmenu( "", SKELETON::PopupMenuPosition::mouse_pointer );
     }
 
     else if( is_under_mouse() ) operate_view( get_control().button_press( event ) );

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -844,7 +844,9 @@ void ToolBar::slot_clicked_delete()
     std::cout << "ToolBar::slot_clicked_delete\n";
 #endif
 
-    m_admin->set_command( "toolbar_delete_view", m_url );
+    // ツールバーの削除ボタンを押すとポップアップメニューを表示するビューがあります。
+    // GdkEvent が必要なため、コマンドを即時実行してイベント処理中に表示します。
+    m_admin->set_command_immediately( "toolbar_delete_view", m_url );
 }
 
 
@@ -873,7 +875,9 @@ void ToolBar::slot_clicked_favorite()
     std::cout << "ToolBar::slot_clicked_favorite\n";
 #endif
 
-    m_admin->set_command( "toolbar_set_favorite", m_url );
+    // ツールバーのお気に入りボタンを押すとポップアップメニューを表示するビューがあります。
+    // GdkEvent が必要なため、コマンドを即時実行してイベント処理中に表示します。
+    m_admin->set_command_immediately( "toolbar_set_favorite", m_url );
 }
 
 

--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -210,7 +210,9 @@ void View::show_popupmenu( const std::string& url, bool use_slot )
             // 自動的に画面内に収まるように調整します。
             popupmenu->popup_at_widget( this, Gdk::GRAVITY_NORTH_WEST, Gdk::GRAVITY_NORTH_WEST, nullptr );
         }
-        else popupmenu->popup( 0, gtk_get_current_event_time() );
+        // 現在のイベントに関連するマウスポインターの座標にメニューを表示する
+        // nullptr を渡すことで現在のイベントから自動的に座標を取得します。
+        else popupmenu->popup_at_pointer( nullptr );
     }
 }
 

--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -185,8 +185,12 @@ bool View::is_mouse_on_view() const
 
 
 
-// ポップアップメニュー表示
-void View::show_popupmenu( const std::string& url, bool use_slot )
+/** @brief ポップアップメニューを指定位置に表示する
+ *
+ * @param[in] url      ビューのURL、またはメニューを識別するID文字列
+ * @param[in] position ポップアップメニューの表示位置
+ */
+void View::show_popupmenu( const std::string& url, PopupMenuPosition position )
 {
     // ポップアップメニューを表示する前にメニューのアクティブ状態を切り替える
     activate_act_before_popupmenu( url );
@@ -204,7 +208,7 @@ void View::show_popupmenu( const std::string& url, bool use_slot )
             popupmenu->signal_hide().connect( sigc::mem_fun( *this, &View::slot_hide_popupmenu ) );
         }
 
-        if( use_slot ) {
+        if( position == PopupMenuPosition::view_top_left ) {
             // viewの左上とメニューの左上を揃える
             // メニューのサイズが大きく、ディスプレイの外にはみ出す場合でも、
             // 自動的に画面内に収まるように調整します。

--- a/src/skeleton/view.h
+++ b/src/skeleton/view.h
@@ -11,6 +11,12 @@
 
 namespace SKELETON
 {
+    /// @brief ポップアップメニューの表示位置
+    enum class PopupMenuPosition {
+        mouse_pointer, ///< マウスポインターの位置
+        view_top_left, ///< ビューの左上
+    };
+
     class Admin;
 
     // 自分がポップアップviewの時に(ポップアップウィンドウ( SKELETON::PopupWin ) 経由で)
@@ -153,8 +159,8 @@ namespace SKELETON
         // 数字入力ジャンプ用に sig_key_press() から呼び出す
         bool release_keyjump_key( int key );
 
-        // ポップアップメニュー表示
-        void show_popupmenu( const std::string& url, bool use_slot = false );
+        // ポップアップメニューを指定位置に表示する
+        void show_popupmenu( const std::string& url, PopupMenuPosition position );
 
         // ポップアップメニューがmapした時に呼び出されるスロット
         void slot_map_popupmenu();


### PR DESCRIPTION
このPull request は https://github.com/JDimproved/JDim/issues/1516#issuecomment-2671562878 の「アイデア2: コマンドの即時実行」を実装します。

### Fix toolbar button menu display and apply `popup_at_pointer()`

ビューを右クリックしたときのコンテキストメニュー表示処理を `Gtk::Menu::popup_at_pointer()` に変更します。
この関数は、処理中のマウスポインターの座標にメニューを表示します。

従来の実装では、メニューのサイズが大きい場合、ディスプレイの外にはみ出してメニュー項目が一部見えなくなることがありました。
`popup_at_pointer()` を使用することで、メニューが画面内に収まるよう自動的に調整されます。

しかし、`popup_at_pointer()` に変更すると、ツールバーボタンのポップアップメニューが表示されなくなる問題が発生しました。
これは、`Gtk::Menu` の新しいAPIが `GdkEvent` を必要とするためです。
ツールバーボタンのクリック時にはコマンドを送信するだけでメニュー表示を実行しないため、イベント処理を抜けた後では `GdkEvent` を取得できず、 `popup_at_pointer()` に必要な情報を渡せません。

この問題を解決するため、ツールバーボタンの「削除」や「お気に入り追加」ボタンをクリックしたときに送信するコマンドを、待ち行列に追加する `SKELETON::Admin::set_command()` から即時実行する `set_command_immediately()` に変更しました。これにより、イベント処理中に `popup_at_pointer()` を呼び出してメニューを表示できるようになります。

**注意:**

ポップアップメニューの即時実行により、コマンドの実行順序が入れ替わったり、トランザクション管理に影響を与えたりする可能性があります。例えば、複数のコマンドが同時に実行される場合、メニューが重複表示されたり、コマンドが無視されたりするなど、意図しない動作が発生するかもしれません。

---

Change the context menu display process when right-clicking a view to use `Gtk::Menu::popup_at_pointer()`. This function displays the menu at the current mouse pointer position during event processing.

Previously, if the menu size was too large, it could overflow beyond the display area, causing some menu items to become partially invisible. Using `popup_at_pointer()` ensures that the menu is automatically adjusted to fit within the screen.

However, changing to `popup_at_pointer()` caused an issue where the popup menu for toolbar buttons was not displayed. This is because the new `Gtk::Menu` API requires a `GdkEvent`, but clicking a toolbar button only sends a command without executing the menu display.  As a result, after event processing has exited, `GdkEvent` is no longer accessible, and the required information for `popup_at_pointer()` cannot be provided.

To address this issue, the command sent when clicking the "Delete" and "Add to Favorites" toolbar buttons has been changed from `SKELETON::Admin::set_command()`, which adds the command to a queue, to `set_command_immediately()`, which executes it immediately.  This allows `popup_at_pointer()` to be called during event processing, ensuring that the menu is displayed correctly.

**Note:**

Executing the popup menu immediately may affect the execution order of commands and transaction management. For example, if multiple commands are executed simultaneously, unintended behavior such as duplicate menu display or ignored commands may occur.

---

### Change View::show_popupmenu() argument for better readability

`SKELETON::View::show_popupmenu()` の第2引数を `bool` 型から、ポップアップメニューの表示位置を指定する `enum class PopupMenuPosition` に変更します。

表示位置の指定方法が名前で明確に表現され、直感的なインターフェースとなるため、コードの可読性が向上します。また、デフォルト引数を廃止し、明示的な指定を必須とすることで、意図しない挙動を防ぎます。

---

The second argument of `SKELETON::View::show_popupmenu()` has been changed from a `bool` to an `enum class PopupMenuPosition`, which specifies the position where the popup menu should be displayed.

This change makes the position specification method explicitly named and provides an intuitive interface, improving code readability.  Additionally, the default argument has been removed, making explicit specification mandatory to prevent unintended behavior.

---

関連のissue: #1516
