### PR TITLE
Disable search toolbar buttons to improve UI consistency

### DIFF
--- a/src/article/articleviewsearch.cpp
+++ b/src/article/articleviewsearch.cpp
@@ -444,7 +444,7 @@ void ArticleViewSearch::operate_search( const std::string& controlid )
 
     if( id == CONTROL::Cancel ){
         focus_view();
-        ARTICLE::get_admin()->set_command( "close_searchbar" );
+        // 一貫性のあるUIにするため、検索のタブではESCキーで検索バーを閉じない。
     }
     else if( id == CONTROL::DrawOutAnd ) reload();
 }

--- a/src/article/toolbarsearch.cpp
+++ b/src/article/toolbarsearch.cpp
@@ -30,7 +30,12 @@ SearchToolBar::SearchToolBar()
     // 検索バー    
     get_searchbar()->append( *get_tool_search( CORE::COMP_SEARCH_ARTICLE ) );
     get_searchbar()->append( m_tool_bm );
-    get_searchbar()->append( *get_button_close_searchbar() );
+    // 一貫性のあるUIにするため検索のタブでは検索バーを常に開いたままにする。
+    // そのため、検索バーを閉じるボタンは無効にする。
+    auto button_close_searchbar = get_button_close_searchbar();
+    get_searchbar()->append( *button_close_searchbar );
+    button_close_searchbar->set_sensitive( false );
+    button_close_searchbar->set_tooltip_text( "検索バーは常に表示されます。" );
 
     SearchToolBar::pack_buttons();
 }
@@ -57,7 +62,14 @@ void SearchToolBar::pack_buttons()
                 break;
 
             case ITEM_SEARCH:
-                get_buttonbar().append( *get_button_open_searchbar() );
+                // 一貫性のあるUIにするため検索のタブでは検索バーを常に開いたままにする。
+                // そのため、検索バーを開くボタンは無効にする。
+                {
+                    auto button_open_searchbar = get_button_open_searchbar();
+                    get_buttonbar().append( *button_open_searchbar );
+                    button_open_searchbar->set_sensitive( false );
+                    button_open_searchbar->set_tooltip_text( "検索バーは常に表示されます。" );
+                }
                 break;
 
             case ITEM_RELOAD:


### PR DESCRIPTION
検索機能のツールバーにある「検索バーを開く」および「検索バーを閉じる」ボタンが、常に検索バーが表示されている状況下で期待通りに機能しない問題に対応しました。

以下の修正を行っています。

- 検索ボックスでESCキーを押しても検索バーが閉じないように変更しました。
- 検索バーを常に表示させるため、「検索バーを閉じる」ボタンを無効化し、ツールチップで「検索バーは常に表示されます。」と補足説明を追加しました。
- 同様に、「検索バーを開く」ボタンも常に無効化し、ツールチップで「検索バーは常に表示されます。」と補足説明を追加しました。

これにより、検索機能のUIにおけるボタンの挙動の一貫性を向上させ、ユーザーの混乱を防ぎます。

---

Disable search toolbar buttons to improve UI consistency for search features. The "Open Search Bar" and "Close Search Bar" buttons in the search feature toolbars (Title Search and Cached Log Search) did not function as expected because the search bar is always visible.

This commit addresses the issue by:

- Preventing the search bar from closing when the ESC key is pressed in the search box.
- Disabling the "Close Search Bar" button and adding a tooltip "The search bar is always visible."
- Disabling the "Open Search Bar" button and adding a tooltip "The search bar is always visible."

These changes enhance UI consistency and prevent user confusion in the search features.

Closes #1549
