### PR TITLE
Bump version to 0.17.0-beta

### DIFF
--- a/docs/manual/2026.md
+++ b/docs/manual/2026.md
@@ -11,6 +11,12 @@ layout: default
 
 <a name="0.17.0-unreleased"></a>
 ### [0.17.0-unreleased](https://github.com/JDimproved/JDim/compare/JDim-v0.16.0...master) (unreleased)
+- ([#1588](https://github.com/JDimproved/JDim/pull/1588))
+  Fix crash in `parse_date_id` triggered by certain ID field patterns
+- ([#1586](https://github.com/JDimproved/JDim/pull/1586))
+  Add gcc-c++ to dependencies for Red Hat
+- ([#1585](https://github.com/JDimproved/JDim/pull/1585))
+  Update histories
 - ([#1583](https://github.com/JDimproved/JDim/pull/1583))
   Bump version to 0.16.1-alpha and increment micro version for dev cycle
 

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 
 project('jdim', 'cpp',
-        version : '0.16.1-alpha',
+        version : '0.17.0-beta',
         license : 'GPL2',
         meson_version : '>= 0.61.0',
         default_options : ['warning_level=3', 'cpp_std=c++20'])

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -15,10 +15,10 @@
 // SEE ALSO: ENVIRONMENT::get_jdversion()
 
 #define MAJORVERSION 0
-#define MINORVERSION 16
-#define MICROVERSION 1
-#define JDDATE_FALLBACK    "20260404"
-#define JDTAG     "alpha"
+#define MINORVERSION 17
+#define MICROVERSION 0
+#define JDDATE_FALLBACK    "20260620"
+#define JDTAG     "beta"
 
 //---------------------------------
 


### PR DESCRIPTION
## Update histories

## Bump version to 0.17.0-beta

機能フリーズ期間に入るためバージョン番号をベータ版に更新します。

関連のissue: #1584
