### PR TITLE
Pink post fix

### DIFF
--- a/src/dbtree/article2ch.cpp
+++ b/src/dbtree/article2ch.cpp
@@ -16,6 +16,7 @@
 #include "login2ch.h"
 
 #include <sstream>
+#include <ctime>
 
 using namespace DBTREE;
 
@@ -49,7 +50,7 @@ std::string Article2ch::create_write_message( const std::string& name, const std
             << "&MESSAGE=" << MISC::url_encode_plus( msg, enc )
             << "&bbs=" << DBTREE::board_id( get_url() )
             << "&key=" << get_key()
-            << "&time=" << get_time_modified()
+            << "&time=" << time(0)
             << "&submit=" << MISC::url_encode_plus( "書き込む", enc )
             // XXX: ブラウザの種類に関係なく含めて問題ないか？
             << "&oekaki_thread1=";

--- a/src/jdlib/cookiemanager.cpp
+++ b/src/jdlib/cookiemanager.cpp
@@ -142,7 +142,8 @@ bool SimpleCookieParser::parse( const std::string& input, SimpleCookie& result )
         // ルート(/)以外のpathは解析失敗にする
         if( regex.length( 1 ) ) return false;
     }
-    if( regex.exec( R"-(domain=([^;]+))-", input, offset, icase, newline, usemigemo, wchar ) ) {
+    // Cookie の仕様により、ドメイン名の先頭のドットは無視する
+    if( regex.exec( R"-(domain=\.?([^;]+))-", input, offset, icase, newline, usemigemo, wchar ) ) {
         result.domain = regex.str( 1 );
     }
 
@@ -160,7 +161,7 @@ void SimpleCookieManager::feed( const std::string& hostname, const std::string& 
     SimpleCookie result;
     if( ! m_parser.parse( input, result ) ) return;
 
-    // ドメインの解析結果が空、またはホスト名と一致する場合はホスト名を使う
+    // ドメインの解析結果が空、または先頭にドットがついたホスト名と一致する場合はホスト名を使う
     if( result.domain.empty() || result.domain == "." + hostname ) {
         result.domain = hostname;
     }
@@ -225,5 +226,8 @@ void SimpleCookieManager::delete_cookie_by_host( const std::string& hostname )
             m_storage.erase( it );
         }
         i = hostname.find( '.', i + 1 );
+        if (i != std::string::npos) {
+            ++i; // ドメイン名の先頭から区切り(.)を取り除くためピリオドの分1個進める
+        }
     }
 }

--- a/src/jdlib/cookiemanager.cpp
+++ b/src/jdlib/cookiemanager.cpp
@@ -206,6 +206,9 @@ std::string SimpleCookieManager::get_cookie_by_host( const std::string& hostname
             }
         }
         i = hostname.find( '.', i + 1 );
+        if (i != std::string::npos) {
+            ++i; // ピリオドの分1個進める
+        }
     }
     return output;
 }


### PR DESCRIPTION
<!-- SPDX-License-Identifier: FSFAP -->
<!--
Pull request(PR)の作成ありがとうございます！
このコメントやテンプレートは変形・削除しても問題ありません。

PRの説明はレビューの手掛かり・助けになりますので記入をお願いいたします。
大抵のケースではgitコミットメッセージをコピーして貼り付ければOKです。
コミットメッセージだけでは説明が不十分と判断したときはテンプレートをご利用ください。

RFC 0013[1] が承認されてPRで取り込む修正のライセンスが GPL-2.0-or-later に変更されました。
また、寛容なライセンスが使われているファイルを修正するときはそのライセンスが適用されます。

ファイルを新しく作成するときはファイルの冒頭にライセンスを表示するSPDX形式のコメントを追加していただけると幸いです。
詳しくは CONTRIBUTING.md または RFC 0013 を参照してください。

[1]: https://github.com/JDimproved/rfcs/tree/master/docs/0013-introduce-license-gpl-2.0-or-later.md
-->

#### 変更の概要
Pinkチャンネルに書き込めない不具合の対応

#### 背景や動機
Pinkチャンネルでは未だにyuki=akariが使われているようだが、
JDimからyuki=akariが送信されていないようなので修正しようと思った。

#### 変更内容
SimpleCookieManager::get_cookie_by_hostでCookieのarrayがうまく文字列に
変換できていなさそうなので処理の修正。

#### やらないこと
このプルリクエストが正しいのであれば、
SimpleCookieManager::delete_cookie_by_host
も修正がいるかも知れないです

#### レビューしてほしいポイント
C++の知識が疎くてより良い書き方などあったら修正をお願いします。

#### 補足
5chのJDimのスレには、この修正を当てなくてもPinkチャンネルに書けている
というレスもあるので、本当に必要な処理かわからないです。