### PR TITLE
Bump version to 0.14.0-beta

### DIFF
--- a/docs/manual/2025.md
+++ b/docs/manual/2025.md
@@ -10,6 +10,28 @@ layout: default
 
 <a name="0.14.0-unreleased"></a>
 ### [0.14.0-unreleased](https://github.com/JDimproved/JDim/compare/f0e585533cc...master) (unreleased)
+- ([#1551](https://github.com/JDimproved/JDim/pull/1551))
+  Bump version to 0.14.0-beta
+- ([#1550](https://github.com/JDimproved/JDim/pull/1550))
+  Disable search toolbar buttons to improve UI consistency
+- ([#1548](https://github.com/JDimproved/JDim/pull/1548))
+  fix: Resolve muon-master job build failure in Weekly CI
+- ([#1546](https://github.com/JDimproved/JDim/pull/1546))
+  Fix abone-by-selection failure when range starts/ends at specific text nodes
+- ([#1545](https://github.com/JDimproved/JDim/pull/1545))
+  Fix "Aborn selected responses" not working when selection includes separator
+- ([#1542](https://github.com/JDimproved/JDim/pull/1542))
+  Add build configuration for riscv64 snap package
+- ([#1541](https://github.com/JDimproved/JDim/pull/1541))
+  Fix confirmation dialog expanding to full screen width
+- ([#1539](https://github.com/JDimproved/JDim/pull/1539))
+  Refactor session containers: replace `std::list` with `std::vector` for URLs and lock states
+- ([#1538](https://github.com/JDimproved/JDim/pull/1538))
+  Pink post fix
+- ([#1537](https://github.com/JDimproved/JDim/pull/1537))
+  5chに時間が古いと言われてかけなくなったので、timeに現在時間を入れたとても暫定的な対応
+- ([#1535](https://github.com/JDimproved/JDim/pull/1535))
+  Update histories
 
 
 <a name="0.14.0-alpha20250403"></a>

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 
 project('jdim', 'cpp',
-        version : '0.14.0-alpha',
+        version : '0.14.0-beta',
         license : 'GPL2',
         meson_version : '>= 0.61.0',
         default_options : ['warning_level=3', 'cpp_std=c++17'])

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -17,8 +17,8 @@
 #define MAJORVERSION 0
 #define MINORVERSION 14
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20250403"
-#define JDTAG     "alpha"
+#define JDDATE_FALLBACK    "20250614"
+#define JDTAG     "beta"
 
 //---------------------------------
 


### PR DESCRIPTION
### Update histories

### version to 0.14.0-beta

機能フリーズ期間に入るためバージョン番号をベータ版に更新します。

関連のissue: #1536
