### PR TITLE
Add flag to reduce load during tab operations in `ImageAdmin::restore()`

### DIFF
--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -121,7 +121,9 @@ void ImageAdmin::restore( const bool only_locked )
     std::list< bool > list_locked = SESSION::get_image_locked();
     std::list< bool >::iterator it_locked = list_locked.begin();
 
-    for( int page = 0; it_url != list_url.end(); ++it_url, ++page ){
+    // タブ操作中を表すフラグを設定して、ビューの更新処理を無効化します。
+    SESSION::set_tab_operating( get_url(), true );
+    for( int page = 0; it_url != list_url.end(); ++page ){
 
         // タブのロック状態
         bool lock_img = false;
@@ -136,6 +138,12 @@ void ImageAdmin::restore( const bool only_locked )
         if( page == SESSION::image_page() ) set_page_num = get_tab_nums();
 
         COMMAND_ARGS command_arg = url_to_openarg( *it_url, true, lock_img );
+        // it_url のインクリメントはここで行い、終端に達しているかチェックします。
+        // 終端に達していたらタブ操作中を表すフラグを解除して、ビューの更新処理を有効化します。
+        ++it_url;
+        if( it_url == list_url.end() ) {
+            SESSION::set_tab_operating( get_url(), false );
+        }
         if( ! command_arg.url.empty() ) open_view( command_arg );
     }
 


### PR DESCRIPTION
`ImageAdmin::restore()` で、前回開いていたURLを復元する際に、タブ操作中のビューの再描画を無効化するフラグ（`SESSION::set_tab_operating()`）を設定するように修正します。
また、復元するURLが最後の一つになったときに、このフラグを解除して一度だけ後続の処理を行います。この修正により、タブ操作中のビューの更新処理がスキップされ、読み込みの負荷が低減します。

**修正の効果:**

`gprof` を有効にしてビルドした JDim を使用し、約 1000 個の画像タブを開くキャッシュディレクトリを指定して起動と終了を行い、プロファイルを計測しました。その結果、修正の適用前は `ImageAdmin::update_status_of_all_views()` が Flat profile の上位に入っていましたが、修正の適用後は順位が 2000 程度下がり、負荷が減少します。体感では、JDimの起動にかかる時間に変化は見られませんが、プロファイルの改善により今後の性能改善の基盤とします。

---

Modify `ImageAdmin::restore()` to set a flag (`SESSION::set_tab_operating()`) that disables view redraws during tab operations while restoring previously opened URLs.  Additionally, clear this flag and perform subsequent processing only once when the last URL is restored. This change skips view update processing during tab operations, reducing the load.

**Effects of the change:**

We built JDim with `gprof` enabled and measured the profile by specifying a cache directory containing approximately 1000 image tabs and then performing startup and shutdown. As a result, before applying the change, `ImageAdmin::update_status_of_all_views()` ranked high in the Flat profile, but after applying the change, its rank dropped by about 2,000, reducing the load. While no noticeable difference is observed in the startup time of JDim, the profile improvement serves as a foundation for future performance enhancements.

関連のissue: #1522
