### PR TITLE
Set 'time' parameter to 30 seconds before current time for 5ch posts

### DIFF
--- a/src/dbtree/article2ch.cpp
+++ b/src/dbtree/article2ch.cpp
@@ -43,6 +43,9 @@ std::string Article2ch::create_write_message( const std::string& name, const std
     if( msg.empty() ) return std::string();
 
     const Encoding enc{ utf8_post ? Encoding::utf8 : get_encoding() };
+    // 5chサーバーが現在時刻の`time`値でCookie発行を拒否し書き込みに失敗する場合があるため、
+    // 現在時刻から30秒前のUNIXタイムスタンプにする。
+    constexpr int kTimeOffsetSeconds = 30;
 
     std::stringstream ss_post;
     ss_post << "FROM=" << MISC::url_encode_plus( name, enc )
@@ -50,7 +53,7 @@ std::string Article2ch::create_write_message( const std::string& name, const std
             << "&MESSAGE=" << MISC::url_encode_plus( msg, enc )
             << "&bbs=" << DBTREE::board_id( get_url() )
             << "&key=" << get_key()
-            << "&time=" << time(0)
+            << "&time=" << ( time(0) - kTimeOffsetSeconds )
             << "&submit=" << MISC::url_encode_plus( "書き込む", enc )
             // XXX: ブラウザの種類に関係なく含めて問題ないか？
             << "&oekaki_thread1=";


### PR DESCRIPTION
5chへの書き込み時にtimeパラメータを現在時刻の30秒前に設定します。
これまでの調査により、JDimから5chへの書き込みが失敗する主な原因の一つとして、投稿データに含まれるtimeパラメータの値が不適切であることが
判明しました。

現在のtimeパラメータは`time(0)`で取得した現在時刻のUNIXタイムスタンプを設定していますが、これにより5chサーバー側でのCookie発行が妨げられていました。

外部の先行調査（JaneStyleプラグインの挙動分析）から、timeパラメータを「現在時刻より30秒前のUNIXタイムスタンプ」に設定することで、サーバーがリクエストを正しく認識し、書き込みに必要なCookie（MonaTicketやacorn）を発行してくれることが確認されています。

このコミットでは、timeパラメータの値を`time(0) - 30`に変更し、書き込み機能の安定化を図ります。

---

A key cause of 5ch posting failures was identified as an incorrect 'time' parameter. Currently, the 'time' parameter uses the current UNIX timestamp (time(0)), which prevents the 5ch server from issuing necessary cookies.

Based on external research (JaneStyle plugin analysis), setting 'time' to 30 seconds before the current timestamp allows the server to correctly process the request and issue essential cookies (MonaTicket and acorn).

This commit changes the 'time' parameter to `time(0) - 30` to stabilize the posting functionality.

関連のissue: #1531
