### PR TITLE
Refactor session containers: replace std::list with std::vector for URLs and lock states

### DIFF
--- a/src/article/articleadmin.cpp
+++ b/src/article/articleadmin.cpp
@@ -118,8 +118,8 @@ void ArticleAdmin::restore( const bool only_locked )
     const bool online = SESSION::is_online();
     SESSION::set_online( false );
 
-    const std::list< std::string >& list_url = SESSION::get_article_URLs();
-    std::list< std::string >::const_iterator it_url = list_url.begin();
+    const std::vector<std::string>& list_url = SESSION::get_article_URLs();
+    auto it_url = list_url.begin();
 
     std::list< std::string > list_switchhistory = SESSION::get_article_switchhistory();
 

--- a/src/article/articleadmin.cpp
+++ b/src/article/articleadmin.cpp
@@ -123,8 +123,8 @@ void ArticleAdmin::restore( const bool only_locked )
 
     std::list< std::string > list_switchhistory = SESSION::get_article_switchhistory();
 
-    const std::list< bool >& list_locked = SESSION::get_article_locked();
-    std::list< bool >::const_iterator it_locked = list_locked.begin();
+    const std::vector<char>& list_locked = SESSION::get_article_locked();
+    auto it_locked = list_locked.begin();
 
     for( int page = 0; it_url != list_url.end(); ++it_url, ++page ){
 

--- a/src/board/boardadmin.cpp
+++ b/src/board/boardadmin.cpp
@@ -89,8 +89,8 @@ void BoardAdmin::restore( const bool only_locked )
 
     std::list< std::string > list_switchhistory = SESSION::get_board_switchhistory();
 
-    std::list< bool > list_locked = SESSION::get_board_locked();
-    std::list< bool >::iterator it_locked = list_locked.begin();
+    const std::vector<char>& list_locked = SESSION::get_board_locked();
+    auto it_locked = list_locked.begin();
 
     for( int page = 0; it_url != list_url.end(); ++it_url, ++page ){
 

--- a/src/board/boardadmin.cpp
+++ b/src/board/boardadmin.cpp
@@ -84,8 +84,8 @@ void BoardAdmin::restore( const bool only_locked )
     const bool online = SESSION::is_online();
     SESSION::set_online( false );
 
-    const std::list< std::string >& list_url = SESSION::get_board_URLs();
-    std::list< std::string >::const_iterator it_url = list_url.begin();
+    const std::vector<std::string>& list_url = SESSION::get_board_URLs();
+    auto it_url = list_url.begin();
 
     std::list< std::string > list_switchhistory = SESSION::get_board_switchhistory();
 

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -2321,7 +2321,7 @@ void Core::set_command( const COMMAND_ARGS& command )
             if( current_url.rfind( command.url, 0 ) == 0 ) current_url = command.url;
 
             // タブを開く位置を取得
-            const std::list<std::string> list_urls = ARTICLE::get_admin()->get_URLs();
+            const std::vector<std::string> list_urls = ARTICLE::get_admin()->get_URLs();
             for( const std::string& url : list_urls ) {
 
                 if( url == command.url ) break;

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -3146,7 +3146,7 @@ void Core::exec_command()
         // ロックされている画像があるか調べる
         bool img_locked = false;
         if( ! CONFIG::get_restore_image() ){
-            std::list< bool > list_locked = SESSION::get_image_locked();
+            const std::vector<char>& list_locked = SESSION::get_image_locked();
             img_locked = std::any_of( list_locked.cbegin(), list_locked.cend(), []( bool b ) { return b; } );
         }
 

--- a/src/history/historymanager.cpp
+++ b/src/history/historymanager.cpp
@@ -278,8 +278,8 @@ void History_Manager::viewhistory2xml()
 
     // タブに表示されているViewのアドレスを取得
     std::set< std::string > taburls;
-    const std::list< std::string >& article_urls = SESSION::get_article_URLs();
-    const std::list< std::string >& board_urls = SESSION::get_board_URLs();
+    const std::vector<std::string>& article_urls = SESSION::get_article_URLs();
+    const std::vector<std::string>& board_urls = SESSION::get_board_URLs();
 
     for( const std::string& url : article_urls ) {
 #ifdef _DEBUG

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -115,8 +115,8 @@ void ImageAdmin::restore( const bool only_locked )
 
     int set_page_num = 0;
 
-    std::list< std::string > list_url = SESSION::image_URLs();
-    std::list< std::string >::iterator it_url= list_url.begin();
+    const std::vector<std::string>& list_url = SESSION::image_URLs();
+    auto it_url = list_url.begin();
 
     std::list< bool > list_locked = SESSION::get_image_locked();
     std::list< bool >::iterator it_locked = list_locked.begin();
@@ -196,9 +196,9 @@ int ImageAdmin::get_tab_nums()
 //
 // 含まれているページのURLのリスト取得
 //
-std::list< std::string > ImageAdmin::get_URLs()
+std::vector<std::string> ImageAdmin::get_URLs()
 {
-    std::list< std::string > urls;
+    std::vector<std::string> urls;
     m_iconbox.foreach( [&urls]( Gtk::Widget& w ) {
         auto view = dynamic_cast< SKELETON::View* >( &w );
         if( view ) {
@@ -1164,7 +1164,7 @@ void ImageAdmin::save_all()
             int overwrite = Gtk::RESPONSE_NO;
             bool use_name_in_cache = false;
 
-            const std::list<std::string> list_urls = get_URLs();
+            const std::vector<std::string> list_urls = get_URLs();
             for( const std::string& url : list_urls ) {
 
                 if( ! DBIMG::is_cached( url ) || DBIMG::get_mosaic( url ) ) continue;

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -118,8 +118,8 @@ void ImageAdmin::restore( const bool only_locked )
     const std::vector<std::string>& list_url = SESSION::image_URLs();
     auto it_url = list_url.begin();
 
-    std::list< bool > list_locked = SESSION::get_image_locked();
-    std::list< bool >::iterator it_locked = list_locked.begin();
+    const std::vector<char>& list_locked = SESSION::get_image_locked();
+    auto it_locked = list_locked.begin();
 
     // タブ操作中を表すフラグを設定して、ビューの更新処理を無効化します。
     SESSION::set_tab_operating( get_url(), true );
@@ -1265,9 +1265,9 @@ void ImageAdmin::save_all()
 
 
 // ページがロックされているかリストで取得
-std::list< bool > ImageAdmin::get_locked()
+std::vector<char> ImageAdmin::get_locked()
 {
-    std::list< bool > locked;
+    std::vector<char> locked;
 
     m_iconbox.foreach( [&locked]( Gtk::Widget& w ) {
         const auto view = dynamic_cast< SKELETON::View* >( &w );

--- a/src/image/imageadmin.h
+++ b/src/image/imageadmin.h
@@ -61,7 +61,7 @@ namespace IMAGE
         int get_tab_nums() override;
 
         // 含まれているページのURLのリスト取得
-        std::list< std::string > get_URLs() override;
+        std::vector<std::string> get_URLs() override;
 
         // 現在表示してるページ番号
         int get_current_page() override;

--- a/src/image/imageadmin.h
+++ b/src/image/imageadmin.h
@@ -93,7 +93,7 @@ namespace IMAGE
         SKELETON::View* get_current_view() override;
 
         // ページがロックされているかリストで取得
-        std::list< bool > get_locked() override;
+        std::vector<char> get_locked() override;
 
         // タブのロック/アンロック
         bool is_lockable( const int page ) override;

--- a/src/menuslots.cpp
+++ b/src/menuslots.cpp
@@ -1103,7 +1103,7 @@ void Core::slot_clear_post_history()
     // ビューの表示更新
     CORE::core_set_command( "redraw_article" );
 
-    std::list< std::string > list_urls = BOARD::get_admin()->get_URLs();
+    std::vector<std::string> list_urls = BOARD::get_admin()->get_URLs();
     for( const std::string& url : list_urls ) CORE::core_set_command( "update_board", url );
 }
 

--- a/src/menuslots.cpp
+++ b/src/menuslots.cpp
@@ -1103,7 +1103,7 @@ void Core::slot_clear_post_history()
     // ビューの表示更新
     CORE::core_set_command( "redraw_article" );
 
-    std::vector<std::string> list_urls = BOARD::get_admin()->get_URLs();
+    const std::vector<std::string>& list_urls = BOARD::get_admin()->get_URLs();
     for( const std::string& url : list_urls ) CORE::core_set_command( "update_board", url );
 }
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -44,15 +44,16 @@ int win_article_page;
 int win_image_page;
 
 std::vector<std::string> board_urls;
-std::list< bool > board_locked;
+// bool フラグを格納するが vector<bool> は特殊化で取り扱いに注意が必要なので利用しない
+std::vector<char> board_locked;
 std::list< std::string > board_switchhistory;
 
 std::vector<std::string> article_urls;
-std::list< bool > article_locked;
+std::vector<char> article_locked;
 std::list< std::string > article_switchhistory;
 
 std::vector<std::string> image_urls;
-std::list< bool > image_locked;
+std::vector<char> image_locked;
 
 std::string items_sidebar_toolbar_str;
 std::vector< int > items_sidebar_toolbar;
@@ -308,7 +309,7 @@ static void read_list_urls( JDLIB::ConfLoader& cf, const std::string& id_urls,  
 }
 
 
-static void read_list_locked( JDLIB::ConfLoader& cf, const std::string& id_locked, std::list< bool >& list_locked )
+static void read_list_locked( JDLIB::ConfLoader& cf, const std::string& id_locked, std::vector<char>& list_locked )
 {
     list_locked.clear();
 
@@ -889,8 +890,8 @@ const std::vector<std::string>& SESSION::get_board_URLs(){ return board_urls; }
 void SESSION::set_board_URLs( std::vector<std::string> urls ){ board_urls = std::move( urls ); }
 
 // スレ一覧のロック状態
-const std::list< bool >& SESSION::get_board_locked(){ return board_locked; }
-void SESSION::set_board_locked( const std::list< bool >& locked ){ board_locked = locked; }
+const std::vector<char>& SESSION::get_board_locked(){ return board_locked; }
+void SESSION::set_board_locked( std::vector<char> locked ){ board_locked = std::move( locked ); }
 
 // スレ一覧の切り替え履歴    
 const std::list< std::string >& SESSION::get_board_switchhistory(){ return board_switchhistory; }
@@ -903,8 +904,8 @@ const std::vector<std::string>& SESSION::get_article_URLs(){ return article_urls
 void SESSION::set_article_URLs( std::vector<std::string> urls ){ article_urls = std::move( urls ); }
 
 // スレタブのロック状態
-const std::list< bool >& SESSION::get_article_locked(){ return article_locked; }
-void SESSION::set_article_locked( const std::list< bool >& locked ){ article_locked = locked; }
+const std::vector<char>& SESSION::get_article_locked(){ return article_locked; }
+void SESSION::set_article_locked( std::vector<char> locked ){ article_locked = std::move( locked ); }
 
 // スレタブの切り替え履歴    
 const std::list< std::string >& SESSION::get_article_switchhistory(){ return article_switchhistory; }
@@ -917,8 +918,8 @@ const std::vector<std::string>& SESSION::image_URLs(){ return image_urls; }
 void SESSION::set_image_URLs( std::vector<std::string> urls ){ image_urls = std::move( urls ); }
 
 // 画像タブのロック状態
-const std::list< bool >& SESSION::get_image_locked(){ return image_locked; }
-void SESSION::set_image_locked( const std::list< bool >& locked ){ image_locked = locked; }
+const std::vector<char>& SESSION::get_image_locked(){ return image_locked; }
+void SESSION::set_image_locked( std::vector<char> locked ){ image_locked = std::move( locked ); }
 
 // サイドバーのツールバーの項目
 const std::string& SESSION::get_items_sidebar_toolbar_str(){ return items_sidebar_toolbar_str; }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -43,15 +43,15 @@ int win_board_page;
 int win_article_page;
 int win_image_page;
 
-std::list< std::string > board_urls;
+std::vector<std::string> board_urls;
 std::list< bool > board_locked;
 std::list< std::string > board_switchhistory;
 
-std::list< std::string > article_urls;
+std::vector<std::string> article_urls;
 std::list< bool > article_locked;
 std::list< std::string > article_switchhistory;
 
-std::list< std::string > image_urls;
+std::vector<std::string> image_urls;
 std::list< bool > image_locked;
 
 std::string items_sidebar_toolbar_str;
@@ -285,6 +285,18 @@ static std::vector<int> parse_items( const std::string& items_str )
 
 
 static void read_list_urls( JDLIB::ConfLoader& cf, const std::string& id_urls,  std::list< std::string >& list_urls )
+{
+    list_urls.clear();
+
+    const std::string str_tmp = cf.get_option_str( id_urls, "" );
+    if( ! str_tmp.empty() ){
+        std::list<std::string> list_tmp = MISC::split_line( str_tmp );
+        for( std::string& url : list_tmp ) if( ! url.empty() ) list_urls.push_back( std::move( url ) );
+    }
+}
+
+
+static void read_list_urls( JDLIB::ConfLoader& cf, const std::string& id_urls,  std::vector<std::string>& list_urls )
 {
     list_urls.clear();
 
@@ -548,7 +560,11 @@ void SESSION::save_session()
         if( ! url.empty() ) str_article_urls.append( " \"" + url + "\"" );
     }
     for( const std::string& url : image_urls ) {
-        if( ! url.empty() ) str_image_urls.append( " \"" + url + "\"" );
+        if( ! url.empty() ) {
+            str_image_urls.append( " \"" );
+            str_image_urls.append( url );
+            str_image_urls.push_back( '"' );
+        }
     }
 
     // 開いているタブのロック状態
@@ -869,8 +885,8 @@ void SESSION::set_bbslist_page( const int page ){ win_bbslist_page = page; }
 // 前回閉じたときに開いていたboardのページ番号とURL
 int SESSION::board_page(){ return win_board_page; }
 void SESSION::set_board_page( const int page ){ win_board_page = page; }
-const std::list< std::string >& SESSION::get_board_URLs(){ return board_urls; }
-void SESSION::set_board_URLs( const std::list< std::string >& urls ){ board_urls = urls; }
+const std::vector<std::string>& SESSION::get_board_URLs(){ return board_urls; }
+void SESSION::set_board_URLs( std::vector<std::string> urls ){ board_urls = std::move( urls ); }
 
 // スレ一覧のロック状態
 const std::list< bool >& SESSION::get_board_locked(){ return board_locked; }
@@ -883,8 +899,8 @@ void SESSION::set_board_switchhistory( const std::list< std::string >& hist ){ b
 // 前回閉じたときに開いていたスレタブのページ番号とURL
 int SESSION::article_page(){ return win_article_page; }
 void SESSION::set_article_page( const int page ){ win_article_page = page; }
-const std::list< std::string >& SESSION::get_article_URLs(){ return article_urls; }
-void SESSION::set_article_URLs( const std::list< std::string >& urls ){ article_urls = urls; }
+const std::vector<std::string>& SESSION::get_article_URLs(){ return article_urls; }
+void SESSION::set_article_URLs( std::vector<std::string> urls ){ article_urls = std::move( urls ); }
 
 // スレタブのロック状態
 const std::list< bool >& SESSION::get_article_locked(){ return article_locked; }
@@ -897,8 +913,8 @@ void SESSION::set_article_switchhistory( const std::list< std::string >& hist ){
 // 前回閉じたときに開いていたimageのページ番号とURL
 int SESSION::image_page(){ return win_image_page; }
 void SESSION::set_image_page( const int page ){ win_image_page = page; }
-const std::list< std::string >& SESSION::image_URLs(){ return image_urls; }
-void SESSION::set_image_URLs( const std::list< std::string >& urls ){ image_urls = urls; }
+const std::vector<std::string>& SESSION::image_URLs(){ return image_urls; }
+void SESSION::set_image_URLs( std::vector<std::string> urls ){ image_urls = std::move( urls ); }
 
 // 画像タブのロック状態
 const std::list< bool >& SESSION::get_image_locked(){ return image_locked; }

--- a/src/session.h
+++ b/src/session.h
@@ -269,8 +269,8 @@ namespace SESSION
     void set_board_URLs( std::vector<std::string> urls );
 
     // スレ一覧のロック状態
-    const std::list< bool >& get_board_locked();
-    void set_board_locked( const std::list< bool >& locked );
+    const std::vector<char>& get_board_locked();
+    void set_board_locked( std::vector<char> locked );
 
     // スレ一覧の切り替え履歴    
     const std::list< std::string >& get_board_switchhistory();
@@ -283,8 +283,8 @@ namespace SESSION
     void set_article_URLs( std::vector<std::string> urls );
 
     // スレタブのロック状態
-    const std::list< bool >& get_article_locked();
-    void set_article_locked( const std::list< bool >& locked );
+    const std::vector<char>& get_article_locked();
+    void set_article_locked( std::vector<char> locked );
 
     // スレタブの切り替え履歴    
     const std::list< std::string >& get_article_switchhistory();
@@ -297,8 +297,8 @@ namespace SESSION
     void set_image_URLs( std::vector<std::string> urls );
 
     // 画像タブのロック状態
-    const std::list< bool >& get_image_locked();
-    void set_image_locked( const std::list< bool >& locked );
+    const std::vector<char>& get_image_locked();
+    void set_image_locked( std::vector<char> locked );
 
     // 現在開いているサイドバーのページ
     int get_sidebar_current_page();

--- a/src/session.h
+++ b/src/session.h
@@ -265,8 +265,8 @@ namespace SESSION
     // 前回閉じたときに開いていたスレ一覧のページ番号とURL
     int board_page();
     void set_board_page( const int page );
-    const std::list< std::string >& get_board_URLs();
-    void set_board_URLs( const std::list< std::string >& urls );
+    const std::vector<std::string>& get_board_URLs();
+    void set_board_URLs( std::vector<std::string> urls );
 
     // スレ一覧のロック状態
     const std::list< bool >& get_board_locked();
@@ -279,8 +279,8 @@ namespace SESSION
     // 前回閉じたときに開いていたスレタブのページ番号とURL
     int article_page();
     void set_article_page( const int page );
-    const std::list< std::string >& get_article_URLs();
-    void set_article_URLs( const std::list< std::string >& urls );
+    const std::vector<std::string>& get_article_URLs();
+    void set_article_URLs( std::vector<std::string> urls );
 
     // スレタブのロック状態
     const std::list< bool >& get_article_locked();
@@ -293,8 +293,8 @@ namespace SESSION
     // 前回閉じたときに開いていたimageのページ番号とURL
     int image_page();
     void set_image_page( const int page );
-    const std::list< std::string >& image_URLs();
-    void set_image_URLs( const std::list< std::string >& urls );
+    const std::vector<std::string>& image_URLs();
+    void set_image_URLs( std::vector<std::string> urls );
 
     // 画像タブのロック状態
     const std::list< bool >& get_image_locked();

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -2671,9 +2671,9 @@ void Admin::slot_append_favorite()
 
 
 // ページがロックされているかリストで取得
-std::list< bool > Admin::get_locked()
+std::vector<char> Admin::get_locked()
 {
-    std::list< bool > locked;
+    std::vector<char> locked;
     
     const int pages = m_notebook->get_n_pages();
     if( pages ){

--- a/src/skeleton/admin.cpp
+++ b/src/skeleton/admin.cpp
@@ -343,10 +343,10 @@ int Admin::get_tab_nums()
 //
 // 含まれているページのURLのリスト取得
 //
-std::list<std::string> Admin::get_URLs()
+std::vector<std::string> Admin::get_URLs()
 {
-    std::list<std::string> urls;
-    
+    std::vector<std::string> urls;
+
     const int pages = m_notebook->get_n_pages();
     if( pages ){
 

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -16,6 +16,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <vector>
 
 
 namespace SKELETON
@@ -100,7 +101,7 @@ namespace SKELETON
         virtual int get_tab_nums();
 
         // 含まれているページのURLのリスト取得
-        virtual std::list< std::string > get_URLs();
+        virtual std::vector<std::string> get_URLs();
 
         // Core からのクロック入力。
         // Coreでタイマーをひとつ動かして全体の同期を取るようにしているので

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -321,7 +321,7 @@ namespace SKELETON
         virtual void append_favorite_impl( const std::string& url ) {}
 
         // ページがロックされているかリストで取得
-        virtual std::list< bool > get_locked();
+        virtual std::vector<char> get_locked();
 
         // タブのロック/アンロック
         virtual bool is_lockable( const int page );


### PR DESCRIPTION
This PR refactors session data containers for URLs and lock states from std::list to std::vector.

### Change container for session URL lists from std::list to std::vector

タブやセッション情報で利用していたURLリストのコンテナを`std::list`から`std::vector`に統一しました。これにより、イテレーションやランダムアクセスのパフォーマンスが向上し、APIの整合性も高まりました。関連する関数定義やクラスの仮想関数も全てvector型に修正しています。

---

Unified the containers for URL lists used in tabs and session information from std::list to std::vector. This improves iteration and random access performance, and enhances API consistency. All related function definitions and virtual methods have also been
updated to use vector.

### Replace std::list<bool> with std::vector<char> for session lock state lists

スレッド一覧や画像タブなどのロック状態リストの内部実装を、`std::list<bool>`から`std::vector<char>`へ変更しました。`vector<bool>`の特殊化による取り扱いの難しさを避けるため、`vector<char>`を採用しています。これによりメモリ効率とAPIの一貫性が向上します。関連するクラスや関数の型も全て修正しました。

---

Changed the implementation of lock state lists for thread lists and image tabs from `std::list<bool>` to `std::vector<char>`.  `vector<char>` is used instead of `vector<bool>` to avoid the complexity of vector<bool> specialization.  This improves memory efficiency and API consistency.  All related classes and functions have been updated accordingly.

関連のissue: https://github.com/JDimproved/JDim/issues/1522