### PR TITLE
Update histories

### DIFF
--- a/docs/manual/2025.md
+++ b/docs/manual/2025.md
@@ -9,7 +9,53 @@ layout: default
 ## {{ page.title }}
 
 <a name="0.14.0-unreleased"></a>
-### [0.14.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.13.0...master) (unreleased)
+### [0.14.0-unreleased](https://github.com/JDimproved/JDim/compare/f0e585533cc...master) (unreleased)
+
+
+<a name="0.14.0-alpha20250403"></a>
+### [0.14.0-alpha20250403](https://github.com/JDimproved/JDim/compare/JDim-v0.13.0...f0e585533cc) (2025-04-03)
+- ([#1534](https://github.com/JDimproved/JDim/pull/1534))
+  Fix failing muon-master job in GitHub Actions Weekly CI
+- ([#1532](https://github.com/JDimproved/JDim/pull/1532))
+  Add version number to User-Agent string
+- ([#1530](https://github.com/JDimproved/JDim/pull/1530))
+  Add flag to reduce load during tab operations in `ImageAdmin::restore()`
+- ([#1529](https://github.com/JDimproved/JDim/pull/1529))
+  Optimize closing multiple images using a queue and idle handler
+- ([#1528](https://github.com/JDimproved/JDim/pull/1528))
+  Improve popup menu positioning for toolbar buttons
+- ([#1527](https://github.com/JDimproved/JDim/pull/1527))
+  Remove unnecessary `process_raw_lines()` from `NodeTree2ch` and `NodeTreeBase`
+- ([#1526](https://github.com/JDimproved/JDim/pull/1526))
+  Fix toolbar button menu display and apply `popup_at_pointer()`
+- ([#1525](https://github.com/JDimproved/JDim/pull/1525))
+  Fix processing of subject with full-width spaces in thread list abone
+- ([#1523](https://github.com/JDimproved/JDim/pull/1523))
+  Revert "View: Adjust context menu position to prevent it from going off-screen"
+- ([#1521](https://github.com/JDimproved/JDim/pull/1521))
+  Remove support code for GTK versions older than 3.24.6
+- ([#1520](https://github.com/JDimproved/JDim/pull/1520))
+  Add context menu display via menu key in Image View
+- ([#1519](https://github.com/JDimproved/JDim/pull/1519))
+  Fix context menu is displayed at an incorrect position
+- ([#1518](https://github.com/JDimproved/JDim/pull/1518))
+  `ConfigItems`: Fix a loading error in the thread hiding settings
+- ([#1514](https://github.com/JDimproved/JDim/pull/1514))
+  Allow specifying search start position in thread view by mouse click
+- ([#1512](https://github.com/JDimproved/JDim/pull/1512))
+  Fix: Incorrect thread title matching when aboning threads with emojis
+- ([#1510](https://github.com/JDimproved/JDim/pull/1510))
+  Add a theme selection page to the setup wizard
+- ([#1509](https://github.com/JDimproved/JDim/pull/1509))
+  `FontColorPref`: Add dark theme color preset
+- ([#1507](https://github.com/JDimproved/JDim/pull/1507))
+  Update CI settings (2025-01)
+- ([#1506](https://github.com/JDimproved/JDim/pull/1506))
+  Update requirements for dependencies (gcc >= 10)
+- ([#1505](https://github.com/JDimproved/JDim/pull/1505))
+  Bump version to 0.14.0-alpha
+- ([#1504](https://github.com/JDimproved/JDim/pull/1504))
+  Fix compiler warnings for `-Wrange-loop-construct`
 
 
 <a name="JDim-v0.13.0"></a>

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -17,7 +17,7 @@
 #define MAJORVERSION 0
 #define MINORVERSION 14
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20250118"
+#define JDDATE_FALLBACK    "20250403"
 #define JDTAG     "alpha"
 
 //---------------------------------


### PR DESCRIPTION
### Update `JDDATE_FALLBACK` macro to 20250403

### Update histories

更新履歴の項目が長くなったため分割します。

関連のissue: #1536 

