### PR TITLE
Allow user commands to use single-quoted arguments with $VIEW

### DIFF
--- a/docs/manual/usrcmd.md
+++ b/docs/manual/usrcmd.md
@@ -43,7 +43,14 @@ layout: default
 
 <dl>
   <dt>$VIEW</dt>
-  <dd>ネットワーク設定で指定されたwebブラウザで開く ( 例: <code>$VIEW $LINK</code> でリンクをブラウザで開く )</dd>
+  <dd>ネットワーク設定で指定されたwebブラウザで開く ( 例: <code>$VIEW $LINK</code> でリンクをブラウザで開く )<br>
+    <b>$VIEW</b> コマンドのURL引数は、シングルクオート(')、ダブルクオート(")、またはクオートなしで指定可能です。例：
+    <ul>
+      <li><code>$VIEW '$LINK'</code> <small>(v0.15.0-alpha20250820 からサポート)</small></li>
+      <li><code>$VIEW "$LINK"</code></li>
+      <li><code>$VIEW $LINK</code></li>
+    </ul>
+  </dd>
   <dt>$DIALOG</dt>
   <dd><code>$DIALOG</code>の後の文字列をダイアログ表示</dd>
 

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -4280,9 +4280,8 @@ void Core::open_by_browser( const std::string& url )
     std::string command_openurl = CONFIG::get_command_openurl();
     if( !command_openurl.empty() ){
 
-        // urlの先頭と最後のの " を取る
-        std::string tmp_url = url.substr( url.find_first_not_of( '\"' ) );
-        tmp_url.erase( tmp_url.find_last_not_of( '\"' ) + 1 );
+        // URLの先頭と最後のクオート（" または '）を取り除く
+        std::string tmp_url = MISC::remove_quotes( url );
 
         command_openurl = MISC::replace_str( command_openurl, "%LINK", tmp_url );
         command_openurl = MISC::replace_str( command_openurl, "%s", tmp_url );

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -427,6 +427,32 @@ std::string MISC::remove_str_regex( const std::string& str1, const std::string& 
 }
 
 
+/**
+ * @brief クオートで囲まれた文字列を抽出します。
+ *
+ * 入力文字列がシングルクオート（'）またはダブルクオート（"）で囲まれている場合、
+ * クオート内部の文字列を返します。囲まれていない場合は元の文字列を返します。
+ *
+ * 以下のような特殊ケースでは元の文字列をそのまま返します：
+ * - クオートが対になっていない場合（例："abc）
+ * - 異なる種類のクオートで囲まれている場合（例："abc'）
+ *
+ * @param str 入力文字列
+ * @return クオート内の文字列、または元の文字列
+ */
+std::string MISC::remove_quotes( std::string_view str )
+{
+    if( str.size() >= 2 ) {
+        const char first = str.front();
+        const char last = str.back();
+        if( ( first == '\'' || first == '"' ) && first == last ) {
+            return std::string( str.substr( 1, str.size() - 2 ) );
+        }
+    }
+    return std::string( str );
+}
+
+
 /** @brief front_sep, back_sep に囲まれた文字列を切り出す
  *
  * @param[in] str 処理する文字列

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -89,6 +89,9 @@ namespace MISC
     // 正規表現を使ってstr1からqueryで示された文字列を除く
     std::string remove_str_regex( const std::string& str1, const std::string& query );
 
+    // クオートで囲まれた文字列を抽出します。
+    std::string remove_quotes( std::string_view str );
+
     /// front_sep, back_sep に囲まれた文字列を切り出す
     std::string cut_str( const std::string& str, std::string_view front_sep, std::string_view back_sep );
 

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -225,6 +225,75 @@ TEST_F(RemoveStrStartEndTest, much_end_marks)
 }
 
 
+class MISC_RemoveQuotesTest : public ::testing::Test {};
+
+// 正常なケース: クオートがない文字列
+TEST_F(MISC_RemoveQuotesTest, no_quotes)
+{
+    EXPECT_EQ( MISC::remove_quotes( "http://example.com" ), "http://example.com" );
+    EXPECT_EQ( MISC::remove_quotes( "url" ), "url" );
+}
+
+// 正常なケース: ダブルクオートで囲まれた文字列
+TEST_F(MISC_RemoveQuotesTest, double_quotes)
+{
+    EXPECT_EQ( MISC::remove_quotes( "\"http://example.com\"" ), "http://example.com" );
+    EXPECT_EQ( MISC::remove_quotes( "\"url\"" ), "url" );
+}
+
+// 正常なケース: シングルクオートで囲まれた文字列
+TEST_F(MISC_RemoveQuotesTest, single_quotes)
+{
+    EXPECT_EQ( MISC::remove_quotes( "'http://example.com'" ), "http://example.com" );
+    EXPECT_EQ( MISC::remove_quotes( "'url'" ), "url" );
+}
+
+// エッジケース: 空の文字列
+TEST_F(MISC_RemoveQuotesTest, empty_string)
+{
+    EXPECT_EQ( MISC::remove_quotes( "" ), "" );
+}
+
+// エッジケース: クオートの種類が不一致
+// 動作の想定: 対になっていないため、変更なし
+TEST_F(MISC_RemoveQuotesTest, mismatched_quotes)
+{
+    EXPECT_EQ( MISC::remove_quotes( "'test string\"" ), "'test string\"" );
+    EXPECT_EQ( MISC::remove_quotes( "\"test string'" ), "\"test string'" );
+}
+
+// エッジケース: 片側のみのクオート
+// 動作の想定: 対になっていないため、変更なし
+TEST_F(MISC_RemoveQuotesTest, unpaired_quotes)
+{
+    EXPECT_EQ( MISC::remove_quotes( "\"test string" ), "\"test string" );
+    EXPECT_EQ( MISC::remove_quotes( "test string\"" ), "test string\"" );
+    EXPECT_EQ( MISC::remove_quotes( "'test string" ), "'test string"  );
+    EXPECT_EQ( MISC::remove_quotes( "test string'" ), "test string'"  );
+}
+
+// エッジケース: 複数のクオート（例：`"'url'"`）
+// 動作の想定: 外側のクオートのみを削除
+TEST_F(MISC_RemoveQuotesTest, nested_quotes)
+{
+    EXPECT_EQ( MISC::remove_quotes( "\"'http://example.com'\"" ), "'http://example.com'" );
+    EXPECT_EQ( MISC::remove_quotes( "'\"url\"'" ), "\"url\"" );
+}
+
+// エッジケース: 空のクオート
+TEST_F(MISC_RemoveQuotesTest, empty_quotes) {
+    EXPECT_EQ( MISC::remove_quotes( "''" ), "" );
+    EXPECT_EQ( MISC::remove_quotes( "\"\"" ), "" );
+}
+
+// エッジケース: 不正なURL（例：`http://'example.com'`）
+// 動作の想定: クオートが先頭と末尾にないため、変更なし
+TEST_F(MISC_RemoveQuotesTest, invalid_url_like_quotes)
+{
+    EXPECT_EQ( MISC::remove_quotes("http://'example.com'" ), "http://'example.com'" );
+}
+
+
 class CutStrFrontBackTest : public ::testing::Test {};
 
 TEST_F(CutStrFrontBackTest, empty_data)


### PR DESCRIPTION
### Add `MISC::remove_quotes()` helper function for quote handling

ユーザーコマンドでシングルクオートを使用できない不具合を修正するために、文字列の先頭と末尾のクオートを取り除く新しいヘルパー関数 `MISC::remove_quotes()` を追加しました。

この関数は、ダブルクオート `"` とシングルクオート `'` の両方に対応しており、`src/core.cpp` のロジックをより簡潔にするために使用されます。また、再利用可能なユーティリティとして、将来の機能追加にも役立ちます。

同時に、この関数の動作を保証するために、`test/gtest_jdlib_miscutil.cpp` に単体テストを追加しました。正常系とエッジケースの両方を網羅することで、関数の信頼性を確保しています。

---

This commit introduces a new helper function, `MISC::remove_quotes()`, to strip leading and trailing quotes from a string. This function is a preparatory step to fix the bug where user commands fail when arguments are wrapped in single quotes.

`MISC::remove_quotes()` handles both single (`'`) and double (`"`) quotes, providing a clean and reusable utility that will be used to simplify the logic in `src/core.cpp`.

To ensure correctness, this change also includes a comprehensive set of unit tests in `test/gtest_jdlib_miscutil.cpp`, covering various edge cases.

### Allow user commands to use single-quoted arguments with `$VIEW`

ユーザーコマンドの `$VIEW` 引数にシングルクオートを使用すると、コマンドが正しく実行されない不具合を修正します。

これまでの実装では、引数のクオート削除処理がダブルクオートのみを対象としていたため、シングルクオートが残ったままコマンドラインに渡され、実行に失敗していました。

このコミットでは、新しいヘルパー関数 `MISC::remove_quotes()` を使用して、 `$VIEW` コマンドの引数からダブルクオートとシングルクオートの両方を正しく取り除くように変更しました。これにより、ユーザーはどちらのクオートも自由に利用できるようになります。

また、オンラインマニュアル `docs/manual/usrcmd.md` を更新し、 `$VIEW` コマンドがシングルクオートの使用をサポートすることを明記しました。

---

This commit fixes a bug where user commands fail to execute when the `$VIEW` argument is enclosed in single quotes.

Previously, the quote removal logic for arguments only handled double quotes, causing single quotes to be passed to the command line and resulting in execution errors.

The fix involves using the new `MISC::remove_quotes` helper function to properly strip both single and double quotes from `$VIEW` arguments. This ensures that users can now reliably use either type of quote.

Additionally, the online manual (`docs/manual/usrcmd.md`) has been updated to document the newly supported use of single quotes with the `$VIEW` command.

Closes #1557
