### PR TITLE
Fix crash in parse_date_id triggered by certain ID field patterns

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1904,7 +1904,7 @@ void NodeTreeBase::parse_date_id( NODE* header, std::string_view str )
 
         if(
             // ID
-            ( str[ start_block ] == 'I' && str[ start_block + 1 ] == 'D' )
+            ( str.compare( start_block, 2, "ID" ) == 0 )
 
             // HOST
             || ( str.compare( start_block, 4, "HOST" ) == 0 )


### PR DESCRIPTION
日付・ID解析処理で特定の入力によりクラッシュする問題を修正します

ID判定で文字列のインデックスアクセスを行っていたため、
特定の形式の入力において `std::string_view` の範囲外アクセスが発生し、
アサーション失敗により異常終了する場合がありました。

ID判定を `std::string_view::compare()` を用いた安全な比較に変更し、
範囲外アクセスを防止します。

この問題は @mtasaka さんにより報告および修正案が提示されました。
ご協力ありがとうございます。

---

Fix a crash caused by out-of-bounds access in ID parsing.

The previous implementation accessed `string_view` by index when
checking for "ID". Under certain input patterns, this could lead
to an out-of-bounds access and trigger a `std::string_view` assertion
failure.

Replace the check with `std::string_view::compare()` to ensure safe
substring comparison.

Reported and patch suggested by @mtasaka.

修正にあたり不具合報告をしていただきありがとうございました。
Ref: https://github.com/JDimproved/JDim/issues/1587
Ref: https://mao.5ch.io/test/read.cgi/linux/1764825297/495-513n
