### PR TITLE
fix: Resolve muon-master job build failure in Weekly CI

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -81,7 +81,10 @@ jobs:
       - name: build muon stage2
         run: |
           cd muon-src
-          ./stage1/muon-bootstrap setup -Dman-pages=disabled -Dmeson-docs=disabled -Dmeson-tests=disabled -Dlibarchive=disabled -Dlibcurl=disabled -Dlibpkgconf=enabled ../muon-build
+          # Disable libpkgconf. The version available in the GitHub Actions environment (1.8.1)
+          # doesn't meet muon's requirement (>= 1.9.0), causing build failures.
+          # Using the system's pkg-config binary instead.
+          ./stage1/muon-bootstrap setup -Dman-pages=disabled -Dmeson-docs=disabled -Dmeson-tests=disabled -Dlibarchive=disabled -Dlibcurl=disabled -Dlibpkgconf=disabled ../muon-build
           ./stage1/muon-bootstrap samu -C ../muon-build
           cd ..
       - run: ./muon-build/muon version


### PR DESCRIPTION
Weekly CI の muon-master ジョブにおいて、JDim のビルド時に `gtkmm-3.0` 依存関係が見つからないエラーで失敗していました。
これは、muon のビルド時に `-Dlibpkgconf=enabled` オプションを使用していたものの、GitHub Actions 環境の `libpkgconf` のバージョン (1.8.1) が muon が要求するバージョン (>= 1.9.0) を満たしていなかったためです。

このバージョンミスマッチにより、muon が `pkg-config` を介して `gtkmm-3.0` の依存情報を適切に解決できていませんでした。

修正として、muon のビルドステップで `-Dlibpkgconf=enabled` オプションを `-Dlibpkgconf=disabled` に変更します。これにより、 muon はシステムにインストールされている `pkg-config` バイナリを使用するようになり、依存関係の問題が解決します。

---

The Weekly CI's muon-master job was failing during JDim's build due to a missing `gtkmm-3.0` dependency. This was caused by a version mismatch of `libpkgconf`: `muon` was built with `-Dlibpkgconf=enabled`, but the `libpkgconf` version (1.8.1) in the GitHub Actions environment did not meet `muon`'s requirement (>= 1.9.0). This mismatch prevented `muon` from properly resolving `gtkmm-3.0` dependency via `pkg-config`.

This commit modifies the `muon` build step to `-Dlibpkgconf=disabled`.  This resolves the dependency issue by allowing Muon to use the system's pkg-config binary instead of the bundled libpkgconf.

Closes #1547
