### PR TITLE
Remove unnecessary process_raw_lines() from NodeTree2ch and NodeTreeBase

### DIFF
--- a/src/dbtree/nodetree2ch.cpp
+++ b/src/dbtree/nodetree2ch.cpp
@@ -58,17 +58,6 @@ NodeTree2ch::~NodeTree2ch()
 }
 
 
-//
-// キャッシュに保存する前の前処理
-//
-// 先頭にrawモードのステータスが入っていたら取り除く
-//
-char* NodeTree2ch::process_raw_lines( std::string& rawlines )
-{
-    return NodeTree2chCompati::process_raw_lines( rawlines );
-}
-
-
 /** @brief 5chスレッドの拡張属性を取り出す
  *
  * @param[in] str スレのレス番号1(`>>1`)の本文テキストデータ

--- a/src/dbtree/nodetree2ch.h
+++ b/src/dbtree/nodetree2ch.h
@@ -31,8 +31,6 @@ namespace DBTREE
 
       protected:
 
-        char* process_raw_lines( std::string& rawlines ) override;
-
         void create_loaderdata( JDLIB::LOADERDATA& data ) override;
 
         void parse_extattr( std::string_view str ) override;

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1438,9 +1438,11 @@ void NodeTreeBase::add_raw_lines( std::string& buffer_lines )
     }
 
     // 保存前にrawデータを加工
-    char* rawlines = process_raw_lines( buffer_lines );
+    // process_raw_lines() は不要になったため直接 data() を呼び出しています。
+    char* rawlines = buffer_lines.data();
 
-    size_t lng = strlen( rawlines );
+    // NOTE: lng の値は、 std::strlen(rawlines) ですが、加工が不要なため長さ計算を省略しています。
+    std::size_t lng = buffer_lines.size();
     if( ! lng ) return;
 
     // サーバが range を無視してデータを送ってきたときのレジューム処理

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -296,8 +296,8 @@ namespace DBTREE
         virtual void create_loaderdata( JDLIB::LOADERDATA& data ){}
 
         // 保存前にrawデータを加工
-        // デフォルトでは何もしない
-        virtual char* process_raw_lines( std::string& rawlines ){ return rawlines.data(); }
+        // NOTE: 派生クラスでのrawデータ加工が不要になったため、メンバー関数を削除しました。
+        virtual char* process_raw_lines( std::string& rawlines ) = delete;
 
         // raw データを dat に変換
         // デフォルトでは何もしない


### PR DESCRIPTION
cppcheck 2.17で、 `NodeTree2ch::process_raw_lines()` が基底クラスに処理を移譲しているだけだと指摘されます。 `process_raw_lines()` はキャッシュ保存前の前処理を行う派生クラスで必要でしたが、現在は利用されていません。そのため、`NodeTree2ch::process_raw_lines()` と `NodeTreeBase::process_raw_lines()` の実装および関連する呼び出しを削除します。

---

cppcheck 2.17 reports that `NodeTree2ch::process_raw_lines()` merely delegates to the base class. `process_raw_lines()` was needed for preprocessing before cache storage in derived classes, but it is no longer used. Therefore, I remove the implementations of `NodeTree2ch::process_raw_lines()` and `NodeTreeBase::process_raw_lines()` along with their related calls.

---

cppcheck 2.17のレポート:
```
src/dbtree/nodetree2ch.h:34:15: style: The function 'process_raw_lines' overrides a function in a base class but just delegates back to the base class. [uselessOverride]
        char* process_raw_lines( std::string& rawlines ) override;
              ^
src/dbtree/nodetreebase.h:300:23: note: Virtual function in base class
        virtual char* process_raw_lines( std::string& rawlines ){ return rawlines.data(); }
                      ^
src/dbtree/nodetree2ch.h:34:15: note: Function in derived class
        char* process_raw_lines( std::string& rawlines ) override;
              ^
```
