### PR TITLE
fix: Correct duplicate URL display in the post error dialog

### DIFF
--- a/src/message/post.h
+++ b/src/message/post.h
@@ -79,6 +79,12 @@ namespace MESSAGE
 
         void receive_data( std::string_view buf ) override;
         void receive_finish() override;
+
+      protected:
+        /**
+         * @brief エラーメッセージをクリーンアップ（テスト用にprotected）。
+         */
+        std::string process_error_message( const std::string& html_errmsg, std::time_t& samba_sec_out );
     };
     
 }

--- a/test/gtest_message_post.cpp
+++ b/test/gtest_message_post.cpp
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "message/post.h"
+
+#include "gtest/gtest.h"
+
+
+namespace {
+
+// PostTestを無名名前空間に定義
+class PostTest : public ::testing::Test, public MESSAGE::Post
+{
+public:
+    PostTest() : MESSAGE::Post(nullptr, "dummy_url", "dummy_msg", false) {} // ダミーURLで初期化
+};
+
+TEST_F(PostTest, process_error_message_handles_duplicate_link)
+{
+    // 同一リンクの重複除去を確認
+    std::time_t samba_sec = 0;
+    std::string errmsg = "<b>エラー: <a href=\"https://example.com\">https://example.com</a></b>";
+    EXPECT_EQ( process_error_message( errmsg, samba_sec ), "<b>エラー:  https://example.com</b>" );
+    EXPECT_EQ( samba_sec, 0 ); // sambaマッチなし
+}
+
+TEST_F(PostTest, process_error_message_preserves_different_link)
+{
+    // 異なるリンクのhrefとテキストを保持
+    std::time_t samba_sec = 0;
+    std::string errmsg = "<b>エラー: <a href=\"https://example.com\">詳細リンク</a></b>";
+    EXPECT_EQ( process_error_message( errmsg, samba_sec ), "<b>エラー:  https://example.com 詳細リンク</b>" );
+    EXPECT_EQ( samba_sec, 0 );
+}
+
+TEST_F(PostTest, process_error_message_handles_multiple_links)
+{
+    // 複数リンクの処理を確認
+    std::time_t samba_sec = 0;
+    std::string errmsg = "<b><a href=\"url1\">url1</a> <a href=\"url2\">text2</a></b>";
+    EXPECT_EQ( process_error_message( errmsg, samba_sec ), "<b> url1  url2 text2</b>" );
+}
+
+TEST_F(PostTest, process_error_message_handles_empty_link)
+{
+    // 空リンクの処理を確認
+    std::time_t samba_sec = 0;
+    std::string errmsg = "<a href=\"url\"></a>";
+    EXPECT_EQ( process_error_message( errmsg, samba_sec ), " url " );
+}
+
+TEST_F(PostTest, process_error_message_handles_samba_sec)
+{
+    // samba秒の抽出を確認
+    std::time_t samba_sec = 0;
+    std::string errmsg = "ERROR: Samba24:Caution 25 秒たたないと書けません。";
+    EXPECT_EQ( process_error_message( errmsg, samba_sec ), "ERROR: Samba24:Caution 25 秒たたないと書けません。" );
+    EXPECT_EQ( samba_sec, 25 );
+}
+
+TEST_F(PostTest, process_error_message_handles_no_tags)
+{
+    // タグなしメッセージの改行処理を確認
+    std::time_t samba_sec = 0;
+    std::string errmsg = "シンプルなエラー<br>メッセージ";
+    EXPECT_EQ( process_error_message( errmsg, samba_sec ), "シンプルなエラー\nメッセージ" );
+    EXPECT_EQ( samba_sec, 0 );
+}
+
+TEST_F(PostTest, process_error_message_handles_invalid_html)
+{
+    // 不正HTMLの処理を確認
+    std::time_t samba_sec = 0;
+    std::string errmsg = "<a href=\"url\">text</a><invalid>";
+    EXPECT_EQ( process_error_message( errmsg, samba_sec ), " url text<invalid>" );
+}
+
+TEST_F(PostTest, process_error_message_handles_special_chars)
+{
+    // 特殊文字リンクの処理を確認
+    std::time_t samba_sec = 0;
+    std::string errmsg = "<a href=\"https://example.com/path%20with%20space\">path with space</a>";
+    EXPECT_EQ( process_error_message( errmsg, samba_sec ), " https://example.com/path%20with%20space path with space" );
+    EXPECT_EQ( samba_sec, 0 );
+}
+
+TEST_F(PostTest, process_error_message_handles_nested_links)
+{
+    // ネストされた<a>タグを外側から順に処理（hrefとテキストを連結）
+    std::time_t samba_sec = 0;
+    std::string errmsg = "<a href=\"outer\">outer<a href=\"inner\">inner</a></a>";
+    EXPECT_EQ( process_error_message( errmsg, samba_sec ), " outer outer inner inner" );
+    EXPECT_EQ( samba_sec, 0 );
+}
+
+TEST_F(PostTest, process_error_message_handles_empty_input)
+{
+    // 空入力の処理を確認
+    std::time_t samba_sec = 0;
+    std::string errmsg = "";
+    EXPECT_EQ( process_error_message( errmsg, samba_sec ), "" );
+    EXPECT_EQ( samba_sec, 0 );
+}
+
+TEST_F(PostTest, process_error_message_handles_multiple_br_hr)
+{
+    // 複数<br><hr>の改行処理を確認
+    std::time_t samba_sec = 0;
+    std::string errmsg = "エラー<br><br><a href=\"url\">url</a><hr><hr>";
+    EXPECT_EQ( process_error_message( errmsg, samba_sec ), "エラー\n\n url\n-------------------\n\n-------------------\n" );
+    EXPECT_EQ( samba_sec, 0 );
+}
+
+TEST_F(PostTest, process_error_message_handles_invalid_samba_sec)
+{
+    // 不正samba秒の処理を確認
+    std::time_t samba_sec = 0;
+    std::string errmsg = "ERROR: Samba24:Caution invalid 秒";
+    EXPECT_EQ( process_error_message( errmsg, samba_sec ), "ERROR: Samba24:Caution invalid 秒" );
+    EXPECT_EQ( samba_sec, 0 ); // atoiが不正値で0を返す
+}
+
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -16,6 +16,7 @@ sources = [
   'gtest_jdlib_miscutil.cpp',
   'gtest_jdlib_span.cpp',
   'gtest_message_messageviewbase.cpp',
+  'gtest_message_post.cpp',
   'gtest_xml_dom.cpp',
 ]
 


### PR DESCRIPTION
### feat: Add helper function to process error messages in Post class

投稿エラーダイアログでURLが二重に表示される不具合を修正するため、エラーメッセージのクリーンアップと`<a>`タグ処理を行うヘルパー関数 `MESSAGE::Post::process_error_message()` を追加します。

この関数は、`href`属性とリンクテキストが一致する場合にのみ、URLの重複を削除します。また、samba秒の抽出などの関連処理も一元化します。これにより、副作用のないロジックを独立してテストできるようになります。

本コミットには、関数の正確性を検証するための広範な単体テストも含まれています。

---

Adds a new helper function, `MESSAGE::Post::process_error_message()`, to clean up error messages and handle `<a>` tags. This is a preparatory step to fix the bug where URLs appear duplicated in the post error dialog.

The function removes redundant URLs when the `href` attribute and link text are identical, while preserving both when they are different.  It also centralizes related logic, such as extracting the samba seconds, allowing for side-effect-free unit testing.

Comprehensive unit tests are included to verify the function's correctness in various scenarios.

### fix: Correct duplicate URL display in the post error dialog

投稿に失敗した際に、エラーメッセージ内でURLが二重に表示される問題を修正します。これまでの実装では、`<a>`タグ内の `href`属性とリンクテキストを常に両方表示していたため、両者が同じURLである場合に重複して表示されていました。

この修正では、新しく追加したヘルパー関数 `Post::process_error_message()` を使用して、エラーメッセージを適切に処理します。これにより、重複したURLは削除され、エラーダイアログがより簡潔で分かりやすくなります。また、samba秒の副作用処理を呼び出し側に戻すことで、懸念されていた副作用の問題も解消されます。

---

This commit fixes a bug where URLs would appear duplicated in the post error dialog upon failed submissions.

Previously, the error message processing logic would always display both the `href` attribute and the link text from `<a>` tags.  This caused a redundant URL display when both were identical.

The fix replaces the old logic with a call to the new `Post::process_error_message()` helper function, which intelligently handles `<a>` tags by removing duplicate URLs. This makes the error dialog cleaner and more user-friendly. The side-effect logic for samba seconds is also correctly moved to the caller.

Closes #1559
