### PR TITLE
Add version number to User-Agent string

### DIFF
--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -205,10 +205,10 @@ namespace CONFIG
 #define CONF_REGEX_RES_AA "\"" CONF_REGEX_RES_AA_DEFAULT "\""
 
 // 2ch にアクセスするときのエージェント名
-#define CONF_AGENT_FOR2CH "Monazilla/1.00 JD"
+#define CONF_AGENT_FOR2CH "Monazilla/1.00 JD/2006.1.1"
 
 // 2ch外にアクセスするときのエージェント名
-#define CONF_AGENT_FOR_DATA "Monazilla/1.00 JD"
+#define CONF_AGENT_FOR_DATA "Monazilla/1.00 JD/2006.1.1"
 
 // 2ch にログインするときのX-2ch-UA
 #define CONF_X_2CH_UA "Navigator for 2ch 1.7.5"


### PR DESCRIPTION
ユーザーエージェント文字列の初期設定を更新してブラウザの識別子にバージョン番号を追加します。

5ch.netのスレッドに書き込みを試みると、「ERROR: 不正な UserAgent を検出しました。」というエラーメッセージが表示され、書き込みに失敗する問題が報告されていました。新しいユーザーエージェント文字列を利用すると書き込みエラーを回避することができます。

新しいユーザーエージェント文字列は「Monazilla/1.00 JD/2006.1.1」にします。

**背景:**

"JDim" を利用しない理由は、JDimはJDの仕様を引き継ぎ、初期設定でも "JD" が使用され続けているためです。そのため、互換性を保つ観点から "JD" を使用するほうが適切と判断しました。

バージョン番号の部分は「2006.1.1」にします。これはJDバージョン1がリリースされた日付に基づいています。一般的にユーザーエージェント文字列のバージョン番号は新しいリリースごとに値が更新されます。
しかし、5ch.netで使用されているユーザーを識別するどんぐりシステムの仕様により、バージョン番号部分を変更するとユーザー識別用の警備員アカウントが変わってしまいます。そこで、バージョン番号を固定値とすることで、書き込みエラーの回避と警備員アカウントの維持を目指します。

----

Update the default User-Agent string setting to add a version number to the browser identifier.

There have been reports of issues when attempting to post on 5ch.net threads, where an error message "ERROR: Invalid UserAgent detected." is displayed and posting fails. Using the new User-Agent string can avoid these posting errors.

The new User-Agent string will be "Monazilla/1.00 JD/2006.1.1".

**Background:**

The reason for not using "JDim" is that JDim inherits JD's specifications, and "JD" continues to be used in the default settings.  Therefore, I determined that using "JD" is more appropriate from a compatibility perspective.

The version number part will be "2006.1.1", based on the date when JD version 1 was released. Typically, the version number in a User-Agent string is updated with each new release. However, due to the specifications of the Donguri system used on 5ch.net for user identification, changing the version number part would result in a change to the security account. Therefore, by setting the version number as a fixed value, we aim to avoid posting errors while maintaining the security account.

関連のissue: #1531
