### PR TITLE
Fix confirmation dialog expanding to full screen width

### DIFF
--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -861,6 +861,7 @@ void MessageViewBase::post_fin()
                           m_post->get_return_html(), "詳細" );
 
         ddiag.set_title( "書き込みエラー" );
+        ddiag.set_default_size( 600, 400 );
         ddiag.run();
     }
 }

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -425,6 +425,7 @@ void Post::receive_finish()
             }
 
             ConfirmDiag mdiag( m_url, diagmsg );
+            mdiag.set_default_size( 600, 400 );
             const int response = mdiag.run();
             mdiag.hide();
             if( response != Gtk::RESPONSE_OK ){


### PR DESCRIPTION
投稿確認ダイアログのサイズが画面幅いっぱいに広がる問題を修正します。

5ch.netのスレッドに書き込んだとき、投稿確認ダイアログの幅がデスクトップ全体に広がってしまうとの報告がありました。
原因は、`ConfirmDiag` に初期サイズが指定されていなかったため、環境によってはウィンドウが画面全体に拡大されてしまうことでした。
本修正では、`ConfirmDiag` に `set_default_size(600, 400)` を指定し、適切なサイズで表示されるようにしています。

また、同様の問題が `MessageViewBase::post_fin()` 内の `SKELETON::DetailDiag` にもあったため、あわせて初期サイズの設定を追加しています。

---

When posting to a thread on 5ch.net, the confirmation dialog was reported to stretch across the entire desktop width.  The cause was that `ConfirmDiag` did not have an explicit default size, which could result in oversized windows depending on the environment.  This commit sets a default size of `600x400` for `ConfirmDiag` to ensure an appropriate display size.

Additionally, a similar issue was found in `MessageViewBase::post_fin()` with a `SKELETON::DetailDiag`, so a default size is also added there.

修正にあたり不具合報告をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1722942440/730

Closes #1540
