### PR TITLE
Bump version to 0.16.1-alpha and increment micro version for dev cycle

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 
 project('jdim', 'cpp',
-        version : '0.16.0',
+        version : '0.16.1-alpha',
         license : 'GPL2',
         meson_version : '>= 0.61.0',
         default_options : ['warning_level=3', 'cpp_std=c++20'])

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -16,9 +16,9 @@
 
 #define MAJORVERSION 0
 #define MINORVERSION 16
-#define MICROVERSION 0
-#define JDDATE_FALLBACK    "20260316"
-#define JDTAG     ""
+#define MICROVERSION 1
+#define JDDATE_FALLBACK    "20260328"
+#define JDTAG     "alpha"
 
 //---------------------------------
 


### PR DESCRIPTION
開発中のバージョンであることを明確にするため、alpha 版に更新します。
また、バグ修正リリースを想定したバージョニングとしてマイクロバージョンを 1 増やします。

JDim 0.16.0 は当初2026年7月のリリースを予定していましたが、５ちゃんねるのドメイン変更への対応として2026年3月に臨時リリースしました。
このとき開発版は 0.16.0-alpha であったため、バグ修正として 0.15.1 を採用するとバージョン番号が逆行する問題がありました。

この問題を避けるため、開発版のバージョンを 0.16.1-alpha に更新します。

---

Update version to 0.16.1-alpha to clearly indicate a development build.

Increment the micro version as part of an experimental versioning strategy for bugfix releases.

Originally, JDim 0.16.0 was planned for release in July 2026.  However, due to the 5ch domain migration, it was released early in March 2026 as an emergency bugfix version.

At that time, the development version was already 0.16.0-alpha, so using 0.15.1 for the bugfix release would have caused a version regression.

To avoid this inconsistency, the development version is updated to 0.16.1-alpha.

#### RFC 0014: alpha タグ導入による開発バージョン管理

[RFC 0014](https://github.com/JDimproved/rfcs/blob/master/docs/0014-jdim-versioning-with-alpha-tag.md)では未解決の問題として「現行リリースのバグ修正版をリリースする必要が生じた際はどうするか」を挙げています。
2026-03-16 にリリースしたバージョン0.16.0で問題が顕在化したため、今回は実験的にマイクロバージョンを増やします。
