### PR TITLE
Optimize closing multiple images using a queue and idle handler

### DIFF
--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -671,11 +671,16 @@ void ImageAdmin::close_other_views( const std::string& url )
     m_iconbox.foreach( [this, &url]( Gtk::Widget& w ) {
         auto view = dynamic_cast< SKELETON::View* >( &w );
         if( view && view->get_url() != url ) {
-            set_command( "close_view", view->get_url() );
+            // ウインドウのフリーズを回避するため、
+            // 閉じる画像のURLをキューに追加し、割り込みハンドラにコマンド送信を委ねます。
+            m_que_close_url.push( view->get_url() );
         }
     } );
 
-    set_command( "set_imgtab_operating", "", "false" );
+    // 割り込みハンドラが未接続であれば接続を行います。
+    if( m_conn_close_cmd.empty() ) {
+        m_conn_close_cmd = Glib::signal_idle().connect( sigc::mem_fun( *this, &ImageAdmin::slot_close_command ) );
+    }
 }
 
 
@@ -689,11 +694,14 @@ void ImageAdmin::close_left_views( const std::string& url )
     for( auto&& widget : m_iconbox.get_children() ) {
         if( auto view{ dynamic_cast<SKELETON::View*>( widget ) } ) {
             if( view->get_url() == url ) break;
-            set_command( "close_view", view->get_url() );
+            // 閉じる画像のURLをキューに追加し、割り込みハンドラにコマンド送信を委ねます。
+            m_que_close_url.push( view->get_url() );
         }
     }
 
-    set_command( "set_imgtab_operating", "", "false" );
+    if( m_conn_close_cmd.empty() ) {
+        m_conn_close_cmd = Glib::signal_idle().connect( sigc::mem_fun( *this, &ImageAdmin::slot_close_command ) );
+    }
 }
 
 
@@ -713,11 +721,14 @@ void ImageAdmin::close_right_views( const std::string& url )
     for( ++it; it != widgets.end(); ++it ) {
         auto view = dynamic_cast< SKELETON::View* >( *it );
         if( view ) {
-            set_command( "close_view", view->get_url() );
+            // 閉じる画像のURLをキューに追加し、割り込みハンドラにコマンド送信を委ねます。
+            m_que_close_url.push( view->get_url() );
         }
     }
 
-    set_command( "set_imgtab_operating", "", "false" );
+    if( m_conn_close_cmd.empty() ) {
+        m_conn_close_cmd = Glib::signal_idle().connect( sigc::mem_fun( *this, &ImageAdmin::slot_close_command ) );
+    }
 }
 
 
@@ -748,13 +759,16 @@ void ImageAdmin::close_error_views( const std::string& mode )
                 || ( mode == "nocached"  && code == HTTP_INIT ) // キャッシュに無い(削除済み)の画像
                 || mode == "all"  // 読み込み中も含めて閉じる
                 ){
-                set_command( "close_view", url );
+                // 閉じる画像のURLをキューに追加し、割り込みハンドラにコマンド送信を委ねます。
+                m_que_close_url.push( view->get_url() );
                 if( mode == "all" ) DBIMG::stop_load( url );
             }
         }
     }
 
-    set_command( "set_imgtab_operating", "", "false" );
+    if( m_conn_close_cmd.empty() ) {
+        m_conn_close_cmd = Glib::signal_idle().connect( sigc::mem_fun( *this, &ImageAdmin::slot_close_command ) );
+    }
 }
 
 
@@ -778,11 +792,14 @@ void ImageAdmin::close_noerror_views()
             if( ! DBIMG::is_cached ( url ) ) continue;
 
             const int code = DBIMG::get_code( url );
-            if( code == HTTP_OK ) set_command( "close_view", url );
+            // 閉じる画像のURLをキューに追加し、割り込みハンドラにコマンド送信を委ねます。
+            if( code == HTTP_OK ) m_que_close_url.push( view->get_url() );
         }
     }
 
-    set_command( "set_imgtab_operating", "", "false" );
+    if( m_conn_close_cmd.empty() ) {
+        m_conn_close_cmd = Glib::signal_idle().connect( sigc::mem_fun( *this, &ImageAdmin::slot_close_command ) );
+    }
 }
 
 

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -640,6 +640,27 @@ void ImageAdmin::close_window()
 }
 
 
+/** @brief キューからURLを取り出して画像を閉じるコマンドを送信する割り込みハンドラ
+ *
+ * @details 多量の画像URLを一度に閉じると、ウインドウが操作を受け付けなくなりフリーズします。
+ * そのため、保留中の優先度が高いイベントがないときに実行する割り込みハンドラで
+ * 閉じるコマンドの送信を断続的に行い、メインスレッドで他の処理が実行できるようにします。
+ * @note このメンバー関数はスレッドセーフではないため、
+ * メインスレッドまたは割り込みハンドラから呼び出す必要があります。
+ * @return キューが空になったら false を返してハンドラの接続を解除する
+ */
+bool ImageAdmin::slot_close_command()
+{
+    if( ! m_que_close_url.empty() ) {
+        std::string target_url = std::move( m_que_close_url.front() );
+        m_que_close_url.pop();
+        set_command( "close_view", target_url );
+        return true; // 継続
+    }
+    set_command( "set_imgtab_operating", "", "false" );
+    return false; // 終了
+}
+
 //
 // url 以外の画像を閉じる
 //

--- a/src/image/imageadmin.h
+++ b/src/image/imageadmin.h
@@ -33,6 +33,8 @@ namespace IMAGE
         std::list<std::unique_ptr<SKELETON::View>> m_list_view;
         /// @brief 画像を閉じるURLを入れるキュー（待ち行列）
         std::queue<std::string> m_que_close_url;
+        /// @brief 割り込みハンドラの接続状況を管理する
+        sigc::connection m_conn_close_cmd;
 
         int m_scroll;
         int m_counter_scroll{};

--- a/src/image/imageadmin.h
+++ b/src/image/imageadmin.h
@@ -9,6 +9,7 @@
 #include "skeleton/admin.h"
 
 #include <memory>
+#include <queue>
 #include <string>
 
 
@@ -30,6 +31,8 @@ namespace IMAGE
         Gtk::EventBox m_view;
 
         std::list<std::unique_ptr<SKELETON::View>> m_list_view;
+        /// @brief 画像を閉じるURLを入れるキュー（待ち行列）
+        std::queue<std::string> m_que_close_url;
 
         int m_scroll;
         int m_counter_scroll{};
@@ -128,6 +131,8 @@ namespace IMAGE
 
         bool copy_file( const std::string& url, const std::string& path_from, const std::string& path_to );
         void save_all();
+
+        bool slot_close_command();
     };
 
     IMAGE::ImageAdmin* get_admin();


### PR DESCRIPTION
### Implement an interrupt handler for sending commands to close image views

画像ビューを閉じるコマンドを送信する割り込みハンドラを実装します。

画像を閉じるためのURLを格納するキューが空でない場合、URLを取り出して閉じるコマンドを送信し、trueを返して処理を継続します。
キューが空の場合、タブ操作の状態をfalseに切り替え、falseを返してハンドラの接続を解除します。

**背景:**

多量の画像を閉じる際、一度にすべての閉じるコマンドを送信すると保留中のイベントが蓄積され、ウインドウがフリーズする問題が発生していました。
そこで、`Glib::signal_idle()` を利用し、保留中の優先度が高いイベントがないときに実行する割り込みハンドラで閉じるコマンドを少しずつ送信するように変更しました。これにより、画像を閉じる処理を断続的に実行できます。

**注意:**

`ImageAdmin::slot_close_command()` は、スレッドセーフではないためメインスレッドや割り込みハンドラで呼び出す必要があります。

---

If the queue storing URLs for closing images is not empty, retrieve a URL, send the close command, and return true to continue processing.  If the queue is empty, switch the tab operation state to false, return false to disconnect the handler, and end processing.

**Background:**

When closing a large number of images, sending all close commands at once caused pending events to accumulate, resulting in window freezing.  To address this issue, `Glib::signal_idle()` is used to execute an interrupt handler that sends close commands gradually when there are no high-priority pending events. This ensures that the image-closing process runs intermittently.

**Note:**

`ImageAdmin::slot_close_command()` is not thread-safe and must be called from the main thread or an interrupt handler.

### Optimize closing multiple images using a queue and idle handler

複数の画像を閉じる処理において、画像を閉じるコマンドを直接送信するのではなく、閉じるURLをキュー（待ち行列）に追加する方式に変更します。
また、割り込みハンドラが未接続の場合に接続し、コマンド送信を委ねます。
この修正により、多数の画像を閉じる際のウインドウフリーズを回避します。

以下の処理で割り込みハンドラを利用して複数の画像を閉じます：

- URL 以外の画像を閉じる
- URL の左側の画像を閉じる
- URL の右側の画像を閉じる
- エラーになっている画像を閉じる
- エラーでない画像を閉じる

---

In the process of closing multiple images, instead of sending the close command directly, the URLs of images to be closed are now added to a queue (FIFO). Connect the idle handler if it is not already connected, delegating command transmission to the handler.

The following processes now utilize the interrupt handler for closing multiple images:

- Close images other than the given URL
- Close images to the left of the given URL
- Close images to the right of the given URL
- Close images with errors
- Close images without errors

関連のissue: #1522
