### PR TITLE
Update actions/checkout to v7 to address Node.js 20 deprecation warning

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,7 +20,7 @@ jobs:
       # https://github.com/JDimproved/JDim/issues/943
       AVOID_CRASH: -Wl,--push-state,--no-as-needed -lcrypt -Wl,--pop-state
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: dependencies installation
         run: |
           sudo apt update
@@ -53,7 +53,7 @@ jobs:
             cxx: clang++-15
             package: clang-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: dependencies installation
         run: |
           sudo apt update
@@ -96,7 +96,7 @@ jobs:
             cxx: clang++-20
             package: clang-20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: dependencies installation
         run: |
           sudo apt update
@@ -121,7 +121,7 @@ jobs:
           - config_args: -Dtls=openssl -Dsessionlib=xsmp -Dalsa=enabled -Dpangolayout=enabled
             packages: libssl-dev libasound2-dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: dependencies installation (${{ matrix.deps.packages }})
         run: |
           sudo apt update
@@ -146,7 +146,7 @@ jobs:
           - config_args: -Dtls=openssl -Dsessionlib=xsmp -Dalsa=enabled -Dpangolayout=enabled
             packages: libssl-dev libasound2-dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: dependencies installation (${{ matrix.deps.packages }})
         run: |
           sudo apt update
@@ -159,7 +159,7 @@ jobs:
   manual-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/jekyll-build-pages@v1
         with:
           source: ./docs

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -15,7 +15,7 @@ jobs:
       CC: gcc-14
       CXX: g++-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: dependencies installation
         run: |
           sudo apt update
@@ -31,7 +31,7 @@ jobs:
       CC: clang-18
       CXX: clang++-18
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: dependencies installation
         run: |
           sudo apt update
@@ -47,7 +47,7 @@ jobs:
       CC: gcc-14
       CXX: g++-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: dependencies installation
         run: |
           sudo apt update
@@ -63,7 +63,7 @@ jobs:
       CC: gcc-13
       CXX: g++-13
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: dependencies installation
         run: |
           sudo apt update


### PR DESCRIPTION
GitHub Actionsのactions/checkoutをv7へ更新します

Node.js 20のサポート終了に伴い、 GitHub ActionsでNode.js 24への移行を促す警告が表示されるため、 actions/checkoutを最新版へ更新して警告を解消します。

---

GitHub Actions warns that Node.js 20 is deprecated and automatically upgrades the runtime to Node.js 24.  Update actions/checkout to the latest major version to eliminate the warning and keep the CI workflow up to date.

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
