### PR TITLE
Bump version to 0.17.1-alpha and increment micro version for dev cycle

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 
 project('jdim', 'cpp',
-        version : '0.17.0',
+        version : '0.17.1-alpha',
         license : 'GPL2',
         meson_version : '>= 0.61.0',
         default_options : ['warning_level=3', 'cpp_std=c++20'])

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -17,7 +17,7 @@
 #define MAJORVERSION 0
 #define MINORVERSION 17
 #define MICROVERSION 0
-#define JDDATE_FALLBACK    "20260711"
+#define JDDATE_FALLBACK    "20260718"
 #define JDTAG     ""
 
 //---------------------------------


### PR DESCRIPTION
開発中のバージョンであることを明確にするため、alpha 版に更新します。
また、バグ修正リリースを想定したバージョニングとしてマイクロバージョンを 1 増やします。

---

Update version to 0.17.1-alpha to clearly indicate a development build.

Increment the micro version as part of an experimental versioning strategy for bugfix releases.
