### PR TITLE
Add build configuration for riscv64 snap package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,8 @@ architectures:
     build-for: arm64
   - build-on: armhf
     build-for: armhf
+  - build-on: riscv64
+    build-for: riscv64
 
 # https://snapcraft.io/docs/gnome-extension
 parts:


### PR DESCRIPTION
2025年3月31日以降、snapパッケージで利用しているランタイムである[GNOME Extension][1]（gnome-42-2204）は、stableチャンネルにおいてriscv64アーキテクチャを[サポート][2]するようになりました。

これに対応するため、snapcraft.yamlにriscv64向けのビルド設定を追加します。

[1]: https://snapcraft.io/docs/gnome-extension
[2]: https://github.com/ubuntu/gnome-sdk/issues/285

---

Since March 31, 2025, the GNOME Extension (gnome-42-2204) runtime used by snap packages has started supporting the riscv64 architecture on the stable channel.

To align with this update, this commit adds build configuration for riscv64 in snapcraft.yaml.
