### PR TITLE
Fix abone-by-selection failure when range starts/ends at specific text nodes

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -546,8 +546,8 @@ std::string DrawAreaBase::str_selection() const
 /**
  * @brief 範囲選択の開始位置に対応するレス番号を取得します。
  *
- * 選択範囲の開始位置が「ここまで読んだ」セパレーターに含まれる場合でも、
- * 正しいレス番号を返します。
+ * 選択範囲の開始位置が通常のレス位置、または「ここまで読んだ」セパレーター、
+ * あるいはその親ヘッダーに含まれる場合に対応し、適切なレス番号を返します。
  *
  * @return 選択範囲の開始位置のレス番号。選択されていない場合や、
  * 有効なレス番号が取得できない場合は0を返します。
@@ -561,9 +561,15 @@ int DrawAreaBase::get_selection_resnum_from() const
     // 範囲選択の開始位置がレス番号を持っているなら返す。
     if( const int res_number = layout->res_number; res_number ) return res_number;
 
+    const LAYOUT* header = layout->header;
     // 範囲選択の開始位置の親ヘッダーが新着セパレータなら新着セパレータの位置(レス番号)を返す。
-    if( layout->header == m_layout_tree->get_separator() ) {
-        return m_layout_tree->get_separator_new();
+    if( header == m_layout_tree->get_separator() ) {
+        const int res_number = m_layout_tree->get_separator_new();
+        return res_number;
+    }
+    if( header ) {
+        const int res_number = header->res_number;
+        return res_number;
     }
     return 0;
 }
@@ -572,8 +578,9 @@ int DrawAreaBase::get_selection_resnum_from() const
 /**
  * @brief 範囲選択の終了位置に対応するレス番号を取得します。
  *
- * 選択範囲の終了位置が「ここまで読んだ」セパレーターに含まれる場合でも、
- * 正しいレス番号を返します。
+ * 選択範囲の終了位置が通常のレス位置、または「ここまで読んだ」セパレーター、
+ * あるいはその親ヘッダーに含まれる場合に対応し、適切なレス番号を返します。
+ * セパレーターに含まれる場合はその直前のレス番号を返します。
  *
  * @return 選択範囲の終了位置のレス番号。選択されていない場合や、
  * 有効なレス番号が取得できない場合は0を返します。
@@ -587,9 +594,15 @@ int DrawAreaBase::get_selection_resnum_to() const
     // 範囲選択の終了位置がレス番号を持っているなら返す。
     if( const int res_number = layout->res_number; res_number ) return res_number;
 
+    const LAYOUT* header = layout->header;
     // 範囲選択の終了位置の親ヘッダーが新着セパレータなら新着セパレータの位置(レス番号)の一つ前を返す。
-    if( layout->header == m_layout_tree->get_separator() ) {
-        return m_layout_tree->get_separator_new() - 1;
+    if( header == m_layout_tree->get_separator() ) {
+        const int res_number = m_layout_tree->get_separator_new() - 1;
+        return res_number;
+    }
+    if( header ) {
+        const int res_number = header->res_number;
+        return res_number;
     }
     return 0;
 }


### PR DESCRIPTION
スレビューの「選択範囲のレスをあぼーん」機能が、レス表示上の特定の文字位置を範囲選択の始点または終点に含んだ場合に動作しない不具合を修正しました。

`get_selection_resnum_from()`および`get_selection_resnum_to()`関数において、選択範囲の始点または終点がレス番号を持たないヘッダー（例: 投稿者名、メール欄、投稿時間など）である場合でも、関連するレス番号を正しく取得できるようロジックを更新しました。これにより、特定の文字位置を含む範囲でも「選択範囲のレスをあぼーん」機能が正常に動作するようになります。

また、これらのメンバー関数にDoxygen形式のコメントを追加し、コードの可読性とドキュメントを向上させました。

---

Fixed a bug where the "Abonn selected range of responses" function in the Review View did not work when the selected range included specific text positions within the response display at its start or end.

The logic in `get_selection_resnum_from()` and `get_selection_resnum_to()` functions has been updated. This ensures that the correct response number is retrieved even when the selection range starts or ends with headers that do not directly have a response number (e.g., poster name, email field, post time). This allows the "Abonn selected range of responses" function to work correctly even when specific text positions are included in the range.

Additionally, Doxygen-style comments have been added to these member functions to improve code readability and documentation.

Closes #1544
