### PR TITLE
Improve popup menu positioning for toolbar buttons

### DIFF
--- a/src/article/articleadmin.h
+++ b/src/article/articleadmin.h
@@ -23,6 +23,9 @@ namespace JDLIB
 
 namespace ARTICLE
 {
+    /// @brief ツールバーの削除ボタンを紐づけるID
+    static constexpr std::size_t kToolbarWidgetDelete = 0;
+
     class ArticleToolBar;
     class ArticleToolBarSimple;
     class SearchToolBar;

--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -956,7 +956,9 @@ void ArticleViewBase::close_view()
 //
 void ArticleViewBase::delete_view()
 {
-    show_popupmenu( "popup_menu_delete", SKELETON::PopupMenuPosition::mouse_pointer );
+    // IDに紐づけたツールバーボタンを取得してポップアップメニューの表示位置に指定します。
+    show_popupmenu( "popup_menu_delete", SKELETON::PopupMenuPosition::toolbar_button,
+                    get_admin()->get_anchor_widget( kToolbarWidgetDelete ) );
 }
 
 

--- a/src/article/toolbar.cpp
+++ b/src/article/toolbar.cpp
@@ -138,6 +138,8 @@ void ArticleToolBar::pack_buttons()
 
             case ITEM_DELETE:
                 get_buttonbar().append( *get_button_delete() );
+                // ポップアップメニューの配置に利用するためツールバーボタンをIDに紐づけします。
+                get_admin()->set_anchor_widget( kToolbarWidgetDelete, get_button_delete() );
 
                 break;
 

--- a/src/board/boardadmin.h
+++ b/src/board/boardadmin.h
@@ -16,6 +16,11 @@
 
 namespace BOARD
 {
+    /// @brief ツールバーのお気に入り追加ボタンを紐づけるID
+    static constexpr std::size_t kToolbarWidgetFavoriteAdd = 0;
+    /// @brief ツールバーの削除ボタンを紐づけるID
+    static constexpr std::size_t kToolbarWidgetDelete = 1;
+
     class BoardToolBar;
 
     class BoardAdmin : public SKELETON::Admin

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -2476,7 +2476,9 @@ void BoardViewBase::write()
 //
 void BoardViewBase::delete_view()
 {
-    show_popupmenu( "popup_menu_delete", SKELETON::PopupMenuPosition::mouse_pointer );
+    // IDに紐づけたツールバーボタンを取得してポップアップメニューの表示位置に指定します。
+    show_popupmenu( "popup_menu_delete", SKELETON::PopupMenuPosition::toolbar_button,
+                    get_admin()->get_anchor_widget( kToolbarWidgetDelete ) );
 }
 
 
@@ -2485,7 +2487,8 @@ void BoardViewBase::delete_view()
 //
 void BoardViewBase::set_favorite()
 {
-    show_popupmenu( "popup_menu_favorite", SKELETON::PopupMenuPosition::mouse_pointer );
+    show_popupmenu( "popup_menu_favorite", SKELETON::PopupMenuPosition::toolbar_button,
+                    get_admin()->get_anchor_widget( kToolbarWidgetFavoriteAdd ) );
 }
 
 

--- a/src/board/toolbar.cpp
+++ b/src/board/toolbar.cpp
@@ -86,10 +86,13 @@ void BoardToolBar::pack_toolbar()
                 get_buttonbar().append( *get_button_favorite() );
                 set_tooltip( *get_button_favorite(), CONTROL::get_label_motions( CONTROL::AppendFavorite )
                              + "\n\nスレ一覧のタブか選択したスレをお気に入りに直接Ｄ＆Ｄしても登録可能" );
+                // ポップアップメニューの配置に利用するためツールバーボタンをIDに紐づけします。
+                get_admin()->set_anchor_widget( kToolbarWidgetFavoriteAdd, get_button_favorite() );
                 break;
 
             case ITEM_DELETE:
                 get_buttonbar().append( *get_button_delete() );
+                get_admin()->set_anchor_widget( kToolbarWidgetDelete, get_button_delete() );
                 break;
 
             case ITEM_QUIT:

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -2064,6 +2064,31 @@ View* Admin::get_current_view()
 }
 
 
+/** @brief 配置用のウィジェットを取得する
+ *
+ * @param[in] id 紐づけのID
+ * @return id に紐づけられたウィジェット、無ければ nullptr を返す
+ */
+Gtk::Widget* Admin::get_anchor_widget( const std::size_t id )
+{
+    if( m_vec_anchor_widget.size() <= id ) return nullptr;
+    return m_vec_anchor_widget[id];
+}
+
+
+/** @brief 配置用のウィジェットを設定する
+ *
+ * @note Admin では anchor_widget の寿命を管理しない。
+ * @param[in] id            紐づけのID
+ * @param[in] anchor_widget IDに紐づける配置用ウィジェット
+ */
+void Admin::set_anchor_widget( const std::size_t id, Gtk::Widget* anchor_widget )
+{
+    if( m_vec_anchor_widget.size() <= id ) {
+        m_vec_anchor_widget.resize( id + 1 );
+    }
+    m_vec_anchor_widget[id] = anchor_widget;
+}
 
 
 //

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -69,6 +69,9 @@ namespace SKELETON
         bool m_use_switchhistory{};
         std::list< std::string > m_list_switchhistory;
 
+        /// @brief 配置用ウィジェットのポインターを保持する。Adminではウィジェットの寿命を管理しない。
+        std::vector<Gtk::Widget*> m_vec_anchor_widget;
+
     public:
 
         explicit Admin( const std::string& url );
@@ -151,6 +154,10 @@ namespace SKELETON
         void set_current_page_focus( const Glib::VariantBase& page );
 
         virtual View* get_current_view();
+
+        // 配置用のウィジェットを取得する/設定する
+        Gtk::Widget* get_anchor_widget( const std::size_t id );
+        void set_anchor_widget( const std::size_t id, Gtk::Widget* anchor_widget );
 
     protected:
 

--- a/src/skeleton/view.cpp
+++ b/src/skeleton/view.cpp
@@ -9,6 +9,7 @@
 #include "config/globalconf.h"
 #include "history/historymanager.h"
 #include "jdlib/miscgtk.h"
+#include "jdlib/miscmsg.h"
 
 #include "global.h"
 #include "session.h"
@@ -187,10 +188,11 @@ bool View::is_mouse_on_view() const
 
 /** @brief ポップアップメニューを指定位置に表示する
  *
- * @param[in] url      ビューのURL、またはメニューを識別するID文字列
- * @param[in] position ポップアップメニューの表示位置
+ * @param[in] url           ビューのURL、またはメニューを識別するID文字列
+ * @param[in] position      ポップアップメニューの表示位置
+ * @param[in] anchor_widget メニューの表示位置に指定するウィジェット
  */
-void View::show_popupmenu( const std::string& url, PopupMenuPosition position )
+void View::show_popupmenu( const std::string& url, PopupMenuPosition position, Gtk::Widget* anchor_widget )
 {
     // ポップアップメニューを表示する前にメニューのアクティブ状態を切り替える
     activate_act_before_popupmenu( url );
@@ -214,9 +216,23 @@ void View::show_popupmenu( const std::string& url, PopupMenuPosition position )
             // 自動的に画面内に収まるように調整します。
             popupmenu->popup_at_widget( this, Gdk::GRAVITY_NORTH_WEST, Gdk::GRAVITY_NORTH_WEST, nullptr );
         }
-        // 現在のイベントに関連するマウスポインターの座標にメニューを表示する
-        // nullptr を渡すことで現在のイベントから自動的に座標を取得します。
-        else popupmenu->popup_at_pointer( nullptr );
+        else if( position == PopupMenuPosition::mouse_pointer ) {
+            // 現在のイベントに関連するマウスポインターの座標にメニューを表示する
+            // nullptr を渡すことで現在のイベントから自動的に座標を取得します。
+            popupmenu->popup_at_pointer( nullptr );
+        }
+        else if( position == PopupMenuPosition::toolbar_button && anchor_widget ) {
+            // anchor_widgetの右下とメニューの右上を揃える
+            // メニューのサイズが大きく、ディスプレイの外にはみ出す場合でも、
+            // 自動的に画面内に収まるように調整します。
+            popupmenu->popup_at_widget( anchor_widget, Gdk::GRAVITY_SOUTH_EAST, Gdk::GRAVITY_NORTH_EAST, nullptr );
+        }
+        else {
+            std::string errmsg = "View::show_popupmenu: Incorrect argument value: position=";
+            errmsg.append( std::to_string( static_cast<int>( position ) ) );
+            errmsg.append( static_cast<bool>( anchor_widget ) ? ", with anchor" : "without anchor" );
+            MISC::ERRMSG( errmsg );
+        }
     }
 }
 

--- a/src/skeleton/view.h
+++ b/src/skeleton/view.h
@@ -15,6 +15,7 @@ namespace SKELETON
     enum class PopupMenuPosition {
         mouse_pointer, ///< マウスポインターの位置
         view_top_left, ///< ビューの左上
+        toolbar_button, ///< ツールバーボタンの下
     };
 
     class Admin;
@@ -160,7 +161,7 @@ namespace SKELETON
         bool release_keyjump_key( int key );
 
         // ポップアップメニューを指定位置に表示する
-        void show_popupmenu( const std::string& url, PopupMenuPosition position );
+        void show_popupmenu( const std::string& url, PopupMenuPosition position, Gtk::Widget* anchor_widget = nullptr );
 
         // ポップアップメニューがmapした時に呼び出されるスロット
         void slot_map_popupmenu();


### PR DESCRIPTION
このPull request は https://github.com/JDimproved/JDim/issues/1516#issuecomment-2671562878 の「アイデア3: `popup_at_widget()`を適切に使う」を実装します。

### Add popup menu positioning for toolbar buttons and implement error handling

`SKELETON::View::show_popupmenu()` の第2引数 `position` に `PopupMenuPosition::toolbar_button` （ツールバーボタンの下）を追加します。さらに、表示位置のウィジェットを指定する第3引数 `anchor_widget` を追加します。この引数を省略可能にすることで、不要な場合は明示的に指定せずに関数を呼び出せるようにします。

さらに、引数の値が誤っていてポップアップメニューを正常に配置できない場合、メニュー表示の代わりにエラーメッセージをコンソールに出力するエラー処理を実装します。

**背景:**

変更前は、ツールバーボタンを押した際にポップアップメニューがマウスポインターの位置に表示されていたため、ツールバーとの関連が分かりにくい問題がありました。 `PopupMenuPosition::toolbar_button` を追加することで、ツールバーボタンとポップアップメニューの関係が直感的に分かる配置にできます。

---

Add `PopupMenuPosition::toolbar_button` (below the toolbar button) as an option for the `position` parameter in `SKELETON::View::show_popupmenu()`. Additionally, introduce a third parameter, `anchor_widget`, to specify the reference widget for positioning. This parameter is optional, allowing the function to be called without explicitly specifying it when unnecessary.

Additionally, implement error handling to output an error message to the console instead of displaying the menu if the argument values are incorrect and the popup menu cannot be positioned properly.

**Background:**

Previously, popup menus appeared at the mouse pointer position when pressing a toolbar button, making the relationship between the toolbar and the menu unclear. By adding `PopupMenuPosition::toolbar_button`, the menu can be positioned in a way that makes the relationship between the toolbar button and the popup menu more intuitive.

### Add functionality to associate and manage widgets by ID in `Admin`

`Admin` に配置用ウィジェットのポインターをIDに紐づけて保持するコンテナーと、ウィジェットを設定・取得するメンバー関数を実装します。

`Admin` に、配置用ウィジェットのポインターをIDに紐づけて保持するコンテナー `m_vec_anchor_widget` を追加します。また、ウィジェットを設定・取得するメンバー関数 `get_anchor_widget()` と `set_anchor_widget()` を実装します。これらの関数は、ビューとツールバーの間でウィジェットを参照するために使用します。なお、 `set_anchor_widget()` では、必要に応じてコンテナーのサイズを拡張します。

**注意:**

`Admin` ではコンテナーに追加したウィジェットの寿命を管理しません。

**背景:**

ビューとツールバーは互いに参照しておらず、ウィジェットを参照する手段がありませんでした。2つのクラスは `Admin` にアクセスできるため、 `Admin` を介してウィジェットを参照する仕組みを構築します。

---

Implement a container in `Admin` to hold anchor widget pointers associated with IDs and member functions to set/get widgets.

Add a container `m_vec_anchor_widget` to `Admin` to hold pointers to anchor widgets associated with IDs. Implement member functions `get_anchor_widget()` and `set_anchor_widget()` to set and retrieve widgets. These functions are used to reference widgets between the view and the toolbar. In `set_anchor_widget()`, expand the container size as needed.

**Note:**

`Admin` does not manage the lifetime of widgets added to the container.

**Background:**

The view and toolbar do not reference each other, and there was no way to reference widgets. Since both classes can access `Admin`, implement a mechanism to reference widgets via `Admin`.

### Improve popup menu positioning for toolbar buttons

スレ一覧とスレビューでツールバーの構築方法とポップアップメニューの表示を修正し、ツールバーボタンのメニューを直感的に理解しやすい配置にします。

**変更内容:**

- ポップアップメニューを表示するツールバーボタンをツールバーに追加するとき、`Admin` に紐づけます。
- ポップアップメニューを表示する処理で、メニューの表示位置を `PopupMenuPosition::toolbar_button` に変更します。
- `Admin` に紐づけたツールバーボタンを取得し、その位置をポップアップメニューの表示位置として指定します。

**背景:**

従来は、マウスポインターの位置にツールバーボタンのメニューが表示されていたため、ツールバーとの関連が分かりにくい問題がありました。
この変更により、ツールバーボタンのメニューを直感的な配置にします。

----

Refactored toolbar construction and popup menu display in the thread list and thread view to make the placement of toolbar button menus more intuitive.

**Changes:**

- Associate toolbar buttons with `Admin` when adding them to the toolbar.
- Change the popup menu's display position to `PopupMenuPosition::toolbar_button`.
- Retrieve the toolbar button associated with `Admin` and use its position for displaying the popup menu.

**Background:**

Previously, toolbar button menus were displayed at the mouse pointer position, making their relationship to the toolbar unclear.  This change makes the toolbar button menus intuitively positioned.

Closes #1516
